### PR TITLE
invoice: fix NPE in DefaultInvoiceDao

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -530,28 +530,48 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         }, events);
     }
 
-    protected Payment createPaymentAndCheckForCompletion(final Account account, final Invoice invoice, final BigDecimal amount, final Currency currency, final NextEvent... events) {
-        return doCallAndCheckForCompletion(new Function<Void, Payment>() {
+    protected Payment createPaymentAndCheckForCompletion(final Account account,
+                                                         final Invoice invoice,
+                                                         final BigDecimal amount,
+                                                         final Currency currency,
+                                                         final NextEvent... events) {
+        try {
+            return createPaymentAndCheckForCompletion(account,
+                                                      invoice,
+                                                      amount,
+                                                      currency,
+                                                      UUID.randomUUID().toString(),
+                                                      UUID.randomUUID().toString(),
+                                                      events);
+        } catch (final PaymentApiException e) {
+            fail(e.toString());
+            return null;
+        }
+    }
+
+    protected Payment createPaymentAndCheckForCompletion(final Account account,
+                                                         final Invoice invoice,
+                                                         final BigDecimal amount,
+                                                         final Currency currency,
+                                                         final String paymentExternalKey,
+                                                         final String transactionExternalKey,
+                                                         final NextEvent... events) throws PaymentApiException {
+        return doCallAndCheckForCompletionWithException(new FunctionWithException<Void, Payment, PaymentApiException>() {
             @Override
-            public Payment apply(@Nullable final Void input) {
-                try {
-                    final InvoicePayment invoicePayment = invoicePaymentApi.createPurchaseForInvoicePayment(account,
-                                                                                                            invoice.getId(),
-                                                                                                            account.getPaymentMethodId(),
-                                                                                                            null,
-                                                                                                            amount,
-                                                                                                            currency,
-                                                                                                            null,
-                                                                                                            UUID.randomUUID().toString(),
-                                                                                                            UUID.randomUUID().toString(),
-                                                                                                            ImmutableList.<PluginProperty>of(),
-                                                                                                            PAYMENT_OPTIONS,
-                                                                                                            callContext);
-                    return paymentApi.getPayment(invoicePayment.getPaymentId(), false, true, ImmutableList.<PluginProperty>of(), callContext);
-                } catch (final PaymentApiException e) {
-                    fail(e.toString());
-                    return null;
-                }
+            public Payment apply(@Nullable final Void input) throws PaymentApiException {
+                final InvoicePayment invoicePayment = invoicePaymentApi.createPurchaseForInvoicePayment(account,
+                                                                                                        invoice.getId(),
+                                                                                                        account.getPaymentMethodId(),
+                                                                                                        null,
+                                                                                                        amount,
+                                                                                                        currency,
+                                                                                                        null,
+                                                                                                        paymentExternalKey,
+                                                                                                        transactionExternalKey,
+                                                                                                        ImmutableList.<PluginProperty>of(),
+                                                                                                        PAYMENT_OPTIONS,
+                                                                                                        callContext);
+                return paymentApi.getPayment(invoicePayment.getPaymentId(), false, true, ImmutableList.<PluginProperty>of(), callContext);
             }
         }, events);
     }
@@ -921,6 +941,22 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
     }
 
     private <T> T doCallAndCheckForCompletion(final Function<Void, T> f, final NextEvent... events) {
+        try {
+            return doCallAndCheckForCompletionWithException(new FunctionWithException<Void, T, RuntimeException>() {
+                                                                @Override
+                                                                public T apply(final Void input) throws RuntimeException {
+                                                                    return f.apply(input);
+                                                                }
+                                                            },
+                                                            events);
+        } catch (final RuntimeException e) {
+            fail(e.getMessage());
+            return null;
+        }
+
+    }
+
+    private <T, E extends Throwable> T doCallAndCheckForCompletionWithException(final FunctionWithException<Void, T, E> f, final NextEvent... events) throws E {
         final Joiner joiner = Joiner.on(", ");
         log.debug("            ************    STARTING BUS HANDLER CHECK : {} ********************", joiner.join(events));
 
@@ -931,6 +967,11 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
         log.debug("            ************    DONE WITH BUS HANDLER CHECK    ********************");
         return result;
+    }
+
+    public interface FunctionWithException<F, T, E extends Throwable> {
+
+        T apply(F input) throws E;
     }
 
     protected void recordUsageData(final UUID subscriptionId, final String trackingId, final String unitType, final LocalDate startDate, final Long amount, final CallContext context) throws UsageApiException {

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestInvoicePayment.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestInvoicePayment.java
@@ -190,6 +190,52 @@ public class TestInvoicePayment extends TestIntegrationBase {
         Assert.assertEquals(invoiceUserApi.getAccountBalance(account.getId(), callContext).compareTo(BigDecimal.ZERO), 0);
     }
 
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1230")
+    public void testMultiplePartialPaymentsWithSameExternalKeys() throws Exception {
+        // 2012-05-01T00:03:42.000Z
+        clock.setTime(new DateTime(2012, 5, 1, 0, 3, 42, 0));
+
+        final AccountData accountData = getAccountData(0);
+        final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
+        accountChecker.checkAccount(account.getId(), accountData, callContext);
+
+        final DefaultEntitlement baseEntitlement = createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey", "Shotgun", ProductCategory.BASE, BillingPeriod.MONTHLY, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), null, InvoiceItemType.FIXED, new BigDecimal("0")));
+        invoiceChecker.checkChargedThroughDate(baseEntitlement.getId(), new LocalDate(2012, 5, 1), callContext);
+
+        // Put the account in AUTO_PAY_OFF to make sure payment system does not try to pay the initial invoice
+        add_AUTO_PAY_OFF_Tag(account.getId(), ObjectType.ACCOUNT);
+
+        // 2012-05-31 => DAY 30 have to get out of trial {I0, P0}
+        addDaysAndCheckForCompletion(30, NextEvent.PHASE, NextEvent.INVOICE);
+
+        Invoice invoice2 = invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 31), new LocalDate(2012, 6, 30), InvoiceItemType.RECURRING, new BigDecimal("249.95")));
+        invoiceChecker.checkChargedThroughDate(baseEntitlement.getId(), new LocalDate(2012, 6, 30), callContext);
+
+        // Invoice is not paid
+        Assert.assertEquals(paymentApi.getAccountPayments(account.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext).size(), 0);
+        Assert.assertEquals(invoice2.getBalance().compareTo(new BigDecimal("249.95")), 0);
+        Assert.assertEquals(invoiceUserApi.getAccountBalance(account.getId(), callContext).compareTo(invoice2.getBalance()), 0);
+
+        // Trigger partial payment
+        final Payment payment1 = createPaymentAndCheckForCompletion(account, invoice2, BigDecimal.TEN, account.getCurrency(), NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        paymentChecker.checkPayment(account.getId(), 1, callContext, new ExpectedPaymentCheck(new LocalDate(2012, 5, 31), BigDecimal.TEN, TransactionStatus.SUCCESS, invoice2.getId(), Currency.USD));
+        Assert.assertEquals(payment1.getTransactions().size(), 1);
+        Assert.assertEquals(payment1.getPurchasedAmount().compareTo(BigDecimal.TEN), 0);
+        Assert.assertEquals(payment1.getTransactions().get(0).getProcessedAmount().compareTo(BigDecimal.TEN), 0);
+        invoice2 = invoiceUserApi.getInvoice(invoice2.getId(), callContext);
+        Assert.assertEquals(invoice2.getBalance().compareTo(new BigDecimal("239.95")), 0);
+        Assert.assertEquals(invoiceUserApi.getAccountBalance(account.getId(), callContext).compareTo(invoice2.getBalance()), 0);
+
+        // Trigger another partial payment with same external keys
+        try {
+            createPaymentAndCheckForCompletion(account, invoice2, BigDecimal.TEN, account.getCurrency(), payment1.getExternalKey(), payment1.getTransactions().get(0).getExternalKey(), NextEvent.INVOICE_PAYMENT_ERROR);
+            Assert.fail("Shouldn't have been able to create a payment");
+        } catch (final PaymentApiException e) {
+            Assert.assertEquals(e.getCode(), (int) ErrorCode.PAYMENT_ACTIVE_TRANSACTION_KEY_EXISTS.getCode());
+        }
+    }
+
     @Test(groups = "slow")
     public void testPartialRefunds() throws Exception {
         // 2012-05-01T00:03:42.000Z

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -437,9 +437,6 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                 // Bulk insert the invoice items
                 createInvoiceItemsFromTransaction(transInvoiceItemSqlDao, invoiceItemsToCreate, context);
 
-
-
-
                 // CBA COMPLEXITY...
                 //
                 // Optimized path where we don't need to refresh invoices
@@ -464,11 +461,11 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                         return ImmutableList.<InvoiceItemModelDao>of();
                     } else {
                         return transInvoiceItemSqlDao.getByIds(Collections2.<InvoiceItemModelDao, String>transform(invoiceItemsToCreate, new Function<InvoiceItemModelDao, String>() {
-                                                                                                                       @Override
-                                                                                                                       public String apply(final InvoiceItemModelDao input) {
-                                                                                                                           return input.getId().toString();
-                                                                                                                       }
-                                                                                                                   }),
+                                                                   @Override
+                                                                   public String apply(final InvoiceItemModelDao input) {
+                                                                       return input.getId().toString();
+                                                                   }
+                                                               }),
                                                                context);
                     }
                 } else {
@@ -477,7 +474,6 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
             }
         });
     }
