### PR TITLE
usage: ensure TenantContext#getAccountId is always populated

### DIFF
--- a/usage/src/main/java/org/killbill/billing/usage/api/BaseUserApi.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/BaseUserApi.java
@@ -30,6 +30,8 @@ import org.killbill.billing.util.callcontext.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
+
 public class BaseUserApi {
 
     private static final Logger logger = LoggerFactory.getLogger(BaseUserApi.class);
@@ -54,6 +56,7 @@ public class BaseUserApi {
     }
 
     private List<RawUsageRecord> getUsageFromPlugin(@Nullable final UUID subscriptionId, final LocalDate startDate, final LocalDate endDate, final TenantContext tenantContext) {
+        Preconditions.checkNotNull(tenantContext.getAccountId(), "TenantContext has no accountId");
 
         final Set<String> allServices = pluginRegistry.getAllServices();
         // No plugin registered

--- a/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultUsageUserApi.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultUsageUserApi.java
@@ -89,8 +89,9 @@ public class DefaultUsageUserApi extends BaseUserApi implements UsageUserApi {
     }
 
     @Override
-    public RolledUpUsage getUsageForSubscription(final UUID subscriptionId, final String unitType, final LocalDate startDate, final LocalDate endDate, final TenantContext tenantContext) {
-
+    public RolledUpUsage getUsageForSubscription(final UUID subscriptionId, final String unitType, final LocalDate startDate, final LocalDate endDate, final TenantContext tenantContextNoAccountId) {
+        final InternalTenantContext internalCallContext = internalCallContextFactory.createInternalTenantContext(subscriptionId, ObjectType.SUBSCRIPTION, tenantContextNoAccountId);
+        final TenantContext tenantContext = internalCallContextFactory.createTenantContext(internalCallContext);
         final List<RawUsageRecord> rawUsage = getSubscriptionUsageFromPlugin(subscriptionId, startDate, endDate, tenantContext);
         if (rawUsage != null) {
             final List<RolledUpUnit> rolledUpAmount = getRolledUpUnitsForRawPluginUsage(subscriptionId, unitType, rawUsage);
@@ -103,9 +104,9 @@ public class DefaultUsageUserApi extends BaseUserApi implements UsageUserApi {
     }
 
     @Override
-    public List<RolledUpUsage> getAllUsageForSubscription(final UUID subscriptionId, final List<LocalDate> transitionTimes, final TenantContext tenantContext) {
-
-        final InternalTenantContext internalCallContext = internalCallContextFactory.createInternalTenantContext(subscriptionId, ObjectType.SUBSCRIPTION, tenantContext);
+    public List<RolledUpUsage> getAllUsageForSubscription(final UUID subscriptionId, final List<LocalDate> transitionTimes, final TenantContext tenantContextNoAccountId) {
+        final InternalTenantContext internalCallContext = internalCallContextFactory.createInternalTenantContext(subscriptionId, ObjectType.SUBSCRIPTION, tenantContextNoAccountId);
+        final TenantContext tenantContext = internalCallContextFactory.createTenantContext(internalCallContext);
         List<RolledUpUsage> result = new ArrayList<RolledUpUsage>();
         LocalDate prevDate = null;
         for (LocalDate curDate : transitionTimes) {


### PR DESCRIPTION
This is useful for usage plugins for instance.