### PR TITLE
jaxrs: Fix to correctly reflect prices for subscription through catal…

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionJson.java
@@ -413,7 +413,10 @@ public class SubscriptionJson extends JsonBase {
                 }
 
                 final PlanPhase curPlanPhase = subscriptionEvent.getNextPhase();
-                if (curPlanPhase == null || curPlanPhase.getName().equals(currentPhaseName)) {
+                if (curPlanPhase == null /* No phase -> no price */ ||
+                    /* Same phase ? */
+                    (curPlanPhase.getName().equals(currentPhaseName) /* same phase name */ &&
+                     (subscriptionEvent.getPrevPhase() == null || subscriptionEvent.getPrevPhase().getCatalog().getEffectiveDate().compareTo(curPlanPhase.getCatalog().getEffectiveDate()) == 0)) /* same catalog version */)  {
                     continue;
                 }
                 currentPhaseName = curPlanPhase.getName();

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
@@ -1329,4 +1329,82 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(refreshedSubscription.getPrices().get(1).getRecurringPrice(), new BigDecimal("249.95"));
 
     }
+
+
+    @Test(groups = "slow", description = "See https://github.com/killbill/killbill/issues/1397")
+    public void testSubscriptionEventsWithCatalogChange() throws Exception {
+
+        // effDt = 2013-02-08T00:00:00+00:00
+        callbackServlet.pushExpectedEvents(ExtBusEventType.TENANT_CONFIG_CHANGE);
+        String catalog1 = uploadTenantCatalog("org/killbill/billing/server/SpyCarBasic.xml", true);
+        callbackServlet.assertListenerStatus();
+        Assert.assertNotNull(catalog1);
+
+        // effDt = 2014-02-08T00:00:00+00:00
+        callbackServlet.pushExpectedEvents(ExtBusEventType.TENANT_CONFIG_CHANGE);
+        String catalog2 = uploadTenantCatalog("org/killbill/billing/server/SpyCarBasic.v2.xml", true);
+        callbackServlet.assertListenerStatus();
+        Assert.assertNotNull(catalog2);
+
+
+        final DateTime initialDate = new DateTime(2014, 1, 2, 0, 3, 42, 0);
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+
+        final Account accountJson = createAccountWithDefaultPaymentMethod();
+
+        final Subscription input = new Subscription();
+        input.setAccountId(accountJson.getAccountId());
+        input.setPlanName("super-monthly");
+
+        callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CREATION,
+                                           ExtBusEventType.SUBSCRIPTION_CREATION,
+                                           ExtBusEventType.ENTITLEMENT_CREATION,
+                                           ExtBusEventType.ACCOUNT_CHANGE,  // The BCD is updated in that case
+                                           ExtBusEventType.INVOICE_CREATION); // $0 Fixed price
+        final Subscription entitlementJson = subscriptionApi.createSubscription(input,
+                                                                                null,
+                                                                                null,
+                                                                                false,
+                                                                                false,
+                                                                                true,
+                                                                                DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC,
+                                                                                NULL_PLUGIN_PROPERTIES,
+                                                                                requestOptions);
+        Assert.assertEquals(entitlementJson.getPlanName(), "super-monthly");
+        callbackServlet.assertListenerStatus();
+
+        // MOVE AFTER TRIAL
+        callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_PHASE,
+                                           ExtBusEventType.INVOICE_CREATION,
+                                           ExtBusEventType.INVOICE_PAYMENT_SUCCESS,
+                                           ExtBusEventType.PAYMENT_SUCCESS);
+        clock.addDays(30); // 2014-02-01
+        callbackServlet.assertListenerStatus();
+
+        // Go to catalog V2
+        clock.addDays(8); // 2014-02-09
+
+        callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CHANGE, ExtBusEventType.SUBSCRIPTION_CHANGE);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), input, null, BillingActionPolicy.IMMEDIATE, NULL_PLUGIN_PROPERTIES, requestOptions);
+        Subscription refreshedSubscription1 = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
+        callbackServlet.assertListenerStatus();
+        Assert.assertNotNull(refreshedSubscription1);
+
+        final Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
+        Assert.assertEquals(subscription.getPrices().size(), 3);
+        Assert.assertEquals(subscription.getPrices().get(0).getPhaseName(), "super-monthly-trial");
+        Assert.assertEquals(subscription.getPrices().get(0).getFixedPrice(), BigDecimal.ZERO);
+        Assert.assertNull(subscription.getPrices().get(0).getRecurringPrice());
+
+        Assert.assertEquals(subscription.getPrices().get(1).getPhaseName(), "super-monthly-evergreen");
+        Assert.assertNull(subscription.getPrices().get(1).getFixedPrice());
+        Assert.assertEquals(subscription.getPrices().get(1).getRecurringPrice(), new BigDecimal("1000.00"));
+
+        // Should reflect the catalog change price
+        Assert.assertEquals(subscription.getPrices().get(2).getPhaseName(), "super-monthly-evergreen");
+        Assert.assertNull(subscription.getPrices().get(2).getFixedPrice());
+        Assert.assertEquals(subscription.getPrices().get(2).getRecurringPrice(), new BigDecimal("1200.00"));
+
+
+    }
 }

--- a/profiles/killbill/src/test/resources/org/killbill/billing/server/SpyCarBasic.v2.xml
+++ b/profiles/killbill/src/test/resources/org/killbill/billing/server/SpyCarBasic.v2.xml
@@ -166,11 +166,11 @@
                     <recurringPrice>
                         <price>
                             <currency>GBP</currency>
-                            <value>750.00</value>
+                            <value>850.00</value>
                         </price>
                         <price>
                             <currency>USD</currency>
-                            <value>1000.00</value>
+                            <value>1200.00</value>
                         </price>
                     </recurringPrice>
                 </recurring>


### PR DESCRIPTION
…og versions. See #1397

This PR is based on top of `subscription-events-fix` which includes the fix for `https://github.com/killbill/killbill/issues/1396`.

I think we should also revisit our `equals` inside our catalog code, and make the following systematic:
* `XmlElement` should be included in the `equals` method. Do a pass and make sure this is the case. (E.g missing `recurringBillingMode` in `DeafultPlan`). Or should we enforce only the `required` fields?
* `XmlElement` with `XmlIDREF` should not be included as they could trigger loops.So, should we have `product` in the `Plan` equality `https://github.com/killbill/killbill/blob/master/catalog/src/main/java/org/killbill/billing/catalog/DefaultPlan.java#L380`. CVould we only check on its `ID` (`name`) instead?
* `Others` Not included. For instance, we correctly ignore `Product` from `DefaultPlanPhase` [here]( https://github.com/killbill/killbill/blob/master/catalog/src/main/java/org/killbill/billing/catalog/DefaultPlanPhase.java#L78)
* We are currently not looking at the referenced catalog effective date, so as an example 2 `Plans` in two different catalog versions would show up as 'equal' as long as their attributes are the same. This includes every single details, incl, usage attributes (which I am not sure we are checking correctly). We should define what equality really means.