-
 
     @Override
     public List<InvoiceModelDao> getInvoicesBySubscription(final UUID subscriptionId, final InternalTenantContext context) {
@@ -944,7 +940,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                 //
                 // In case of notifyOfPaymentInit we always want to record the row with success = false
                 // Otherwise, if the payment id is null, the payment wasn't attempted (e.g. no payment method so we don't record an attempt but send
-                // an event nonetheless (e.g. for Overdue)
+                // an event nonetheless (e.g. for Overdue))
                 //
                 if (!completion || invoicePayment.getPaymentId() != null) {
                     //
@@ -963,8 +959,19 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                     if (existingAttempt == null) {
                         createAndRefresh(transactional, invoicePayment, context);
                     } else {
+                        final UUID updatedPaymentId;
+                        if (invoicePayment.getPaymentId() == null) {
+                            // Likely invalid state (https://github.com/killbill/killbill/issues/1230) but go ahead nonetheless to run the payment state machine validations
+                            updatedPaymentId = existingAttempt.getPaymentId();
+                        } else if (existingAttempt.getPaymentId() == null) {
+                            updatedPaymentId = invoicePayment.getPaymentId();
+                        } else {
+                            Preconditions.checkState(invoicePayment.getPaymentId().equals(existingAttempt.getPaymentId()),
+                                                     "PaymentAttempt cannot change paymentId: attemptId=%s, newInvoicePaymentId=%s, existingPaymentId=%s", existingAttempt.getId(), invoicePayment.getPaymentId(), existingAttempt.getPaymentId());
+                            updatedPaymentId = invoicePayment.getPaymentId();
+                        }
                         transactional.updateAttempt(existingAttempt.getId().toString(),
-                                                    invoicePayment.getPaymentId().toString(),
+                                                    updatedPaymentId == null ? null : updatedPaymentId.toString(),
                                                     invoicePayment.getPaymentDate().toDate(),
                                                     invoicePayment.getAmount(),
                                                     invoicePayment.getCurrency(),
@@ -1249,7 +1256,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                 // Invoice creation event sent on COMMITTED
                 if (InvoiceStatus.COMMITTED.equals(newStatus)) {
                     notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, invoice, context);
-                // Deactivate any usage trackingIds if necessary
+                    // Deactivate any usage trackingIds if necessary
                 } else if (InvoiceStatus.VOID.equals(newStatus)) {
                     final InvoiceTrackingSqlDao trackingSqlDao = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
                     final List<InvoiceTrackingModelDao> invoiceTrackingModelDaos = trackingSqlDao.getTrackingsForInvoices(ImmutableList.of(invoiceId.toString()), context);
@@ -1433,19 +1440,15 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                 // Keep invoice up-to-date for CBA below
                 parentInvoice.addInvoiceItem(parentCreditItem);
 
-
                 // Create Mapping relation
                 final InvoiceParentChildrenSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceParentChildrenSqlDao.class);
                 final InvoiceParentChildModelDao invoiceRelation = new InvoiceParentChildModelDao(parentInvoice.getId(), childInvoice.getId(), childInvoice.getAccountId());
                 createAndRefresh(transactional, invoiceRelation, parentAccountContext);
 
-
                 // Add child CBA complexity and notify bus on child invoice creation
                 final CBALogicWrapper childCbaWrapper = new CBALogicWrapper(childAccount.getId(), childInvoicesTags, childAccountContext, entitySqlDaoWrapperFactory);
                 childCbaWrapper.runCBALogicWithNotificationEvents(ImmutableSet.of(), ImmutableSet.of(childInvoice.getId()), ImmutableList.of(childInvoice));
                 notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, childInvoice, childAccountContext);
-
-
 
                 // Add parent CBA complexity and notify bus on child invoice creation
                 final CBALogicWrapper cbaWrapper = new CBALogicWrapper(childAccount.getParentAccountId(), parentInvoicesTags, parentAccountContext, entitySqlDaoWrapperFactory);
@@ -1456,8 +1459,6 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
             }
         });
     }
