### PR TITLE
server: remove server from list of DDL to install

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillBillEmbeddedDBProvider.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillBillEmbeddedDBProvider.java
@@ -41,8 +41,7 @@ public class KillBillEmbeddedDBProvider extends EmbeddedDBProvider {
                                                 "subscription",
                                                 "tenant",
                                                 "usage",
-                                                "util",
-                                                "server"}) {
+                                                "util"}) {
             ddlFiles.add("org/killbill/billing/" + module + "/ddl.sql");
         }
         return ddlFiles;


### PR DESCRIPTION
`killbill-platform-server` does ship `org/killbill/billing/server/ddl.sql` but we don't need to install it in Kill Bill.
