### PR TITLE
entitlement: subscription: add logging around invalid specifiers

### DIFF
--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/DefaultEntitlementApi.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/DefaultEntitlementApi.java
@@ -454,11 +454,13 @@ public class DefaultEntitlementApi extends DefaultEntitlementApiBase implements 
 
     private BaseEntitlementWithAddOnsSpecifier getFirstBaseEntitlementWithAddOnsSpecifier(final Iterable<BaseEntitlementWithAddOnsSpecifier> baseEntitlementWithAddOnsSpecifiers) throws SubscriptionBaseApiException {
         if (baseEntitlementWithAddOnsSpecifiers == null) {
+            log.warn("getFirstBaseEntitlementWithAddOnsSpecifier: baseEntitlementWithAddOnsSpecifiers is null");
             throw new SubscriptionBaseApiException(ErrorCode.SUB_CREATE_INVALID_ENTITLEMENT_SPECIFIER);
         }
 
         final Iterator<BaseEntitlementWithAddOnsSpecifier> iterator = baseEntitlementWithAddOnsSpecifiers.iterator();
         if (!iterator.hasNext()) {
+            log.warn("getFirstBaseEntitlementWithAddOnsSpecifier: baseEntitlementWithAddOnsSpecifiers is empty");
             throw new SubscriptionBaseApiException(ErrorCode.SUB_CREATE_INVALID_ENTITLEMENT_SPECIFIER);
         }
 

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/svcs/DefaultSubscriptionBaseCreateApi.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/svcs/DefaultSubscriptionBaseCreateApi.java
@@ -186,8 +186,11 @@ public class DefaultSubscriptionBaseCreateApi extends SubscriptionApiBase {
         SubscriptionBaseBundle bundle = null;
         if (subscriptionBaseWithAddOnsSpecifier.getBundleId() != null) {
             bundle = dao.getSubscriptionBundleFromId(subscriptionBaseWithAddOnsSpecifier.getBundleId(), context);
-            if (bundle == null ||
-                (subscriptionBaseWithAddOnsSpecifier.getBundleExternalKey() != null && !subscriptionBaseWithAddOnsSpecifier.getBundleExternalKey().equals(bundle.getExternalKey()))) {
+            if (bundle == null) {
+                log.warn("getBundleWithSanity: bundle is missing");
+                throw new SubscriptionBaseApiException(ErrorCode.SUB_CREATE_INVALID_ENTITLEMENT_SPECIFIER);
+            } else if (subscriptionBaseWithAddOnsSpecifier.getBundleExternalKey() != null && !subscriptionBaseWithAddOnsSpecifier.getBundleExternalKey().equals(bundle.getExternalKey())) {
+                log.warn("getBundleWithSanity: specified bundleExternalKey {} doesn't match existing bundleExternalKey {}", subscriptionBaseWithAddOnsSpecifier.getBundleExternalKey(), bundle.getExternalKey());
                 throw new SubscriptionBaseApiException(ErrorCode.SUB_CREATE_INVALID_ENTITLEMENT_SPECIFIER);
             }
         } else if (subscriptionBaseWithAddOnsSpecifier.getBundleExternalKey() != null) {
@@ -298,6 +301,7 @@ public class DefaultSubscriptionBaseCreateApi extends SubscriptionApiBase {
                     basePlanSpecifier = cur;
                     basePlan = plan;
                 } else {
+                    log.warn("createPlansIfNeededAndReorderBPOrStandaloneSpecFirstWithSanity: multiple basePlanSpecifier");
                     throw new SubscriptionBaseApiException(ErrorCode.SUB_CREATE_INVALID_ENTITLEMENT_SPECIFIER);
                 }
             } else {
@@ -314,6 +318,7 @@ public class DefaultSubscriptionBaseCreateApi extends SubscriptionApiBase {
         outputEntitlementPlans.addAll(addOnsPlans);
 
         if (!outputEntitlementSpecifier.isEmpty() && !standaloneSpecifiers.isEmpty()) {
+            log.warn("createPlansIfNeededAndReorderBPOrStandaloneSpecFirstWithSanity: both outputEntitlementSpecifier and standaloneSpecifiers specified");
             throw new SubscriptionBaseApiException(ErrorCode.SUB_CREATE_INVALID_ENTITLEMENT_SPECIFIER);
         }
 


### PR DESCRIPTION
The ErrorCode `SUB_CREATE_INVALID_ENTITLEMENT_SPECIFIER` doesn't allow for an error message to be passed. Add some logging to help the user understand the issue.
