### PR TITLE
Make record_id columns the bigint type in Postgres

### DIFF
--- a/util/src/main/resources/org/killbill/billing/util/ddl-postgresql.sql
+++ b/util/src/main/resources/org/killbill/billing/util/ddl-postgresql.sql
@@ -45,3 +45,28 @@ CREATE OR REPLACE FUNCTION hour(ts TIMESTAMP WITH TIME ZONE) RETURNS INTEGER AS 
         RETURN result;
     END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+/* Alter 'serial' columns to 'bigint' because 'serial' is 32bit in PG while 64bit in MySQL */
+CREATE OR REPLACE FUNCTION update_serial_to_bigserial_oncreate()
+        RETURNS event_trigger LANGUAGE plpgsql AS $$
+DECLARE
+    r record;
+    matches text[];
+BEGIN
+    FOR r IN SELECT * FROM pg_event_trigger_ddl_commands()
+    LOOP
+	    SELECT regexp_matches(current_query(), E'\\m(\\w+)\\s+serial\\M') INTO matches;
+	    IF r.object_type = 'table' AND array_length(matches, 1) > 0 THEN
+            RAISE NOTICE 'Altering % % column % from serial to bigint',
+                     r.object_type,
+                     r.object_identity,
+                     matches[1];
+             EXECUTE 'ALTER TABLE ' || r.object_identity || ' ALTER COLUMN ' || matches[1] || ' TYPE bigint';
+        END IF;
+    END LOOP;
+END
+$$;
+
+CREATE EVENT TRIGGER update_serial_to_bigint_oncreate
+   ON ddl_command_end WHEN TAG IN ('CREATE TABLE')
+   EXECUTE PROCEDURE update_serial_to_bigint_oncreate();

--- a/util/src/main/resources/org/killbill/billing/util/ddl-postgresql.sql
+++ b/util/src/main/resources/org/killbill/billing/util/ddl-postgresql.sql
@@ -47,7 +47,7 @@ CREATE OR REPLACE FUNCTION hour(ts TIMESTAMP WITH TIME ZONE) RETURNS INTEGER AS 
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 /* Alter 'serial' columns to 'bigint' because 'serial' is 32bit in PG while 64bit in MySQL */
-CREATE OR REPLACE FUNCTION update_serial_to_bigserial_oncreate()
+CREATE OR REPLACE FUNCTION update_serial_to_bigint_oncreate()
         RETURNS event_trigger LANGUAGE plpgsql AS $$
 DECLARE
     r record;


### PR DESCRIPTION
In MySQL the record_id columns are created as type `serial` which is a 64-bit integer, but `serial` in Postgres is a 32-bit integer (the `bigserial` type is 64-bit). Add an event trigger function that alters `serial` columns to the `bigint` type after a `CREATE TABLE` DDL event.