### PR TITLE
Payment Method Refresh Fix

### DIFF
--- a/payment/src/main/java/org/killbill/billing/payment/core/PaymentMethodProcessor.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/PaymentMethodProcessor.java
@@ -691,7 +691,7 @@ public class PaymentMethodProcessor extends ProcessorBase {
 
         boolean shouldUpdateDefaultPaymentMethod = true;
         if (account.getPaymentMethodId() != null) {
-            final PaymentMethodModelDao currentDefaultPaymentMethod = getPaymentMethodById(account.getPaymentMethodId(), false, context);
+            final PaymentMethodModelDao currentDefaultPaymentMethod = getPaymentMethodById(account.getPaymentMethodId(), true, context);
             shouldUpdateDefaultPaymentMethod = pluginName.equals(currentDefaultPaymentMethod.getPluginName());
         }
         if (shouldUpdateDefaultPaymentMethod) {


### PR DESCRIPTION
Fix for "org.killbill.billing.payment.api.PaymentApiException: Internal payment error : Payment method xxx does not exist" when a default payment method is removed and a different payment method is selected as default during a payment method refresh.  Payment method has already been deleted by the time we get to this point, so we need to include deleted payment methods when retrieving old payment method.