### PR TITLE
util: Add a mechanism to not return old node_infos entries

### DIFF
--- a/util/src/main/java/org/killbill/billing/util/nodes/dao/NodeInfoDao.java
+++ b/util/src/main/java/org/killbill/billing/util/nodes/dao/NodeInfoDao.java
@@ -25,6 +25,8 @@ public interface NodeInfoDao {
 
     public void updateNodeInfo(final String nodeName, final String nodeInfo);
 
+    public void setUpdatedDate(final String nodeName);
+
     public void delete(final String nodeName);
 
     public List<NodeInfoModelDao> getAll();

--- a/util/src/main/java/org/killbill/billing/util/nodes/dao/NodeInfoSqlDao.java
+++ b/util/src/main/java/org/killbill/billing/util/nodes/dao/NodeInfoSqlDao.java
@@ -36,12 +36,15 @@ public interface NodeInfoSqlDao {
     public void updateNodeInfo(@Bind("nodeName") final String nodeName, @Bind("nodeInfo") final String nodeInfo, @Bind("updatedDate") final Date updatedDate);
 
     @SqlUpdate
+    public void setUpdatedDate(@Bind("nodeName") final String nodeName, @Bind("updatedDate") final Date updatedDate);
+
+    @SqlUpdate
     public void delete(@Bind("nodeName") final String nodeName);
 
     @SqlQuery
-    public NodeInfoModelDao getByNodeName(@Bind("nodeName") final String nodeName);
+    public NodeInfoModelDao getByNodeName(@Bind("nodeName") final String nodeName, @Bind("updatedDate") final Date updatedDate);
 
     @SqlQuery
-    public List<NodeInfoModelDao> getAll();
+    public List<NodeInfoModelDao> getAll(@Bind("updatedDate") final Date updatedDate);
 
 }

--- a/util/src/main/resources/org/killbill/billing/util/nodes/dao/NodeInfoSqlDao.sql.stg
+++ b/util/src/main/resources/org/killbill/billing/util/nodes/dao/NodeInfoSqlDao.sql.stg
@@ -41,6 +41,7 @@ getByNodeName() ::= <<
 select <allTableFields("")>
 from <tableName()>
 where node_name = :nodeName
+and updated_date \> :updatedDate
 and is_active = '1'
 ;
 >>
@@ -49,6 +50,7 @@ getAll() ::= <<
 select <allTableFields("")>
 from <tableName()>
 where is_active = '1'
+and updated_date \> :updatedDate
 order by node_name asc
 ;
 >>
@@ -57,6 +59,13 @@ updateNodeInfo() ::= <<
 update <tableName()>
 set node_info = :nodeInfo
 , updated_date = :updatedDate
+where node_name = :nodeName
+;
+>>
+
+setUpdatedDate() ::= <<
+update <tableName()>
+set updated_date = :updatedDate
 where node_name = :nodeName
 ;
 >>

--- a/util/src/test/java/org/killbill/billing/util/nodes/dao/TestNodeInfoDao.java
+++ b/util/src/test/java/org/killbill/billing/util/nodes/dao/TestNodeInfoDao.java
@@ -24,6 +24,7 @@ import org.killbill.billing.util.UtilTestSuiteWithEmbeddedDB;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestNodeInfoDao extends UtilTestSuiteWithEmbeddedDB {
 
@@ -49,7 +50,6 @@ public class TestNodeInfoDao extends UtilTestSuiteWithEmbeddedDB {
         assertEquals(all.size(), 1);
         assertEquals(all.get(0), newNode1);
 
-
         final DateTime initialBootTime2 = clock.getUTCNow();
         final NodeInfoModelDao node2 = new NodeInfoModelDao(-1L, "node2", initialBootTime2, now, "nodeInfo", true);
         nodeInfoDao.create(node2);
@@ -67,6 +67,15 @@ public class TestNodeInfoDao extends UtilTestSuiteWithEmbeddedDB {
         assertEquals(all.size(), 2);
         assertEquals(all.get(0), newNode1);
         assertEquals(all.get(1), newNode2);
+
+        now = clock.getUTCNow();
+        Thread.sleep(1001);
+        nodeInfoDao.setUpdatedDate(newNode1.getNodeName());
+        nodeInfoDao.setUpdatedDate(newNode2.getNodeName());
+        all = nodeInfoDao.getAll();
+        assertEquals(all.size(), 2);
+        assertTrue(all.get(0).getUpdatedDate().compareTo(now) >= 0);
+        assertTrue(all.get(1).getUpdatedDate().compareTo(now) >= 0);
     }
 
 }

--- a/util/src/test/java/org/killbill/billing/util/nodes/dao/TestNodeInfoDao.java
+++ b/util/src/test/java/org/killbill/billing/util/nodes/dao/TestNodeInfoDao.java
@@ -68,14 +68,13 @@ public class TestNodeInfoDao extends UtilTestSuiteWithEmbeddedDB {
         assertEquals(all.get(0), newNode1);
         assertEquals(all.get(1), newNode2);
 
-        now = clock.getUTCNow();
-        Thread.sleep(1001);
+        clock.addDeltaFromReality(5000);
         nodeInfoDao.setUpdatedDate(newNode1.getNodeName());
         nodeInfoDao.setUpdatedDate(newNode2.getNodeName());
         all = nodeInfoDao.getAll();
         assertEquals(all.size(), 2);
-        assertTrue(all.get(0).getUpdatedDate().compareTo(now) >= 0);
-        assertTrue(all.get(1).getUpdatedDate().compareTo(now) >= 0);
+        assertTrue(all.get(0).getUpdatedDate().compareTo(now) > 0);
+        assertTrue(all.get(1).getUpdatedDate().compareTo(now) > 0);
     }
 
 }


### PR DESCRIPTION
The cleanup of the node_info entries relies on the KB shutdown sequence.

Hiwever, there is no guarantee that such shutdown sequence got initiated (e.g OOM JVM crash)
or that it terminated cleanly (k8s KILL -9 pod is takes too long), so with this change we introduce
an executor that refreshes the `updated_date` and the code has been modified to only return recent values
 (updated within last 3 minutes).