### PR TITLE
util: introduce thread-local dirty DB flag

### DIFF
--- a/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlementApi.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlementApi.java
@@ -18,7 +18,6 @@
 
 package org.killbill.billing.entitlement.api;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -45,9 +44,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestDefaultEntitlementApi extends EntitlementTestSuiteWithEmbeddedDB {
@@ -542,7 +539,6 @@ public class TestDefaultEntitlementApi extends EntitlementTestSuiteWithEmbeddedD
 
     }
 
-
     @Test(groups = "slow")
     public void testCreateEntitlementInThePast() throws AccountApiException, EntitlementApiException, SubscriptionBaseApiException {
         final LocalDate initialDate = new LocalDate(2013, 8, 7);
@@ -644,7 +640,6 @@ public class TestDefaultEntitlementApi extends EntitlementTestSuiteWithEmbeddedD
         assertEquals(result.getLastActiveProduct().getName(), "Pistol");
 
     }
-
 
     @Test(groups = "slow")
     public void testCreateBaseWithEntitlementInTheFuture() throws AccountApiException, EntitlementApiException, SubscriptionApiException {
@@ -757,7 +752,6 @@ public class TestDefaultEntitlementApi extends EntitlementTestSuiteWithEmbeddedD
         assertEquals(entitlement.getEffectiveStartDate(), initialDate);
     }
 
-
     @Test(groups = "slow")
     public void testCreateBaseSubscriptionsWithAddOns() throws AccountApiException, EntitlementApiException, SubscriptionApiException {
         final LocalDate initialDate = new LocalDate(2013, 8, 7);
@@ -804,7 +798,6 @@ public class TestDefaultEntitlementApi extends EntitlementTestSuiteWithEmbeddedD
         Assert.assertEquals(entitlementsForBundle2.size(), 2);
 
     }
