### PR TITLE
Fix for plan changes that eventually specify an effectiveDateForExistingSubscriptions value

### DIFF
--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -624,7 +624,7 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
                         // Iterate through all more recent version of the catalog to find possible effectiveDateForExistingSubscriptions transition for this Plan
                         Plan nextPlan = catalog.getNextPlanVersion(currentPlan);
                         while (nextPlan != null ) {
-                            if ( nextPlan.getEffectiveDateForExistingSubscriptions() != null) {
+                            if (nextPlan.getEffectiveDateForExistingSubscriptions() != null) {
                                 final DateTime nextEffectiveDate = new DateTime(nextPlan.getEffectiveDateForExistingSubscriptions()).toDateTime(DateTimeZone.UTC);
                                 final PlanPhase nextPlanPhase = nextPlan.findPhase(planPhase.getName());
 

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -623,15 +623,17 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
 
                         // Iterate through all more recent version of the catalog to find possible effectiveDateForExistingSubscriptions transition for this Plan
                         Plan nextPlan = catalog.getNextPlanVersion(currentPlan);
-                        while (nextPlan != null && nextPlan.getEffectiveDateForExistingSubscriptions() != null) {
-                            final DateTime nextEffectiveDate = new DateTime(nextPlan.getEffectiveDateForExistingSubscriptions()).toDateTime(DateTimeZone.UTC);
-                            final PlanPhase nextPlanPhase = nextPlan.findPhase(planPhase.getName());
+                        while (nextPlan != null ) {
+                            if ( nextPlan.getEffectiveDateForExistingSubscriptions() != null) {
+                                final DateTime nextEffectiveDate = new DateTime(nextPlan.getEffectiveDateForExistingSubscriptions()).toDateTime(DateTimeZone.UTC);
+                                final PlanPhase nextPlanPhase = nextPlan.findPhase(planPhase.getName());
 
-                            // Computed from the nextPlan
-                            final DateTime catalogEffectiveDateForNextPlan = CatalogDateHelper.toUTCDateTime(nextPlan.getCatalog().getEffectiveDate());
-                            final SubscriptionBillingEvent newBillingTransition = new DefaultSubscriptionBillingEvent(SubscriptionBaseTransitionType.CHANGE, nextPlan, nextPlanPhase, nextEffectiveDate,
+                                // Computed from the nextPlan
+                                final DateTime catalogEffectiveDateForNextPlan = CatalogDateHelper.toUTCDateTime(nextPlan.getCatalog().getEffectiveDate());
+                                final SubscriptionBillingEvent newBillingTransition = new DefaultSubscriptionBillingEvent(SubscriptionBaseTransitionType.CHANGE, nextPlan, nextPlanPhase, nextEffectiveDate,
                                                                                                                       cur.getTotalOrdering(), cur.getNextBillingCycleDayLocal(), catalogEffectiveDateForNextPlan);
-                            candidatesCatalogChangeEvents.add(newBillingTransition);
+                                candidatesCatalogChangeEvents.add(newBillingTransition);
+                        	}
                             nextPlan = catalog.getNextPlanVersion(nextPlan);
                         }
                     }


### PR DESCRIPTION
This fix is to address the situation I find myself in, where I have many existing subscriptions and existing catalog versions, but only the most recent catalog version specifies an `effectiveDateForExistingSubscriptions` value. My expectation was that this would cause the plan to be applied to existing subscriptions starting on that date, but it was not. Upon investigation, I found a loop that stopped looking at catalog versions if no `effectiveDateForExistingSubscriptions` was specified. Thus it stopped looking too soon and never found the catalog version that _did_ have that date specified. After applying this fix, my invoices started picking up the most recent catalog prices, as expected.