### PR TITLE
invoice: skip catalogEffectiveDate check during invoicing

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogEffectiveDate.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogEffectiveDate.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020-2020 Equinix, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+
+public class TestCatalogEffectiveDate extends TestIntegrationBase {
+
+    private CallContext testCallContext;
+    private Account account;
+
+    @BeforeMethod(groups = "slow")
+    public void beforeMethod() throws Exception {
+        if (hasFailed()) {
+            return;
+        }
+
+        super.beforeMethod();
+
+        // Setup tenant
+        clock.setTime(new DateTime("2020-09-20T12:56:02"));
+        testCallContext = setupTenant();
+
+        // Setup account in right tenant
+        account = setupAccount(testCallContext);
+    }
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1373")
+    public void testHistoricalCatalogChange() throws Exception {
+        uploadCatalog("WeaponsHireSmall-v1.xml");
+        assertListenerStatus();
+
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly", null);
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null), UUID.randomUUID().toString(), null, null, false, true, ImmutableList.<PluginProperty>of(), testCallContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 1, testCallContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2020, 9, 20), null, InvoiceItemType.FIXED, new BigDecimal("100.00")),
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2020, 9, 20), new LocalDate(2020, 10, 20), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+
+        uploadCatalog("WeaponsHireSmall-v2.xml");
+        assertListenerStatus();
+
+        checkNoMoreInvoiceToGenerate(account.getId(), testCallContext);
+    }
+
+    private void uploadCatalog(final String name) throws CatalogApiException, IOException {
+        catalogUserApi.uploadCatalog(Resources.asCharSource(Resources.getResource("catalogs/testCatalogEffectiveDate/" + name), Charsets.UTF_8).read(), testCallContext);
+    }
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationWithCatalogUpdate.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationWithCatalogUpdate.java
@@ -74,7 +74,6 @@ public class TestIntegrationWithCatalogUpdate extends TestIntegrationBase {
     @Inject
     private CatalogUserApi catalogUserApi;
 
-    private Tenant tenant;
     private CallContext testCallContext;
     private Account account;
 
@@ -93,10 +92,10 @@ public class TestIntegrationWithCatalogUpdate extends TestIntegrationBase {
         init = clock.getUTCNow();
 
         // Setup tenant
-        setupTenant();
+        testCallContext = setupTenant();
 
         // Setup account in right tenant
-        setupAccount();
+        account = setupAccount(testCallContext);
     }
 
     @Test(groups = "slow")
@@ -420,27 +419,4 @@ public class TestIntegrationWithCatalogUpdate extends TestIntegrationBase {
         assertListenerStatus();
         return entitlementApi.getEntitlementForId(entitlementId, testCallContext);
     }
-
-    private void setupTenant() throws TenantApiException {
-        final UUID uuid = UUID.randomUUID();
-        final String externalKey = uuid.toString();
-        final String apiKey = externalKey + "-Key";
-        final String apiSecret = externalKey + "-$3cr3t";
-        // Only place where we use callContext
-        tenant = tenantUserApi.createTenant(new DefaultTenant(uuid, init, init, externalKey, apiKey, apiSecret), callContext);
-
-        testCallContext = new DefaultCallContext(null, tenant.getId(), "tester", CallOrigin.EXTERNAL, UserType.TEST,
-                                                 "good reason", "trust me", uuid, clock);
-    }
-
-    private void setupAccount() throws Exception {
-
-        final AccountData accountData = getAccountData(0);
-        account = accountUserApi.createAccount(accountData, testCallContext);
-        assertNotNull(account);
-
-        final PaymentMethodPlugin info = createPaymentMethodPlugin();
-        paymentApi.addPaymentMethod(account, UUID.randomUUID().toString(), BeatrixIntegrationModule.NON_OSGI_PLUGIN_NAME, true, info, PLUGIN_PROPERTIES, testCallContext);
-    }
-
 }

--- a/beatrix/src/test/resources/catalogs/testCatalogEffectiveDate/WeaponsHireSmall-v1.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogEffectiveDate/WeaponsHireSmall-v1.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2020-2020 Equinix, Inc
+  ~ Copyright 2014-2020 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2020-09-16T10:34:25</effectiveDate>
+    <catalogName>WeaponsHireSmall</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <products>
+        <product name="Pistol">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <phaseType>TRIAL</phaseType>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+            <changePolicyCase>
+                <policy>END_OF_TERM</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_SUBSCRIPTION</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>END_OF_TERM</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>BUNDLE</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="pistol-monthly">
+            <product>Pistol</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <fixed>
+                    <fixedPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>100</value>
+                        </price>
+                    </fixedPrice>
+                </fixed>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>49.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>pistol-monthly</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogEffectiveDate/WeaponsHireSmall-v2.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogEffectiveDate/WeaponsHireSmall-v2.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2020-2020 Equinix, Inc
+  ~ Copyright 2014-2020 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2020-09-18T11:19:01</effectiveDate>
+    <catalogName>WeaponsHireSmall</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <products>
+        <product name="Pistol">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <phaseType>TRIAL</phaseType>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+            <changePolicyCase>
+                <policy>END_OF_TERM</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_SUBSCRIPTION</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>END_OF_TERM</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>BUNDLE</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="pistol-monthly">
+            <product>Pistol</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <fixed>
+                    <fixedPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>100</value>
+                        </price>
+                    </fixedPrice>
+                </fixed>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>49.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        <plan name="pistol-yearly">
+            <product>Pistol</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>ANNUAL</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>129.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>pistol-monthly</plan>
+                <plan>pistol-yearly</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemCatalogBase.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemCatalogBase.java
@@ -123,22 +123,14 @@ public class InvoiceItemCatalogBase extends InvoiceItemBase implements InvoiceIt
 
     @Override
     public boolean matches(final Object o) {
-
         if (!super.matches(o)) {
             return false;
         }
         final InvoiceItemCatalogBase that = (InvoiceItemCatalogBase) o;
-        if (catalogEffectiveDate != null &&
-            that.catalogEffectiveDate != null &&
-            catalogEffectiveDate.compareTo(that.catalogEffectiveDate) != 0 &&
-            // https://github.com/killbill/killbill/issues/1370
-            Math.abs(Seconds.secondsBetween(catalogEffectiveDate, that.catalogEffectiveDate).getSeconds()) != 0) {
-            return false;
-        } else if (catalogEffectiveDate == null || that.catalogEffectiveDate == null) {
-            /* At least one such item has a 'null' catalogEffectiveDate, reflecting a prior 0.22 release item
-             * => we default to true to avoid re-generating existing items (See https://github.com/killbill/killbill/issues/1251)
-             */
-        }
+
+        // Note: we don't check the catalogEffectiveDate here as a mismatch shouldn't trigger a repair (https://github.com/killbill/killbill/issues/1373).
+        // Changes to the catalog should be handled via the catalog feature EffectiveDateForExistingSubscriptions exclusively and explicitly.
+        // As a side effect, catalogEffectiveDate is also ignored for equals() (which relies on this method).
 
         if (phaseName != null ? !phaseName.equals(that.phaseName) : that.phaseName != null) {
             return false;


### PR DESCRIPTION
A mismatch of `catalogEffectiveDate` on disk will be ignored moving forward (e.g we won't trigger a repair).

This works around https://github.com/killbill/killbill/issues/1373: in junction, we don't have enough information to get the "sticky" catalog in case a subsequent catalog was uploaded in the past at t1 < t < t2, where t1 is the initial catalog effective
date and t2 the billing event effective date.
