### PR TITLE
security: return custom permissions from all Realms

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillBillShiroWebModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillBillShiroWebModule.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -19,7 +19,7 @@
 package org.killbill.billing.server.modules;
 
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Set;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
@@ -28,11 +28,12 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.shiro.authc.pam.ModularRealmAuthenticator;
 import org.apache.shiro.authc.pam.ModularRealmAuthenticatorWith540;
-import org.apache.shiro.authz.ModularRealmAuthorizer;
 import org.apache.shiro.cache.CacheManager;
 import org.apache.shiro.guice.web.ShiroWebModuleWith435;
+import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.mgt.SubjectDAO;
 import org.apache.shiro.realm.Realm;
+import org.apache.shiro.realm.text.IniRealm;
 import org.apache.shiro.session.mgt.SessionManager;
 import org.apache.shiro.session.mgt.eis.SessionDAO;
 import org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter;
@@ -45,6 +46,7 @@ import org.killbill.billing.server.security.KillBillWebSessionManager;
 import org.killbill.billing.server.security.KillbillJdbcTenantRealm;
 import org.killbill.billing.util.config.definition.RbacConfig;
 import org.killbill.billing.util.config.definition.RedisCacheConfig;
+import org.killbill.billing.util.config.definition.SecurityConfig;
 import org.killbill.billing.util.glue.EhcacheShiroManagerProvider;
 import org.killbill.billing.util.glue.KillBillShiroModule;
 import org.killbill.billing.util.glue.RealmsFromShiroIniProvider;
@@ -56,7 +58,10 @@ import org.killbill.billing.util.security.shiro.realm.KillBillOktaRealm;
 import org.skife.config.ConfigSource;
 import org.skife.config.ConfigurationObjectFactory;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
 import com.google.inject.Key;
+import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.AnnotatedBindingBuilder;
 import com.google.inject.matcher.AbstractMatcher;