-
 
     @Test(groups = "slow", expectedExceptions = EntitlementApiException.class)
     public void testCreateBaseSubscriptionsWithAddOnsMissingBase() throws AccountApiException, EntitlementApiException, SubscriptionApiException {

--- a/subscription/src/test/java/org/killbill/billing/subscription/SubscriptionTestSuiteWithEmbeddedDB.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/SubscriptionTestSuiteWithEmbeddedDB.java
@@ -36,11 +36,14 @@ import org.killbill.billing.subscription.api.timeline.SubscriptionBaseTimelineAp
 import org.killbill.billing.subscription.api.transfer.SubscriptionBaseTransferApi;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseBundle;
 import org.killbill.billing.subscription.api.user.TestSubscriptionHelper;
+import org.killbill.billing.subscription.engine.addon.AddonUtils;
 import org.killbill.billing.subscription.engine.dao.SubscriptionDao;
 import org.killbill.billing.subscription.glue.TestDefaultSubscriptionModuleWithEmbeddedDB;
 import org.killbill.billing.util.config.definition.SubscriptionConfig;
 import org.killbill.billing.util.dao.NonEntityDao;
+import org.killbill.bus.api.PersistentBus;
 import org.killbill.clock.ClockMock;
+import org.killbill.notificationq.api.NotificationQueueService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -65,10 +68,12 @@ public class SubscriptionTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuiteW
     protected SubscriptionBaseInternalApi subscriptionInternalApi;
     @Inject
     protected SubscriptionBaseTransferApi transferApi;
-
+    @Inject
+    protected PersistentBus bus;
     @Inject
     protected SubscriptionBaseTimelineApi repairApi;
-
+    @Inject
+    protected NotificationQueueService notificationQueueService;
     @Inject
     protected CatalogService catalogService;
     @Inject
@@ -79,7 +84,8 @@ public class SubscriptionTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuiteW
     protected ClockMock clock;
     @Inject
     protected BusService busService;
-
+    @Inject
+    protected AddonUtils addonUtils;
     @Inject
     protected TestSubscriptionHelper testUtil;
     @Inject

--- a/subscription/src/test/java/org/killbill/billing/subscription/engine/dao/TestSubscriptionDao.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/engine/dao/TestSubscriptionDao.java
@@ -37,6 +37,9 @@ import org.killbill.billing.subscription.events.SubscriptionBaseEvent;
 import org.killbill.billing.subscription.events.user.ApiEventBuilder;
 import org.killbill.billing.subscription.events.user.ApiEventCreate;
 import org.killbill.billing.util.UUIDs;
+import org.killbill.billing.util.glue.KillbillApiAopModule;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.IDBI;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -165,5 +168,55 @@ public class TestSubscriptionDao extends SubscriptionTestSuiteWithEmbeddedDB {
         assertEquals(result5.get(2).getExternalKey(), bundle2.getExternalKey());
 
 
+    }
+
+    @Test(groups = "slow")
+    public void testDirtyFlag() throws SubscriptionBaseApiException {
+        // @BeforeMethod created the account
+        KillbillApiAopModule.resetDirtyDBFlag();
+
+        final IDBI dbiSpy = Mockito.spy(dbi);
+        final IDBI roDbiSpy = Mockito.spy(roDbi);
+        final SubscriptionDao subscriptionDao = new DefaultSubscriptionDao(dbiSpy,
+                                                                           roDbiSpy,
+                                                                           clock,
+                                                                           addonUtils,
+                                                                           notificationQueueService,
+                                                                           bus,
+                                                                           controlCacheDispatcher,
+                                                                           nonEntityDao,
+                                                                           internalCallContextFactory);
+        Mockito.verify(dbiSpy, Mockito.times(0)).open();
+        Mockito.verify(roDbiSpy, Mockito.times(0)).open();
+
+        Assert.assertEquals(subscriptionDao.getSubscriptionBundleForAccount(accountId, internalCallContext).size(), 0);
+        Mockito.verify(dbiSpy, Mockito.times(0)).open();
+        Mockito.verify(roDbiSpy, Mockito.times(1)).open();
+
+        Assert.assertEquals(subscriptionDao.getSubscriptionBundleForAccount(accountId, internalCallContext).size(), 0);
+        Mockito.verify(dbiSpy, Mockito.times(0)).open();
+        Mockito.verify(roDbiSpy, Mockito.times(2)).open();
+
+        final String externalKey = UUID.randomUUID().toString();
+        final DateTime startDate = clock.getUTCNow();
+        final DateTime createdDate = startDate.plusSeconds(10);
+        final DefaultSubscriptionBaseBundle bundleDef = new DefaultSubscriptionBaseBundle(externalKey, accountId, startDate, startDate, createdDate, createdDate);
+        final SubscriptionBaseBundle bundle = subscriptionDao.createSubscriptionBundle(bundleDef, catalog, false, internalCallContext);
+        Mockito.verify(dbiSpy, Mockito.times(1)).open();
+        Mockito.verify(roDbiSpy, Mockito.times(2)).open();
+
+        Assert.assertEquals(subscriptionDao.getSubscriptionBundleForAccount(accountId, internalCallContext).size(), 1);
+        Mockito.verify(dbiSpy, Mockito.times(2)).open();
+        Mockito.verify(roDbiSpy, Mockito.times(2)).open();
+
+        Assert.assertEquals(subscriptionDao.getSubscriptionBundleForAccount(accountId, internalCallContext).size(), 1);
+        Mockito.verify(dbiSpy, Mockito.times(3)).open();
+        Mockito.verify(roDbiSpy, Mockito.times(2)).open();
+
+        KillbillApiAopModule.resetDirtyDBFlag();
+
+        Assert.assertEquals(subscriptionDao.getSubscriptionBundleForAccount(accountId, internalCallContext).size(), 1);
+        Mockito.verify(dbiSpy, Mockito.times(3)).open();
+        Mockito.verify(roDbiSpy, Mockito.times(3)).open();
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/glue/KillbillApiAopModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillbillApiAopModule.java
@@ -81,7 +81,7 @@ public class KillbillApiAopModule extends AbstractModule {
     }
 
     public static Boolean getDirtyDBFlag() {
-        return perThreadDirtyDBFlag.get();
+        return perThreadDirtyDBFlag.get() == Boolean.TRUE;
     }
 
     private static final Matcher<Method> SYNTHETIC_METHOD_MATCHER = new Matcher<Method>() {

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestSuiteWithEmbeddedDB.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestSuiteWithEmbeddedDB.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import javax.sql.DataSource;
 
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
+import org.killbill.billing.util.glue.KillbillApiAopModule;
 import org.killbill.commons.embeddeddb.EmbeddedDB;
 import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
@@ -63,6 +64,7 @@ public class GuicyKillbillTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuite
     public void beforeMethod() throws Exception {
         cleanupAllTables();
         controlCacheDispatcher.clearAll();
+        KillbillApiAopModule.resetDirtyDBFlag();
     }
 
     protected void cleanupAllTables() {


### PR DESCRIPTION
If an API call uses the RW instance and then fetches data from the RO instance, state might be inconsistent due to replication delays between master and slave(s).

To work-around this, add a thread local dirty flag: if data is changed, any further call will use the RW instance.
