### PR TITLE
Modified code to store planName, phaseName linkedInvoiceId and other …

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -322,11 +322,19 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                                                      invoiceForExternalCharge.getId(),
                                                                                      accountId,
                                                                                      charge.getBundleId(),
+                                                                                     charge.getSubscriptionId(),
+                                                                                     charge.getPlanName(),
+                                                                                     charge.getPhaseName(),
+                                                                                     charge.getPrettyPlanName(),
+                                                                                     charge.getPrettyPhaseName(),
                                                                                      charge.getDescription(),
                                                                                      startDate,
                                                                                      endDate,
                                                                                      charge.getAmount(),
-                                                                                     charge.getCurrency());
+                                                                                     charge.getRate(),
+                                                                                     charge.getCurrency(),
+                                                                                     charge.getLinkedItemId());
+
                     invoiceForExternalCharge.addInvoiceItem(externalCharge);
                 }
 


### PR DESCRIPTION
…related fields in External charges (in the db) while trying to create External Charge Invoice Line Item. External Charges without those fields will continue to work the same.