### PR TITLE
util: always redirect bus events and notifications to RW DB instance

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/BeatrixIntegrationModule.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/BeatrixIntegrationModule.java
@@ -24,6 +24,7 @@ import org.killbill.billing.GuicyKillbillTestWithEmbeddedDBModule;
 import org.killbill.billing.account.glue.DefaultAccountModule;
 import org.killbill.billing.api.TestApiListener;
 import org.killbill.billing.beatrix.glue.BeatrixModule;
+import org.killbill.billing.beatrix.integration.db.TestDBRouterAPI;
 import org.killbill.billing.beatrix.integration.overdue.IntegrationTestOverdueModule;
 import org.killbill.billing.beatrix.util.AccountChecker;
 import org.killbill.billing.beatrix.util.AuditChecker;
@@ -57,6 +58,7 @@ import org.killbill.billing.util.glue.ExportModule;
 import org.killbill.billing.util.glue.GlobalLockerModule;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.killbill.billing.util.glue.KillBillShiroModule;
+import org.killbill.billing.util.glue.KillbillApiAopModule;
 import org.killbill.billing.util.glue.NodesModule;
 import org.killbill.billing.util.glue.NonEntityDaoModule;
 import org.killbill.billing.util.glue.RecordIdModule;
@@ -111,6 +113,7 @@ public class BeatrixIntegrationModule extends KillBillModule {
         install(new BroadcastModule(configSource));
         install(new KillBillShiroModuleOnlyIniRealm(configSource));
         install(new BeatrixModule(configSource));
+        install(new KillbillApiAopModule());
 
         bind(AccountChecker.class).asEagerSingleton();
         bind(SubscriptionChecker.class).asEagerSingleton();
@@ -119,6 +122,7 @@ public class BeatrixIntegrationModule extends KillBillModule {
         bind(RefundChecker.class).asEagerSingleton();
         bind(AuditChecker.class).asEagerSingleton();
         bind(TestApiListener.class).asEagerSingleton();
+        bind(TestDBRouterAPI.class).asEagerSingleton();
     }
 
     private final class DefaultInvoiceModuleWithSwitchRepairLogic extends DefaultInvoiceModule {

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -120,6 +120,7 @@ import org.killbill.billing.util.dao.NonEntityDao;
 import org.killbill.billing.util.nodes.KillbillNodesApi;
 import org.killbill.billing.util.tag.ControlTagType;
 import org.killbill.bus.api.PersistentBus;
+import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.skife.config.ConfigurationObjectFactory;
 import org.skife.config.TimeSpan;
 import org.slf4j.Logger;
@@ -335,10 +336,14 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
         // Start services
         lifecycle.fireStartupSequencePriorEventRegistration();
-        busService.getBus().register(busHandler);
+        registerHandlers();
         lifecycle.fireStartupSequencePostEventRegistration();
 
         paymentPlugin.clear();
+    }
+
+    protected void registerHandlers() throws EventBusException {
+        busService.getBus().register(busHandler);
     }
 
     @AfterMethod(groups = "slow")

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/db/TestDBRouter.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/db/TestDBRouter.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration.db;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.joda.time.DateTime;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.integration.TestIntegrationBase;
+import org.killbill.billing.callcontext.DefaultTenantContext;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.notification.plugin.api.ExtBusEvent;
+import org.killbill.billing.osgi.api.ROTenantContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.bus.api.PersistentBus.EventBusException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.eventbus.Subscribe;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestDBRouter extends TestIntegrationBase {
+
+    @Inject
+    private TestDBRouterAPI testDBRouterAPI;
+
+    private PublicListener publicListener;
+    private AtomicInteger externalBusCount;
+
+    @Override
+    @BeforeMethod(groups = "slow")
+    public void beforeMethod() throws Exception {
+        super.beforeMethod();
+
+        this.externalBusCount = new AtomicInteger(0);
+        testDBRouterAPI.reset();
+    }
+
+    @Override
+    protected void registerHandlers() throws EventBusException {
+        super.registerHandlers();
+
+        publicListener = new PublicListener();
+        externalBus.register(publicListener);
+    }
+
+    @AfterMethod(groups = "slow")
+    public void afterMethod() throws Exception {
+        externalBus.unregister(publicListener);
+        super.afterMethod();
+    }
+
+    @Test(groups = "slow")
+    public void testWithBusEvents() throws Exception {
+        final DateTime initialDate = new DateTime(2012, 2, 1, 0, 3, 42, 0, testTimeZone);
+        clock.setTime(initialDate);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(2));
+        assertNotNull(account);
+
+        final DefaultEntitlement bpEntitlement = createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey", "Shotgun", ProductCategory.BASE, BillingPeriod.MONTHLY, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        assertNotNull(bpEntitlement);
+
+        await().atMost(10, SECONDS)
+               .until(new Callable<Boolean>() {
+                   @Override
+                   public Boolean call() throws Exception {
+                       // Expecting ACCOUNT_CREATE, ACCOUNT_CHANGE, SUBSCRIPTION_CREATION (2), ENTITLEMENT_CREATE INVOICE_CREATION
+                       return externalBusCount.get() == 6;
+                   }
+               });
+    }
+
+    private void assertNbCalls(final int expectedNbRWCalls, final int expectedNbROCalls) {
+        assertEquals(testDBRouterAPI.getNbRWCalls(), expectedNbRWCalls);
+        assertEquals(testDBRouterAPI.getNbRoCalls(), expectedNbROCalls);
+    }
+
+    public class PublicListener {
+
+        @Subscribe
+        public void handleExternalEvents(final ExtBusEvent event) {
+            testDBRouterAPI.reset();
+
+            final TenantContext tenantContext = new DefaultTenantContext(callContext.getAccountId(), callContext.getTenantId());
+            // Only RO tenant will trigger use of RO DBI (initiated by plugins)
+            final ROTenantContext roTenantContext = new ROTenantContext(tenantContext);
+
+            // RO calls goes to RW DB by default
+            testDBRouterAPI.doROCall(tenantContext);
+            assertNbCalls(1, 0);
+
+            testDBRouterAPI.doROCall(callContext);
+            assertNbCalls(2, 0);
+
+            // Even if the thread is dirty (previous RW calls), the plugin asked for RO DBI
+            testDBRouterAPI.doROCall(roTenantContext);
+            assertNbCalls(2, 1);
+
+            // Make sure subsequent calls go back to the RW DB
+            testDBRouterAPI.doROCall(tenantContext);
+            assertNbCalls(3, 1);
+
+            testDBRouterAPI.doRWCall(callContext);
+            assertNbCalls(4, 1);
+
+            testDBRouterAPI.doROCall(roTenantContext);
+            assertNbCalls(4, 2);
+
+            testDBRouterAPI.doROCall(callContext);
+            assertNbCalls(5, 2);
+
+            testDBRouterAPI.doROCall(tenantContext);
+            assertNbCalls(6, 2);
+
+            testDBRouterAPI.doChainedROCall(tenantContext);
+            assertNbCalls(7, 2);
+
+            testDBRouterAPI.doChainedRWCall(callContext);
+            assertNbCalls(8, 2);
+
+            // Increment only if there are no errors
+            externalBusCount.incrementAndGet();
+        }
+    }
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/db/TestDBRouterAPI.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/db/TestDBRouterAPI.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration.db;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.killbill.billing.KillbillApi;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.entity.dao.DBRouterUntyped;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.IDBI;
+
+public class TestDBRouterAPI implements KillbillApi {
+
+    private final AtomicInteger rwCalls = new AtomicInteger(0);
+    private final AtomicInteger roCalls = new AtomicInteger(0);
+
+    private final DBRouterUntyped dbRouter;
+
+    @Inject
+    public TestDBRouterAPI() {
+        final IDBI dbi = Mockito.mock(IDBI.class);
+        Mockito.when(dbi.open()).thenAnswer(new Answer<Handle>() {
+            @Override
+            public Handle answer(final InvocationOnMock invocation) {
+                rwCalls.incrementAndGet();
+                return null;
+            }
+        });
+        final IDBI roDbi = Mockito.mock(IDBI.class);
+        Mockito.when(roDbi.open()).thenAnswer(new Answer<Handle>() {
+            @Override
+            public Handle answer(final InvocationOnMock invocation) {
+                roCalls.incrementAndGet();
+                return null;
+            }
+        });
+
+        this.dbRouter = new DBRouterUntyped(dbi, roDbi);
+    }
+
+    public void reset() {
+        rwCalls.set(0);
+        roCalls.set(0);
+    }
+
+    public void doRWCall(final CallContext callContext) {
+        dbRouter.getHandle(false);
+    }
+
+    public void doROCall(final TenantContext tenantContext) {
+        dbRouter.getHandle(true);
+    }
+
+    // Nesting dolls
+    public void doChainedROCall(final TenantContext tenantContext) {
+        doROCall(tenantContext);
+    }
+
+    // Nesting dolls
+    public void doChainedRWCall(final CallContext callContext) {
+        doRWCall(callContext);
+    }
+
+    public int getNbRWCalls() {
+        return rwCalls.get();
+    }
+
+    public int getNbRoCalls() {
+        return roCalls.get();
+    }
+}

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/JaxRSAopModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/JaxRSAopModule.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.server.modules;
+
+import java.lang.reflect.Method;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.killbill.billing.jaxrs.resources.JaxrsResource;
+import org.killbill.billing.util.entity.dao.DBRouterUntyped;
+import org.killbill.billing.util.glue.KillbillApiAopModule;
+import org.killbill.commons.profiling.Profiling.WithProfilingCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.matcher.Matchers;
+
+public class JaxRSAopModule extends AbstractModule {
+
+    private static final Logger logger = LoggerFactory.getLogger(KillbillApiAopModule.class);
+
+    private static final Matcher<Method> API_RESOURCE_METHOD_MATCHER = new Matcher<Method>() {
+        @Override
+        public boolean matches(final Method method) {
+            return !method.isSynthetic() &&
+                   (
+                           method.getAnnotation(DELETE.class) != null ||
+                           method.getAnnotation(GET.class) != null ||
+                           method.getAnnotation(HEAD.class) != null ||
+                           method.getAnnotation(OPTIONS.class) != null ||
+                           method.getAnnotation(POST.class) != null ||
+                           method.getAnnotation(PUT.class) != null
+                   );
+        }
+
+        @Override
+        public Matcher<Method> and(final Matcher<? super Method> other) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Matcher<Method> or(final Matcher<? super Method> other) {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    @Override
+    protected void configure() {
+        bindInterceptor(Matchers.subclassesOf(JaxrsResource.class),
+                        API_RESOURCE_METHOD_MATCHER,
+                        new JaxRsMethodInterceptor());
+    }
+
+    public static class JaxRsMethodInterceptor implements MethodInterceptor {
+
+        @Override
+        public Object invoke(final MethodInvocation invocation) throws Throwable {
+            return DBRouterUntyped.withRODBIAllowed(isRODBIAllowed(invocation),
+                                                    new WithProfilingCallback<Object, Throwable>() {
+                                                        @Override
+                                                        public Object execute() throws Throwable {
+                                                            logger.debug("Entering JAX-RS call {}, arguments: {}", invocation.getMethod(), invocation.getArguments());
+                                                            final Object proceed = invocation.proceed();
+                                                            logger.debug("Exiting  JXA-RS call {}, returning: {}", invocation.getMethod(), proceed);
+                                                            return proceed;
+                                                        }
+                                                    });
+        }
+
+        private boolean isRODBIAllowed(final MethodInvocation invocation) {
+            return invocation.getMethod().getAnnotation(GET.class) != null;
+        }
+    }
+}

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2017 Groupon, Inc
- * Copyright 2014-2017 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -179,6 +179,7 @@ public class KillbillServerModule extends KillbillPlatformModule {
         install(new GlobalLockerModule(configSource));
         install(new KillBillShiroAopModule());
         install(new KillbillApiAopModule());
+        install(new JaxRSAopModule());
         install(new KillBillShiroWebModule(servletContext, skifeConfigSource));
         install(new NonEntityDaoModule(configSource));
         install(new PaymentModule(configSource));

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestDBRouterResources.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestDBRouterResources.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.jaxrs;
+
+import javax.inject.Inject;
+
+import org.killbill.billing.beatrix.integration.db.TestDBRouterAPI;
+import org.killbill.billing.jaxrs.resources.TestDBRouterResource;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestDBRouterResources extends TestJaxrsBase {
+
+    @Inject
+    private TestDBRouterAPI testDBRouterAPI;
+
+    @Inject
+    private TestDBRouterResource testDBRouterResource;
+
+    @Test(groups = "slow")
+    public void testJaxRSAoPRouting() throws Exception {
+        testDBRouterResource.doChainedROROCalls();
+        assertNbCalls(0, 2);
+
+        testDBRouterResource.doChainedRWROCalls();
+        assertNbCalls(2, 0);
+
+        testDBRouterResource.doChainedRORWROCalls();
+        assertNbCalls(2, 1);
+    }
+
+    private void assertNbCalls(final int expectedNbRWCalls, final int expectedNbROCalls) {
+        assertEquals(testDBRouterAPI.getNbRWCalls(), expectedNbRWCalls);
+        assertEquals(testDBRouterAPI.getNbRoCalls(), expectedNbROCalls);
+    }
+}

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
@@ -38,12 +38,14 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.joda.time.LocalDate;
 import org.killbill.billing.GuicyKillbillTestWithEmbeddedDBModule;
 import org.killbill.billing.api.TestApiListener;
+import org.killbill.billing.beatrix.integration.db.TestDBRouterAPI;
 import org.killbill.billing.client.KillBillClient;
 import org.killbill.billing.client.KillBillHttpClient;
 import org.killbill.billing.client.model.Payment;
 import org.killbill.billing.client.model.PaymentTransaction;
 import org.killbill.billing.client.model.Tenant;
 import org.killbill.billing.invoice.glue.DefaultInvoiceModule;
+import org.killbill.billing.jaxrs.resources.TestDBRouterResource;
 import org.killbill.billing.jetty.HttpServer;
 import org.killbill.billing.jetty.HttpServerConfig;
 import org.killbill.billing.lifecycle.glue.BusModule;
@@ -75,6 +77,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
@@ -146,7 +149,14 @@ public class TestJaxrsBase extends KillbillClient {
         protected Module getModule(final ServletContext servletContext) {
             return Modules.override(new KillbillServerModule(servletContext, serverConfig, configSource)).with(new GuicyKillbillTestWithEmbeddedDBModule(configSource),
                                                                                                                new InvoiceModuleWithMockSender(configSource),
-                                                                                                               new PaymentMockModule(configSource));
+                                                                                                               new PaymentMockModule(configSource),
+                                                                                                               new Module() {
+                                                                                                                   @Override
+                                                                                                                   public void configure(final Binder binder) {
+                                                                                                                       binder.bind(TestDBRouterAPI.class).asEagerSingleton();
+                                                                                                                       binder.bind(TestDBRouterResource.class).asEagerSingleton();
+                                                                                                                   }
+                                                                                                               });
         }
 
     }

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/resources/TestDBRouterResource.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/resources/TestDBRouterResource.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.jaxrs.resources;
+
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.joda.time.DateTimeZone;
+import org.killbill.billing.GuicyKillbillTestSuite;
+import org.killbill.billing.beatrix.integration.db.TestDBRouterAPI;
+import org.killbill.billing.callcontext.MutableCallContext;
+import org.killbill.billing.callcontext.MutableInternalCallContext;
+import org.killbill.billing.util.callcontext.CallOrigin;
+import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.callcontext.UserType;
+
+@Path("/testDbResource")
+public class TestDBRouterResource implements JaxrsResource {
+
+    private final MutableInternalCallContext internalCallContext = new MutableInternalCallContext(InternalCallContextFactory.INTERNAL_TENANT_RECORD_ID,
+                                                                                                  1687L,
+                                                                                                  DateTimeZone.UTC,
+                                                                                                  GuicyKillbillTestSuite.getClock().getUTCNow(),
+                                                                                                  UUID.randomUUID(),
+                                                                                                  UUID.randomUUID().toString(),
+                                                                                                  CallOrigin.TEST,
+                                                                                                  UserType.TEST,
+                                                                                                  "Testing",
+                                                                                                  "This is a test",
+                                                                                                  GuicyKillbillTestSuite.getClock().getUTCNow(),
+                                                                                                  GuicyKillbillTestSuite.getClock().getUTCNow());
+
+    private final MutableCallContext callContext = new MutableCallContext(internalCallContext);
+
+    private final TestDBRouterAPI testDBRouterAPI;
+
+    @Inject
+    public TestDBRouterResource(final TestDBRouterAPI testDBRouterAPI) {
+        this.testDBRouterAPI = testDBRouterAPI;
+    }
+
+    @POST
+    public Response doChainedRWROCalls() {
+        testDBRouterAPI.reset();
+        testDBRouterAPI.doRWCall(callContext);
+        testDBRouterAPI.doROCall(callContext);
+        return Response.ok().build();
+    }
+
+    @GET
+    public Response doChainedROROCalls() {
+        testDBRouterAPI.reset();
+        testDBRouterAPI.doROCall(callContext);
+        testDBRouterAPI.doROCall(callContext);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/chained")
+    public Response doChainedRORWROCalls() {
+        testDBRouterAPI.reset();
+        testDBRouterAPI.doROCall(callContext);
+        // Naughty: @GET method doing a RW call... Verify the underlying code will detect it and mark the thread as dirty
+        testDBRouterAPI.doRWCall(callContext);
+        testDBRouterAPI.doROCall(callContext);
+        return Response.ok().build();
+    }
+}

--- a/profiles/killpay/src/main/java/org/killbill/billing/server/modules/KillpayServerModule.java
+++ b/profiles/killpay/src/main/java/org/killbill/billing/server/modules/KillpayServerModule.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Groupon, Inc
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -91,6 +91,7 @@ public class KillpayServerModule extends KillbillServerModule {
         install(new GlobalLockerModule(configSource));
         install(new KillBillShiroAopModule());
         install(new KillbillApiAopModule());
+        install(new JaxRSAopModule());
         install(new KillBillShiroWebModule(servletContext, skifeConfigSource));
         install(new NonEntityDaoModule(configSource));
         install(new PaymentModule(configSource));

--- a/util/src/main/java/org/killbill/billing/util/glue/KillbillApiAopModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillbillApiAopModule.java
@@ -22,11 +22,9 @@ import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.killbill.billing.KillbillApi;
-import org.killbill.billing.callcontext.DefaultTenantContext;
-import org.killbill.billing.callcontext.InternalCallContext;
-import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.osgi.api.ROTenantContext;
 import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.entity.dao.DBRouterUntyped;
 import org.killbill.commons.profiling.Profiling;
 import org.killbill.commons.profiling.Profiling.WithProfilingCallback;
 import org.killbill.commons.profiling.ProfilingFeature.ProfilingFeatureType;
@@ -40,95 +38,6 @@ import com.google.inject.matcher.Matchers;
 public class KillbillApiAopModule extends AbstractModule {
 
     private static final Logger logger = LoggerFactory.getLogger(KillbillApiAopModule.class);
-    private static final ThreadLocal<Boolean> perThreadDirtyDBFlag = new ThreadLocal<Boolean>();
-
-    static {
-        // Set an initial value
-        resetDirtyDBFlag();
-    }
-
-    @Override
-    protected void configure() {
-
-        bindInterceptor(Matchers.subclassesOf(KillbillApi.class),
-                        Matchers.not(SYNTHETIC_METHOD_MATCHER),
-                        new ProfilingMethodInterceptor());
-    }
-
-    public static class ProfilingMethodInterceptor implements MethodInterceptor {
-
-        private final Profiling prof = new Profiling<Object, Throwable>();
-
-        @Override
-        public Object invoke(final MethodInvocation invocation) throws Throwable {
-            return prof.executeWithProfiling(ProfilingFeatureType.API, invocation.getMethod().getName(), new WithProfilingCallback() {
-                @Override
-                public Object execute() throws Throwable {
-                    final boolean useRODBIfAvailable = shouldUseRODBIfAvailable(invocation);
-                    if (!useRODBIfAvailable) {
-                        setDirtyDBFlag();
-                    }
-
-                    try {
-                        logger.debug("Entering API call {}, arguments: {}", invocation.getMethod(), invocation.getArguments());
-                        final Object proceed = invocation.proceed();
-                        logger.debug("Exiting  API call {}, returning: {}", invocation.getMethod(), proceed);
-                        return proceed;
-                    } finally {
-                        resetDirtyDBFlag();
-                    }
-                }
-            });
-        }
-
-        private boolean shouldUseRODBIfAvailable(final MethodInvocation invocation) {
-            // Verify if the flag is already set for re-entrant calls
-            if (getDirtyDBFlag()) {
-                return false;
-            }
-
-            final Object[] arguments = invocation.getArguments();
-            if (arguments.length == 0) {
-                return false;
-            }
-
-            // Snowflakes from server filters
-            final boolean safeROOperations = "getTenantByApiKey".equals(invocation.getMethod().getName()) || "login".equals(invocation.getMethod().getName());
-            if (safeROOperations) {
-                return true;
-            }
-
-            for (int i = arguments.length - 1; i >= 0; i--) {
-                final Object argument = arguments[i];
-                // DefaultTenantContext belongs to killbill-internal-api and shouldn't be used by plugins
-                final boolean fromJAXRS = argument instanceof DefaultTenantContext && !(argument instanceof CallContext);
-                // Kill Bill internal re-entrant calls
-                final boolean fromInternalAPIs = argument instanceof InternalTenantContext && !(argument instanceof InternalCallContext);
-                // RO DB explicitly requested by a plugin
-                final boolean pluginRequestROInstance = argument instanceof ROTenantContext && !(argument instanceof CallContext);
-                if (fromJAXRS || fromInternalAPIs || pluginRequestROInstance) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-    }
-
-    public static void setDirtyDBFlag() {
-        perThreadDirtyDBFlag.set(true);
-    }
-
-    public static void resetDirtyDBFlag() {
-        perThreadDirtyDBFlag.set(false);
-    }
-
-    public static Boolean getDirtyDBFlag() {
-        // If unset, we don't come from an API call (i.e. through KillbillApiAopModule): could be bus events for instance.
-        // In that case, for safety, always go to the RW instance.
-        return perThreadDirtyDBFlag.get() == null ||
-               perThreadDirtyDBFlag.get() == Boolean.TRUE;
-    }
 
     private static final Matcher<Method> SYNTHETIC_METHOD_MATCHER = new Matcher<Method>() {
         @Override
@@ -146,4 +55,68 @@ public class KillbillApiAopModule extends AbstractModule {
             throw new UnsupportedOperationException();
         }
     };
+
+    @Override
+    protected void configure() {
+        bindInterceptor(Matchers.subclassesOf(KillbillApi.class),
+                        Matchers.not(SYNTHETIC_METHOD_MATCHER),
+                        new ProfilingMethodInterceptor());
+    }
+
+    public static class ProfilingMethodInterceptor implements MethodInterceptor {
+
+        private final Profiling<Object, Throwable> prof = new Profiling<Object, Throwable>();
+
+        @Override
+        public Object invoke(final MethodInvocation invocation) throws Throwable {
+            final WithProfilingCallback<Object, Throwable> callback = new WithProfilingCallback<Object, Throwable>() {
+                @Override
+                public Object execute() throws Throwable {
+                    logger.debug("Entering API call {}, arguments: {}", invocation.getMethod(), invocation.getArguments());
+                    final Object proceed = invocation.proceed();
+                    logger.debug("Exiting  API call {}, returning: {}", invocation.getMethod(), proceed);
+                    return proceed;
+                }
+            };
+
+            if (forcedRODBI(invocation)) {
+                return prof.executeWithProfiling(ProfilingFeatureType.API,
+                                                 invocation.getMethod().getName(),
+                                                 new WithProfilingCallback<Object, Throwable>() {
+                                                     @Override
+                                                     public Object execute() throws Throwable {
+                                                         return DBRouterUntyped.withRODBIAllowed(true, callback);
+                                                     }
+                                                 });
+            } else {
+                return prof.executeWithProfiling(ProfilingFeatureType.API,
+                                                 invocation.getMethod().getName(),
+                                                 callback);
+            }
+        }
+
+        private boolean forcedRODBI(final MethodInvocation invocation) {
+            // Snowflakes from server filters
+            final boolean safeROOperations = "getTenantByApiKey".equals(invocation.getMethod().getName()) || "login".equals(invocation.getMethod().getName());
+            if (safeROOperations) {
+                return true;
+            }
+
+            final Object[] arguments = invocation.getArguments();
+            if (arguments.length == 0) {
+                return false;
+            }
+
+            for (int i = arguments.length - 1; i >= 0; i--) {
+                final Object argument = arguments[i];
+                // RO DB explicitly requested by a plugin
+                final boolean pluginRequestROInstance = argument instanceof ROTenantContext && !(argument instanceof CallContext);
+                if (pluginRequestROInstance) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
 }

--- a/util/src/main/java/org/killbill/billing/util/glue/KillbillApiAopModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillbillApiAopModule.java
@@ -124,7 +124,10 @@ public class KillbillApiAopModule extends AbstractModule {
     }
 
     public static Boolean getDirtyDBFlag() {
-        return perThreadDirtyDBFlag.get() == Boolean.TRUE;
+        // If unset, we don't come from an API call (i.e. through KillbillApiAopModule): could be bus events for instance.
+        // In that case, for safety, always go to the RW instance.
+        return perThreadDirtyDBFlag.get() == null ||
+               perThreadDirtyDBFlag.get() == Boolean.TRUE;
     }
 
     private static final Matcher<Method> SYNTHETIC_METHOD_MATCHER = new Matcher<Method>() {

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestSuiteWithEmbeddedDB.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestSuiteWithEmbeddedDB.java
@@ -23,7 +23,6 @@ import javax.inject.Named;
 import javax.sql.DataSource;
 
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
-import org.killbill.billing.util.glue.KillbillApiAopModule;
 import org.killbill.commons.embeddeddb.EmbeddedDB;
 import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
@@ -64,7 +63,6 @@ public class GuicyKillbillTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuite
     public void beforeMethod() throws Exception {
         cleanupAllTables();
         controlCacheDispatcher.clearAll();
-        KillbillApiAopModule.resetDirtyDBFlag();
     }
 
     protected void cleanupAllTables() {


### PR DESCRIPTION
RO DBI is now invoked only for JAX-RS `GET` endpoints and when plugins specifically ask for it.