### PR TITLE
invoice: reduce number of queries when creating invoices

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationInvoiceWithRepairLogic.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationInvoiceWithRepairLogic.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -721,7 +721,7 @@ public class TestIntegrationInvoiceWithRepairLogic extends TestIntegrationBase {
         newItems.add(recurring3);
         newItems.add(repair3);
         shellInvoice.addInvoiceItems(newItems);
-        invoiceDao.createInvoice(shellInvoice, ImmutableSet.of(), new FutureAccountNotifications(), internalCallContext);
+        invoiceDao.createInvoice(shellInvoice, ImmutableSet.of(), new FutureAccountNotifications(), null, internalCallContext);
 
 
         // Move ahead one month, verify nothing from previous data was generated

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -64,6 +64,7 @@ import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.invoice.api.user.DefaultInvoiceNotificationInternalEvent;
 import org.killbill.billing.invoice.api.user.DefaultNullInvoiceEvent;
 import org.killbill.billing.invoice.calculator.InvoiceCalculatorUtils;
+import org.killbill.billing.invoice.dao.ExistingInvoiceMetadata;
 import org.killbill.billing.invoice.dao.InvoiceDao;
 import org.killbill.billing.invoice.dao.InvoiceItemModelDao;
 import org.killbill.billing.invoice.dao.InvoiceModelDao;
@@ -622,7 +623,8 @@ public class InvoiceDispatcher {
                 }
 
                 // Commit invoice on disk
-                commitInvoiceAndSetFutureNotifications(account, invoiceModelDao, trackingIds, futureAccountNotifications, internalCallContext);
+                final ExistingInvoiceMetadata existingInvoiceMetadata = new ExistingInvoiceMetadata(existingInvoices);
+                commitInvoiceAndSetFutureNotifications(account, invoiceModelDao, trackingIds, futureAccountNotifications, existingInvoiceMetadata, internalCallContext);
                 success = true;
 
                 try {
@@ -810,7 +812,7 @@ public class InvoiceDispatcher {
     private void commitInvoiceAndSetFutureNotifications(final ImmutableAccountData account,
                                                         final FutureAccountNotifications futureAccountNotifications,
                                                         final InternalCallContext context) {
-        commitInvoiceAndSetFutureNotifications(account, null, ImmutableSet.of(), futureAccountNotifications, context);
+        commitInvoiceAndSetFutureNotifications(account, null, ImmutableSet.of(), futureAccountNotifications, null, context);
     }
 
 
@@ -818,10 +820,11 @@ public class InvoiceDispatcher {
                                                         @Nullable final InvoiceModelDao invoiceModelDao,
                                                         final Set<InvoiceTrackingModelDao> trackingIds,
                                                         final FutureAccountNotifications futureAccountNotifications,
+                                                        final ExistingInvoiceMetadata existingInvoiceMetadata,
                                                         final InternalCallContext context) {
         final boolean isThereAnyItemsLeft = invoiceModelDao != null && !invoiceModelDao.getInvoiceItems().isEmpty();
         if (isThereAnyItemsLeft) {
-            invoiceDao.createInvoice(invoiceModelDao, trackingIds, futureAccountNotifications, context);
+            invoiceDao.createInvoice(invoiceModelDao, trackingIds, futureAccountNotifications, existingInvoiceMetadata, context);
         } else {
             invoiceDao.setFutureAccountNotificationsForEmptyInvoice(account.getId(), futureAccountNotifications, context);
         }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -307,20 +307,22 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     public void createInvoice(final InvoiceModelDao invoice,
                               final Set<InvoiceTrackingModelDao> trackingIds,
                               final FutureAccountNotifications callbackDateTimePerSubscriptions,
+                              final ExistingInvoiceMetadata existingInvoiceMetadata,
                               final InternalCallContext context) {
-        createInvoices(ImmutableList.<InvoiceModelDao>of(invoice), trackingIds, callbackDateTimePerSubscriptions, context);
+        createInvoices(ImmutableList.<InvoiceModelDao>of(invoice), trackingIds, callbackDateTimePerSubscriptions, existingInvoiceMetadata, context);
     }
 
     @Override
     public List<InvoiceItemModelDao> createInvoices(final List<InvoiceModelDao> invoices,
                                                     final Set<InvoiceTrackingModelDao> trackingIds,
                                                     final InternalCallContext context) {
-        return createInvoices(invoices, trackingIds, new FutureAccountNotifications(), context);
+        return createInvoices(invoices, trackingIds, new FutureAccountNotifications(), null, context);
     }
 
     private List<InvoiceItemModelDao> createInvoices(final Iterable<InvoiceModelDao> invoices,
                                                      final Set<InvoiceTrackingModelDao> trackingIds,
                                                      final FutureAccountNotifications callbackDateTimePerSubscriptions,
+                                                     @Nullable final ExistingInvoiceMetadata existingInvoiceMetadataOrNull,
                                                      final InternalCallContext context) {
         // Track invoices that are being created
         final Collection<UUID> createdInvoiceIds = new HashSet<UUID>();
@@ -349,6 +351,15 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         return transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<List<InvoiceItemModelDao>>() {
             @Override
             public List<InvoiceItemModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
+                final ExistingInvoiceMetadata existingInvoiceMetadata;
+                if (existingInvoiceMetadataOrNull == null) {
+                    final List<InvoiceModelDao> allInvoicesForAccount = invoiceDaoHelper.getAllInvoicesByAccountFromTransaction(true, invoicesTags, entitySqlDaoWrapperFactory, context);
+                    invoiceDaoHelper.populateChildren(allInvoicesForAccount, invoicesTags, entitySqlDaoWrapperFactory, context);
+                    existingInvoiceMetadata = new ExistingInvoiceMetadata(allInvoicesForAccount);
+                } else {
+                    existingInvoiceMetadata = existingInvoiceMetadataOrNull;
+                }
+
                 final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
                 final InvoiceItemSqlDao transInvoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
 
@@ -357,7 +368,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                     invoiceByInvoiceId.put(invoiceModelDao.getId(), invoiceModelDao);
                     final boolean isNotShellInvoice = invoiceIdsReferencedFromItems.remove(invoiceModelDao.getId());
 
-                    final InvoiceModelDao invoiceOnDisk = invoiceSqlDao.getById(invoiceModelDao.getId().toString(), context);
+                    final InvoiceModelDao invoiceOnDisk = existingInvoiceMetadata.getExistingInvoice(invoiceModelDao.getId());
                     if (isNotShellInvoice) {
                         // Create the invoice if this is not a shell invoice and it does not already exist
                         if (invoiceOnDisk == null) {
@@ -371,7 +382,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
 
                     // Create the invoice items if needed (note: they may not necessarily belong to that invoice)
                     for (final InvoiceItemModelDao invoiceItemModelDao : invoiceModelDao.getInvoiceItems()) {
-                        final InvoiceItemModelDao existingInvoiceItem = transInvoiceItemSqlDao.getById(invoiceItemModelDao.getId().toString(), context);
+                        final InvoiceItemModelDao existingInvoiceItem = existingInvoiceMetadata.getExistingInvoiceItem(invoiceItemModelDao.getId());
                         // Because of AUTO_INVOICING_REUSE_DRAFT we expect an invoice were items might already exist.
                         // Also for ALLOWED_INVOICE_ITEM_TYPES, we expect plugins to potentially modify the amount
                         if (existingInvoiceItem == null) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/ExistingInvoiceMetadata.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/ExistingInvoiceMetadata.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItem;
 
@@ -29,6 +30,9 @@ public class ExistingInvoiceMetadata {
 
     private final Map<UUID, InvoiceModelDao> invoicesCache = new HashMap<UUID, InvoiceModelDao>();
     private final Map<UUID, InvoiceItemModelDao> invoiceItemsCache = new HashMap<UUID, InvoiceItemModelDao>();
+
+    private InvoiceSqlDao invoiceSqlDao;
+    private InvoiceItemSqlDao invoiceItemSqlDao;
 
     public ExistingInvoiceMetadata(final Iterable<Invoice> existingInvoices) {
         for (final Invoice invoice : existingInvoices) {
@@ -48,11 +52,24 @@ public class ExistingInvoiceMetadata {
         }
     }
 
-    public InvoiceModelDao getExistingInvoice(final UUID invoiceId) {
-        return invoicesCache.get(invoiceId);
+    public ExistingInvoiceMetadata(final InvoiceSqlDao invoiceSqlDao, final InvoiceItemSqlDao invoiceItemSqlDao) {
+        this.invoiceSqlDao = invoiceSqlDao;
+        this.invoiceItemSqlDao = invoiceItemSqlDao;
     }
 
-    public InvoiceItemModelDao getExistingInvoiceItem(final UUID invoiceItemId) {
-        return invoiceItemsCache.get(invoiceItemId);
+    public InvoiceModelDao getExistingInvoice(final UUID invoiceId, final InternalTenantContext context) {
+        if (invoiceSqlDao != null) {
+            return invoiceSqlDao.getById(invoiceId.toString(), context);
+        } else {
+            return invoicesCache.get(invoiceId);
+        }
+    }
+
+    public InvoiceItemModelDao getExistingInvoiceItem(final UUID invoiceItemId, final InternalTenantContext context) {
+        if (invoiceItemSqlDao != null) {
+            return invoiceItemSqlDao.getById(invoiceItemId.toString(), context);
+        } else {
+            return invoiceItemsCache.get(invoiceItemId);
+        }
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/ExistingInvoiceMetadata.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/ExistingInvoiceMetadata.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.dao;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItem;
+
+public class ExistingInvoiceMetadata {
+
+    private final Map<UUID, InvoiceModelDao> invoicesCache = new HashMap<UUID, InvoiceModelDao>();
+    private final Map<UUID, InvoiceItemModelDao> invoiceItemsCache = new HashMap<UUID, InvoiceItemModelDao>();
+
+    public ExistingInvoiceMetadata(final Iterable<Invoice> existingInvoices) {
+        for (final Invoice invoice : existingInvoices) {
+            invoicesCache.put(invoice.getId(), new InvoiceModelDao(invoice));
+            for (final InvoiceItem invoiceItem : invoice.getInvoiceItems()) {
+                invoiceItemsCache.put(invoiceItem.getId(), new InvoiceItemModelDao(invoiceItem));
+            }
+        }
+    }
+
+    public ExistingInvoiceMetadata(final Collection<InvoiceModelDao> existingInvoices) {
+        for (final InvoiceModelDao invoiceModelDao : existingInvoices) {
+            invoicesCache.put(invoiceModelDao.getId(), invoiceModelDao);
+            for (final InvoiceItemModelDao invoiceItemModelDao : invoiceModelDao.getInvoiceItems()) {
+                invoiceItemsCache.put(invoiceItemModelDao.getId(), invoiceItemModelDao);
+            }
+        }
+    }
+
+    public InvoiceModelDao getExistingInvoice(final UUID invoiceId) {
+        return invoicesCache.get(invoiceId);
+    }
+
+    public InvoiceItemModelDao getExistingInvoiceItem(final UUID invoiceItemId) {
+        return invoiceItemsCache.get(invoiceItemId);
+    }
+}

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/ExistingInvoiceMetadata.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/ExistingInvoiceMetadata.java
@@ -17,7 +17,6 @@
 
 package org.killbill.billing.invoice.dao;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -39,15 +38,6 @@ public class ExistingInvoiceMetadata {
             invoicesCache.put(invoice.getId(), new InvoiceModelDao(invoice));
             for (final InvoiceItem invoiceItem : invoice.getInvoiceItems()) {
                 invoiceItemsCache.put(invoiceItem.getId(), new InvoiceItemModelDao(invoiceItem));
-            }
-        }
-    }
-
-    public ExistingInvoiceMetadata(final Collection<InvoiceModelDao> existingInvoices) {
-        for (final InvoiceModelDao invoiceModelDao : existingInvoices) {
-            invoicesCache.put(invoiceModelDao.getId(), invoiceModelDao);
-            for (final InvoiceItemModelDao invoiceItemModelDao : invoiceModelDao.getInvoiceItems()) {
-                invoiceItemsCache.put(invoiceItemModelDao.getId(), invoiceItemModelDao);
             }
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2017 Groupon, Inc
- * Copyright 2014-2017 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -40,12 +40,14 @@ import org.killbill.billing.util.entity.dao.EntityDao;
 
 public interface InvoiceDao extends EntityDao<InvoiceModelDao, Invoice, InvoiceApiException> {
 
-
+    // Used by InvoiceDispatcher only for regular invoice runs
     void createInvoice(final InvoiceModelDao invoice,
                        final Set<InvoiceTrackingModelDao> trackingIds,
                        final FutureAccountNotifications callbackDateTimePerSubscriptions,
+                       final ExistingInvoiceMetadata existingInvoiceMetadata,
                        final InternalCallContext context);
 
+    // Used by APIs, for HA, etc.
     List<InvoiceItemModelDao> createInvoices(final List<InvoiceModelDao> invoices,
                                              final Set<InvoiceTrackingModelDao> trackingIds,
                                              final InternalCallContext context);

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -64,7 +64,9 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
     @Override
     public void createInvoice(final InvoiceModelDao invoice,
                               final Set<InvoiceTrackingModelDao> trackingIds,
-                              final FutureAccountNotifications callbackDateTimePerSubscriptions, final InternalCallContext context) {
+                              final FutureAccountNotifications callbackDateTimePerSubscriptions,
+                              final ExistingInvoiceMetadata existingInvoiceMetadata,
+                              final InternalCallContext context) {
         synchronized (monitor) {
             storeInvoice(invoice, context);
         }
@@ -83,7 +85,9 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
     }
 
     @Override
-    public List<InvoiceItemModelDao> createInvoices(final List<InvoiceModelDao> invoiceModelDaos, final Set<InvoiceTrackingModelDao> trackingIds, final InternalCallContext context) {
+    public List<InvoiceItemModelDao> createInvoices(final List<InvoiceModelDao> invoiceModelDaos,
+                                                    final Set<InvoiceTrackingModelDao> trackingIds,
+                                                    final InternalCallContext context) {
         synchronized (monitor) {
             final List<InvoiceItemModelDao> createdItems = new LinkedList<InvoiceItemModelDao>();
             for (final InvoiceModelDao invoice : invoiceModelDaos) {


### PR DESCRIPTION
Instead of fetching existing invoices and invoice items one by one in the `createInvoices` transaction (e.g. `AUTO_INVOICING_REUSE_DRAFT` use case), bulk retrieve all of them.

In the case of regular invoice runs, this will likely speed up things, because we already have the information (we save at least 2 queries per invoice run, linear with the number of invoice items being created). However, in the case of direct API calls (e.g. create adjustment) and HA (bus listener), this will likely slow things down (in most cases, we will retrieve more information than actually needed). Since these are infrequent codepaths, it's probably okay (we could optimize further depending on the codepath, but it would increase the DAO logic complexity).

@sbrossie FYI, this is orthogonal to the caching work we were talking about. Just randomly came across this as I was investigating some perf data.
