### PR TITLE
Use request.getSeverName() when useForwardHeaders is enabled

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/util/JaxrsUriBuilder.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/util/JaxrsUriBuilder.java
@@ -106,7 +106,7 @@ public class JaxrsUriBuilder {
                 // Use "remote" value to support X-Forwarded headers (assumes RemoteIpValve or similar is configured)
                 // See https://github.com/killbill/killbill/issues/566
                 uriBuilder.scheme(request.getScheme())
-                          .host(MoreObjects.firstNonNull(jaxrsConfig.getJaxrsLocationHost(), uriInfo.getAbsolutePath().getHost())) // Should we look for X-Forwarded-By instead?
+                          .host(MoreObjects.firstNonNull(jaxrsConfig.getJaxrsLocationHost(), request.getServerName()))
                           .port(request.getServerPort());
             } else {
                 uriBuilder.scheme(uriInfo.getAbsolutePath().getScheme())


### PR DESCRIPTION
When `useForwardHeaders` is enabled, use `request.getServerName()` instead of `uriInfo` to get the hostname.  In cases where multiple dns names point at a single killbill instance, the hostname used to access the api will be the one returned in the location header (when `jaxrsLocationHost` is not specified).  Let me know if you see any issues!  :bowtie: 