### PR TITLE
util: don't always use RO DB by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.141.58</version>
+        <version>0.141.59-SNAPSHOT</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.19.11-SNAPSHOT</version>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -201,7 +201,6 @@
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
             <artifactId>killbill-platform-osgi-api</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>


### PR DESCRIPTION
Unless plugins explicitly request it, redirect all plugin calls to the RW instance to work around replication delays.

See https://github.com/killbill/killbill-platform/pull/30 and https://github.com/killbill/killbill-analytics-plugin/pull/80.