### PR TITLE
invoice: Filter out $0 REPAIR items.

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/AccountItemTree.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/AccountItemTree.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.invoice.tree;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -160,7 +161,13 @@ public class AccountItemTree {
         for (SubscriptionItemTree tree : subscriptionItemTree.values()) {
             final List<InvoiceItem> simplifiedView = tree.getView();
             if (simplifiedView.size() > 0) {
-                result.addAll(simplifiedView);
+                for (final InvoiceItem i : simplifiedView) {
+                    // Filter out $0 REPAIR_ADJ - these items make a lot of sense conceptually for us but may confuse users...
+                    if (i.getAmount().compareTo(BigDecimal.ZERO) == 0 && i.getInvoiceItemType() == InvoiceItemType.REPAIR_ADJ) {
+                        continue;
+                    }
+                    result.add(i);
+                }
             }
         }
         return result;


### PR DESCRIPTION
In scenarios of full item adjustements with a subscription cancelled prior its EOT
the invoice item tree will generate a REPAIR item for the non billable period but because
everything was already credited through full item adj. such item would be generated with a $0 value.

While this makes a lot of sense from a cleanliness of diagrams, this may end up confusing our users, so
filter them out prior writing on disk.