### PR TITLE
Adding a getUnits method to Catalog interface.

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/VersionedCatalog.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/VersionedCatalog.java
@@ -278,6 +278,7 @@ public class VersionedCatalog extends ValidatingConfig<VersionedCatalog> impleme
         return versionForDate(requestedDate).getCurrentSupportedCurrencies();
     }
 
+    @Override
     public Unit[] getUnits(final DateTime requestedDate) throws CatalogApiException {
         return versionForDate(requestedDate).getCurrentUnits();
     }

--- a/catalog/src/test/java/org/killbill/billing/catalog/MockCatalog.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/MockCatalog.java
@@ -41,6 +41,7 @@ import org.killbill.billing.catalog.api.PlanSpecifier;
 import org.killbill.billing.catalog.api.PriceList;
 import org.killbill.billing.catalog.api.PriceListSet;
 import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.Unit;
 import org.killbill.billing.catalog.rules.DefaultCaseCancelPolicy;
 import org.killbill.billing.catalog.rules.DefaultCaseChangePlanAlignment;
 import org.killbill.billing.catalog.rules.DefaultCaseChangePlanPolicy;
@@ -107,6 +108,11 @@ public class MockCatalog extends StandaloneCatalog implements Catalog {
     @Override
     public Currency[] getSupportedCurrencies(final DateTime requestedDate) throws CatalogApiException {
         return getCurrentSupportedCurrencies();
+    }
+
+    @Override
+    public Unit[] getUnits(final DateTime requestedDate) throws CatalogApiException {
+        return getCurrentUnits();
     }
 
     @Override


### PR DESCRIPTION
Noticed this method was missing - if you call `CatalogUserApi::getCatalog` within a plugin, you can now get units from the returned `Catalog`.  Should be more consistent w/ `StaticCatalog` now (which already has `getCurrentUnits` method).  Also opened pull request in killbill-api.  Let me know if there are any issues!  🤓 