### PR TITLE
entitlement: Optimize path where we fetch an entitlement by id

### DIFF
--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateDao.java
@@ -59,13 +59,24 @@ public interface BlockingStateDao extends EntityDao<BlockingStateModelDao, Block
     public List<BlockingState> getBlockingState(UUID blockableId, BlockingStateType blockingStateType, DateTime upToDate, InternalTenantContext context);
 
     /**
-     * Return all events (past and future) across all services) for a given callcontext (account_record_id)
+     * Return all events (past and future) across all services for a given callcontext (account_record_id)
      *
      * @param catalog full catalog
      * @param context call context
      * @return list of all blocking states for that account
      */
     public List<BlockingState> getBlockingAllForAccountRecordId(VersionedCatalog catalog, InternalTenantContext context);
+
+    /**
+     * Return all events (past and future) across all services for a given set of blockableIds
+     *
+     * @param blockableIds ids of the blockable object
+     * @param context call context
+     * @return list of all blocking states for that account
+     */
+    public List<BlockingState> getByBlockingIds(Iterable<UUID> blockableIds, InternalTenantContext context);
+
+
 
     /**
      * Set new blocking states

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.entitlement.dao;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -34,6 +35,7 @@ import org.killbill.commons.jdbi.template.KillBillSqlDaoStringTemplate;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.unstable.BindIn;
 
 @KillBillSqlDaoStringTemplate
 public interface BlockingStateSqlDao extends EntitySqlDao<BlockingStateModelDao, BlockingState> {
@@ -59,8 +61,15 @@ public interface BlockingStateSqlDao extends EntitySqlDao<BlockingStateModelDao,
                                                                              @Bind("service") String serviceName,
                                                                              @SmartBindBean final InternalTenantContext context);
 
+
+    @SqlQuery
+    public abstract List<BlockingStateModelDao> getByBlockingIds(@BindIn("ids") final Iterable<UUID> ids,
+                                                                 @SmartBindBean final InternalTenantContext context);
+
+
     @SqlUpdate
     @Audited(ChangeType.DELETE)
     public void unactiveEvent(@Bind("id") String id,
                               @SmartBindBean final InternalCallContext context);
+
 }

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
@@ -204,6 +204,23 @@ public class DefaultBlockingStateDao extends EntityDaoBase<BlockingStateModelDao
     }
 
     @Override
+    public List<BlockingState> getByBlockingIds(Iterable<UUID> blockableIds, final InternalTenantContext context) {
+        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<BlockingState>>() {
+            @Override
+            public List<BlockingState> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
+                final BlockingStateSqlDao sqlDao = entitySqlDaoWrapperFactory.become(BlockingStateSqlDao.class);
+                return new ArrayList<BlockingState>(Collections2.transform(sqlDao.getByBlockingIds(blockableIds, context),
+                                                                           new Function<BlockingStateModelDao, BlockingState>() {
+                                                                               @Override
+                                                                               public BlockingState apply(@Nullable final BlockingStateModelDao src) {
+                                                                                   return BlockingStateModelDao.toBlockingState(src);
+                                                                               }
+                                                                           }));
+            }
+        });
+    }
+
+    @Override
     public void setBlockingStatesAndPostBlockingTransitionEvent(final Map<BlockingState, Optional<UUID>> states, final InternalCallContext context) {
 
         final boolean groupBusEvents = eventBus.shouldAggregateSubscriptionEvents(context);

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
@@ -239,6 +239,11 @@ public class ProxyBlockingStateDao implements BlockingStateDao {
     }
 
     @Override
+    public List<BlockingState> getByBlockingIds(final Iterable<UUID> blockableIds, final InternalTenantContext context) {
+        return delegate.getByBlockingIds(blockableIds, context);
+    }
+
+    @Override
     public void setBlockingStatesAndPostBlockingTransitionEvent(final Map<BlockingState, Optional<UUID>> states, final InternalCallContext context) {
         delegate.setBlockingStatesAndPostBlockingTransitionEvent(states, context);
     }

--- a/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
+++ b/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
@@ -119,6 +119,19 @@ and is_active = '1'
 ;
 >>
 
+getByBlockingIds() ::= <<
+select
+<allTableFields("")>
+from
+<tableName()>
+where blockable_id in (<ids>)
+and is_active = '1'
+<AND_CHECK_TENANT("")>
+<defaultOrderBy("")>
+;
+>>
+
+
 unactiveEvent() ::= <<
 update
 <tableName()>

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/dao/MockBlockingStateDao.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/dao/MockBlockingStateDao.java
@@ -88,6 +88,19 @@ public class MockBlockingStateDao extends MockEntityDaoBase<BlockingStateModelDa
     }
 
     @Override
+    public List<BlockingState> getByBlockingIds(final Iterable<UUID> blockableIds, final InternalTenantContext context) {
+        final List<BlockingState> result = new ArrayList<>();
+        for (UUID cur : blockableIds) {
+            final List<BlockingState> objs = blockingStates.get(cur);
+            if (objs != null && !objs.isEmpty()) {
+                result.addAll(objs);
+            }
+
+        }
+        return result;
+    }
+
+    @Override
     public synchronized void setBlockingStatesAndPostBlockingTransitionEvent(final Map<BlockingState, Optional<UUID>> states, final InternalCallContext context) {
         for (final BlockingState state : states.keySet()) {
             if (blockingStates.get(state.getBlockedId()) == null) {


### PR DESCRIPTION
Prior the fix, we would pull all blocking states on the account, but after the fix we pull the minimum we need,
which is whatever is set at the `ACCOUNT`, `SUBSCRIPTION_BUNDLE` and `SUBSCRIPTION` -- both base subscription and add-on if required -- level.

⚠️ This is by no means this end of the story, but I think this should take care of the following bottlenecks:

```
        at org.killbill.billing.entitlement.dao.DefaultBlockingStateDao.getBlockingAllForAccountRecordId(DefaultBlockingStateDao.java:191)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:313)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:293)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:441)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:266)
        at org.killbill.billing.entitlement.api.svcs.DefaultEntitlementApiBase.getEntitlementForId(DefaultEntitlementApiBase.java:137)
        at org.killbill.billing.entitlement.api.DefaultEntitlementApi.getEntitlementForId(DefaultEntitlementApi.java:205)
        at org.killbill.billing.entitlement.api.DefaultEntitlementApi$$EnhancerByGuice$$f24f0c80.CGLIB$getEntitlementForId$0(<generated>)
        at org.killbill.billing.entitlement.api.DefaultEntitlementApi$$EnhancerByGuice$$f24f0c80$$FastClassByGuice$$86954824.invoke(<generated>)
        at com.google.inject.internal.cglib.proxy.$MethodProxy.invokeSuper(MethodProxy.java:228)
        at com.google.inject.internal.InterceptorStackCallback$InterceptedMethodInvocation.proceed(InterceptorStackCallback.java:76)
        at org.killbill.billing.util.glue.KillbillApiAopModule$ProfilingMethodInterceptor$1.execute(KillbillApiAopModule.java:76)
        at org.killbill.commons.profiling.Profiling.executeWithProfiling(Profiling.java:35)
        at org.killbill.billing.util.glue.KillbillApiAopModule$ProfilingMethodInterceptor.invoke(KillbillApiAopModule.java:92)
        at com.google.inject.internal.InterceptorStackCallback$InterceptedMethodInvocation.proceed(InterceptorStackCallback.java:78)
        at com.google.inject.internal.InterceptorStackCallback.intercept(InterceptorStackCallback.java:54)
        at org.killbill.billing.entitlement.api.DefaultEntitlementApi$$EnhancerByGuice$$f24f0c80.getEntitlementForId(<generated>)
        at org.killbill.billing.jaxrs.resources.SubscriptionResource.cancelSubscriptionPlan(SubscriptionResource.java:608)
```

And also, as a side effect -- to be confirmed:

```
        at org.killbill.billing.entitlement.dao.DefaultBlockingStateDao.getBlockingAllForAccountRecordId(DefaultBlockingStateDao.java:191)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:313)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:293)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:441)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:266)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.buildForEntitlement(EventsStreamBuilder.java:135)
        at org.killbill.billing.entitlement.engine.core.EventsStreamBuilder.refresh(EventsStreamBuilder.java:118)
        at org.killbill.billing.entitlement.api.DefaultEntitlement.refresh(DefaultEntitlement.java:819)
        at org.killbill.billing.entitlement.api.DefaultEntitlement.computeAddOnBlockingStates(DefaultEntitlement.java:830)
        at org.killbill.billing.entitlement.api.DefaultEntitlement$1.doCall(DefaultEntitlement.java:365)
        at org.killbill.billing.entitlement.api.DefaultEntitlement$1.doCall(DefaultEntitlement.java:341)
        at org.killbill.billing.entitlement.api.EntitlementPluginExecution.executeWithPlugin(EntitlementPluginExecution.java:97)
        at org.killbill.billing.entitlement.api.DefaultEntitlement.cancelEntitlementWithDate(DefaultEntitlement.java:377)
        at org.killbill.billing.jaxrs.resources.SubscriptionResource$3.doOperation(SubscriptionResource.java:623)
        at org.killbill.billing.jaxrs.resources.SubscriptionResource$3.doOperation(SubscriptionResource.java:611)
        at org.killbill.billing.jaxrs.resources.SubscriptionResource$EntitlementCallCompletion.withSynchronization(SubscriptionResource.java:836)
        at org.killbill.billing.jaxrs.resources.SubscriptionResource.cancelSubscriptionPlan(SubscriptionResource.java:658)
```