### PR TITLE
Fix issue when using AUTO_INVOICING_REUSE_DRAFT and with (subscriptio…

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1030,7 +1030,7 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
             }
         }
         if (nbNotifications != 0) {
-            log.info(": {} queue(s) with more notification(s) to process", nbNotifications);
+            log.info("Remaining {} notifications to process", nbNotifications);
         }
         return nbNotifications == 0;
     }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationParentInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationParentInvoice.java
@@ -68,8 +68,6 @@ import static org.testng.Assert.assertTrue;
 
 public class TestIntegrationParentInvoice extends TestIntegrationBase {
 
-    @Inject
-    private NotificationQueueService notificationQueueService;
 
     @Test(groups = "slow")
     public void testParentInvoiceGeneration() throws Exception {

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
@@ -43,7 +43,6 @@ import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.entitlement.api.DefaultEntitlement;
 import org.killbill.billing.entitlement.api.Entitlement;
 import org.killbill.billing.entitlement.api.Entitlement.EntitlementActionPolicy;
-import org.killbill.billing.invoice.api.DefaultInvoiceService;
 import org.killbill.billing.invoice.api.DryRunType;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceApiException;
@@ -90,9 +89,6 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
 
     @Inject
     private OSGIServiceRegistration<InvoicePluginApi> pluginRegistry;
-
-    @Inject
-    private NotificationQueueService notificationQueueService;
 
     private TestInvoicePluginApi testInvoicePluginApi;
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -395,7 +395,9 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                 billingEventSqlDao.create(new InvoiceBillingEventModelDao(invoiceModelDao.getId(), BillingEventSerializer.serialize(billingEvents), context.getCreatedDate()), context);
                             }
                             createdInvoiceIds.add(invoiceModelDao.getId());
-                        } else if (invoiceOnDisk.getStatus() != invoiceModelDao.getStatus() || invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) != 0) {
+                        } else if (invoiceOnDisk.getStatus() != invoiceModelDao.getStatus() || /* Update if status is different */
+                                   (invoiceModelDao.getTargetDate() != null && /* Update if target date is specified and prev was either null or different */
+                                    (invoiceOnDisk.getTargetDate() == null || invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) != 0))) {
                             invoiceSqlDao.updateStatusAndTargetDate(invoiceModelDao.getId().toString(), invoiceModelDao.getStatus().toString(), invoiceModelDao.getTargetDate(), context);
                             committedReusedInvoiceId.add(invoiceModelDao.getId());
                         }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -395,11 +396,22 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                 billingEventSqlDao.create(new InvoiceBillingEventModelDao(invoiceModelDao.getId(), BillingEventSerializer.serialize(billingEvents), context.getCreatedDate()), context);
                             }
                             createdInvoiceIds.add(invoiceModelDao.getId());
-                        } else if ((invoiceOnDisk.getStatus() == InvoiceStatus.DRAFT && invoiceModelDao.getStatus() == InvoiceStatus.COMMITTED) || /* Update if status is needed */
-                                   (invoiceModelDao.getTargetDate() != null && /* Update if target date is specified and prev was either null or prior to new date */
-                                    (invoiceOnDisk.getTargetDate() == null || invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) < 0))) {
-                            invoiceSqlDao.updateStatusAndTargetDate(invoiceModelDao.getId().toString(), invoiceModelDao.getStatus().toString(), invoiceModelDao.getTargetDate(), context);
-                            committedReusedInvoiceId.add(invoiceModelDao.getId());
+                        } else {
+                            // Transition to COMMITTED or keep current status
+                            final InvoiceStatus newStatus = (InvoiceStatus.COMMITTED == invoiceModelDao.getStatus() && InvoiceStatus.COMMITTED != invoiceOnDisk.getStatus()) ? InvoiceStatus.COMMITTED : invoiceOnDisk.getStatus();
+
+                            // Update if target date is specified and prev targetDate was either null or prior to new date
+                            final LocalDate newTargetDate = (invoiceModelDao.getTargetDate() != null &&
+                                                             (invoiceOnDisk.getTargetDate() == null ||
+                                                              invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) < 0)) ?
+                                                            invoiceModelDao.getTargetDate() :
+                                                            invoiceOnDisk.getTargetDate();
+
+                            // If either newStatus or newTargetDate was updated perform the update
+                            if (newStatus != invoiceOnDisk.getStatus() || !Objects.equals(newTargetDate, invoiceOnDisk.getTargetDate())) {
+                                invoiceSqlDao.updateStatusAndTargetDate(invoiceModelDao.getId().toString(), newStatus.toString(), newTargetDate, context);
+                                committedReusedInvoiceId.add(invoiceModelDao.getId());
+                            }
                         }
                     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -395,8 +395,8 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                 billingEventSqlDao.create(new InvoiceBillingEventModelDao(invoiceModelDao.getId(), BillingEventSerializer.serialize(billingEvents), context.getCreatedDate()), context);
                             }
                             createdInvoiceIds.add(invoiceModelDao.getId());
