### PR TITLE
invoice: reduce log level of InvoiceItemGeneratorLogger

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceItemGenerator.java
@@ -48,6 +48,7 @@ public abstract class InvoiceItemGenerator {
         private final UUID accountId;
         private final String type;
         private final Logger delegate;
+        private final boolean enabled;
 
         private StringBuilder logStringBuilder = null;
 
@@ -56,17 +57,18 @@ public abstract class InvoiceItemGenerator {
             this.accountId = accountId;
             this.type = type;
             this.delegate = delegate;
+            this.enabled = delegate.isDebugEnabled();
         }
 
         public void append(final Object event, final Collection<InvoiceItem> items) {
-            if (items.isEmpty()) {
+            if (!enabled || items.isEmpty()) {
                 return;
             }
             append(event, items.toArray(new InvoiceItem[items.size()]));
         }
 
         public void append(final Object event, final InvoiceItem... items) {
-            if (items.length == 0) {
+            if (!enabled || items.length == 0) {
                 return;
             }
 
@@ -80,8 +82,8 @@ public abstract class InvoiceItemGenerator {
         }
 
         public void logItems() {
-            if (logStringBuilder != null) {
-                delegate.info(getLogStringBuilder().toString());
+            if (enabled && logStringBuilder != null) {
+                delegate.debug(getLogStringBuilder().toString());
             }
         }
 


### PR DESCRIPTION
This fixes https://github.com/killbill/killbill/issues/851.

You can re-enable this logging by adding the following to your logback.xml:
```
  <logger name="org.killbill.billing.invoice.generator" level="DEBUG"/>
```