### PR TITLE
Add units list to CatalogJson

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultUnit.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultUnit.java
@@ -29,13 +29,10 @@ import org.killbill.xmlloader.ValidationErrors;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class DefaultUnit extends ValidatingConfig<StandaloneCatalog> implements Unit {
-
+    
     @XmlAttribute(required = true)
     @XmlID
     private String name;
-
-    @XmlAttribute(required = false)
-    private String prettyName;
 
     /* (non-Javadoc)
      * @see org.killbill.billing.catalog.Unit#getName()
@@ -47,7 +44,7 @@ public class DefaultUnit extends ValidatingConfig<StandaloneCatalog> implements 
 
     @Override
     public String getPrettyName() {
-        return prettyName;
+        return name;
     }
 
     @Override
@@ -60,20 +57,12 @@ public class DefaultUnit extends ValidatingConfig<StandaloneCatalog> implements 
     public void initialize(final StandaloneCatalog catalog, final URI sourceURI) {
         super.initialize(catalog, sourceURI);
         CatalogSafetyInitializer.initializeNonRequiredNullFieldsWithDefaultValue(this);
-        if (prettyName == null) {
-            this.prettyName = name;
-        }
     }
+
 
     public DefaultUnit setName(final String name) {
         this.name = name;
         return this;
-    }
-
-    public DefaultUnit setPrettyName(final String prettyName) {
-        this.prettyName = prettyName;
-        return this;
-
     }
 
     @Override

--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultUnit.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultUnit.java
@@ -60,11 +60,10 @@ public class DefaultUnit extends ValidatingConfig<StandaloneCatalog> implements 
     public void initialize(final StandaloneCatalog catalog, final URI sourceURI) {
         super.initialize(catalog, sourceURI);
         CatalogSafetyInitializer.initializeNonRequiredNullFieldsWithDefaultValue(this);
-        if(prettyName == null){
+        if (prettyName == null) {
             this.prettyName = name;
         }
     }
-
 
     public DefaultUnit setName(final String name) {
         this.name = name;

--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultUnit.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultUnit.java
@@ -29,10 +29,13 @@ import org.killbill.xmlloader.ValidationErrors;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class DefaultUnit extends ValidatingConfig<StandaloneCatalog> implements Unit {
-    
+
     @XmlAttribute(required = true)
     @XmlID
     private String name;
+
+    @XmlAttribute(required = false)
+    private String prettyName;
 
     /* (non-Javadoc)
      * @see org.killbill.billing.catalog.Unit#getName()
@@ -44,7 +47,7 @@ public class DefaultUnit extends ValidatingConfig<StandaloneCatalog> implements 
 
     @Override
     public String getPrettyName() {
-        return name;
+        return prettyName;
     }
 
     @Override
@@ -57,11 +60,19 @@ public class DefaultUnit extends ValidatingConfig<StandaloneCatalog> implements 
     public void initialize(final StandaloneCatalog catalog, final URI sourceURI) {
         super.initialize(catalog, sourceURI);
         CatalogSafetyInitializer.initializeNonRequiredNullFieldsWithDefaultValue(this);
+        if(prettyName == null){
+            this.prettyName = name;
+        }
     }
 
 
     public DefaultUnit setName(final String name) {
         this.name = name;
+        return this;
+    }
+
+    public DefaultUnit setPrettyName(final String prettyName) {
+        this.prettyName = prettyName;
         return this;
     }
 

--- a/catalog/src/main/java/org/killbill/billing/catalog/VersionedCatalog.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/VersionedCatalog.java
@@ -274,6 +274,10 @@ public class VersionedCatalog extends ValidatingConfig<VersionedCatalog> impleme
         return versionForDate(requestedDate).getCurrentSupportedCurrencies();
     }
 
+    public Unit[] getUnits(final DateTime requestedDate) throws CatalogApiException {
+        return versionForDate(requestedDate).getCurrentUnits();
+    }
+
     @Override
     public Collection<Plan> getPlans(final DateTime requestedDate) throws CatalogApiException {
         return versionForDate(requestedDate).getCurrentPlans();

--- a/catalog/src/main/java/org/killbill/billing/catalog/plugin/StandaloneCatalogMapper.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/plugin/StandaloneCatalogMapper.java
@@ -358,7 +358,6 @@ public class StandaloneCatalogMapper {
     private DefaultUnit toDefaultUnit(final Unit input) {
         final DefaultUnit result = new DefaultUnit();
         result.setName(input.getName());
-        result.setPrettyName(input.getPrettyName());
         return result;
     }
 

--- a/catalog/src/main/java/org/killbill/billing/catalog/plugin/StandaloneCatalogMapper.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/plugin/StandaloneCatalogMapper.java
@@ -358,6 +358,7 @@ public class StandaloneCatalogMapper {
     private DefaultUnit toDefaultUnit(final Unit input) {
         final DefaultUnit result = new DefaultUnit();
         result.setName(input.getName());
+        result.setPrettyName(input.getPrettyName());
         return result;
     }
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/CatalogJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/CatalogJson.java
@@ -174,7 +174,6 @@ public class CatalogJson {
         if (tieredBlocks != null && tieredBlocks.length > 0) {
             for (int i=0; i < tieredBlocks.length; i++) {
                 tieredBlocksJson.add(new TieredBlockJson(tieredBlocks[i].getUnit().getName(),
-                                                         tieredBlocks[i].getUnit().getPrettyName(),
                                                          tieredBlocks[i].getSize().toString(),
                                                          tieredBlocks[i].getMax().toString(),
                                                          buildPrices(tieredBlocks[i].getPrice())));
@@ -461,30 +460,24 @@ public class CatalogJson {
     }
 
     public static class TieredBlockJson {
-        private final String name;
-        private final String prettyName;
+        private final String unit;
         private final String size;
         private final String max;
         private final List<PriceJson> prices;
 
         @JsonCreator
-        public TieredBlockJson(@JsonProperty("name") final String name,
-                               @JsonProperty("prettyName") final String prettyName,
+        public TieredBlockJson(@JsonProperty("unit") final String unit,
                                @JsonProperty("size") final String size,
                                @JsonProperty("max") final String max,
                                @JsonProperty("prices") final List<PriceJson> prices) {
-            this.name = name;
-            this.prettyName = prettyName;
+            this.unit = unit;
             this.size = size;
             this.max = max;
             this.prices = prices;
         }
 
-        public String getName() {
-            return name;
-        }
-        public String getPrettyName() {
-            return prettyName;
+        public String getUnit() {
+            return unit;
         }
         public String getSize() {
             return size;
@@ -499,8 +492,7 @@ public class CatalogJson {
         @Override
         public String toString() {
             final StringBuilder sb = new StringBuilder("TieredBlockJson{");
-            sb.append("name='").append(name).append('\'');
-            sb.append("prettyName='").append(prettyName).append('\'');
+            sb.append("unit='").append(unit).append('\'');
             sb.append(", size=").append(size);
             sb.append(", max=").append(max);
             sb.append(", prices=").append(prices);
@@ -519,10 +511,7 @@ public class CatalogJson {
 
             final TieredBlockJson blockJson = (TieredBlockJson) o;
 
-            if (name != null ? !name.equals(blockJson.name) : blockJson.name != null) {
-                return false;
-            }
-            if (prettyName != null ? !prettyName.equals(blockJson.prettyName) : blockJson.prettyName != null) {
+            if (unit != null ? !unit.equals(blockJson.unit) : blockJson.unit != null) {
                 return false;
             }
             if (size != null ? !size.equals(blockJson.size) : blockJson.size != null) {
@@ -540,8 +529,7 @@ public class CatalogJson {
 
         @Override
         public int hashCode() {
-            int result = name != null ? name.hashCode() : 0;
-            result = 31 * result + (prettyName != null ? prettyName.hashCode() : 0);
+            int result = unit != null ? unit.hashCode() : 0;
             result = 31 * result + (size != null ? size.hashCode() : 0);
             result = 31 * result + (max != null ? max.hashCode() : 0);
             result = 31 * result + (prices != null ? prices.hashCode() : 0);


### PR DESCRIPTION
Discussed w/ @sruthipendyala - we thought it is better to include one list of all the units w/ prettyName instead of including prettyName on every single tier block - this also allows the API to be backwards compatible.  Reverted the commit that removed unit and added name and prettyName to TierBlockJson, added back prettyName functionality to DefaultUnit, added units to CatalogJson.  🌴  