### PR TITLE
Ignore unknown properties when deserializing invoice item item details

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/details/UsageConsumableInArrearTierUnitAggregate.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/details/UsageConsumableInArrearTierUnitAggregate.java
@@ -19,11 +19,12 @@ package org.killbill.billing.invoice.usage.details;
 
 import java.math.BigDecimal;
 
-import org.killbill.billing.invoice.usage.details.UsageInArrearTierUnitDetail;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UsageConsumableInArrearTierUnitAggregate extends UsageInArrearTierUnitDetail {
 
     private final int tierBlockSize;

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/details/UsageInArrearTierUnitDetail.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/details/UsageInArrearTierUnitDetail.java
@@ -20,8 +20,10 @@ package org.killbill.billing.invoice.usage.details;
 import java.math.BigDecimal;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UsageInArrearTierUnitDetail {
 
     protected final int tier;


### PR DESCRIPTION
Ignore unknown properties when deserializing invoice item item details - this allows plugins to add their own "stuff" to item details in addition to the built-in tier/unit/quantity.  Let me know if there are any issues! 🤓 