### PR TITLE
server: make sure to clear the userToken from the MDC context

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/filters/KillbillMDCInsertingServletFilter.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/filters/KillbillMDCInsertingServletFilter.java
@@ -33,6 +33,7 @@ import com.sun.jersey.spi.container.ContainerResponseWriter;
 
 import static org.killbill.billing.util.callcontext.InternalCallContextFactory.MDC_KB_ACCOUNT_RECORD_ID;
 import static org.killbill.billing.util.callcontext.InternalCallContextFactory.MDC_KB_TENANT_RECORD_ID;
+import static org.killbill.billing.util.callcontext.InternalCallContextFactory.MDC_KB_USER_TOKEN;
 
 @Singleton
 public class KillbillMDCInsertingServletFilter implements ContainerRequestFilter, ContainerResponseFilter {
@@ -75,9 +76,10 @@ public class KillbillMDCInsertingServletFilter implements ContainerRequestFilter
             // Removing possibly inexistent item is OK
             MDC.remove(MDC_REQUEST_ID);
 
-            // Cleanup
+            // Cleanup (this needs to be kept in sync with InternalCallContextFactory)
             MDC.remove(MDC_KB_ACCOUNT_RECORD_ID);
             MDC.remove(MDC_KB_TENANT_RECORD_ID);
+            MDC.remove(MDC_KB_USER_TOKEN);
         }
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/callcontext/InternalCallContextFactory.java
+++ b/util/src/main/java/org/killbill/billing/util/callcontext/InternalCallContextFactory.java
@@ -49,6 +49,7 @@ public class InternalCallContextFactory {
     // Long, not long, to avoid NPE with ==
     public static final Long INTERNAL_TENANT_RECORD_ID = 0L;
 
+    // This needs to be kept in sync with KillbillMDCInsertingServletFilter
     public static final String MDC_KB_ACCOUNT_RECORD_ID = "kb.accountRecordId";
     public static final String MDC_KB_TENANT_RECORD_ID = "kb.tenantRecordId";
     public static final String MDC_KB_USER_TOKEN = "kb.userToken";


### PR DESCRIPTION
The `userToken` wasn't cleaned-up, so it was shared across requests, making production logs debugging quite confusing 😑 