-                        } else if (invoiceOnDisk.getStatus() == InvoiceStatus.DRAFT && invoiceModelDao.getStatus() == InvoiceStatus.COMMITTED) {
-                            invoiceSqlDao.updateStatus(invoiceModelDao.getId().toString(), InvoiceStatus.COMMITTED.toString(), context);
+                        } else if (invoiceOnDisk.getStatus() != invoiceModelDao.getStatus() || invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) != 0) {
+                            invoiceSqlDao.updateStatusAndTargetDate(invoiceModelDao.getId().toString(), invoiceModelDao.getStatus().toString(), invoiceModelDao.getTargetDate(), context);
                             committedReusedInvoiceId.add(invoiceModelDao.getId());
                         }
                     }
@@ -1252,7 +1252,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                     throw new InvoiceApiException(ErrorCode.INVOICE_INVALID_STATUS, newStatus, invoiceId, invoice.getStatus());
                 }
 
-                transactional.updateStatus(invoiceId.toString(), newStatus.toString(), context);
+                transactional.updateStatusAndTargetDate(invoiceId.toString(), newStatus.toString(), invoice.getTargetDate(), context);
 
                 // Run through all invoices
                 // Current invoice could be a credit item that needs to be rebalanced

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -395,9 +395,9 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                 billingEventSqlDao.create(new InvoiceBillingEventModelDao(invoiceModelDao.getId(), BillingEventSerializer.serialize(billingEvents), context.getCreatedDate()), context);
                             }
                             createdInvoiceIds.add(invoiceModelDao.getId());
-                        } else if (invoiceOnDisk.getStatus() != invoiceModelDao.getStatus() || /* Update if status is different */
-                                   (invoiceModelDao.getTargetDate() != null && /* Update if target date is specified and prev was either null or different */
-                                    (invoiceOnDisk.getTargetDate() == null || invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) != 0))) {
+                        } else if ((invoiceOnDisk.getStatus() == InvoiceStatus.DRAFT && invoiceModelDao.getStatus() == InvoiceStatus.COMMITTED) || /* Update if status is needed */
+                                   (invoiceModelDao.getTargetDate() != null && /* Update if target date is specified and prev was either null or prior to new date */
+                                    (invoiceOnDisk.getTargetDate() == null || invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) < 0))) {
                             invoiceSqlDao.updateStatusAndTargetDate(invoiceModelDao.getId().toString(), invoiceModelDao.getStatus().toString(), invoiceModelDao.getTargetDate(), context);
                             committedReusedInvoiceId.add(invoiceModelDao.getId());
                         }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceSqlDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceSqlDao.java
@@ -21,6 +21,7 @@ package org.killbill.billing.invoice.dao;
 import java.util.List;
 import java.util.UUID;
 
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.invoice.api.Invoice;
@@ -49,9 +50,10 @@ public interface InvoiceSqlDao extends EntitySqlDao<InvoiceModelDao, Invoice> {
                                               @SmartBindBean final InternalTenantContext context);
     @SqlUpdate
     @Audited(ChangeType.UPDATE)
-    void updateStatus(@Bind("id") String invoiceId,
-                      @Bind("status") String status,
-                      @SmartBindBean final InternalCallContext context);
+    void updateStatusAndTargetDate(@Bind("id") String invoiceId,
+                                   @Bind("status") String status,
+                                   @Bind("targetDate") LocalDate targetDate,
+                                   @SmartBindBean final InternalCallContext context);
 
 
     @SqlQuery

--- a/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceSqlDao.sql.stg
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceSqlDao.sql.stg
@@ -67,9 +67,9 @@ getInvoiceByInvoiceItemId() ::= <<
   ;
 >>
 
-updateStatus() ::= <<
+updateStatusAndTargetDate() ::= <<
     UPDATE <tableName()>
-    SET status = :status
+    SET status = :status, target_date = :targetDate
     WHERE id = :id
     <AND_CHECK_TENANT("")>;
 >>


### PR DESCRIPTION
…n) dates in the past.

The scenario is one where we have AUTO_INVOICING_DRAFT/AUTO_INVOICING_REUSE_DRAFT set on the account
and we create some subscriptions in the past.

There will be an initial bus event for the start date creating the invoice and adding the first RECURRING period (from test example: 8/7 -> 9/1)
Then, a notification be picked up immediately for the next RECURRING period as its effective date is in the past (9/1 -> 10/1)

Unfortunately prior the fix the targetDate which is computed as the max(event date, all invoices targetDate) is wrong because targetDate from (resused) invoice
was not updated.

This fix will now update the targetDate associated with the ongoing (reused) invoice and therefore avoid all the REPAIR we were seeing.