### PR TITLE
Metrics service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.44</version>
+        <version>0.45-SNAPSHOT</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.15.6-SNAPSHOT</version>


### PR DESCRIPTION
Makes sure killbill points to snapshot version of platform (with metrics service included).

See https://github.com/killbill/killbill-platform/pull/11