-
-
 
     @Override
     public List<InvoiceItemModelDao> getInvoiceItemsByParentInvoice(final UUID parentInvoiceId, final InternalTenantContext context) throws InvoiceApiException {
@@ -1480,7 +1481,6 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
             }
         });
     }
-
 
     @Override
     public List<AuditLogWithHistory> getInvoiceAuditLogsWithHistoryForId(final UUID invoiceId, final AuditLevel auditLevel, final InternalTenantContext context) {
@@ -1565,8 +1565,6 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         }
     }
 
-
-
     // PERF: fetch tags once. See also https://github.com/killbill/killbill/issues/720.
     private List<Tag> getInvoicesTags(final InternalTenantContext context) {
         return tagInternalApi.getTagsForAccountType(ObjectType.INVOICE, false, context);
@@ -1575,7 +1573,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     private static boolean checkAgainstExistingInvoiceItemState(final InvoiceItemModelDao existingInvoiceItem, final InvoiceItemModelDao inputInvoiceItem) {
         boolean itemShouldBeUpdated = false;
         if (inputInvoiceItem.getAmount() != null) {
-            itemShouldBeUpdated = existingInvoiceItem.getAmount() == null /* unlikely */|| inputInvoiceItem.getAmount().compareTo(existingInvoiceItem.getAmount()) != 0;
+            itemShouldBeUpdated = existingInvoiceItem.getAmount() == null /* unlikely */ || inputInvoiceItem.getAmount().compareTo(existingInvoiceItem.getAmount()) != 0;
         } else if (!itemShouldBeUpdated && inputInvoiceItem.getDescription() != null) {
             itemShouldBeUpdated = existingInvoiceItem.getDescription() == null || inputInvoiceItem.getDescription().compareTo(existingInvoiceItem.getDescription()) != 0;
         } else if (!itemShouldBeUpdated && inputInvoiceItem.getItemDetails() != null) {


### PR DESCRIPTION
In case a duplicate transaction external key was used, invoice would throw a NPE in the priorCall.

This fixes https://github.com/killbill/killbill/issues/1230.
