### PR TITLE
#221 : Allow deployments as non-root resources.

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/security/TenantFilter.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/security/TenantFilter.java
@@ -134,8 +134,7 @@ public class TenantFilter implements Filter {
 
         if (request instanceof HttpServletRequest) {
             final HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-            // TODO Wrong - See https://github.com/killbill/killbill/issues/221
-            final String path = httpServletRequest.getRequestURI();
+            final String path = httpServletRequest.getPathInfo();
             final String httpMethod = httpServletRequest.getMethod();
             if (    // Chicken - egg problem
                     isTenantCreationRequest(path, httpMethod) ||


### PR DESCRIPTION
httpServletRequest.getPathInfo() returns now the correct path and does not include the server path where it is deployed.
