### PR TITLE
catalog: revisit simple plan validation

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/CatalogUpdater.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/CatalogUpdater.java
@@ -282,10 +282,10 @@ public class CatalogUpdater {
     }
 
     private void validateNewPlanDescriptor(final SimplePlanDescriptor desc) throws CatalogApiException {
-        if (desc.getProductCategory() == null ||
-            desc.getBillingPeriod() == null ||
-            (desc.getAmount() == null || desc.getAmount().compareTo(BigDecimal.ZERO) < 0) ||
-            desc.getCurrency() == null) {
+        final boolean invalidPlan = desc.getPlanId() == null && (desc.getProductCategory() == null || desc.getBillingPeriod() == null);
+        final boolean invalidPrice = (desc.getAmount() == null || desc.getAmount().compareTo(BigDecimal.ZERO) < 0) ||
+                                     desc.getCurrency() == null;
+        if (invalidPlan || invalidPrice) {
             throw new CatalogApiException(ErrorCode.CAT_INVALID_SIMPLE_PLAN_DESCRIPTOR, desc);
         }
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/CatalogResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/CatalogResource.java
@@ -492,6 +492,11 @@ public class CatalogResource extends JaxRsResourceBase {
             public TimeUnit getTrialTimeUnit() {
                 return simplePlan.getTrialTimeUnit();
             }
+
+            @Override
+            public String toString() {
+                return simplePlan.toString();
+            }
         };
 
         catalogUserApi.addSimplePlan(desc, null, callContext);


### PR DESCRIPTION
This was breaking the Kaui screen to add currency on an existing plan.
