### PR TITLE
jaxrs: fix NPE in getPaymentsForInvoice

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/JaxRsResourceBase.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/JaxRsResourceBase.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -553,7 +552,35 @@ public abstract class JaxRsResourceBase implements JaxrsResource {
         return properties;
     }
 
-    protected InvoicePayment createPurchaseForInvoice(final Account account, final UUID invoiceId, final BigDecimal amountToPay, final UUID paymentMethodId, final Boolean externalPayment, final String paymentExternalKey, final String transactionExternalKey, final Iterable<PluginProperty> pluginProperties, final CallContext callContext) throws PaymentApiException {
+    protected InvoicePayment createPurchaseForInvoice(final Account account,
+                                                      final UUID invoiceId,
+                                                      final BigDecimal amountToPay,
+                                                      final UUID paymentMethodId,
+                                                      final Boolean externalPayment,
+                                                      final String paymentExternalKey,
+                                                      final String transactionExternalKey,
+                                                      final Iterable<PluginProperty> pluginProperties,
+                                                      final CallContext callContext) throws PaymentApiException {
+        return createPurchaseForInvoice(account,
+                                        invoiceId,
+                                        amountToPay,
+                                        paymentMethodId,
+                                        paymentExternalKey,
+                                        transactionExternalKey,
+                                        pluginProperties,
+                                        createInvoicePaymentControlPluginApiPaymentOptions(externalPayment),
+                                        callContext);
+    }
+
+    protected InvoicePayment createPurchaseForInvoice(final Account account,
+                                                      final UUID invoiceId,
+                                                      final BigDecimal amountToPay,
+                                                      final UUID paymentMethodId,
+                                                      final String paymentExternalKey,
+                                                      final String transactionExternalKey,
+                                                      final Iterable<PluginProperty> pluginProperties,
+                                                      final PaymentOptions paymentOptions,
+                                                      final CallContext callContext) throws PaymentApiException {
         try {
             return invoicePaymentApi.createPurchaseForInvoicePayment(account,
                                                                      invoiceId,
@@ -564,7 +591,7 @@ public abstract class JaxRsResourceBase implements JaxrsResource {
                                                                      paymentExternalKey,
                                                                      transactionExternalKey,
                                                                      pluginProperties,
-                                                                     createInvoicePaymentControlPluginApiPaymentOptions(externalPayment),
+                                                                     paymentOptions,
                                                                      callContext);
         } catch (final PaymentApiException e) {
             if (e.getCode() == ErrorCode.PAYMENT_PLUGIN_EXCEPTION.getCode() /* &&


### PR DESCRIPTION
Handle the case of invoice payments with a NULL payment id (i.e. when the payment is aborted by a payment control plugin). These won't be returned by the API.

For testing, I had to add a new (undocumented) query parameter to the createInstantPayment API, in order to add an additional payment control plugin to the chain.

This fixes https://github.com/killbill/killbill/issues/1288.
