### PR TITLE
Add Access-Control-Expose-Headers to ResponseCorsFilter

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/filters/ResponseCorsFilter.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/filters/ResponseCorsFilter.java
@@ -63,6 +63,7 @@ public class ResponseCorsFilter implements Filter {
         res.addHeader("Access-Control-Allow-Origin", "*");
         res.addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS");
         res.addHeader("Access-Control-Allow-Headers", allowedHeaders);
+        res.addHeader("Access-Control-Expose-Headers", allowedHeaders);
         chain.doFilter(request, response);
     }
 


### PR DESCRIPTION
Add Access-Control-Expose-Headers to fix "Refused to get unsafe header" error when calling API from web browser via CORS