### PR TITLE
Fix for multiple invoice plugin issue

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -176,7 +176,7 @@ public class InvoicePluginDispatcher {
                     final InvoiceItem sanitizedInvoiceItem = validateAndSanitizeInvoiceItemFromPlugin(originalInvoice, additionalInvoiceItem, invoicePlugin);
                     additionalInvoiceItems.add(sanitizedInvoiceItem);
                 }
-                invoiceUpdated = invoiceUpdated || updateOriginalInvoiceWithPluginInvoiceItems(originalInvoice, additionalInvoiceItems);
+                invoiceUpdated = updateOriginalInvoiceWithPluginInvoiceItems(originalInvoice, additionalInvoiceItems) || invoiceUpdated;
             }
         }
 


### PR DESCRIPTION
Fix for issue where invoice items returned by plugins are not added to the invoice.  Short circuit or prevented `updateOriginalInvoiceWithPluginInvoiceItems` from being called after the 1st invoice plugin.  