### PR TITLE
Node infos logging during start and stop sequence

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/listeners/CleanupListener.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/listeners/CleanupListener.java
@@ -28,7 +28,6 @@ import javax.servlet.ServletContextListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ch.qos.logback.classic.LoggerContext;
 import net.sf.log4jdbc.sql.jdbcapi.DriverSpy;
 
 public class CleanupListener implements ServletContextListener {
@@ -75,9 +74,5 @@ public class CleanupListener implements ServletContextListener {
                 logger.warn("Unable to de-register driver", e);
             }
         }
-
-//         avoid memory leaks: https://logback.qos.ch/manual/jmxConfig.html
-        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        lc.stop();
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/nodes/DefaultKillbillNodesService.java
+++ b/util/src/main/java/org/killbill/billing/util/nodes/DefaultKillbillNodesService.java
@@ -86,6 +86,7 @@ public class DefaultKillbillNodesService implements KillbillNodesService {
         try {
             // Re-Compute including the plugins
             createBootNodeInfo(false);
+            logger.info("Created nodeInfo for {}", CreatorName.get());
         } catch (JsonProcessingException e) {
             logger.error("Failed to create bootNodeInfo", e);
         }
@@ -93,6 +94,7 @@ public class DefaultKillbillNodesService implements KillbillNodesService {
 
     @LifecycleHandlerType(LifecycleLevel.STOP_SERVICE)
     public void stop() {
+        logger.info("Deleting nodeInfo for {}", CreatorName.get());
         nodeInfoDao.delete(CreatorName.get());
     }
 


### PR DESCRIPTION
Enable shutdown traces and add specific traces for nodeInfo start/stop sequence.

Also see https://github.com/killbill/killbill-platform/pull/74