### PR TITLE
util: change default catalog

### DIFF
--- a/util/src/main/java/org/killbill/billing/util/config/definition/CatalogConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/CatalogConfig.java
@@ -24,7 +24,7 @@ import org.skife.config.Description;
 public interface CatalogConfig extends KillbillConfig {
 
     @Config("org.killbill.catalog.uri")
-    @Default("SpyCarBasic.xml")
+    @Default("SpyCarAdvanced.xml")
     @Description("Default Catalog location, either in the classpath or in the filesystem. For multi-tenancy, one should use APIs to load per-tenant catalog")
     String getCatalogURI();
 }


### PR DESCRIPTION
We had several `SpyCarBasic.xml`, so I removed the one in the killbill profile in 0.22.12 (we now only ship `SpyCarAdvanced.xml` without a namespace). The config wasn't changed before the release unfortunately. 

For now, I've updated the docs: https://github.com/killbill/killbill-docs/commit/1ed21a18c6493234a5719781f32d993c60adfd1c