### PR TITLE
Catalog performance

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -126,6 +126,10 @@
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-concurrent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-embeddeddb-h2</artifactId>
             <scope>test</scope>
         </dependency>

--- a/catalog/src/main/java/org/killbill/billing/catalog/CatalogSafetyInitializer.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/CatalogSafetyInitializer.java
@@ -34,7 +34,7 @@ public class CatalogSafetyInitializer {
 
 
     public static final Integer DEFAULT_NON_REQUIRED_INTEGER_FIELD_VALUE = -1;
-    public static final Double DEFAULT_NON_REQUIRED_DOUBLE_FIELD_VALUE = new Double(-1);
+    public static final Double DEFAULT_NON_REQUIRED_DOUBLE_FIELD_VALUE = (double) -1;
 
     private static final Map<Class, LinkedList<Field>> perCatalogClassNonRequiredFields = new HashMap<Class, LinkedList<Field>>();
 

--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultBlock.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultBlock.java
@@ -52,7 +52,7 @@ public class DefaultBlock extends ValidatingConfig<StandaloneCatalog> implements
     private DefaultUnit unit;
 
     @XmlElement(required = true)
-    private Double size;
+    private double size;
 
     @XmlElement(required = true)
     private DefaultInternationalPrice prices;
@@ -108,7 +108,7 @@ public class DefaultBlock extends ValidatingConfig<StandaloneCatalog> implements
     public DefaultBlock() {
     }
 
-    public DefaultBlock(final DefaultUnit unit, final Double size, final DefaultInternationalPrice prices, final BigDecimal overriddenPrice, Currency currency) {
+    public DefaultBlock(final DefaultUnit unit, final double size, final DefaultInternationalPrice prices, final BigDecimal overriddenPrice, Currency currency) {
         this.unit = unit;
         this.size = size;
         this.prices = prices != null ? new DefaultInternationalPrice(prices, overriddenPrice, currency) : null;
@@ -135,7 +135,7 @@ public class DefaultBlock extends ValidatingConfig<StandaloneCatalog> implements
         return this;
     }
 
-    public DefaultBlock setSize(final Double size) {
+    public DefaultBlock setSize(final double size) {
         this.size = size;
         return this;
     }
@@ -155,22 +155,13 @@ public class DefaultBlock extends ValidatingConfig<StandaloneCatalog> implements
         if (this == o) {
             return true;
         }
-        if (!(o instanceof DefaultBlock)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
         final DefaultBlock that = (DefaultBlock) o;
 
-        if (minTopUpCredit != null ? !minTopUpCredit.equals(that.minTopUpCredit) : that.minTopUpCredit != null) {
-            return false;
-        }
-        if (phase != null ? !phase.equals(that.phase) : that.phase != null) {
-            return false;
-        }
-        if (prices != null ? !prices.equals(that.prices) : that.prices != null) {
-            return false;
-        }
-        if (size != null ? !size.equals(that.size) : that.size != null) {
+        if (Double.compare(that.size, size) != 0) {
             return false;
         }
         if (type != that.type) {
@@ -179,17 +170,26 @@ public class DefaultBlock extends ValidatingConfig<StandaloneCatalog> implements
         if (unit != null ? !unit.equals(that.unit) : that.unit != null) {
             return false;
         }
-
-        return true;
+        if (prices != null ? !prices.equals(that.prices) : that.prices != null) {
+            return false;
+        }
+        if (minTopUpCredit != null ? !minTopUpCredit.equals(that.minTopUpCredit) : that.minTopUpCredit != null) {
+            return false;
+        }
+        return phase != null ? phase.equals(that.phase) : that.phase == null;
     }
 
     @Override
     public int hashCode() {
-        int result = type != null ? type.hashCode() : 0;
+        int result;
+        final long temp;
+        result = type != null ? type.hashCode() : 0;
         result = 31 * result + (unit != null ? unit.hashCode() : 0);
-        result = 31 * result + (size != null ? size.hashCode() : 0);
+        temp = Double.doubleToLongBits(size);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
         result = 31 * result + (prices != null ? prices.hashCode() : 0);
         result = 31 * result + (minTopUpCredit != null ? minTopUpCredit.hashCode() : 0);
+        result = 31 * result + (phase != null ? phase.hashCode() : 0);
         return result;
     }
 
@@ -200,10 +200,7 @@ public class DefaultBlock extends ValidatingConfig<StandaloneCatalog> implements
             out.writeUTF(type.name());
         }
         out.writeObject(unit);
-        out.writeBoolean(size != null);
-        if (size != null) {
-            out.writeDouble(size);
-        }
+        out.writeDouble(size);
         out.writeObject(prices);
         out.writeBoolean(minTopUpCredit != null);
         if (minTopUpCredit != null) {
@@ -215,7 +212,7 @@ public class DefaultBlock extends ValidatingConfig<StandaloneCatalog> implements
     public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
         this.type = in.readBoolean() ? BlockType.valueOf(in.readUTF()) : null;
         this.unit = (DefaultUnit) in.readObject();
-        this.size = in.readBoolean() ? in.readDouble() : null;
+        this.size = in.readDouble();
         this.prices = (DefaultInternationalPrice) in.readObject();
         this.minTopUpCredit = in.readBoolean() ? in.readDouble() : null;
     }

--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultPrice.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultPrice.java
@@ -40,6 +40,7 @@ import org.killbill.xmlloader.ValidationErrors;
 public class DefaultPrice extends ValidatingConfig<StandaloneCatalog> implements Price, Externalizable {
 
     private static final Map<String, BigDecimal> frequentValues = new ConcurrentHashMap<String, BigDecimal>();
+    private static final int FREQUENT_VALUES_CACHE_SIZE = Integer.parseInt(System.getProperty("org.killbill.catalog.frequentValuesCacheSize", "1000"));
 
     @XmlElement(required = true)
     private Currency currency;
@@ -76,9 +77,14 @@ public class DefaultPrice extends ValidatingConfig<StandaloneCatalog> implements
     }
 
     public DefaultPrice setValue(final BigDecimal value) {
+        if (value == null) {
+            this.value = value;
+            return this;
+        }
+
         final String valueAsString = value.toString();
 
-        if (!frequentValues.containsKey(valueAsString) && frequentValues.size() < 1000) {
+        if (!frequentValues.containsKey(valueAsString) && frequentValues.size() < FREQUENT_VALUES_CACHE_SIZE) {
             frequentValues.put(valueAsString, value);
         }
 

--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultTieredBlock.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultTieredBlock.java
@@ -35,14 +35,14 @@ import org.killbill.billing.catalog.api.TieredBlockPriceOverride;
 public class DefaultTieredBlock extends DefaultBlock implements TieredBlock, Externalizable {
 
     @XmlElement(required = true)
-    private Double max;
+    private double max;
 
     @Override
     public Double getMax() {
         return max;
     }
 
-    public DefaultTieredBlock setMax(final Double max) {
+    public DefaultTieredBlock setMax(final double max) {
         this.max = max;
         return this;
     }
@@ -72,7 +72,7 @@ public class DefaultTieredBlock extends DefaultBlock implements TieredBlock, Ext
         if (this == o) {
             return true;
         }
-        if (!(o instanceof DefaultTieredBlock)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
         if (!super.equals(o)) {
@@ -81,17 +81,15 @@ public class DefaultTieredBlock extends DefaultBlock implements TieredBlock, Ext
 
         final DefaultTieredBlock that = (DefaultTieredBlock) o;
 
-        if (max != null ? !max.equals(that.max) : that.max != null) {
-            return false;
-        }
-
-        return true;
+        return Double.compare(that.max, max) == 0;
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (max != null ? max.hashCode() : 0);
+        final long temp;
+        temp = Double.doubleToLongBits(max);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
         return result;
     }
 

--- a/catalog/src/main/java/org/killbill/billing/catalog/io/VersionedCatalogLoader.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/io/VersionedCatalogLoader.java
@@ -19,53 +19,59 @@
 package org.killbill.billing.catalog.io;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
+import java.io.Closeable;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
 
 import javax.xml.bind.JAXBException;
-import javax.xml.transform.TransformerException;
 
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.catalog.DefaultVersionedCatalog;
 import org.killbill.billing.catalog.StandaloneCatalog;
 import org.killbill.billing.catalog.StandaloneCatalogWithPriceOverride;
 import org.killbill.billing.catalog.api.CatalogApiException;
-import org.killbill.billing.catalog.api.InvalidConfigException;
 import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.catalog.override.PriceOverride;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
-import org.killbill.clock.Clock;
+import org.killbill.billing.util.config.definition.CatalogConfig;
+import org.killbill.commons.concurrent.Executors;
 import org.killbill.xmlloader.UriAccessor;
 import org.killbill.xmlloader.ValidationError;
 import org.killbill.xmlloader.ValidationException;
 import org.killbill.xmlloader.XMLLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.io.Resources;
 import com.google.inject.Inject;
 
-public class VersionedCatalogLoader implements CatalogLoader {
+public class VersionedCatalogLoader implements CatalogLoader, Closeable {
 
     private static final Logger logger = LoggerFactory.getLogger(VersionedCatalogLoader.class);
 
     private static final Object PROTOCOL_FOR_FILE = "file";
     private static final String XML_EXTENSION = ".xml";
 
-    private final Clock clock;
     private final PriceOverride priceOverride;
+    private final ExecutorService executorService;
     private final InternalCallContextFactory internalCallContextFactory;
 
     @Inject
-    public VersionedCatalogLoader(final Clock clock, final PriceOverride priceOverride, final InternalCallContextFactory internalCallContextFactory) {
-        this.clock = clock;
+    public VersionedCatalogLoader(final CatalogConfig config,
+                                  final PriceOverride priceOverride,
+                                  final InternalCallContextFactory internalCallContextFactory) {
+        this.executorService = Executors.newFixedThreadPool(MoreObjects.firstNonNull(config.getCatalogThreadNb(), 1), VersionedCatalogLoader.class.getName());
         this.priceOverride = priceOverride;
         this.internalCallContextFactory = internalCallContextFactory;
     }
@@ -116,36 +122,41 @@ public class VersionedCatalogLoader implements CatalogLoader {
         return Resources.getResource(urlString);
     }
 
-    public VersionedCatalog load(final Iterable<String> catalogXMLs, final boolean filterTemplateCatalog, final Long tenantRecordId) throws CatalogApiException {
+    public VersionedCatalog load(final Collection<String> catalogXMLs, final boolean filterTemplateCatalog, final Long tenantRecordId) throws CatalogApiException {
         try {
-            final DefaultVersionedCatalog result = new DefaultVersionedCatalog();
+            final BlockingQueue<StandaloneCatalog> catalogs = new LinkedBlockingDeque<StandaloneCatalog>(catalogXMLs.size());
             for (final String cur : catalogXMLs) {
-                final InputStream curCatalogStream = new ByteArrayInputStream(cur.getBytes());
-                final StandaloneCatalog catalog = XMLLoader.getObjectFromStream(curCatalogStream, StandaloneCatalog.class);
-                if (!filterTemplateCatalog || !catalog.isTemplateCatalog()) {
-                    result.add(new StandaloneCatalogWithPriceOverride(catalog, priceOverride, tenantRecordId, internalCallContextFactory));
-                }
+                executorService.submit(new Callable<StandaloneCatalog>() {
+
+                    @Override
+                    public StandaloneCatalog call() throws Exception {
+                        final InputStream curCatalogStream = new ByteArrayInputStream(cur.getBytes());
+                        final StandaloneCatalog catalog = XMLLoader.getObjectFromStream(curCatalogStream, StandaloneCatalog.class);
+                        if (!filterTemplateCatalog || !catalog.isTemplateCatalog()) {
+                            catalogs.add(new StandaloneCatalogWithPriceOverride(catalog, priceOverride, tenantRecordId, internalCallContextFactory));
+                        }
+                        return null;
+                    }
+                });
             }
+
+            final DefaultVersionedCatalog result = new DefaultVersionedCatalog();
+            for (int i = 0; i < catalogXMLs.size(); i++) {
+                final StandaloneCatalog catalog = catalogs.take();
+                result.add(catalog);
+            }
+
             XMLLoader.initializeAndValidate(result);
             return result;
         } catch (final ValidationException e) {
             logger.warn("Failed to load catalog for tenantRecordId='{}'", tenantRecordId, e);
-            for (ValidationError ve : e.getErrors()) {
+            for (final ValidationError ve : e.getErrors()) {
                 logger.warn(ve.toString());
             }
             throw new CatalogApiException(e, ErrorCode.CAT_INVALID_FOR_TENANT, tenantRecordId);
-        } catch (final JAXBException e) {
+        } catch (final InterruptedException e) {
             logger.warn("Failed to load catalog for tenantRecordId='{}'", tenantRecordId, e);
             throw new CatalogApiException(e, ErrorCode.CAT_INVALID_FOR_TENANT, tenantRecordId);
-        } catch (final IOException e) {
-            logger.warn("Failed to load catalog for tenantRecordId='{}'", tenantRecordId, e);
-            throw new IllegalStateException(e);
-        } catch (final TransformerException e) {
-            logger.warn("Failed to load catalog for tenantRecordId='{}'", tenantRecordId, e);
-            throw new IllegalStateException(e);
-        } catch (final SAXException e) {
-            logger.warn("Failed to load catalog for tenantRecordId='{}'", tenantRecordId, e);
-            throw new IllegalStateException(e);
         }
     }
 
@@ -225,5 +236,10 @@ public class VersionedCatalogLoader implements CatalogLoader {
             f = "/" + filename;
         }
         return new URI(url.toString() + f);
+    }
+
+    @Override
+    public void close() {
+        executorService.shutdown();
     }
 }

--- a/catalog/src/test/java/org/killbill/billing/catalog/MockCatalogService.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/MockCatalogService.java
@@ -20,14 +20,15 @@ package org.killbill.billing.catalog;
 
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.VersionedCatalog;
-import org.killbill.billing.util.cache.CacheControllerDispatcher;
+import org.killbill.billing.catalog.io.VersionedCatalogLoader;
+import org.mockito.Mockito;
 
 public class MockCatalogService extends DefaultCatalogService {
 
     private final VersionedCatalog catalog;
 
-    public MockCatalogService(final VersionedCatalog catalog, final CacheControllerDispatcher cacheControllerDispatcher) {
-        super(null, null, null, null);
+    public MockCatalogService(final VersionedCatalog catalog) {
+        super(null, null, null, null, Mockito.mock(VersionedCatalogLoader.class));
         this.catalog = catalog;
     }
 

--- a/catalog/src/test/java/org/killbill/billing/catalog/TestCatalogService.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/TestCatalogService.java
@@ -34,7 +34,11 @@ public class TestCatalogService extends CatalogTestSuiteNoDB {
                 return "org/killbill/billing/catalog/versionedCatalog";
             }
 
-        }, tenantInternalApi, catalogCache, cacheInvalidationCallback);
+            @Override
+            public Integer getCatalogThreadNb() {
+                return null;
+            }
+        }, tenantInternalApi, catalogCache, cacheInvalidationCallback, null);
         service.loadCatalog();
         Assert.assertNotNull(service.getFullCatalog(true, true, internalCallContext));
         Assert.assertEquals(service.getFullCatalog(true, true, internalCallContext).getCatalogName(), "WeaponsHireSmall");
@@ -48,7 +52,11 @@ public class TestCatalogService extends CatalogTestSuiteNoDB {
                 return "org/killbill/billing/catalog/WeaponsHire.xml";
             }
 
-        },  tenantInternalApi, catalogCache, cacheInvalidationCallback);
+            @Override
+            public Integer getCatalogThreadNb() {
+                return null;
+            }
+        }, tenantInternalApi, catalogCache, cacheInvalidationCallback, null);
         service.loadCatalog();
         Assert.assertNotNull(service.getFullCatalog(true, true, internalCallContext));
         Assert.assertEquals(service.getFullCatalog(true, true, internalCallContext).getCatalogName(), "Firearms");

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/transfer/TestDefaultSubscriptionTransferApi.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/transfer/TestDefaultSubscriptionTransferApi.java
@@ -67,7 +67,7 @@ public class TestDefaultSubscriptionTransferApi extends SubscriptionTestSuiteNoD
         final DefaultVersionedCatalog versionedCatalog = new DefaultVersionedCatalog();
         final MockCatalog mockCatalog = new MockCatalog();
         versionedCatalog.add(mockCatalog);
-        final CatalogService catalogService = new MockCatalogService(versionedCatalog, cacheControllerDispatcher);
+        final CatalogService catalogService = new MockCatalogService(versionedCatalog);
         final CatalogInternalApi catalogInternalApiWithMockCatalogService = new DefaultCatalogInternalApi(catalogService);
         final SubscriptionCatalogApi subscriptionCatalogInternalApiWithMockCatalogService = new DefaultSubscriptionCatalogApi(catalogInternalApiWithMockCatalogService, clock);
         final SubscriptionBaseApiService apiService = Mockito.mock(SubscriptionBaseApiService.class);

--- a/util/src/main/java/org/killbill/billing/util/cache/KillBillCacheController.java
+++ b/util/src/main/java/org/killbill/billing/util/cache/KillBillCacheController.java
@@ -72,7 +72,13 @@ public class KillBillCacheController<K, V> implements CacheController<K, V> {
         V value;
         try {
             if (!isKeyInCache(key)) {
-                value = computeAndCacheValue(key, cacheLoaderArgument);
+                synchronized (this) {
+                    if (!isKeyInCache(key)) {
+                        value = computeAndCacheValue(key, cacheLoaderArgument);
+                    } else {
+                        value = cache.get(key);
+                    }
+                }
             } else {
                 value = cache.get(key);
             }
@@ -135,8 +141,7 @@ public class KillBillCacheController<K, V> implements CacheController<K, V> {
             return null;
         }
 
-        // Race condition, we may compute it for nothing
-        putIfAbsent(key, value);
+        cache.put(key, value);
 
         return value;
     }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/CatalogConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/CatalogConfig.java
@@ -27,4 +27,9 @@ public interface CatalogConfig extends KillbillConfig {
     @Default("SpyCarAdvanced.xml")
     @Description("Default Catalog location, either in the classpath or in the filesystem. For multi-tenancy, one should use APIs to load per-tenant catalog")
     String getCatalogURI();
+
+    @Config("org.killbill.catalog.loader.threads.pool.nb")
+    @Default("1")
+    @Description("Number of threads for the XML loader")
+    Integer getCatalogThreadNb();
 }


### PR DESCRIPTION
This PR focuses on several performance aspects:

1. Slowness of loading a large number of catalogs: one can now specify `org.killbill.catalog.loader.threads.pool.nb`to load catalogs in parallel
2. Memory usage:
   * Ensure a single thread loads the catalog (synchronization)
   * Reduce the amount of `Double` and `BigDecimal` objects created

Testing was done on my laptop with 74 catalogs (~800 MB). Load time was cut from 28s to 18s (with 5 threads).