### PR TITLE
util: introduce DBRouter

### DIFF
--- a/profiles/killbill/src/test/java/org/killbill/billing/server/security/TestKillbillJdbcTenantRealm.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/security/TestKillbillJdbcTenantRealm.java
@@ -51,7 +51,7 @@ public class TestKillbillJdbcTenantRealm extends TestJaxrsBase {
         super.beforeMethod();
 
         // Create the tenant
-        final DefaultTenantDao tenantDao = new DefaultTenantDao(dbi, roDbi, clock, cacheControllerDispatcher, new DefaultNonEntityDao(dbi), Mockito.mock(InternalCallContextFactory.class), securityConfig);
+        final DefaultTenantDao tenantDao = new DefaultTenantDao(dbi, roDbi, clock, cacheControllerDispatcher, new DefaultNonEntityDao(dbi, roDbi), Mockito.mock(InternalCallContextFactory.class), securityConfig);
         tenant = new DefaultTenant(UUID.randomUUID(), null, null, UUID.randomUUID().toString(),
                                    UUID.randomUUID().toString(), UUID.randomUUID().toString());
         tenantDao.create(new TenantModelDao(tenant), internalCallContext);

--- a/util/src/main/java/org/killbill/billing/util/audit/dao/DefaultAuditDao.java
+++ b/util/src/main/java/org/killbill/billing/util/audit/dao/DefaultAuditDao.java
@@ -45,6 +45,7 @@ import org.killbill.billing.util.dao.NonEntityDao;
 import org.killbill.billing.util.dao.NonEntitySqlDao;
 import org.killbill.billing.util.dao.RecordIdIdMappings;
 import org.killbill.billing.util.dao.TableName;
+import org.killbill.billing.util.entity.dao.DBRouter;
 import org.killbill.billing.util.entity.dao.EntitySqlDao;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
@@ -62,18 +63,18 @@ import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 
 public class DefaultAuditDao implements AuditDao {
 
-    private final NonEntitySqlDao roNonEntitySqlDao;
+    private final DBRouter<NonEntitySqlDao> dbRouter;
     private final EntitySqlDaoTransactionalJdbiWrapper transactionalSqlDao;
 
     @Inject
     public DefaultAuditDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final CacheControllerDispatcher cacheControllerDispatcher, final NonEntityDao nonEntityDao, final InternalCallContextFactory internalCallContextFactory) {
-        this.roNonEntitySqlDao = roDbi.onDemand(NonEntitySqlDao.class);
+        this.dbRouter = new DBRouter<NonEntitySqlDao>(dbi, roDbi, NonEntitySqlDao.class);
         this.transactionalSqlDao = new EntitySqlDaoTransactionalJdbiWrapper(dbi, roDbi, clock, cacheControllerDispatcher, nonEntityDao, internalCallContextFactory);
     }
 
     @Override
     public DefaultAccountAuditLogs getAuditLogsForAccountRecordId(final AuditLevel auditLevel, final InternalTenantContext context) {
-        final UUID accountId = roNonEntitySqlDao.getIdFromObject(context.getAccountRecordId(), TableName.ACCOUNT.getTableName());
+        final UUID accountId = dbRouter.onDemand(true).getIdFromObject(context.getAccountRecordId(), TableName.ACCOUNT.getTableName());
 
         // Lazy evaluate records to minimize the memory footprint (these can yield a lot of results)
         // We usually always want to wrap our queries in an EntitySqlDaoTransactionWrapper... except here.
@@ -115,6 +116,7 @@ public class DefaultAuditDao implements AuditDao {
                                                                        // For tables without history, e.g. TENANT, originalTableNameForHistoryTableName will be null
                                                                        final TableName originalTableNameForHistoryTableName = findTableNameForHistoryTableName(input.getTableName());
 
+                                                                       final NonEntitySqlDao nonEntitySqlDao = dbRouter.onDemand(true);
                                                                        final ObjectType objectType;
                                                                        final UUID auditedEntityId;
                                                                        if (originalTableNameForHistoryTableName != null) {
@@ -123,19 +125,19 @@ public class DefaultAuditDao implements AuditDao {
 
                                                                            if (historyRecordIdIdsCache.get(originalTableNameForHistoryTableName) == null) {
                                                                                if (TableName.ACCOUNT.equals(originalTableNameForHistoryTableName)) {
-                                                                                   final Iterable<RecordIdIdMappings> mappings = roNonEntitySqlDao.getHistoryRecordIdIdMappingsForAccountsTable(originalTableNameForHistoryTableName.getTableName(),
-                                                                                                                                                                                                input.getTableName().getTableName(),
-                                                                                                                                                                                                tenantContext);
+                                                                                   final Iterable<RecordIdIdMappings> mappings = nonEntitySqlDao.getHistoryRecordIdIdMappingsForAccountsTable(originalTableNameForHistoryTableName.getTableName(),
+                                                                                                                                                                                              input.getTableName().getTableName(),
+                                                                                                                                                                                              tenantContext);
                                                                                    historyRecordIdIdsCache.put(originalTableNameForHistoryTableName, RecordIdIdMappings.toMap(mappings));
                                                                                } else if (TableName.TAG_DEFINITIONS.equals(originalTableNameForHistoryTableName)) {
-                                                                                   final Iterable<RecordIdIdMappings> mappings = roNonEntitySqlDao.getHistoryRecordIdIdMappingsForTablesWithoutAccountRecordId(originalTableNameForHistoryTableName.getTableName(),
-                                                                                                                                                                                                               input.getTableName().getTableName(),
-                                                                                                                                                                                                               tenantContext);
+                                                                                   final Iterable<RecordIdIdMappings> mappings = nonEntitySqlDao.getHistoryRecordIdIdMappingsForTablesWithoutAccountRecordId(originalTableNameForHistoryTableName.getTableName(),
+                                                                                                                                                                                                             input.getTableName().getTableName(),
+                                                                                                                                                                                                             tenantContext);
                                                                                    historyRecordIdIdsCache.put(originalTableNameForHistoryTableName, RecordIdIdMappings.toMap(mappings));
                                                                                } else {
-                                                                                   final Iterable<RecordIdIdMappings> mappings = roNonEntitySqlDao.getHistoryRecordIdIdMappings(originalTableNameForHistoryTableName.getTableName(),
-                                                                                                                                                                                input.getTableName().getTableName(),
-                                                                                                                                                                                tenantContext);
+                                                                                   final Iterable<RecordIdIdMappings> mappings = nonEntitySqlDao.getHistoryRecordIdIdMappings(originalTableNameForHistoryTableName.getTableName(),
+                                                                                                                                                                              input.getTableName().getTableName(),
+                                                                                                                                                                              tenantContext);
                                                                                    historyRecordIdIdsCache.put(originalTableNameForHistoryTableName, RecordIdIdMappings.toMap(mappings));
 
                                                                                }
@@ -146,8 +148,8 @@ public class DefaultAuditDao implements AuditDao {
                                                                            objectType = input.getTableName().getObjectType();
 
                                                                            if (recordIdIdsCache.get(input.getTableName()) == null) {
-                                                                               final Iterable<RecordIdIdMappings> mappings = roNonEntitySqlDao.getRecordIdIdMappings(input.getTableName().getTableName(),
-                                                                                                                                                                     tenantContext);
+                                                                               final Iterable<RecordIdIdMappings> mappings = nonEntitySqlDao.getRecordIdIdMappings(input.getTableName().getTableName(),
+                                                                                                                                                                   tenantContext);
                                                                                recordIdIdsCache.put(input.getTableName(), RecordIdIdMappings.toMap(mappings));
                                                                            }
 
@@ -188,35 +190,35 @@ public class DefaultAuditDao implements AuditDao {
         return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLogWithHistory>>() {
             @Override
             public List<AuditLogWithHistory> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final Long targetRecordId = roNonEntitySqlDao.getRecordIdFromObject(objectId.toString(), tableName.getTableName());
+                final Long targetRecordId = dbRouter.onDemand(true).getRecordIdFromObject(objectId.toString(), tableName.getTableName());
                 final List<EntityHistoryModelDao> objectHistory = transactional.getHistoryForTargetRecordId(targetRecordId, context);
 
                 return ImmutableList.<AuditLogWithHistory>copyOf(Collections2.transform(entitySqlDaoWrapperFactory.become(EntitySqlDao.class).getAuditLogsViaHistoryForTargetRecordId(historyTableName.name(),
                                                                                                                                                                                       historyTableName.getTableName().toLowerCase(),
                                                                                                                                                                                       targetRecordId,
                                                                                                                                                                                       context),
-                                                                                 new Function<AuditLogModelDao, AuditLogWithHistory>() {
-                                                                                     @Override
-                                                                                     public AuditLogWithHistory apply(final AuditLogModelDao inputAuditLog) {
-                                                                                         EntityHistoryModelDao historyEntity = null;
-                                                                                         if ( objectHistory != null) {
-                                                                                             for (EntityHistoryModelDao history : objectHistory) {
-                                                                                                 if (history.getHistoryRecordId() == inputAuditLog.getTargetRecordId()) {
-                                                                                                     historyEntity = history;
-                                                                                                     break;
-                                                                                                 }
-                                                                                             }
-                                                                                         }
+                                                                                        new Function<AuditLogModelDao, AuditLogWithHistory>() {
+                                                                                            @Override
+                                                                                            public AuditLogWithHistory apply(final AuditLogModelDao inputAuditLog) {
+                                                                                                EntityHistoryModelDao historyEntity = null;
+                                                                                                if (objectHistory != null) {
+                                                                                                    for (final EntityHistoryModelDao history : objectHistory) {
+                                                                                                        if (history.getHistoryRecordId().equals(inputAuditLog.getTargetRecordId())) {
+                                                                                                            historyEntity = history;
+                                                                                                            break;
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
 
-                                                                                         return new DefaultAuditLogWithHistory((historyEntity == null ? null : historyEntity.getEntity()), inputAuditLog, tableName.getObjectType(), objectId);
-                                                                                     }
-                                                                                 }));
+                                                                                                return new DefaultAuditLogWithHistory((historyEntity == null ? null : historyEntity.getEntity()), inputAuditLog, tableName.getObjectType(), objectId);
+                                                                                            }
+                                                                                        }));
             }
         });
     }
 
     private List<AuditLog> doGetAuditLogsForId(final TableName tableName, final UUID objectId, final AuditLevel auditLevel, final InternalTenantContext context) {
-        final Long recordId = roNonEntitySqlDao.getRecordIdFromObject(objectId.toString(), tableName.getTableName());
+        final Long recordId = dbRouter.onDemand(true).getRecordIdFromObject(objectId.toString(), tableName.getTableName());
         if (recordId == null) {
             return ImmutableList.<AuditLog>of();
         } else {
@@ -230,7 +232,7 @@ public class DefaultAuditDao implements AuditDao {
             throw new IllegalStateException("History table shouldn't be null for " + tableName);
         }
 
-        final Long targetRecordId = roNonEntitySqlDao.getRecordIdFromObject(objectId.toString(), tableName.getTableName());
+        final Long targetRecordId = dbRouter.onDemand(true).getRecordIdFromObject(objectId.toString(), tableName.getTableName());
         final List<AuditLog> allAuditLogs = transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLog>>() {
             @Override
             public List<AuditLog> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {

--- a/util/src/main/java/org/killbill/billing/util/cache/AuditLogCacheLoader.java
+++ b/util/src/main/java/org/killbill/billing/util/cache/AuditLogCacheLoader.java
@@ -28,6 +28,7 @@ import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.util.audit.dao.AuditLogModelDao;
 import org.killbill.billing.util.cache.Cachable.CacheType;
 import org.killbill.billing.util.dao.AuditSqlDao;
+import org.killbill.billing.util.entity.dao.DBRouter;
 import org.skife.jdbi.v2.IDBI;
 
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
@@ -35,12 +36,12 @@ import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 @Singleton
 public class AuditLogCacheLoader extends BaseCacheLoader<String, List<AuditLogModelDao>> {
 
-    private final AuditSqlDao roAuditSqlDao;
+    private final DBRouter<AuditSqlDao> dbRouter;
 
     @Inject
-    public AuditLogCacheLoader(@Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi) {
+    public AuditLogCacheLoader(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi) {
         super();
-        this.roAuditSqlDao = roDbi.onDemand(AuditSqlDao.class);
+        this.dbRouter = new DBRouter<AuditSqlDao>(dbi, roDbi, AuditSqlDao.class);
     }
 
     @Override
@@ -55,6 +56,6 @@ public class AuditLogCacheLoader extends BaseCacheLoader<String, List<AuditLogMo
         final Long targetRecordId = (Long) args[1];
         final InternalTenantContext internalTenantContext = (InternalTenantContext) args[2];
 
-        return roAuditSqlDao.getAuditLogsForTargetRecordId(tableName, targetRecordId, internalTenantContext);
+        return dbRouter.onDemand(true).getAuditLogsForTargetRecordId(tableName, targetRecordId, internalTenantContext);
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/entity/dao/DBRouter.java
+++ b/util/src/main/java/org/killbill/billing/util/entity/dao/DBRouter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.entity.dao;
+
+import org.skife.jdbi.v2.IDBI;
+
+public class DBRouter<C> extends DBRouterUntyped {
+
+    private final C onDemand;
+    private final C roOnDemand;
+
+    public DBRouter(final IDBI dbi, final IDBI roDbi, final Class<C> sqlObjectType) {
+        super(dbi, roDbi);
+        this.onDemand = dbi.onDemand(sqlObjectType);
+        this.roOnDemand = roDbi.onDemand(sqlObjectType);
+    }
+
+    public C onDemand(final boolean requestedRO) {
+        if (shouldUseRODBI(requestedRO)) {
+            return roOnDemand;
+        } else {
+            return onDemand;
+        }
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/entity/dao/DBRouterUntyped.java
+++ b/util/src/main/java/org/killbill/billing/util/entity/dao/DBRouterUntyped.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.entity.dao;
+
+import org.killbill.billing.util.glue.KillbillApiAopModule;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.IDBI;
+import org.skife.jdbi.v2.TransactionCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DBRouterUntyped {
+
+    private static final Logger logger = LoggerFactory.getLogger(DBRouterUntyped.class);
+
+    protected final IDBI dbi;
+    protected final IDBI roDbi;
+
+    public DBRouterUntyped(final IDBI dbi, final IDBI roDbi) {
+        this.dbi = dbi;
+        this.roDbi = roDbi;
+    }
+
+    public Handle getHandle(final boolean requestedRO) {
+        if (shouldUseRODBI(requestedRO)) {
+            return roDbi.open();
+        } else {
+            return dbi.open();
+        }
+    }
+
+    public <T> T onDemand(final boolean requestedRO, final Class<T> sqlObjectType) {
+        if (shouldUseRODBI(requestedRO)) {
+            return roDbi.onDemand(sqlObjectType);
+        } else {
+            return dbi.onDemand(sqlObjectType);
+        }
+    }
+
+    public <T> T inTransaction(final boolean requestedRO, final TransactionCallback<T> callback) {
+        if (shouldUseRODBI(requestedRO)) {
+            return roDbi.inTransaction(callback);
+        } else {
+            return dbi.inTransaction(callback);
+        }
+    }
+
+    boolean shouldUseRODBI(final boolean requestedRO) {
+        if (!requestedRO) {
+            KillbillApiAopModule.setDirtyDBFlag();
+            logger.debug("Dirty flag set, using RW DBI");
+            return false;
+        } else {
+            if (KillbillApiAopModule.getDirtyDBFlag()) {
+                // Redirect to the rw instance, to work-around any replication delay
+                logger.debug("RO DBI handle requested, but dirty flag set, using RW DBI");
+                return false;
+            } else {
+                logger.debug("Using RO DBI");
+                return true;
+            }
+        }
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/entity/dao/EntitySqlDaoTransactionalJdbiWrapper.java
+++ b/util/src/main/java/org/killbill/billing/util/entity/dao/EntitySqlDaoTransactionalJdbiWrapper.java
@@ -24,7 +24,6 @@ import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.dao.NonEntityDao;
 import org.killbill.billing.util.entity.Entity;
-import org.killbill.billing.util.glue.KillbillApiAopModule;
 import org.killbill.clock.Clock;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.IDBI;
@@ -40,8 +39,7 @@ public class EntitySqlDaoTransactionalJdbiWrapper {
 
     private final Logger logger = LoggerFactory.getLogger(EntitySqlDaoTransactionalJdbiWrapper.class);
 
-    private final IDBI dbi;
-    private final IDBI roDbi;
+    private final DBRouterUntyped dbRouter;
     private final Clock clock;
     private final CacheControllerDispatcher cacheControllerDispatcher;
     private final NonEntityDao nonEntityDao;
@@ -49,12 +47,11 @@ public class EntitySqlDaoTransactionalJdbiWrapper {
 
     public EntitySqlDaoTransactionalJdbiWrapper(final IDBI dbi, final IDBI roDbi, final Clock clock, final CacheControllerDispatcher cacheControllerDispatcher,
                                                 final NonEntityDao nonEntityDao, final InternalCallContextFactory internalCallContextFactory) {
-        this.dbi = dbi;
-        this.roDbi = roDbi;
         this.clock = clock;
         this.cacheControllerDispatcher = cacheControllerDispatcher;
         this.nonEntityDao = nonEntityDao;
         this.internalCallContextFactory = internalCallContextFactory;
+        this.dbRouter = new DBRouterUntyped(dbi, roDbi);
     }
 
     public <M extends EntityModelDao> void populateCaches(final M refreshedEntity) {
@@ -89,39 +86,21 @@ public class EntitySqlDaoTransactionalJdbiWrapper {
      */
     public <ReturnType> ReturnType execute(final boolean requestedRO, final EntitySqlDaoTransactionWrapper<ReturnType> entitySqlDaoTransactionWrapper) {
         final String debugInfo = logger.isDebugEnabled() ? getDebugInfo() : null;
-        final boolean ro = shouldUseRODBI(requestedRO, debugInfo);
-        final String debugPrefix = ro ? "RO" : "RW";
 
-        final Handle handle = ro ? roDbi.open() : dbi.open();
-        logger.debug("[{}] DBI handle created, transaction: {}", debugPrefix, debugInfo);
+        final Handle handle = dbRouter.getHandle(requestedRO);
+        logger.debug("DBI handle created, transaction: {}", debugInfo);
         try {
             final EntitySqlDao<EntityModelDao<Entity>, Entity> entitySqlDao = handle.attach(InitialEntitySqlDao.class);
             // The transaction isolation level is now set at the pool level: this avoids 3 roundtrips for each transaction
             // Note that if the pool isn't used (tests or PostgreSQL), the transaction level will depend on the DB configuration
             //return entitySqlDao.inTransaction(TransactionIsolationLevel.READ_COMMITTED, new JdbiTransaction<ReturnType, EntityModelDao<Entity>, Entity>(handle, entitySqlDaoTransactionWrapper));
-            logger.debug("[{}] Starting transaction {}", debugPrefix, debugInfo);
+            logger.debug("Starting transaction {}", debugInfo);
             final ReturnType returnType = entitySqlDao.inTransaction(new JdbiTransaction<ReturnType, EntityModelDao<Entity>, Entity>(handle, entitySqlDaoTransactionWrapper));
-            logger.debug("[{}] Exiting  transaction {}, returning {}", debugPrefix, debugInfo, returnType);
+            logger.debug("Exiting  transaction {}, returning {}", debugInfo, returnType);
             return returnType;
         } finally {
             handle.close();
-            logger.debug("[{}] DBI handle closed,  transaction: {}", debugPrefix, debugInfo);
-        }
-    }
-
-    private boolean shouldUseRODBI(final boolean requestedRO, final String debugInfo) {
-        if (!requestedRO) {
-            KillbillApiAopModule.setDirtyDBFlag();
-            logger.debug("[RW] Dirty flag set, transaction: {}", debugInfo);
-            return false;
-        } else {
-            if (KillbillApiAopModule.getDirtyDBFlag()) {
-                // Redirect to the rw instance, to work-around any replication delay
-                logger.debug("[RW] RO DBI handle requested, but dirty flag set, transaction: {}", debugInfo);
-                return false;
-            } else {
-                return true;
-            }
+            logger.debug("DBI handle closed,  transaction: {}", debugInfo);
         }
     }
 
@@ -130,12 +109,7 @@ public class EntitySqlDaoTransactionalJdbiWrapper {
     // to send bus events, record notifications where we need to keep the Connection through the jDBI Handle.
     //
     public <M extends EntityModelDao<E>, E extends Entity, T extends EntitySqlDao<M, E>> T onDemandForStreamingResults(final Class<T> sqlObjectType) {
-        final String debugInfo = logger.isDebugEnabled() ? getDebugInfo() : null;
-        if (shouldUseRODBI(true, debugInfo)) {
-            return roDbi.onDemand(sqlObjectType);
-        } else {
-            return dbi.onDemand(sqlObjectType);
-        }
+        return dbRouter.onDemand(true, sqlObjectType);
     }
 
     /**

--- a/util/src/main/java/org/killbill/billing/util/validation/dao/DatabaseSchemaDao.java
+++ b/util/src/main/java/org/killbill/billing/util/validation/dao/DatabaseSchemaDao.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.killbill.billing.util.entity.dao.DBRouter;
 import org.killbill.billing.util.validation.DefaultColumnInfo;
 import org.skife.jdbi.v2.IDBI;
 
@@ -34,11 +35,11 @@ import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 @Singleton
 public class DatabaseSchemaDao {
 
-    private final DatabaseSchemaSqlDao roDatabaseSchemaSqlDao;
+    private final DBRouter<DatabaseSchemaSqlDao> dbRouter;
 
     @Inject
-    public DatabaseSchemaDao(@Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi) {
-        this.roDatabaseSchemaSqlDao = roDbi.onDemand(DatabaseSchemaSqlDao.class);
+    public DatabaseSchemaDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi) {
+        this.dbRouter = new DBRouter<DatabaseSchemaSqlDao>(dbi, roDbi, DatabaseSchemaSqlDao.class);
     }
 
     public List<DefaultColumnInfo> getColumnInfoList() {
@@ -46,6 +47,6 @@ public class DatabaseSchemaDao {
     }
 
     public List<DefaultColumnInfo> getColumnInfoList(@Nullable final String schemaName) {
-        return roDatabaseSchemaSqlDao.getSchemaInfo(schemaName);
+        return dbRouter.onDemand(true).getSchemaInfo(schemaName);
     }
 }

--- a/util/src/test/java/org/killbill/billing/util/validation/TestValidationManager.java
+++ b/util/src/test/java/org/killbill/billing/util/validation/TestValidationManager.java
@@ -41,7 +41,7 @@ public class TestValidationManager extends UtilTestSuiteWithEmbeddedDB {
     @BeforeClass(groups = "slow")
     public void beforeClass() throws Exception {
         super.beforeClass();
-        final DatabaseSchemaDao dao = new DatabaseSchemaDao(dbi);
+        final DatabaseSchemaDao dao = new DatabaseSchemaDao(dbi, roDbi);
         vm = new ValidationManager(dao);
         vm.loadSchemaInformation(helper.getDatabaseName());
     }


### PR DESCRIPTION
Encapsulate the logic to route between RO and RW DB instance. That way, we always honor the `perThreadDirtyDBFlag`.