@@ -70,10 +75,12 @@ import com.google.inject.spi.TypeListener;
 public class KillBillShiroWebModule extends ShiroWebModuleWith435 {
 
     private final ConfigSource configSource;
+    private final DefaultSecurityManager defaultSecurityManager;
 
     public KillBillShiroWebModule(final ServletContext servletContext, final ConfigSource configSource) {
         super(servletContext);
         this.configSource = configSource;
+        this.defaultSecurityManager = RealmsFromShiroIniProvider.get(configSource);
     }
 
     @Override
@@ -92,9 +99,18 @@ public class KillBillShiroWebModule extends ShiroWebModuleWith435 {
             bind(CacheManager.class).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
         }
 
+        final SecurityConfig securityConfig = new ConfigurationObjectFactory(configSource).build(SecurityConfig.class);
+        final Collection<Realm> realms = defaultSecurityManager.getRealms() != null ? defaultSecurityManager.getRealms() :
+                                         ImmutableSet.<Realm>of(new IniRealm(securityConfig.getShiroResourcePath())); // Mainly for testing
+        for (final Realm realm : realms) {
+            bindRealm().toInstance(realm);
+        }
+
         configureShiroForRBAC();
 
         configureShiroForTenants();
+
+        expose(new TypeLiteral<Set<Realm>>() {});
     }
 
     private void configureShiroForRBAC() {
@@ -127,6 +143,32 @@ public class KillBillShiroWebModule extends ShiroWebModuleWith435 {
         // Realm binding for the tenants (see TenantFilter)
         bind(KillbillJdbcTenantRealm.class).toProvider(KillbillJdbcTenantRealmProvider.class).asEagerSingleton();
         expose(KillbillJdbcTenantRealm.class);
+    }
+
+    @Override
+    protected void bindWebSecurityManager(final AnnotatedBindingBuilder<? super WebSecurityManager> bind) {
+        //super.bindWebSecurityManager(bind);
+        // This following is to work around obscure Guice issues
+        bind.toProvider(KillBillWebSecurityManagerProvider.class).asEagerSingleton();
+    }
+
+    public static final class KillBillWebSecurityManagerProvider implements Provider<DefaultWebSecurityManager> {
+
+        private final Collection<Realm> realms;
+        private final SessionManager sessionManager;
+
+        @Inject
+        public KillBillWebSecurityManagerProvider(final Collection<Realm> realms, final SessionManager sessionManager) {
+            this.realms = realms;
+            this.sessionManager = sessionManager;
+        }
+
+        @Override
+        public DefaultWebSecurityManager get() {
+            final DefaultWebSecurityManager defaultWebSecurityManager = new DefaultWebSecurityManager(realms);
+            defaultWebSecurityManager.setSessionManager(sessionManager);
+            return defaultWebSecurityManager;
+        }
     }
 
     @Override
@@ -175,20 +217,10 @@ public class KillBillShiroWebModule extends ShiroWebModuleWith435 {
                 public void afterInjection(final Object o) {
                     final DefaultWebSecurityManager webSecurityManager = (DefaultWebSecurityManager) o;
 
-                    // Other realms have been injected by Guice (bindRealm().toInstance(...) makes Guice throw a ClassCastException?!)
-                    final Collection<Realm> realmsFromShiroIni = RealmsFromShiroIniProvider.get(configSource);
-
-                    if (webSecurityManager.getAuthorizer() instanceof ModularRealmAuthorizer) {
-                        final ModularRealmAuthorizer modularRealmAuthorizer = (ModularRealmAuthorizer) webSecurityManager.getAuthorizer();
-                        final Collection<Realm> realms = new LinkedList<Realm>(realmsFromShiroIni);
-                        realms.addAll(modularRealmAuthorizer.getRealms());
-                        modularRealmAuthorizer.setRealms(realms);
-                    }
-
                     if (webSecurityManager.getAuthenticator() instanceof ModularRealmAuthenticator) {
                         final ModularRealmAuthenticator authenticator = (ModularRealmAuthenticator) webSecurityManager.getAuthenticator();
                         authenticator.setAuthenticationStrategy(new FirstSuccessfulStrategyWith540());
-                        webSecurityManager.setAuthenticator(new ModularRealmAuthenticatorWith540(realmsFromShiroIni, authenticator));
+                        webSecurityManager.setAuthenticator(new ModularRealmAuthenticatorWith540(webSecurityManager.getRealms(), authenticator));
                     }
                 }
             });

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestSecurity.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestSecurity.java
@@ -152,15 +152,15 @@ public class TestSecurity extends TestJaxrsBase {
         logout();
         login(username, password);
         List<String> permissions = securityApi.getCurrentUserPermissions(requestOptions);
-        Assert.assertEquals(permissions.size(), Permission.values().length);
+        Assert.assertEquals(permissions, ImmutableList.<String>of("*"));
 
-        String newPassword = "IamTheBestWarrior";
+        final String newPassword = "IamTheBestWarrior";
         securityApi.updateUserPassword(username, new UserRoles(username, newPassword, null), requestOptions);
 
         logout();
         login(username, newPassword);
         permissions = securityApi.getCurrentUserPermissions(requestOptions);
-        Assert.assertEquals(permissions.size(), Permission.values().length);
+        Assert.assertEquals(permissions, ImmutableList.<String>of("*"));
 
         final String newRoleDefinition = "somethingLessNice";
         // Only enough permissions to invalidate itself in the last step...

--- a/util/src/main/java/org/killbill/billing/util/glue/RealmsFromShiroIniProvider.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/RealmsFromShiroIniProvider.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -18,14 +18,10 @@
 
 package org.killbill.billing.util.glue;
 
-import java.util.Collection;
-
 import org.apache.shiro.config.ConfigurationException;
 import org.apache.shiro.config.IniSecurityManagerFactory;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.mgt.SecurityManager;
-import org.apache.shiro.realm.Realm;
-import org.apache.shiro.realm.text.IniRealm;
 import org.apache.shiro.util.Factory;
 import org.killbill.billing.util.config.definition.SecurityConfig;
 import org.skife.config.ConfigSource;
@@ -33,42 +29,21 @@ import org.skife.config.ConfigurationObjectFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Provider;
-
 public class RealmsFromShiroIniProvider {
 
     private static final Logger log = LoggerFactory.getLogger(RealmsFromShiroIniProvider.class);
 
-    public static Collection<Realm> get(final ConfigSource configSource) {
+    public static DefaultSecurityManager get(final ConfigSource configSource) {
         final SecurityConfig securityConfig = new ConfigurationObjectFactory(configSource).build(SecurityConfig.class);
 
-        Collection<Realm> realms = null;
         try {
             final Factory<SecurityManager> factory = new IniSecurityManagerFactory(securityConfig.getShiroResourcePath());
             // TODO Pierre hack - lame cast here, but we need to have Shiro go through its reflection magic
             // to parse the [main] section of the ini file. Without duplicating code, this seems to be possible only
             // by going through IniSecurityManagerFactory.
-            final DefaultSecurityManager securityManager = (DefaultSecurityManager) factory.getInstance();
-            realms = securityManager.getRealms();
+            return (DefaultSecurityManager) factory.getInstance();
         } catch (final ConfigurationException e) {
             log.warn("Unable to configure RBAC", e);
-        }
-
-        return realms != null ? realms :
-               ImmutableSet.<Realm>of(new IniRealm(securityConfig.getShiroResourcePath())); // Mainly for testing
-    }
-
-    public static Provider<IniRealm> getIniRealmProvider(final ConfigSource configSource) {
-        for (final Realm cur : get(configSource)) {
-            if (cur instanceof IniRealm) {
-                return new Provider<IniRealm>() {
-                    @Override
-                    public IniRealm get() {
-                        return (IniRealm) cur;
-                    }
-                };
-            }
         }
 
         return null;

--- a/util/src/test/java/org/killbill/billing/util/UtilTestSuiteWithEmbeddedDB.java
+++ b/util/src/test/java/org/killbill/billing/util/UtilTestSuiteWithEmbeddedDB.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -18,8 +18,11 @@
 
 package org.killbill.billing.util;
 
+import java.util.Set;
+
 import javax.inject.Inject;
 
+import org.apache.shiro.realm.Realm;
 import org.killbill.billing.GuicyKillbillTestSuiteWithEmbeddedDB;
 import org.killbill.billing.account.api.ImmutableAccountInternalApi;
 import org.killbill.billing.api.TestApiListener;
@@ -91,6 +94,8 @@ public abstract class UtilTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuite
     protected NodeInfoDao nodeInfoDao;
     @Inject
     protected BroadcastDao broadcastDao;
+    @Inject
+    protected Set<Realm> realms;
 
     @BeforeClass(groups = "slow")
     public void beforeClass() throws Exception {

--- a/util/src/test/java/org/killbill/billing/util/security/api/TestDefaultSecurityApi.java
+++ b/util/src/test/java/org/killbill/billing/util/security/api/TestDefaultSecurityApi.java
@@ -20,25 +20,23 @@ package org.killbill.billing.util.security.api;
 
 import java.util.Set;
 
+import org.apache.shiro.realm.Realm;
+import org.killbill.billing.security.Permission;
+import org.killbill.billing.security.api.SecurityApi;
+import org.killbill.billing.util.UtilTestSuiteNoDB;
 import org.killbill.billing.util.security.shiro.dao.UserDao;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import org.killbill.billing.security.Permission;
-import org.killbill.billing.security.api.SecurityApi;
-import org.killbill.billing.util.UtilTestSuiteNoDB;
-
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class TestDefaultSecurityApi extends UtilTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testRetrievePermissions() throws Exception {
         configureShiro();
-
-        // We don't want the Guice injected one (it has Shiro disabled)
-        final SecurityApi securityApi = new DefaultSecurityApi(Mockito.mock(UserDao.class));
 
         logout();
         final Set<String> anonsPermissions = securityApi.getCurrentUserPermissions(callContext);

--- a/util/src/test/resources/shiro.ini
+++ b/util/src/test/resources/shiro.ini
@@ -16,4 +16,13 @@
 #                                                                                 #
 ###################################################################################
 
-# Dummy file to avoid exceptions in the logs
+[users]
+admin = password, admin
+tester = tester, admin
+pierre = password, creditor
+stephane = password, refunder
+
+[roles]
+admin = *:*
+creditor = invoice:credit, invoice:item_adjust
+refunder = payment:refund


### PR DESCRIPTION
Note the behavior change: wildcard permissions aren't expanded anymore. Built-in (`"account:*"`) and custom (`"acme:*"`) permissions will not be expanded in the API (as custom Realms don't necessarily
expose this information).

This fixes https://github.com/killbill/killbill/issues/1133.
