### PR TITLE
Make usage strings compatible with catalog translations

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
@@ -51,6 +51,6 @@ public class UsageInvoiceItem extends InvoiceItemBase {
 
     @Override
     public String getDescription() {
-        return Objects.firstNonNull(description, String.format("%s (usage item)", usageName));
+        return Objects.firstNonNull(description, usageName);
     }
 }


### PR DESCRIPTION
The current implementation of usage billing appends `(usage item)` to the description of the usage item. This is problematic in that.

1. You should use translations if you want to control the format of the item. 
2. With `(usage item)` appended to the description, you can no longer use translations on this InvoiceItem or at least I cannot figure out how to make them work with the string appended.

The pull requests removes the appended text in order to make translations work as they do with other invoice items. 