### PR TITLE
Index on users.username should be unique

### DIFF
--- a/util/src/main/resources/org/killbill/billing/util/ddl.sql
+++ b/util/src/main/resources/org/killbill/billing/util/ddl.sql
@@ -265,7 +265,7 @@ CREATE TABLE users (
     updated_by varchar(50) DEFAULT NULL,
     PRIMARY KEY(record_id)
 ) /*! CHARACTER SET utf8 COLLATE utf8_bin */;
-CREATE INDEX users_username ON users(username);
+CREATE UNIQUE INDEX users_username ON users(username);
 
 
 DROP TABLE IF EXISTS user_roles;

--- a/util/src/main/resources/org/killbill/billing/util/migration/V20200916171757__recreate_users_index_as_unique.sql
+++ b/util/src/main/resources/org/killbill/billing/util/migration/V20200916171757__recreate_users_index_as_unique.sql
@@ -1,0 +1,2 @@
+drop index users_username on users;
+create unique index users_username ON users(username);


### PR DESCRIPTION
Without this, two requests can come in at the same time and result in duplicate users.

Discussed on mailing list [here](https://groups.google.com/g/killbilling-users/c/KBTGCF3_AI4).
