### PR TITLE
Fixes linkedItemId-mapping issue for TaxInvoiceItem

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/model/TaxInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/TaxInvoiceItem.java
@@ -44,7 +44,7 @@ public class TaxInvoiceItem extends InvoiceItemCatalogBase {
                           @Nullable final UUID subscriptionId, @Nullable final String productName, @Nullable final String planName, @Nullable final String phaseName, @Nullable final String usageName,
                           @Nullable final String prettyProductName, @Nullable final String prettyPlanName, @Nullable final String prettyPhaseName, @Nullable final String prettyUsageName,
                           final LocalDate date, @Nullable final String description, final BigDecimal amount, final Currency currency, @Nullable final UUID linkedItemId, @Nullable final String itemDetails) {
-        super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, usageName, prettyProductName, prettyPlanName, prettyPhaseName, prettyUsageName, date, null, amount, null, currency, null, null, itemDetails, InvoiceItemType.TAX);
+        super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, usageName, prettyProductName, prettyPlanName, prettyPhaseName, prettyUsageName, date, null, amount, null, currency, linkedItemId, null, itemDetails, InvoiceItemType.TAX);
     }
 
     @Override


### PR DESCRIPTION
I'm currently working on a Tax Plugin. 

During development, I noticed something strange. The linkedItemId was always null on a tax-Item - even if the database item has a linkedItemId set. 

after some researched, I noticed that during the mapping from the Database invoice Dao to the actual TaxItem object, the linkedItemId information gets lost. 

Long story short -  I added the linkedItemId field to the super() call in TaxInvoiceItem