### PR TITLE
Add support for Redis password connections

### DIFF
--- a/util/src/main/java/org/killbill/billing/util/config/definition/RedisCacheConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/RedisCacheConfig.java
@@ -19,6 +19,7 @@ package org.killbill.billing.util.config.definition;
 
 import org.skife.config.Config;
 import org.skife.config.Default;
+import org.skife.config.DefaultNull;
 import org.skife.config.Description;
 
 public interface RedisCacheConfig extends KillbillConfig {
@@ -37,4 +38,9 @@ public interface RedisCacheConfig extends KillbillConfig {
     @Default("1")
     @Description("Minimum number of connections")
     public int getConnectionMinimumIdleSize();
+
+    @Config("org.killbill.cache.config.redis.password")
+    @DefaultNull
+    @Description("Redis Password")
+    public String getPassword();
 }

--- a/util/src/main/java/org/killbill/billing/util/glue/RedissonCacheClientProvider.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/RedissonCacheClientProvider.java
@@ -33,16 +33,18 @@ public class RedissonCacheClientProvider implements Provider<RedissonClient> {
 
     private final String address;
     private final int connectionMinimumIdleSize;
+    private final String password;
 
     @Inject
     public RedissonCacheClientProvider(final RedisCacheConfig cacheConfig) {
-        this(cacheConfig.getUrl(), cacheConfig.getConnectionMinimumIdleSize());
+        this(cacheConfig.getUrl(), cacheConfig.getConnectionMinimumIdleSize(), cacheConfig.getPassword());
     }
 
     @VisibleForTesting
-    public RedissonCacheClientProvider(final String address, final int connectionMinimumIdleSize) {
+    public RedissonCacheClientProvider(final String address, final int connectionMinimumIdleSize, final String password) {
         this.address = address;
         this.connectionMinimumIdleSize = connectionMinimumIdleSize;
+        this.password = password;
     }
 
     @Override
@@ -54,6 +56,7 @@ public class RedissonCacheClientProvider implements Provider<RedissonClient> {
         redissonCfg.setCodec(codec)
                    .useSingleServer()
                    .setAddress(address)
+                   .setPassword(password)
                    .setConnectionMinimumIdleSize(connectionMinimumIdleSize);
         return Redisson.create(redissonCfg);
     }

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestSuite.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestSuite.java
@@ -223,7 +223,7 @@ public class GuicyKillbillTestSuite implements IHookable {
             redisServer = new RedisServer(56379);
             redisServer.start();
 
-            redissonClient = new RedissonCacheClientProvider("redis://127.0.0.1:56379", 1).get();
+            redissonClient = new RedissonCacheClientProvider("redis://127.0.0.1:56379", 1, null).get();
 
             theRealClock = new DistributedClockMock();
             ((DistributedClockMock) theRealClock).setRedissonClient(redissonClient);


### PR DESCRIPTION
Our Redis deployment supports password connections only. Kindly your consideration on adding this feature. 