### PR TITLE
Issue 119

### DIFF
--- a/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiCancel.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiCancel.java
@@ -257,9 +257,5 @@ public class TestUserApiCancel extends SubscriptionTestSuiteWithEmbeddedDB {
         final DateTime invalidDate = subscription.getBundleStartDate().minusDays(3);
         // CANCEL in EVERGREEN period with an invalid Date (prior to the Creation Date)
         subscription.cancelWithDate(invalidDate, callContext);
-        assertListenerStatus();
-
-        testListener.pushExpectedEvent(NextEvent.CANCEL);
-        assertListenerStatus();
     }
 }

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiCancel.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiCancel.java
@@ -233,4 +233,33 @@ public class TestUserApiCancel extends SubscriptionTestSuiteWithEmbeddedDB {
 
         assertListenerStatus();
     }
+
+    @Test(groups = "slow", expectedExceptions = SubscriptionBaseApiException.class)
+    public void testCancelSubscriptionWithInvalidRequestedDate() throws SubscriptionBaseApiException {
+        final String prod = "Shotgun";
+        final BillingPeriod term = BillingPeriod.MONTHLY;
+        final String planSet = PriceListSet.DEFAULT_PRICELIST_NAME;
+
+        // CREATE
+        final DefaultSubscriptionBase subscription = testUtil.createSubscription(bundle, prod, term, planSet);
+        PlanPhase currentPhase = subscription.getCurrentPhase();
+        assertEquals(currentPhase.getPhaseType(), PhaseType.TRIAL);
+
+        // MOVE TO NEXT PHASE
+        testListener.pushExpectedEvent(NextEvent.PHASE);
+
+        final Interval it = new Interval(clock.getUTCNow(), clock.getUTCNow().plusDays(31));
+        clock.addDeltaFromReality(it.toDurationMillis());
+        assertListenerStatus();
+        currentPhase = subscription.getCurrentPhase();
+        assertEquals(currentPhase.getPhaseType(), PhaseType.EVERGREEN);
+
+        final DateTime invalidDate = subscription.getBundleStartDate().minusDays(3);
+        // CANCEL in EVERGREEN period with an invalid Date (prior to the Creation Date)
+        subscription.cancelWithDate(invalidDate, callContext);
+        assertListenerStatus();
+
+        testListener.pushExpectedEvent(NextEvent.CANCEL);
+        assertListenerStatus();
+    }
 }


### PR DESCRIPTION
Adding Unit Test to verify the behavior when trying to Cancel a Subscription with an invalid Requested Date.
As requested:
https://groups.google.com/forum/?hl=en#!topic/killbilling-users/Vh0qYjw55ZM
