### PR TITLE
Fix string encoding in PluginResource

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/PluginResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/PluginResource.java
@@ -221,7 +221,7 @@ public class PluginResource extends JaxRsResourceBase {
         }
 
         return Response.status(response.getStatus())
-                       .entity(new String(byteArrayOutputStream.toByteArray()))
+                       .entity(new String(byteArrayOutputStream.toByteArray(), "UTF-8"))
                        .build();
     }
 


### PR DESCRIPTION
Set String encoding to UTF-8 when returning response from plugin servlet.  Fixes issue where special character in response entity caused malformed json to be returned from the servlet endpoint.