### PR TITLE
util: add useful DEBUG-level log entries

### DIFF
--- a/util/src/main/java/org/killbill/billing/util/glue/KillbillApiAopModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillbillApiAopModule.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Groupon, Inc
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -25,12 +25,16 @@ import org.killbill.billing.KillbillApi;
 import org.killbill.commons.profiling.Profiling;
 import org.killbill.commons.profiling.Profiling.WithProfilingCallback;
 import org.killbill.commons.profiling.ProfilingFeature.ProfilingFeatureType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.matcher.Matcher;
 import com.google.inject.matcher.Matchers;
 
 public class KillbillApiAopModule extends AbstractModule {
+
+    private static final Logger logger = LoggerFactory.getLogger(KillbillApiAopModule.class);
 
     @Override
     protected void configure() {
@@ -49,7 +53,10 @@ public class KillbillApiAopModule extends AbstractModule {
             return prof.executeWithProfiling(ProfilingFeatureType.API, invocation.getMethod().getName(), new WithProfilingCallback() {
                 @Override
                 public Object execute() throws Throwable {
-                    return invocation.proceed();
+                    logger.debug("Entering API call {}, arguments: {}", invocation.getMethod(), invocation.getArguments());
+                    final Object proceed = invocation.proceed();
+                    logger.debug("Exiting  API call {}, returning: {}", invocation.getMethod(), proceed);
+                    return proceed;
                 }
             });
         }


### PR DESCRIPTION
This is useful for debugging issues at runtime (e.g. performance).

```
16:37:06.151 [http-worker-78] INFO  c.s.j.a.c.filter.LoggingFilter - 3 * Server in-bound request
3 > POST http://127.0.0.1:8080/1.0/kb/accounts
3 > X-Killbill-ApiKey: e3cea2a3-0aa8-41fd-a438-6770425f872d
3 > Authorization: Basic dGVzdGVyOnRlc3Rlcg==
3 > X-Killbill-ApiSecret: df23bdc6-0429-4169-821f-cbbf4db425da
3 > Accept: application/json
3 > Connection: keep-alive
3 > User-Agent: KillBill-JavaClient/1.0
3 > X-Killbill-Reason: testing
3 > Host: 127.0.0.1:8080
3 > X-Killbill-CreatedBy: Toto
3 > X-Killbill-Comment: no comment
3 > Content-Length: 664
3 > Content-Type: application/json; charset=UTF-8
3 > 
 
16:37:06.163 [http-worker-78] DEBUG  o.k.b.u.g.KillbillApiAopModule - Entering API call public void org.killbill.billing.util.security.api.DefaultSecurityApi.checkCurrentUserPermissions(java.util.List,org.killbill.billing.security.Logical,org.killbill.billing.util.callcontext.TenantContext) throws org.killbill.billing.security.SecurityApiException, arguments: [[account:create], AND, DefaultTenantContext{accountId=null{tenantId=null}] 
16:37:06.163 [http-worker-78] DEBUG  o.k.b.u.g.KillbillApiAopModule - Exiting  API call public void org.killbill.billing.util.security.api.DefaultSecurityApi.checkCurrentUserPermissions(java.util.List,org.killbill.billing.security.Logical,org.killbill.billing.util.callcontext.TenantContext) throws org.killbill.billing.security.SecurityApiException, returning: null 
16:37:06.163 [http-worker-78] DEBUG  o.k.b.u.g.KillbillApiAopModule - Entering API call public org.killbill.billing.account.api.Account org.killbill.billing.account.api.user.DefaultAccountUserApi.createAccount(org.killbill.billing.account.api.AccountData,org.killbill.billing.util.callcontext.CallContext) throws org.killbill.billing.account.api.AccountApiException, arguments: [org.killbill.billing.jaxrs.json.AccountJson$1@1e8fc8a7, CallContextBase{accountId=null, tenantId='28dd803c-ca2c-4bcf-8bdd-6d7f23e31129', userToken='cb1507cf-d375-4957-98c6-2cf926192091', userName='Toto', callOrigin=EXTERNAL, userType=CUSTOMER, reasonCode='testing', comments='no comment', createdDate='2012-08-25T00:00:00.000Z', updatedDate='2012-08-25T00:00:00.000Z'}] 
16:37:06.164 [http-worker-78] DEBUG  o.k.b.u.g.KillbillApiAopModule - Entering API call public java.util.UUID org.killbill.billing.account.api.user.DefaultAccountUserApi.getIdFromKey(java.lang.String,org.killbill.billing.util.callcontext.TenantContext) throws org.killbill.billing.account.api.AccountApiException, arguments: [0d0f396b-9004-4302-a1c9-087d2fed4dee, CallContextBase{accountId=null, tenantId='28dd803c-ca2c-4bcf-8bdd-6d7f23e31129', userToken='cb1507cf-d375-4957-98c6-2cf926192091', userName='Toto', callOrigin=EXTERNAL, userType=CUSTOMER, reasonCode='testing', comments='no comment', createdDate='2012-08-25T00:00:00.000Z', updatedDate='2012-08-25T00:00:00.000Z'}] 
16:37:06.166 [http-worker-78] DEBUG  o.k.b.u.e.d.EntitySqlDaoTransactionalJdbiWrapper - DBI handle created, transaction: org.killbill.billing.account.dao.DefaultAccountDao.getIdFromKey(DefaultAccountDao.java:182) 
16:37:06.166 [http-worker-78] DEBUG  o.k.b.u.e.d.EntitySqlDaoTransactionalJdbiWrapper - Starting transaction org.killbill.billing.account.dao.DefaultAccountDao.getIdFromKey(DefaultAccountDao.java:182) 
16:37:06.194 [http-worker-78] DEBUG  o.k.b.u.e.d.EntitySqlDaoTransactionalJdbiWrapper - Exiting  transaction org.killbill.billing.account.dao.DefaultAccountDao.getIdFromKey(DefaultAccountDao.java:182), returning null 
16:37:06.194 [http-worker-78] DEBUG  o.k.b.u.e.d.EntitySqlDaoTransactionalJdbiWrapper - DBI handle closed,  transaction: org.killbill.billing.account.dao.DefaultAccountDao.getIdFromKey(DefaultAccountDao.java:182) 
16:37:06.194 [http-worker-78] DEBUG  o.k.b.u.g.KillbillApiAopModule - Exiting  API call public java.util.UUID org.killbill.billing.account.api.user.DefaultAccountUserApi.getIdFromKey(java.lang.String,org.killbill.billing.util.callcontext.TenantContext) throws org.killbill.billing.account.api.AccountApiException, returning: null 
16:37:06.196 [http-worker-78] DEBUG  o.k.b.u.e.d.EntitySqlDaoTransactionalJdbiWrapper - DBI handle created, transaction: org.killbill.billing.account.dao.DefaultAccountDao.create(DefaultAccountDao.java:93) 
16:37:06.196 [http-worker-78] DEBUG  o.k.b.u.e.d.EntitySqlDaoTransactionalJdbiWrapper - Starting transaction org.killbill.billing.account.dao.DefaultAccountDao.create(DefaultAccountDao.java:93) 
16:37:06.240 [http-worker-78] DEBUG  o.k.b.u.e.d.EntitySqlDaoTransactionalJdbiWrapper - Exiting  transaction org.killbill.billing.account.dao.DefaultAccountDao.create(DefaultAccountDao.java:93), returning AccountModelDao{externalKey='0d0f396b-9004-4302-a1c9-087d2fed4dee', email='8ea61@2367e', name='f06f746a-03ac-4e42-8a3b-7f228e5aca1f', firstNameLength=4, currency=USD, parentAccountId=null, isPaymentDelegatedToParent=false, billingCycleDayLocal=0, paymentMethodId=null, referenceTime=2012-08-25T00:00:00.000Z, timeZone=UTC, locale='fr', address1='12 rue des ecoles', address2='Poitier', companyName='Renault', city='Quelque part', stateOrProvince='Poitou', country='France', postalCode='44 567', phone='81 53 26 56', notes='notes', migrated=false, isNotifiedForInvoices=false} 
16:37:06.240 [http-worker-78] DEBUG  o.k.b.u.e.d.EntitySqlDaoTransactionalJdbiWrapper - DBI handle closed,  transaction: org.killbill.billing.account.dao.DefaultAccountDao.create(DefaultAccountDao.java:93) 
16:37:06.241 [http-worker-78] DEBUG  o.k.b.u.g.KillbillApiAopModule - Exiting  API call public org.killbill.billing.account.api.Account org.killbill.billing.account.api.user.DefaultAccountUserApi.createAccount(org.killbill.billing.account.api.AccountData,org.killbill.billing.util.callcontext.CallContext) throws org.killbill.billing.account.api.AccountApiException, returning: DefaultAccount [externalKey=0d0f396b-9004-4302-a1c9-087d2fed4dee, email=8ea61@2367e, name=f06f746a-03ac-4e42-8a3b-7f228e5aca1f, firstNameLength=4, phone=81 53 26 56, currency=USD, parentAccountId=null, isPaymentDelegatedToParent=false, billCycleDayLocal=0, paymentMethodId=null, referenceTime=2012-08-25T00:00:00.000Z, timezone=UTC, locale=fr, address1=12 rue des ecoles, address2=Poitier, companyName=Renault, city=Quelque part, stateOrProvince=Poitou, postalCode=44 567, country=France, notes=notes] 
16:37:06.242 [http-worker-78] INFO  c.s.j.a.c.filter.LoggingFilter - 3 * Server out-bound response
3 < 201
3 < Location: http://127.0.0.1:8080/1.0/kb/accounts/1f260b0e-094f-48da-a3e0-c20a4a6f2992
3 < Content-Type: application/json
3 <
```