### PR TITLE
entitlement: pull the minimum we need in DefaultSubscriptionApi.getSubscriptionBundle

### DIFF
--- a/api/src/main/java/org/killbill/billing/entitlement/EntitlementInternalApi.java
+++ b/api/src/main/java/org/killbill/billing/entitlement/EntitlementInternalApi.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -18,6 +19,7 @@
 
 package org.killbill.billing.entitlement;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.joda.time.LocalDate;
@@ -32,9 +34,9 @@ public interface EntitlementInternalApi {
 
     AccountEntitlements getAllEntitlementsForAccount(InternalTenantContext context) throws EntitlementApiException;
 
-    Entitlement getEntitlementForId(final UUID uuid, final InternalTenantContext tenantContext) throws EntitlementApiException;
+    List<Entitlement> getAllEntitlementsForBundle(UUID bundleId, InternalTenantContext context) throws EntitlementApiException;
 
-    Entitlement getEntitlementForExternalKey(final String externalKey, final InternalTenantContext tenantContext) throws EntitlementApiException;
+    Entitlement getEntitlementForId(final UUID uuid, final InternalTenantContext tenantContext) throws EntitlementApiException;
 
     void pause(UUID bundleId, LocalDate effectiveDate, Iterable<PluginProperty> properties, InternalCallContext context) throws EntitlementApiException;
 

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultEntitlementApiBase.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultEntitlementApiBase.java
@@ -1,6 +1,8 @@
 /*
- * Copyright 2014-2019 Groupon, Inc
- * Copyright 2014-2019 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -133,15 +135,33 @@ public class DefaultEntitlementApiBase {
         return new DefaultAccountEntitlements(accountEventsStreams, entitlementsPerBundle);
     }
 
-    public Entitlement getEntitlementForId(final UUID entitlementId, final InternalTenantContext tenantContext) throws EntitlementApiException {
-        final EventsStream eventsStream = eventsStreamBuilder.buildForEntitlement(entitlementId, tenantContext);
-        return new DefaultEntitlement(eventsStream, eventsStreamBuilder, entitlementApi, pluginExecution,
-                                      blockingStateDao, subscriptionInternalApi, checker, notificationQueueService,
-                                      entitlementUtils, dateHelper, clock, securityApi, tenantContext, internalCallContextFactory);
+    public List<Entitlement> getAllEntitlementsForBundle(final UUID bundleId, final InternalTenantContext tenantContext) throws EntitlementApiException {
+        final List<EventsStream> eventsStreamForBundle = eventsStreamBuilder.buildForBundle(bundleId, tenantContext);
+
+        final List<Entitlement> entitlements = new LinkedList<Entitlement>();
+        for (final EventsStream eventsStream : eventsStreamForBundle) {
+            final Entitlement entitlement = new DefaultEntitlement(eventsStream,
+                                                                   eventsStreamBuilder,
+                                                                   entitlementApi,
+                                                                   pluginExecution,
+                                                                   blockingStateDao,
+                                                                   subscriptionInternalApi,
+                                                                   checker,
+                                                                   notificationQueueService,
+                                                                   entitlementUtils,
+                                                                   dateHelper,
+                                                                   clock,
+                                                                   securityApi,
+                                                                   tenantContext,
+                                                                   internalCallContextFactory);
+            entitlements.add(entitlement);
+        }
+
+        return entitlements;
     }
 
-    public Entitlement getEntitlementForExternalKey(final String externalKey, final InternalTenantContext tenantContext) throws EntitlementApiException {
-        final EventsStream eventsStream = eventsStreamBuilder.buildForEntitlement(externalKey, tenantContext);
+    public Entitlement getEntitlementForId(final UUID entitlementId, final InternalTenantContext tenantContext) throws EntitlementApiException {
+        final EventsStream eventsStream = eventsStreamBuilder.buildForEntitlement(entitlementId, tenantContext);
         return new DefaultEntitlement(eventsStream, eventsStreamBuilder, entitlementApi, pluginExecution,
                                       blockingStateDao, subscriptionInternalApi, checker, notificationQueueService,
                                       entitlementUtils, dateHelper, clock, securityApi, tenantContext, internalCallContextFactory);


### PR DESCRIPTION
In 9bc87794d2f183ac92a615013ac112635e44b006, I had optimised the `getSubscriptionBundlesForAccountId` codepath, and to minimize the amount of codepaths to maintained, I had funnelled all get APIs through the same underlying methods.

Back then, our largest account known to us had 35 bundles and 67 subscriptions and this approach worked fine. Nowadays, we have accounts with over 30,000 bundles, so we need to be more mindful as to when we can _pull all by account_record_id_.
