### PR TITLE
Add invoice unit tests for usage transitions + code refactoring

### DIFF
--- a/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalUsageInArrear.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalUsageInArrear.java
@@ -30,6 +30,7 @@ import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.TierBlockPolicy;
 import org.killbill.billing.catalog.api.Usage;
 import org.killbill.billing.junction.BillingEvent;
+import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.usage.api.RawUsageRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -49,19 +50,19 @@ public class TestContiguousIntervalUsageInArrear extends TestUsageInArrearBase {
         final BillingEvent billingEvent1 = createMockBillingEvent(1,
                                                                   new LocalDate(2019, 1, 1).toDateTimeAtStartOfDay(DateTimeZone.UTC),
                                                                   BillingPeriod.MONTHLY,
-                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate);
+                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate, SubscriptionBaseTransitionType.CREATE);
         final BillingEvent billingEvent2 = createMockBillingEvent(1,
                                                                   new LocalDate(2019, 1, 31).toDateTimeAtStartOfDay(DateTimeZone.UTC),
                                                                   BillingPeriod.MONTHLY,
-                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate);
+                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate, SubscriptionBaseTransitionType.CHANGE);
         final BillingEvent billingEvent3 = createMockBillingEvent(5,
                                                                   new LocalDate(2019, 2, 5).toDateTimeAtStartOfDay(DateTimeZone.UTC),
                                                                   BillingPeriod.MONTHLY,
-                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate);
+                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate, SubscriptionBaseTransitionType.CHANGE);
         final BillingEvent billingEvent4 = createMockBillingEvent(10,
                                                                   new LocalDate(2019, 3, 10).toDateTimeAtStartOfDay(DateTimeZone.UTC),
                                                                   BillingPeriod.MONTHLY,
-                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate);
+                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate, SubscriptionBaseTransitionType.CANCEL);
         final ContiguousIntervalConsumableUsageInArrear intervalConsumableInArrear = createContiguousIntervalConsumableInArrear(usage,
                                                                                                                                 ImmutableList.<RawUsageRecord>of(),
                                                                                                                                 targetDate,

--- a/invoice/src/test/java/org/killbill/billing/invoice/usage/TestUsageInArrearBase.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/usage/TestUsageInArrearBase.java
@@ -49,6 +49,7 @@ import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
 import org.killbill.billing.invoice.generator.InvoiceWithMetadata.TrackingRecordId;
 import org.killbill.billing.junction.BillingEvent;
 import org.killbill.billing.subscription.api.SubscriptionBase;
+import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.usage.api.RawUsageRecord;
 import org.killbill.billing.util.config.definition.InvoiceConfig.UsageDetailMode;
 import org.killbill.billing.util.jackson.ObjectMapper;
@@ -184,10 +185,10 @@ public abstract class TestUsageInArrearBase extends InvoiceTestSuiteNoDB {
     }
 
     protected BillingEvent createMockBillingEvent(final DateTime effectiveDate, final BillingPeriod billingPeriod, final List<Usage> usages, final DateTime catalogEffectiveDate) throws Exception {
-        return createMockBillingEvent(BCD, effectiveDate, billingPeriod, usages, catalogEffectiveDate);
+        return createMockBillingEvent(BCD, effectiveDate, billingPeriod, usages, catalogEffectiveDate, SubscriptionBaseTransitionType.CREATE);
     }
 
-    protected BillingEvent createMockBillingEvent(final int bcd, final DateTime effectiveDate, final BillingPeriod billingPeriod, final List<Usage> usages, final DateTime catalogEffectiveDate) throws Exception {
+    protected BillingEvent createMockBillingEvent(final int bcd, final DateTime effectiveDate, final BillingPeriod billingPeriod, final List<Usage> usages, final DateTime catalogEffectiveDate, SubscriptionBaseTransitionType beType) throws Exception {
         final BillingEvent result = Mockito.mock(BillingEvent.class);
         Mockito.when(result.getCurrency()).thenReturn(currency);
         Mockito.when(result.getBillCycleDayLocal()).thenReturn(bcd);
@@ -196,6 +197,7 @@ public abstract class TestUsageInArrearBase extends InvoiceTestSuiteNoDB {
         Mockito.when(result.getSubscriptionId()).thenReturn(subscriptionId);
         Mockito.when(result.getBundleId()).thenReturn(bundleId);
         Mockito.when(result.getCatalogEffectiveDate()).thenReturn(catalogEffectiveDate);
+        Mockito.when(result.getTransitionType()).thenReturn(beType);
 
         final Account account = Mockito.mock(Account.class);
         Mockito.when(account.getId()).thenReturn(accountId);


### PR DESCRIPTION
https://github.com/killbill/killbill/pull/1442/commits/ee68ef7b4efd3b9a58aae5b14723e87f581b4708 : Only commit worth looking at (unclear why there are so many since both branches `fix-for-usages-at-cancel-date` and `fix-for-usages-at-cancel-date2` are up to date with `master` 🤔 