### PR TITLE
Create endpoint for refreshing of paymentmethods

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
@@ -766,7 +766,7 @@ public class AccountResource extends JaxRsResourceBase {
     }
 
     @TimedResource
-    @GET
+    @POST
     @Path("/{accountId:" + UUID_PATTERN + "}/" + PAYMENT_METHODS + "/refresh")
     @Produces(APPLICATION_JSON)
     @ApiOperation(value = "Refresh account payment methods", response = PaymentMethodJson.class, responseContainer = "List")
@@ -775,7 +775,6 @@ public class AccountResource extends JaxRsResourceBase {
     public Response refreshPaymentMethods(@PathParam("accountId") final String accountId,
                                           @QueryParam(QUERY_PAYMENT_PLUGIN_NAME) final String pluginName,
                                           @QueryParam(QUERY_PLUGIN_PROPERTY) final List<String> pluginPropertiesString,
-                                          @QueryParam(QUERY_AUDIT) @DefaultValue("NONE") final AuditMode auditMode,
                                           @HeaderParam(HDR_CREATED_BY) final String createdBy,
                                           @HeaderParam(HDR_REASON) final String reason,
                                           @HeaderParam(HDR_COMMENT) final String comment,
@@ -784,18 +783,9 @@ public class AccountResource extends JaxRsResourceBase {
         final CallContext callContext = context.createContext(createdBy, reason, comment, request);
 
         final Account account = accountUserApi.getAccountById(UUID.fromString(accountId), callContext);
-        final List<PaymentMethod> refreshedPaymentMethods = paymentApi.refreshPaymentMethods(account, pluginName, pluginProperties, callContext);
+        paymentApi.refreshPaymentMethods(account, pluginName, pluginProperties, callContext);
 
-        final AccountAuditLogs accountAuditLogs = auditUserApi.getAccountAuditLogs(account.getId(), auditMode.getLevel(), callContext);
-
-        final List<PaymentMethodJson> json = new ArrayList<PaymentMethodJson>(Collections2.transform(refreshedPaymentMethods, new Function<PaymentMethod, PaymentMethodJson>() {
-            @Override
-            public PaymentMethodJson apply(final PaymentMethod input) {
-                return PaymentMethodJson.toPaymentMethodJson(account, input, accountAuditLogs);
-            }
-        }));
-
-        return Response.status(Status.OK).entity(json).build();
+        return Response.status(Status.OK).build();
     }
 
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
@@ -769,7 +769,7 @@ public class AccountResource extends JaxRsResourceBase {
     @POST
     @Path("/{accountId:" + UUID_PATTERN + "}/" + PAYMENT_METHODS + "/refresh")
     @Produces(APPLICATION_JSON)
-    @ApiOperation(value = "Refresh account payment methods", response = PaymentMethodJson.class, responseContainer = "List")
+    @ApiOperation(value = "Refresh account payment methods")
     @ApiResponses(value = {@ApiResponse(code = 400, message = "Invalid account id supplied"),
                            @ApiResponse(code = 404, message = "Account not found")})
     public Response refreshPaymentMethods(@PathParam("accountId") final String accountId,
@@ -783,7 +783,12 @@ public class AccountResource extends JaxRsResourceBase {
         final CallContext callContext = context.createContext(createdBy, reason, comment, request);
 
         final Account account = accountUserApi.getAccountById(UUID.fromString(accountId), callContext);
-        paymentApi.refreshPaymentMethods(account, pluginName, pluginProperties, callContext);
+
+        if (pluginName != null) {
+            paymentApi.refreshPaymentMethods(account, pluginName, pluginProperties, callContext);
+        } else {
+            paymentApi.refreshPaymentMethods(account, pluginProperties, callContext);
+        }
 
         return Response.status(Status.OK).build();
     }

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
@@ -784,7 +784,7 @@ public class AccountResource extends JaxRsResourceBase {
 
         final Account account = accountUserApi.getAccountById(UUID.fromString(accountId), callContext);
 
-        if (pluginName != null) {
+        if (pluginName != null && !pluginName.isEmpty()) {
             paymentApi.refreshPaymentMethods(account, pluginName, pluginProperties, callContext);
         } else {
             paymentApi.refreshPaymentMethods(account, pluginProperties, callContext);

--- a/payment/src/main/java/org/killbill/billing/payment/provider/ExternalPaymentProviderPlugin.java
+++ b/payment/src/main/java/org/killbill/billing/payment/provider/ExternalPaymentProviderPlugin.java
@@ -117,7 +117,7 @@ public class ExternalPaymentProviderPlugin implements PaymentPluginApi {
 
     @Override
     public List<PaymentMethodInfoPlugin> getPaymentMethods(final UUID kbAccountId, final boolean refreshFromGateway, final Iterable<PluginProperty> properties, final CallContext context) throws PaymentPluginApiException {
-        throw new PaymentPluginApiException("Not implemented", "");
+        return ImmutableList.<PaymentMethodInfoPlugin>of();
     }
 
     @Override


### PR DESCRIPTION
Haven't created any test so far. Feedback welcome which test actually would make sense here as the effect of this method call highly depends on the plugin that is responsible for the payment methods. And the endpoint doesn't do anything else than calling the service method.