### PR TITLE
shiro: add mechanism to bypass authentication from plugins

### DIFF
--- a/entitlement/src/test/java/org/killbill/billing/entitlement/glue/TestEntitlementModule.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/glue/TestEntitlementModule.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014 Groupon, Inc
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -46,7 +46,7 @@ public class TestEntitlementModule extends DefaultEntitlementModule {
         install(new MockTenantModule(configSource));
 
         install(new KillBillShiroModuleOnlyIniRealm(configSource));
-        install(new KillBillShiroAopModule());
+        install(new KillBillShiroAopModule(configSource));
 
         install(new SecurityModule(configSource));
 

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -182,7 +182,7 @@ public class KillbillServerModule extends KillbillPlatformModule {
         install(new DefaultSubscriptionModule(configSource));
         install(new ExportModule(configSource));
         install(new GlobalLockerModule(configSource));
-        install(new KillBillShiroAopModule());
+        install(new KillBillShiroAopModule(configSource));
         install(new KillbillApiAopModule());
         install(new JaxRSAopModule());
         install(new KillBillShiroWebModule(servletContext, skifeConfigSource));

--- a/profiles/killpay/src/main/java/org/killbill/billing/server/modules/KillpayServerModule.java
+++ b/profiles/killpay/src/main/java/org/killbill/billing/server/modules/KillpayServerModule.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -89,7 +89,7 @@ public class KillpayServerModule extends KillbillServerModule {
         install(new DefaultAccountModule(configSource));
         install(new ExportModule(configSource));
         install(new GlobalLockerModule(configSource));
-        install(new KillBillShiroAopModule());
+        install(new KillBillShiroAopModule(configSource));
         install(new KillbillApiAopModule());
         install(new JaxRSAopModule());
         install(new KillBillShiroWebModule(servletContext, skifeConfigSource));

--- a/tenant/src/test/java/org/killbill/billing/tenant/glue/TestTenantModuleNoDB.java
+++ b/tenant/src/test/java/org/killbill/billing/tenant/glue/TestTenantModuleNoDB.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -45,7 +45,7 @@ public class TestTenantModuleNoDB extends TestTenantModule {
         install(new MockAccountModule(configSource));
 
         install(new ShiroModuleNoDB(configSource));
-        install(new KillBillShiroAopModule());
+        install(new KillBillShiroAopModule(configSource));
         install(new SecurityModule(configSource));
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/glue/KillBillShiroAopModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillBillShiroAopModule.java
@@ -1,7 +1,9 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -22,7 +24,7 @@ import java.lang.reflect.Method;
 import org.apache.shiro.aop.AnnotationMethodInterceptor;
 import org.apache.shiro.aop.AnnotationResolver;
 import org.apache.shiro.guice.aop.ShiroAopModule;
-
+import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.security.AnnotationHierarchicalResolver;
 import org.killbill.billing.util.security.AopAllianceMethodInterceptorAdapter;
 import org.killbill.billing.util.security.PermissionAnnotationHandler;
@@ -35,6 +37,12 @@ import com.google.inject.matcher.Matchers;
 public class KillBillShiroAopModule extends ShiroAopModule {
 
     private final AnnotationHierarchicalResolver resolver = new AnnotationHierarchicalResolver();
+
+    private final KillbillConfigSource killbillConfigSource;
+
+    public KillBillShiroAopModule(final KillbillConfigSource configSource) {
+        this.killbillConfigSource = configSource;
+    }
 
     @Override
     protected AnnotationResolver createAnnotationResolver() {
@@ -53,7 +61,7 @@ public class KillBillShiroAopModule extends ShiroAopModule {
         // Inject the Security API
         requestInjection(permissionAnnotationHandler);
 
-        final PermissionAnnotationMethodInterceptor methodInterceptor = new PermissionAnnotationMethodInterceptor(permissionAnnotationHandler, resolver);
+        final PermissionAnnotationMethodInterceptor methodInterceptor = new PermissionAnnotationMethodInterceptor(killbillConfigSource, permissionAnnotationHandler, resolver);
         bindShiroInterceptorWithHierarchy(methodInterceptor);
     }
 

--- a/util/src/main/java/org/killbill/billing/util/security/PermissionAnnotationHandler.java
+++ b/util/src/main/java/org/killbill/billing/util/security/PermissionAnnotationHandler.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Annotation;
 
 import javax.inject.Inject;
 
+import org.apache.shiro.aop.MethodInvocation;
 import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.aop.AuthorizingAnnotationHandler;
 
@@ -46,6 +47,7 @@ public class PermissionAnnotationHandler extends AuthorizingAnnotationHandler {
         super(RequiresPermissions.class);
     }
 
+    @Override
     public void assertAuthorized(final Annotation annotation) throws AuthorizationException {
         if (!(annotation instanceof RequiresPermissions)) {
             return;

--- a/util/src/main/java/org/killbill/billing/util/security/PermissionAnnotationMethodInterceptor.java
+++ b/util/src/main/java/org/killbill/billing/util/security/PermissionAnnotationMethodInterceptor.java
@@ -1,7 +1,9 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -17,12 +19,67 @@
 package org.killbill.billing.util.security;
 
 import org.apache.shiro.aop.AnnotationResolver;
+import org.apache.shiro.aop.MethodInvocation;
+import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.aop.AuthorizingAnnotationHandler;
 import org.apache.shiro.authz.aop.AuthorizingAnnotationMethodInterceptor;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.CallOrigin;
+import org.killbill.billing.util.callcontext.UserType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PermissionAnnotationMethodInterceptor extends AuthorizingAnnotationMethodInterceptor {
 
-    public PermissionAnnotationMethodInterceptor(final AuthorizingAnnotationHandler handler, final AnnotationResolver resolver) {
+    private static final String SKIP_AUTH_FOR_PLUGINS = "org.killbill.security.skipAuthForPlugins";
+    private static final Logger logger = LoggerFactory.getLogger(PermissionAnnotationMethodInterceptor.class);
+
+    private final KillbillConfigSource killbillConfigSource;
+
+    public PermissionAnnotationMethodInterceptor(final KillbillConfigSource killbillConfigSource,
+                                                 final AuthorizingAnnotationHandler handler,
+                                                 final AnnotationResolver resolver) {
         super(handler, resolver);
+        this.killbillConfigSource = killbillConfigSource;
+    }
+
+    @Override
+    public void assertAuthorized(final MethodInvocation mi) throws AuthorizationException {
+        if (shouldSkipAuthForPlugins(mi)) {
+            return;
+        }
+
+        try {
+            ((AuthorizingAnnotationHandler) getHandler()).assertAuthorized(getAnnotation(mi));
+        } catch (final AuthorizationException ae) {
+            // Annotation handler doesn't know why it was called, so add the information here if possible.
+            // Don't wrap the exception here since we don't want to mask the specific exception, such as
+            // UnauthenticatedException etc.
+            if (ae.getCause() == null) {
+                ae.initCause(new AuthorizationException("Not authorized to invoke method: " + mi.getMethod()));
+            }
+            throw ae;
+        }
+    }
+
+    private boolean shouldSkipAuthForPlugins(final MethodInvocation mi) {
+        if (!Boolean.parseBoolean(killbillConfigSource.getString(SKIP_AUTH_FOR_PLUGINS))) {
+            return false;
+        }
+
+        final Object[] arguments = mi.getArguments();
+        // Should be the last one
+        for (int i = arguments.length - 1; i >= 0; i--) {
+            final Object argument = arguments[i];
+            if (argument instanceof CallContext) {
+                final CallContext callContext = (CallContext) argument;
+                if (callContext.getCallOrigin() == CallOrigin.INTERNAL && callContext.getUserType() == UserType.ADMIN) {
+                    logger.debug("Skipping authorization check for userName={}, userToken={}", callContext.getUserName(), callContext.getUserToken());
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/util/src/test/java/org/killbill/billing/util/glue/TestUtilModuleNoDB.java
+++ b/util/src/test/java/org/killbill/billing/util/glue/TestUtilModuleNoDB.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -53,7 +53,7 @@ public class TestUtilModuleNoDB extends TestUtilModule {
         installAuditMock();
 
         install(new ShiroModuleNoDB(configSource));
-        install(new KillBillShiroAopModule());
+        install(new KillBillShiroAopModule(configSource));
         install(new SecurityModule(configSource));
     }
 

--- a/util/src/test/java/org/killbill/billing/util/security/TestPermissionAnnotationMethodInterceptor.java
+++ b/util/src/test/java/org/killbill/billing/util/security/TestPermissionAnnotationMethodInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -80,7 +80,7 @@ public class TestPermissionAnnotationMethodInterceptor extends UtilTestSuiteNoDB
 
         final Injector injector = Guice.createInjector(Stage.PRODUCTION,
                                                        new ShiroModuleNoDB(configSource),
-                                                       new KillBillShiroAopModule(),
+                                                       new KillBillShiroAopModule(configSource),
                                                        new TestSecurityModuleNoDB(configSource),
                                                        new CacheModule(configSource),
                                                        new AbstractModule() {
@@ -111,7 +111,7 @@ public class TestPermissionAnnotationMethodInterceptor extends UtilTestSuiteNoDB
 
         final Injector injector = Guice.createInjector(Stage.PRODUCTION,
                                                        new ShiroModuleNoDB(configSource),
-                                                       new KillBillShiroAopModule(),
+                                                       new KillBillShiroAopModule(configSource),
                                                        new TestSecurityModuleNoDB(configSource),
                                                        new CacheModule(configSource),
                                                        new AbstractModule() {


### PR DESCRIPTION
When `org.killbill.security.skipAuthForPlugins=true`, plugins calling Kill Bill APIs with a context where `CallOrigin.INTERNAL` and `UserType.ADMIN` will not need to be authenticated.
