### PR TITLE
Fixes issue with the endDate mapping for tax items

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemFactory.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemFactory.java
@@ -110,7 +110,7 @@ public class InvoiceItemFactory {
                 item = new UsageInvoiceItem(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, prettyProductName, prettyPlanName, prettyPlanPhaseName, prettyUsageName, startDate, endDate, description, amount, rate, currency, quantity, itemDetails);
                 break;
             case TAX:
-                item = new TaxInvoiceItem(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, prettyProductName, prettyPlanName, prettyPlanPhaseName, prettyUsageName, startDate, description, amount, currency, linkedItemId, itemDetails);
+                item = new TaxInvoiceItem(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, prettyProductName, prettyPlanName, prettyPlanPhaseName, prettyUsageName, startDate, endDate, description, amount, currency, linkedItemId, itemDetails);
                 break;
             case PARENT_SUMMARY:
                 item = new ParentInvoiceItem(id, createdDate, invoiceId, accountId, childAccountId, amount, currency, description);

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/TaxInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/TaxInvoiceItem.java
@@ -37,14 +37,14 @@ public class TaxInvoiceItem extends InvoiceItemCatalogBase {
 
     public TaxInvoiceItem(final UUID id, final UUID invoiceId, final UUID accountId, @Nullable final UUID bundleId,
                           @Nullable final String description, final LocalDate date, final BigDecimal amount, final Currency currency) {
-        this(id, null, invoiceId, accountId, bundleId, null, null, null, null, null, null, null, null, null, date, description, amount, currency, null, null);
+        this(id, null, invoiceId, accountId, bundleId, null, null, null, null, null, null, null, null, null, date, null, description, amount, currency, null, null);
     }
 
     public TaxInvoiceItem(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId, @Nullable final UUID bundleId,
                           @Nullable final UUID subscriptionId, @Nullable final String productName, @Nullable final String planName, @Nullable final String phaseName, @Nullable final String usageName,
                           @Nullable final String prettyProductName, @Nullable final String prettyPlanName, @Nullable final String prettyPhaseName, @Nullable final String prettyUsageName,
-                          final LocalDate date, @Nullable final String description, final BigDecimal amount, final Currency currency, @Nullable final UUID linkedItemId, @Nullable final String itemDetails) {
-        super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, usageName, prettyProductName, prettyPlanName, prettyPhaseName, prettyUsageName, date, null, amount, null, currency, linkedItemId, null, itemDetails, InvoiceItemType.TAX);
+                          final LocalDate startDate, @Nullable final LocalDate endDate, @Nullable final String description, final BigDecimal amount, final Currency currency, @Nullable final UUID linkedItemId, @Nullable final String itemDetails) {
+        super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, usageName, prettyProductName, prettyPlanName, prettyPhaseName, prettyUsageName, startDate, endDate, amount, null, currency, linkedItemId, null, itemDetails, InvoiceItemType.TAX);
     }
 
     @Override

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceItemDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceItemDao.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.joda.time.LocalDate;
+import org.killbill.billing.invoice.model.TaxInvoiceItem;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -196,6 +197,22 @@ public class TestInvoiceItemDao extends InvoiceTestSuiteWithEmbeddedDB {
 
         final InvoiceItemModelDao savedItem = invoiceUtil.getInvoiceItemById(externalChargeInvoiceItem.getId(), context);
         assertSameInvoiceItem(externalChargeInvoiceItem, savedItem);
+    }
+
+    @Test(groups = "slow")
+    public void testTaxInvoiceSqlDao() throws Exception {
+        final UUID invoiceId = UUID.randomUUID();
+        final UUID accountId = account.getId();
+        final UUID bundleId = UUID.randomUUID();
+        final UUID linkedItemId = UUID.randomUUID();
+        final String description = UUID.randomUUID().toString();
+        final LocalDate startDate = new LocalDate(2012, 4, 1);
+        final LocalDate endDate = new LocalDate(2012, 5, 1);
+        final InvoiceItem taxInvoiceItem = new TaxInvoiceItem(UUID.randomUUID(), null, invoiceId, accountId, bundleId, null, null, null, null, null, null, null, null, null, startDate, endDate, description, TEN, Currency.USD, linkedItemId, null);
+        invoiceUtil.createInvoiceItem(taxInvoiceItem, context);
+
+        final InvoiceItemModelDao savedItem = invoiceUtil.getInvoiceItemById(taxInvoiceItem.getId(), context);
+        assertSameInvoiceItem(taxInvoiceItem, savedItem);
     }
 
     @Test(groups = "slow")


### PR DESCRIPTION
The `endDate` is a possible propertie for a tax-item, since the
following methode from killbill-base-plugin makes use of it:
`org.killbill.billing.plugin.api.invoice.PluginInvoiceItem#createTaxItem`
https://github.com/killbill/killbill-plugin-framework-java/blob/master/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoiceItem.java#L58

This PR adds the mapping entry needed to map the endDate from the InvoiceItemDao back to the TaxItem item