### PR TITLE
Integrate EurekaModule for service discovery

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>guice-multibindings</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.netflix.eureka</groupId>
+            <artifactId>eureka-client</artifactId>
+            <version>1.8.7</version>
+        </dependency>
+        <dependency>
             <groupId>com.ning</groupId>
             <artifactId>async-http-client</artifactId>
         </dependency>
@@ -85,6 +90,11 @@
         <dependency>
             <groupId>com.samskivert</groupId>
             <artifactId>jmustache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>1.19.4</version>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>

--- a/util/src/main/java/org/killbill/billing/util/discovery/DefaultEurekaKillbillService.java
+++ b/util/src/main/java/org/killbill/billing/util/discovery/DefaultEurekaKillbillService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.discovery;
+
+
+import com.google.inject.Inject;
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.InstanceInfo;
+
+import org.killbill.billing.platform.api.KillbillService;
+import org.killbill.billing.platform.api.LifecycleHandlerType;
+import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
+import org.killbill.billing.platform.config.DefaultKillbillConfigSource;
+import org.killbill.billing.tenant.api.TenantKV.TenantKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultEurekaKillbillService implements EurekaKillbillService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultEurekaKillbillService.class);
+
+    private ApplicationInfoManager applicationInfoManager;
+
+    public static final String EUREKA_SERVICE_NAME = "eureka-service";
+
+    @Inject
+    public DefaultEurekaKillbillService(ApplicationInfoManager applicationInfoManager) {
+        this.applicationInfoManager = applicationInfoManager;
+    }
+
+    @Override
+    public String getName() {
+        return EUREKA_SERVICE_NAME;
+    }
+
+    @LifecycleHandlerType(LifecycleLevel.INIT_SERVICE)
+    public synchronized void initialize() {
+        logger.info("--------------> Setting Eureka Status to UP <----------------");
+        applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.UP);
+        logger.info("--------------> Finished setting Eureka Status to UP <----------------");
+    }
+
+    @LifecycleHandlerType(LifecycleLevel.STOP_SERVICE)
+    public synchronized void shutdown() {
+        logger.info("--------------> Setting Eureka Status to DOWN <----------------");
+        applicationInfoManager.setInstanceStatus(InstanceInfo.InstanceStatus.DOWN);
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/discovery/EurekaClientOptionalArgs.java
+++ b/util/src/main/java/org/killbill/billing/util/discovery/EurekaClientOptionalArgs.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.discovery;
+
+import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
+import com.sun.jersey.api.client.filter.ClientFilter;
+
+/**
+ * Default to a Jersey1 client. This can be overriden and injected with Guice
+ * using bind(EurekaClientOptionalArgs.class).to(MySubclassOptionalArgs.class).in(Scopes.SINGLETON);
+ */
+public class EurekaClientOptionalArgs extends AbstractDiscoveryClientOptionalArgs<ClientFilter> {
+    public EurekaClientOptionalArgs() {
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/discovery/EurekaKillbillService.java
+++ b/util/src/main/java/org/killbill/billing/util/discovery/EurekaKillbillService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.discovery;
+
+import org.killbill.billing.platform.api.KillbillService;
+
+public interface EurekaKillbillService extends KillbillService {
+}

--- a/util/src/main/java/org/killbill/billing/util/discovery/KillbillInstanceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/discovery/KillbillInstanceConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.discovery;
+
+import com.google.common.base.Strings;
+import com.netflix.appinfo.DataCenterInfo;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.PropertiesInstanceConfig;
+
+import javax.inject.Singleton;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
+
+@Singleton
+public class KillbillInstanceConfig extends PropertiesInstanceConfig implements EurekaInstanceConfig {
+
+    private String hostName;
+
+    public KillbillInstanceConfig() { }
+
+    public KillbillInstanceConfig(String namespace) {
+        super(namespace);
+    }
+
+    public KillbillInstanceConfig(String namespace, DataCenterInfo dataCenterInfo) {
+        super(namespace, dataCenterInfo);
+    }
+
+    @Override
+    public String getInstanceId() {
+        final String appName = getAppname();
+        final UUID uuid = UUID.randomUUID();
+        return appName + ":" + uuid.toString();
+    }
+
+    @Override
+    public String getHostName(boolean refresh) {
+        if(Strings.isNullOrEmpty(hostName)) {
+            determineHostName();
+        }
+        return hostName;
+    }
+
+    protected void determineHostName() {
+        try {
+            hostName = InetAddress.getLocalHost().getCanonicalHostName();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException("Failed to get canonical hostname", e);
+        }
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/discovery/provider/KillbillEurekaInstanceInfoProvider.java
+++ b/util/src/main/java/org/killbill/billing/util/discovery/provider/KillbillEurekaInstanceInfoProvider.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.discovery.provider;
+
+import java.util.Map;
+
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.netflix.appinfo.DataCenterInfo;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+import com.netflix.appinfo.InstanceInfo.PortType;
+import com.netflix.appinfo.LeaseInfo;
+import com.netflix.appinfo.UniqueIdentifier;
+import com.netflix.appinfo.providers.Archaius1VipAddressResolver;
+import com.netflix.appinfo.providers.EurekaConfigBasedInstanceInfoProvider;
+import com.netflix.appinfo.providers.VipAddressResolver;
+
+@Singleton
+public class KillbillEurekaInstanceInfoProvider extends EurekaConfigBasedInstanceInfoProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KillbillEurekaInstanceInfoProvider.class);
+
+    private final EurekaInstanceConfig config;
+
+    private InstanceInfo instanceInfo;
+
+    @Inject(optional = true)
+    private VipAddressResolver vipAddressResolver = null;
+
+    @Inject
+    public KillbillEurekaInstanceInfoProvider(EurekaInstanceConfig config) {
+        super(config);
+        this.config = config;
+    }
+
+    @Override
+    public synchronized InstanceInfo get() {
+        if (instanceInfo == null) {
+            // Build the lease information to be passed to the server based on config
+            LeaseInfo.Builder leaseInfoBuilder = LeaseInfo.Builder.newBuilder()
+                                                                  .setRenewalIntervalInSecs(config.getLeaseRenewalIntervalInSeconds())
+                                                                  .setDurationInSecs(config.getLeaseExpirationDurationInSeconds());
+
+            if (vipAddressResolver == null) {
+                vipAddressResolver = new Archaius1VipAddressResolver();
+            }
+
+            // Builder the instance information to be registered with eureka server
+            InstanceInfo.Builder builder = InstanceInfo.Builder.newBuilder(vipAddressResolver);
+
+            // set the appropriate id for the InstanceInfo, falling back to datacenter Id if applicable, else hostname
+            String instanceId = config.getInstanceId();
+            DataCenterInfo dataCenterInfo = config.getDataCenterInfo();
+            if (instanceId == null || instanceId.isEmpty()) {
+                if (dataCenterInfo instanceof UniqueIdentifier) {
+                    instanceId = ((UniqueIdentifier) dataCenterInfo).getId();
+                } else {
+                    instanceId = config.getHostName(false);
+                }
+            }
+
+            String defaultAddress = config.getIpAddress();
+
+            builder.setNamespace(config.getNamespace())
+                   .setInstanceId(instanceId)
+                   .setAppName(config.getAppname())
+                   .setAppGroupName(config.getAppGroupName())
+                   .setDataCenterInfo(config.getDataCenterInfo())
+                   .setIPAddr(config.getIpAddress())
+                   .setHostName(defaultAddress)
+                   .setPort(config.getNonSecurePort())
+                   .enablePort(PortType.UNSECURE, config.isNonSecurePortEnabled())
+                   .setSecurePort(config.getSecurePort())
+                   .enablePort(PortType.SECURE, config.getSecurePortEnabled())
+                   .setVIPAddress(config.getVirtualHostName())
+                   .setSecureVIPAddress(config.getSecureVirtualHostName())
+                   .setHomePageUrl(config.getHomePageUrlPath(), config.getHomePageUrl())
+                   .setStatusPageUrl(config.getStatusPageUrlPath(), config.getStatusPageUrl())
+                   .setASGName(config.getASGName())
+                   .setHealthCheckUrls(config.getHealthCheckUrlPath(),
+                                       config.getHealthCheckUrl(), config.getSecureHealthCheckUrl());
+
+
+            // Start off with the STARTING state to avoid traffic
+            if (!config.isInstanceEnabledOnit()) {
+                InstanceStatus initialStatus = InstanceStatus.STARTING;
+                LOG.info("Setting initial instance status as: " + initialStatus);
+                builder.setStatus(initialStatus);
+            } else {
+                LOG.info("Setting initial instance status as: {}. This may be too early for the instance to advertise "
+                         + "itself as available. You would instead want to control this via a healthcheck handler.",
+                         InstanceStatus.UP);
+            }
+
+            // Add any user-specific metadata information
+            for (Map.Entry<String, String> mapEntry : config.getMetadataMap().entrySet()) {
+                String key = mapEntry.getKey();
+                String value = mapEntry.getValue();
+                builder.add(key, value);
+            }
+
+            instanceInfo = builder.build();
+            instanceInfo.setLeaseInfo(leaseInfoBuilder.build());
+        }
+        return instanceInfo;
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/discovery/provider/KillbillInstanceConfigProvider.java
+++ b/util/src/main/java/org/killbill/billing/util/discovery/provider/KillbillInstanceConfigProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.discovery.provider;
+
+import javax.inject.Provider;
+
+import org.killbill.billing.util.discovery.KillbillInstanceConfig;
+
+import com.google.inject.Inject;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.discovery.DiscoveryManager;
+import com.netflix.discovery.EurekaNamespace;
+
+public class KillbillInstanceConfigProvider implements Provider<EurekaInstanceConfig> {
+    @Inject(optional = true)
+    @EurekaNamespace
+    private String namespace;
+
+    private KillbillInstanceConfig config;
+
+    @Override
+    public synchronized KillbillInstanceConfig get() {
+        if (config == null) {
+            if (namespace == null) {
+                config = new KillbillInstanceConfig();
+            } else {
+                config = new KillbillInstanceConfig(namespace);
+            }
+
+            // TODO: Remove this when DiscoveryManager is finally no longer used
+            DiscoveryManager.getInstance().setEurekaInstanceConfig(config);
+        }
+        return config;
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/glue/EurekaModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/EurekaModule.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.glue;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.discovery.EurekaClient;
+import com.netflix.discovery.EurekaClientConfig;
+import com.netflix.discovery.providers.DefaultEurekaClientConfigProvider;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.billing.util.discovery.DefaultEurekaKillbillService;
+import org.killbill.billing.util.discovery.EurekaClientOptionalArgs;
+import org.killbill.billing.util.discovery.EurekaKillbillService;
+import org.killbill.billing.util.discovery.provider.KillbillEurekaInstanceInfoProvider;
+import org.killbill.billing.util.discovery.provider.KillbillInstanceConfigProvider;
+
+public class EurekaModule extends KillBillModule {
+
+    public EurekaModule(final KillbillConfigSource configSource) {
+        super(configSource);
+    }
+
+    @Override
+    protected void configure() {
+        // need to eagerly initialize
+        bind(ApplicationInfoManager.class).asEagerSingleton();
+
+        bind(EurekaInstanceConfig.class).toProvider(KillbillInstanceConfigProvider.class).in(Scopes.SINGLETON);
+        bind(EurekaClientConfig.class).toProvider(DefaultEurekaClientConfigProvider.class).in(Scopes.SINGLETON);
+
+        // this is the self instanceInfo used for registration purposes
+        bind(InstanceInfo.class).toProvider(KillbillEurekaInstanceInfoProvider.class).in(Scopes.SINGLETON);
+
+        bind(EurekaClient.class).to(DiscoveryClient.class).in(Scopes.SINGLETON);
+
+        bind(AbstractDiscoveryClientOptionalArgs.class).to(EurekaClientOptionalArgs.class).in(Scopes.SINGLETON);
+
+        bind(EurekaKillbillService.class).to(DefaultEurekaKillbillService.class).asEagerSingleton();
+    }
+
+    @Provides
+    KillbillConfigSource killbillConfigSource() {
+        return configSource;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && getClass().equals(obj.getClass());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+}


### PR DESCRIPTION
This contribution allows KB to register with a Eureka server (https://github.com/Netflix/eureka/) for automated service discovery. The new Guice EurekaModule isn't included in the default `killbill` profile, so this is disabled by default.

I'm unclear if I need to also submit a PR to update the documentation. Should I?

For context, much of this code is based on the Guice module Netflix provides for Eureka: 
https://github.com/Netflix/eureka/blob/master/eureka-client/src/main/java/com/netflix/discovery/guice/EurekaModule.java