### PR TITLE
junction: rewrite BlockingCalculator to be more efficient

### DIFF
--- a/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlement.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlement.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -27,7 +28,6 @@ import org.killbill.billing.account.api.Account;
 import org.killbill.billing.account.api.AccountApiException;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.catalog.api.BillingPeriod;
-import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.catalog.api.PriceListSet;
 import org.killbill.billing.entitlement.EntitlementTestSuiteWithEmbeddedDB;
@@ -301,8 +301,11 @@ public class TestDefaultEntitlement extends EntitlementTestSuiteWithEmbeddedDB {
         assertListenerStatus();
         final Entitlement entitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
 
+        clock.addDeltaFromReality(1000); // Make sure CHANGE does not collide with CREATE
+        assertListenerStatus();
+
         // Immediate change during trial
-        testListener.pushExpectedEvent(NextEvent.CREATE);
+        testListener.pushExpectedEvent(NextEvent.CHANGE);
         final PlanPhaseSpecifier planPhaseSpecifier = new PlanPhaseSpecifier("Assault-Rifle", BillingPeriod.MONTHLY, PriceListSet.DEFAULT_PRICELIST_NAME);
         entitlement.changePlan(new DefaultEntitlementSpecifier(planPhaseSpecifier), ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();


### PR DESCRIPTION
Stacktraces from the load test:

```
catalina-exec-3" #107 daemon prio=5 os_prio=0 tid=0x00007fc6686b5000 nid=0x401 runnable [0x00007fc5192e8000]
   java.lang.Thread.State: RUNNABLE
	at com.google.common.collect.Iterators$5.computeNext(Iterators.java:637)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:141)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:136)
	at com.google.common.collect.Iterators$ConcatenatedIterator.hasNext(Iterators.java:1324)
	at com.google.common.collect.Iterators$5.computeNext(Iterators.java:635)
	at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:141)
	at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:136)
	at com.google.common.collect.Iterators.addAll(Iterators.java:355)
	at com.google.common.collect.Lists.newArrayList(Lists.java:143)
	at com.google.common.collect.Lists.newArrayList(Lists.java:130)
	at org.killbill.billing.junction.plumbing.billing.BlockingCalculator.getAggregateBlockingEventsPerSubscription(BlockingCalculator.java:148)
	at org.killbill.billing.junction.plumbing.billing.BlockingCalculator.insertBlockingEvents(BlockingCalculator.java:115)
	at org.killbill.billing.junction.plumbing.billing.DefaultInternalBillingApi.getBillingEventsForAccountAndUpdateAccountBCD(DefaultInternalBillingApi.java:129)
	at org.killbill.billing.invoice.InvoiceDispatcher.processAccountWithLock(InvoiceDispatcher.java:350)
	at org.killbill.billing.invoice.InvoiceDispatcher.processAccount(InvoiceDispatcher.java:316)
	at org.killbill.billing.invoice.api.user.DefaultInvoiceUserApi.triggerDryRunInvoiceGeneration(DefaultInvoiceUserApi.java:272)
```

```
catalina-exec-3" #107 daemon prio=5 os_prio=0 tid=0x00007fc6686b5000 nid=0x401 runnable [0x00007fc5192e8000]
   java.lang.Thread.State: RUNNABLE
	at java.util.TreeMap.keyIterator(TreeMap.java:1110)
	at java.util.TreeMap$KeySet.iterator(TreeMap.java:1123)
	at java.util.TreeSet.iterator(TreeSet.java:181)
	at org.killbill.billing.junction.plumbing.billing.BlockingCalculator.filter(BlockingCalculator.java:233)
	at org.killbill.billing.junction.plumbing.billing.BlockingCalculator.insertBlockingEvents(BlockingCalculator.java:118)
	at org.killbill.billing.junction.plumbing.billing.DefaultInternalBillingApi.getBillingEventsForAccountAndUpdateAccountBCD(DefaultInternalBillingApi.java:129)
	at org.killbill.billing.invoice.InvoiceDispatcher.processAccountWithLock(InvoiceDispatcher.java:350)
	at org.killbill.billing.invoice.InvoiceDispatcher.processAccount(InvoiceDispatcher.java:316)
	at org.killbill.billing.invoice.api.user.DefaultInvoiceUserApi.triggerDryRunInvoiceGeneration(DefaultInvoiceUserApi.java:272)
```

```
catalina-exec-3" #107 daemon prio=5 os_prio=0 tid=0x00007fc6686b5000 nid=0x401 runnable [0x00007fc5192e8000]
   java.lang.Thread.State: RUNNABLE
	at java.util.HashMap.resize(HashMap.java:704)
	at java.util.HashMap.putVal(HashMap.java:629)
	at java.util.HashMap.put(HashMap.java:612)
	at org.killbill.billing.junction.plumbing.billing.BlockingCalculator.createBlockingDurations(BlockingCalculator.java:324)
	at org.killbill.billing.junction.plumbing.billing.BlockingCalculator.insertBlockingEvents(BlockingCalculator.java:116)
	at org.killbill.billing.junction.plumbing.billing.DefaultInternalBillingApi.getBillingEventsForAccountAndUpdateAccountBCD(DefaultInternalBillingApi.java:129)
	at org.killbill.billing.invoice.InvoiceDispatcher.processAccountWithLock(InvoiceDispatcher.java:350)
	at org.killbill.billing.invoice.InvoiceDispatcher.processAccount(InvoiceDispatcher.java:316)
	at org.killbill.billing.invoice.api.user.DefaultInvoiceUserApi.triggerDryRunInvoiceGeneration(DefaultInvoiceUserApi.java:272)
```