### PR TITLE
Add support for more recent JDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,138 @@
+name: ci
+
+on:
+  - push
+  - workflow_dispatch
+
+env:
+  MAVEN_FLAGS: "-e -B --no-transfer-progress"
+  MAVEN_OPTS: "-Xmx2G -XX:+ExitOnOutOfMemoryError -Dmaven.wagon.rto=60000 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version:
+          - 8
+          - 11
+        java-distribution:
+          - adopt
+          - zulu
+        profile:
+          - travis
+          - mysql
+          - postgresql
+    steps:
+      - name: Checkout killbill
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill
+          ref: ${{ github.ref }}
+          path: killbill
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: ${{ matrix.java-distribution }}
+          java-version: ${{ matrix.java-version }}
+      - name: Configure Sonatype mirror
+        uses: s4u/maven-settings-action@v2.3.0
+        # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
+        with:
+          mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "*", "url": "https://oss.sonatype.org/content/repositories/releases/"}]'
+      - name: Check if killbill-oss-parent SNAPSHOT must be fetched
+        id: killbill-oss-parent
+        run: |
+          REMOTE_SHA=$(git ls-remote --heads https://github.com/killbill/killbill-oss-parent.git ${GITHUB_REF##*/})
+          echo "killbill-oss-parent branch=${GITHUB_REF##*/} sha=${REMOTE_SHA}"
+          cd $GITHUB_WORKSPACE/killbill
+          # Cannot use mvn help:evaluate unfortunately, as the project isn't buildable yet
+          PARENT_POM_VERSION=$(
+             awk '
+              /<dependenc/{exit}
+              /<parent>/{parent++};
+              /<version>/{
+                if (parent == 1) {
+                  sub(/.*<version>/, "");
+                  sub(/<.*/, "");
+                  parent_version = $0;
+                }
+              }
+              /<\/parent>/{parent--};
+              END {
+                print parent_version
+              }' pom.xml
+          )
+          echo "killbill-oss-parent version=${PARENT_POM_VERSION}"
+          if [[ "$PARENT_POM_VERSION" =~ .*"-SNAPSHOT".* ]] && [ ! -z "$REMOTE_SHA" ]; then
+            echo "::set-output name=FETCH_SNAPSHOT::true"
+          else
+            echo "::set-output name=FETCH_SNAPSHOT::false"
+          fi
+      - name: Checkout killbill-oss-parent
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-oss-parent
+          ref: ${{ github.ref }}
+          path: killbill-oss-parent
+      - name: Build killbill-oss-parent
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/killbill-oss-parent
+          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+      - name: Checkout killbill-commons
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-commons
+          ref: ${{ github.ref }}
+          path: killbill-commons
+      - name: Build killbill-commons
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/killbill-commons
+          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+      - name: Checkout killbill-plugin-framework-java
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-plugin-framework-java
+          ref: ${{ github.ref }}
+          path: killbill-plugin-framework-java
+      - name: Build killbill-plugin-framework-java
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/killbill-plugin-framework-java
+          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+      - name: Checkout killbill-platform
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-platform
+          ref: ${{ github.ref }}
+          path: killbill-platform
+      - name: Build killbill-platform
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/killbill-platform
+          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+      - name: Checkout killbill-client-java
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: killbill/killbill-client-java
+          ref: ${{ github.ref }}
+          path: killbill-client-java
+      - name: Build killbill-client-java
+        if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+        run: |
+          cd $GITHUB_WORKSPACE/killbill-client-java
+          mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+      - name: Tests
+        env:
+          MAVEN_PROFILE: ${{ matrix.profile }}
+        run: |
+          cd $GITHUB_WORKSPACE/killbill
+          mvn ${MAVEN_FLAGS} clean install -P${MAVEN_PROFILE}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,144 @@
+name: "CodeQL"
+
+on:
+  - push
+  - workflow_dispatch
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version:
+          - 8
+        java-distribution:
+          - adopt
+        language: ['java']
+    steps:
+    - name: Checkout killbill
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill
+        ref: ${{ github.ref }}
+        path: killbill
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+    - name: Setup Java
+      uses: actions/setup-java@v2
+      with:
+        distribution: ${{ matrix.java-distribution }}
+        java-version: ${{ matrix.java-version }}
+    - name: Configure Sonatype mirror
+      uses: s4u/maven-settings-action@v2.3.0
+      # Go to Sonatype directly to avoid delay syncs (could get rid of this if actions/setup-java were to support mirrors).
+      with:
+        mirrors: '[{"id": "oss-releases", "name": "Sonatype releases", "mirrorOf": "*", "url": "https://oss.sonatype.org/content/repositories/releases/"}]'
+    - name: Check if killbill-oss-parent SNAPSHOT must be fetched
+      id: killbill-oss-parent
+      run: |
+        REMOTE_SHA=$(git ls-remote --heads https://github.com/killbill/killbill-oss-parent.git ${GITHUB_REF##*/})
+        echo "killbill-oss-parent branch=${GITHUB_REF##*/} sha=${REMOTE_SHA}"
+        cd $GITHUB_WORKSPACE/killbill
+        # Cannot use mvn help:evaluate unfortunately, as the project isn't buildable yet
+        PARENT_POM_VERSION=$(
+           awk '
+            /<dependenc/{exit}
+            /<parent>/{parent++};
+            /<version>/{
+              if (parent == 1) {
+                sub(/.*<version>/, "");
+                sub(/<.*/, "");
+                parent_version = $0;
+              }
+            }
+            /<\/parent>/{parent--};
+            END {
+              print parent_version
+            }' pom.xml
+        )
+        echo "killbill-oss-parent version=${PARENT_POM_VERSION}"
+        if [[ "$PARENT_POM_VERSION" =~ .*"-SNAPSHOT".* ]] && [ ! -z "$REMOTE_SHA" ]; then
+          echo "::set-output name=FETCH_SNAPSHOT::true"
+        else
+          echo "::set-output name=FETCH_SNAPSHOT::false"
+        fi
+    - name: Checkout killbill-oss-parent
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-oss-parent
+        ref: ${{ github.ref }}
+        path: killbill-oss-parent
+    - name: Build killbill-oss-parent
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-oss-parent
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Checkout killbill-commons
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-commons
+        ref: ${{ github.ref }}
+        path: killbill-commons
+    - name: Build killbill-commons
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-commons
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Checkout killbill-plugin-framework-java
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-plugin-framework-java
+        ref: ${{ github.ref }}
+        path: killbill-plugin-framework-java
+    - name: Build killbill-plugin-framework-java
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-plugin-framework-java
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Checkout killbill-platform
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-platform
+        ref: ${{ github.ref }}
+        path: killbill-platform
+    - name: Build killbill-platform
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-platform
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Checkout killbill-client-java
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: killbill/killbill-client-java
+        ref: ${{ github.ref }}
+        path: killbill-client-java
+    - name: Build killbill-client-java
+      if: steps.killbill-oss-parent.outputs.FETCH_SNAPSHOT == 'true'
+      run: |
+        cd $GITHUB_WORKSPACE/killbill-client-java
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        source-root: killbill
+    - name: Build killbill
+      run: |
+        cd $GITHUB_WORKSPACE/killbill
+        mvn ${MAVEN_FLAGS} clean install -DskipTests=true
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+      with:
+        checkout_path: ${{ github.workspace }}/killbill

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,18 @@
+0.22.25
+    See https://github.com/killbill/killbill/releases/tag/killbill-0.22.25
+
+0.22.24
+    See https://github.com/killbill/killbill/releases/tag/killbill-0.22.24
+
+0.22.23
+    See https://github.com/killbill/killbill/releases/tag/killbill-0.22.23
+
+0.22.22
+    See https://github.com/killbill/killbill/releases/tag/killbill-0.22.22
+
+0.22.21
+    See https://github.com/killbill/killbill/releases/tag/killbill-0.22.21
+
 0.22.20
     See https://github.com/killbill/killbill/releases/tag/killbill-0.22.20
 

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -89,8 +89,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>objenesis</artifactId>
                     <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/bin/start-server
+++ b/bin/start-server
@@ -29,8 +29,23 @@ PROPERTIES=${PROPERTIES-"$SERVER/src/main/resources/killbill-server.properties"}
 DEBUG_OPTS_ECLIPSE=" -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=12345 "
 DEBUG_OPTS_ECLIPSE_WAIT=" -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=12345 "
 
-# Default JVM settings if unset
-MAVEN_OPTS=${MAVEN_OPTS-"-Djava.awt.headless=true -Duser.timezone=GMT -Xms512m -Xmx2048m -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=512m -XX:+UseConcMarkSweepGC"}
+if type -p java; then
+    _java=java
+elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    _java="$JAVA_HOME/bin/java"
+fi
+
+if [[ "$_java" ]]; then
+    version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    major=$(echo $version | cut -f 1 -d .)
+    minor=$(echo $version | cut -f 2 -d .)
+    COMMON_MAVEN_OPTS="-Djava.awt.headless=true -Duser.timezone=GMT -Xms512m -Xmx2048m -XX:MaxDirectMemorySize=512m"
+    if [ "$major" -eq 1 ] && [ "$minor" -eq 8 ]; then
+        MAVEN_OPTS=${MAVEN_OPTS-"$COMMON_MAVEN_OPTS -XX:+UseConcMarkSweepGC"}
+    else
+        MAVEN_OPTS=${MAVEN_OPTS-"$COMMON_MAVEN_OPTS --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"}
+    fi
+fi
 
 LOG="$SERVER/src/main/resources/logback.xml"
 LOG_DIR="$SERVER/logs"

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -191,17 +191,17 @@
                 <executions>
                     <execution>
                         <id>assemble-load-tool-catalog</id>
-                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <phase>package</phase>
                         <configuration>
                             <createSourcesJar>false</createSourcesJar>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>load-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -215,7 +215,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.LoadCatalog</Main-Class>
@@ -226,17 +226,17 @@
                     </execution>
                     <execution>
                         <id>assemble-xsd-tool-catalog</id>
-                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <phase>package</phase>
                         <configuration>
                             <createSourcesJar>false</createSourcesJar>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -250,7 +250,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.CreateCatalogSchema</Main-Class>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -70,8 +70,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>objenesis</artifactId>
                     <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -102,8 +102,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>objenesis</artifactId>
                     <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -75,8 +75,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>objenesis</artifactId>
                     <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -83,8 +83,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>objenesis</artifactId>
                     <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -211,17 +211,17 @@
                 <executions>
                     <execution>
                         <id>assemble-xsd-tool-overdue</id>
-                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <phase>package</phase>
                         <configuration>
                             <createSourcesJar>false</createSourcesJar>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -235,7 +235,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.overdue.CreateOverdueConfigSchema</Main-Class>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -87,11 +87,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -109,8 +104,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>objenesis</artifactId>
                     <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,4 +65,25 @@
         <!-- Temporary until upgrade to 2.x -->
         <swagger.version>1.6.2</swagger.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <!-- 7.4.0 somehow broke the execution ordering of @BeforeClass (not executed in inheritance order anymore) -->
+                <version>7.3.0</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.53-SNAPSHOT</version>
+        <version>0.144.58</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.22.25-SNAPSHOT</version>
@@ -60,10 +60,6 @@
     </issueManagement>
     <properties>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
-        <killbill-base-plugin.version>4.2.13-SNAPSHOT</killbill-base-plugin.version>
-        <killbill-client.version>1.2.4-SNAPSHOT</killbill-client.version>
-        <killbill-commons.version>0.24.15-SNAPSHOT</killbill-commons.version>
-        <killbill-platform.version>0.40.8-SNAPSHOT</killbill-platform.version>
         <killbill.version>${project.version}</killbill.version>
         <main.basedir>${project.basedir}</main.basedir>
         <!-- Temporary until upgrade to 2.x -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.51</version>
+        <version>0.144.53-SNAPSHOT</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.22.25-SNAPSHOT</version>
@@ -60,6 +60,10 @@
     </issueManagement>
     <properties>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
+        <killbill-base-plugin.version>4.2.13-SNAPSHOT</killbill-base-plugin.version>
+        <killbill-client.version>1.2.4-SNAPSHOT</killbill-client.version>
+        <killbill-commons.version>0.24.15-SNAPSHOT</killbill-commons.version>
+        <killbill-platform.version>0.40.8-SNAPSHOT</killbill-platform.version>
         <killbill.version>${project.version}</killbill.version>
         <main.basedir>${project.basedir}</main.basedir>
         <!-- Temporary until upgrade to 2.x -->

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -101,6 +101,13 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
+            <exclusions>
+                <!-- https://github.com/brettwooldridge/HikariCP/issues/1746 -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.airlift</groupId>

--- a/profiles/killbill/src/main/resources/update-checker/killbill-server-update-list.properties
+++ b/profiles/killbill/src/main/resources/update-checker/killbill-server-update-list.properties
@@ -20,49 +20,134 @@
 
 ### 0.22.x series ###
 
+# 0.22.25
+0.22.25.updates           =
+0.22.25.notices           = This is the latest GA release.
+0.22.25.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.25
+
+# 0.22.24
+0.22.24.updates           = 0.22.25
+0.22.24.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.24.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.24
+
+# 0.22.23
+0.22.23.updates           = 0.22.25
+0.22.23.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.23.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.23
+
+# 0.22.22
+0.22.22.updates           = 0.22.25
+0.22.22.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.22.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.22
+
+# 0.22.21
+0.22.21.updates           = 0.22.25
+0.22.21.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.21.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.21
+
+# 0.22.20
+0.22.20.updates           = 0.22.25
+0.22.20.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.20.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.20
+
+# 0.22.19
+0.22.19.updates           = 0.22.25
+0.22.19.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.19.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.19
+
+# 0.22.18
+0.22.18.updates           = 0.22.25
+0.22.18.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.18.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.18
+
+# 0.22.17
+0.22.17.updates           = 0.22.25
+0.22.17.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.17.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.17
+
+# 0.22.16
+0.22.16.updates           = 0.22.25
+0.22.16.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.16.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.16
+
+# 0.22.15
+0.22.15.updates           = 0.22.25
+0.22.15.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.15.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.15
+
+# 0.22.14
+0.22.14.updates           = 0.22.25
+0.22.14.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.14.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.14
+
+# 0.22.13
+0.22.13.updates           = 0.22.25
+0.22.13.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.13.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.13
+
+# 0.22.12
+0.22.12.updates           = 0.22.25
+0.22.12.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.12.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.12
+
+# 0.22.11
+0.22.11.updates           = 0.22.25
+0.22.11.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.11.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.11
+
+# 0.22.10
+0.22.10.updates           = 0.22.25
+0.22.10.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.10.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.10
+
+# 0.22.9
+0.22.9.updates           = 0.22.25
+0.22.9.notices           = We recommend upgrading to 0.22.25, our latest GA release.
+0.22.9.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.9
+
 # 0.22.8
-0.22.8.updates           =
-0.22.8.notices           = This is the latest GA release.
+0.22.8.updates           = 0.22.25
+0.22.8.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.8.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.8
 
 # 0.22.7
-0.22.7.updates           = 0.22.8
-0.22.7.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.22.7.updates           = 0.22.25
+0.22.7.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.7.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.7
 
 # 0.22.6
-0.22.6.updates           = 0.22.8
-0.22.6.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.22.6.updates           = 0.22.25
+0.22.6.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.6.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.6
 
 # 0.22.5
-0.22.5.updates           = 0.22.8
-0.22.5.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.22.5.updates           = 0.22.25
+0.22.5.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.5.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.5
 
 # 0.22.4
-0.22.4.updates           = 0.22.8
-0.22.4.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.22.4.updates           = 0.22.25
+0.22.4.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.4.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.4
 
 # 0.22.3
-0.22.3.updates           = 0.22.8
-0.22.3.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.22.3.updates           = 0.22.25
+0.22.3.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.3.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.3
 
 # 0.22.2
-0.22.2.updates           = 0.22.8
-0.22.2.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.22.2.updates           = 0.22.25
+0.22.2.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.2.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.2
 
 # 0.22.1
-0.22.1.updates           = 0.22.8
-0.22.1.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.22.1.updates           = 0.22.25
+0.22.1.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.1.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.1
 
 # 0.22.0
-0.22.0.updates           = 0.22.8
-0.22.0.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.22.0.updates           = 0.22.25
+0.22.0.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.22.0.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.22.0
 
 ### 0.21.x series ###
@@ -121,314 +206,314 @@
 
 # 0.20.17
 0.20.17.updates           =
-0.20.17.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.17.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.17.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.17
 
 # 0.20.16
 0.20.16.updates           = 0.20.17
-0.20.16.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.16.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.16.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.16
 
 # 0.20.15
 0.20.15.updates           = 0.20.17
-0.20.15.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.15.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.15.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.15
 
 # 0.20.14
 0.20.14.updates           = 0.20.17
-0.20.14.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.14.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.14.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.14
 
 # 0.20.13
 0.20.13.updates           = 0.20.17
-0.20.13.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.13.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.13.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.13
 
 # 0.20.12
 0.20.12.updates           = 0.20.17
-0.20.12.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.12.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.12.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.12
 
 # 0.20.11
 0.20.11.updates           = 0.20.17
-0.20.11.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.11.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.11.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.11
 
 # 0.20.11
 0.20.11.updates           = 0.20.17
-0.20.11.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.11.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.11.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.11
 
 # 0.20.10
 0.20.10.updates           = 0.20.17
-0.20.10.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.10.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.10.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.10
 
 # 0.20.9
 0.20.9.updates           = 0.20.17
-0.20.9.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.9.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.9.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.9
 
 # 0.20.8
 0.20.8.updates           = 0.20.17
-0.20.8.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.8.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.8.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.8
 
 # 0.20.7
 0.20.7.updates           = 0.20.17
-0.20.7.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.7.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.7.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.7
 
 # 0.20.6
 0.20.6.updates           = 0.20.17
-0.20.6.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.6.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.6.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.6
 
 # 0.20.5
 0.20.5.updates           = 0.20.17
-0.20.5.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.5.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.5.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.5
 
 # 0.20.4
 0.20.4.updates           = 0.20.17
-0.20.4.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.4.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.4.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.4
 
 # 0.20.3
 0.20.3.updates           = 0.20.17
-0.20.3.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.3.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.3.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.3
 
 # 0.20.2
 0.20.2.updates           = 0.20.17
-0.20.2.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.2.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.2.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.2
 
 # 0.20.1
 0.20.1.updates           = 0.20.17
-0.20.1.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.1.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.1.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.1
 
 # 0.20.0
 0.20.0.updates           = 0.20.17
-0.20.0.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.20.0.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.20.0.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.20.0
 
 ### 0.19.x series ###
 
 # 0.19.19
 0.19.19.updates           =
-0.19.19.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.19.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.19.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.19
 
 # 0.19.18
 0.19.18.updates           = 0.19.19
-0.19.18.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.18.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.18.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.18
 
 # 0.19.17
 0.19.17.updates           = 0.19.19
-0.19.17.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.17.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.17.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.17
 
 # 0.19.16
 0.19.16.updates           = 0.19.19
-0.19.16.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.16.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.16.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.16
 
 # 0.19.15
 0.19.15.updates           = 0.19.19
-0.19.15.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.15.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.15.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.15
 
 # 0.19.14
 0.19.14.updates           = 0.19.19
-0.19.14.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.14.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.14.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.14
 
 # 0.19.13
 0.19.13.updates           = 0.19.19
-0.19.13.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.13.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.13.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.13
 
 # 0.19.12
 0.19.12.updates           = 0.19.19
-0.19.12.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.12.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.12.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.12
 
 # 0.19.11
 0.19.11.updates           = 0.19.19
-0.19.11.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.11.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.11.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.11
 
 # 0.19.10
 0.19.10.updates           = 0.19.19
-0.19.10.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.10.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.10.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.10
 
 # 0.19.9
 0.19.9.updates           = 0.19.19
-0.19.9.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.9.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.9.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.9
 
 # 0.19.8
 0.19.8.updates           = 0.19.19
-0.19.8.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.8.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.8.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.8
 
 # 0.19.7
 0.19.7.updates           = 0.19.19
-0.19.7.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.7.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.7.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.7
 
 # 0.19.6
 0.19.6.updates           = 0.19.19
-0.19.6.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.6.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.6.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.6
 
 # 0.19.5
 0.19.5.updates           = 0.19.19
-0.19.5.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.5.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.5.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.5
 
 # 0.19.4
 0.19.4.updates           = 0.19.19
-0.19.4.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.4.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.4.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.4
 
 # 0.19.3
 0.19.3.updates           = 0.19.19
-0.19.3.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.3.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.3.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.3
 
 # 0.19.2
 0.19.2.updates           = 0.19.19
-0.19.2.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.2.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.2.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.2
 
 # 0.19.1
 0.19.1.updates           = 0.19.19
-0.19.1.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.1.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.1.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.1
 
 # 0.19.0
 0.19.0.updates           = 0.19.19
-0.19.0.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.19.0.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.19.0.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.19.0
 
 ### 0.18.x series ###
 
 # 0.18.22
 0.18.22.updates           =
-0.18.22.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.22.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.22.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.22
 
 # 0.18.21
 0.18.21.updates           = 0.18.22
-0.18.21.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.21.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.21.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.21
 
 # 0.18.20
 0.18.20.updates           = 0.18.22
-0.18.20.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.20.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.20.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.20
 
 # 0.18.19
 0.18.19.updates           = 0.18.22
-0.18.19.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.19.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.19.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.19
 
 # 0.18.18
 0.18.18.updates           = 0.18.22
-0.18.18.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.18.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.18.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.18
 
 # 0.18.17
 0.18.17.updates           = 0.18.22
-0.18.17.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.17.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.17.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.17
 
 # 0.18.16
 0.18.16.updates           = 0.18.22
-0.18.16.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.16.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.16.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.16
 
 # 0.18.15
 0.18.15.updates           = 0.18.22
-0.18.15.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.15.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.15.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.15
 
 # 0.18.14
 0.18.14.updates           = 0.18.22
-0.18.14.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.14.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.14.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.14
 
 # 0.18.13
 0.18.13.updates           = 0.18.22
-0.18.13.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.13.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.13.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.13
 
 # 0.18.12
 0.18.12.updates           = 0.18.22
-0.18.12.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.12.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.12.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.12
 
 # 0.18.11
 0.18.11.updates           = 0.18.22
-0.18.11.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.11.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.11.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.11
 
 # 0.18.10
 0.18.10.updates           = 0.18.22
-0.18.10.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.10.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.10.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.10
 
 # 0.18.9
 0.18.9.updates           = 0.18.22
-0.18.9.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.9.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.9.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.9
 
 # 0.18.8
 0.18.8.updates           = 0.18.22
-0.18.8.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.8.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.8.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.8
 
 # 0.18.7
 0.18.7.updates           = 0.18.22
-0.18.7.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.7.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.7.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.7
 
 # 0.18.6
 0.18.6.updates           = 0.18.22
-0.18.6.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.6.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.6.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.6
 
 # 0.18.5
 0.18.5.updates           = 0.18.22
-0.18.5.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.5.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.5.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.5
 
 # 0.18.4
 0.18.4.updates           = 0.18.22
-0.18.4.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.4.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.4.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.4
 
 # 0.18.3
 0.18.3.updates           = 0.18.22
-0.18.3.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.3.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.3.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.3
 
 # 0.18.2
 0.18.2.updates           = 0.18.22
-0.18.2.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.2.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.2.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.2
 
 # 0.18.1
 0.18.1.updates           = 0.18.22
-0.18.1.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.1.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.1.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.1
 
 # 0.18.0
 0.18.0.updates           = 0.18.22
-0.18.0.notices           = We recommend upgrading to 0.22.8, our latest GA release.
+0.18.0.notices           = We recommend upgrading to 0.22.25, our latest GA release.
 0.18.0.release-notes     = https://github.com/killbill/killbill/releases/tag/killbill-0.18.0

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -84,8 +84,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>objenesis</artifactId>
                     <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -109,11 +109,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
         </dependency>
@@ -153,8 +148,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>objenesis</artifactId>
                     <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -345,13 +340,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/migrator.xml</descriptor>
+                    </descriptors>
+                </configuration>
                 <executions>
                     <execution>
                         <id>assemble-migrator</id>
-                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <phase>package</phase>
                         <configuration>
                             <finalName>killbill</finalName>
                             <archive>
@@ -362,21 +362,16 @@
                         </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <descriptors>
-                        <descriptor>src/main/assembly/migrator.xml</descriptor>
-                    </descriptors>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>generate-sources</phase>
                         <goals>
                             <goal>add-source</goal>
                         </goals>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <sources>
                                 <source>${project.build.directory}/generated-sources/java-templates</source>

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestSuite.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestSuite.java
@@ -191,7 +191,7 @@ public class GuicyKillbillTestSuite implements IHookable {
         if (!hasFailed && !result.isSuccess()) {
             // Ignore if the current test method is flaky
             final ITestNGMethod testNGMethod = result.getMethod();
-            final boolean isFlakyTest = testNGMethod != null && testNGMethod.getRetryAnalyzer() != null && testNGMethod.getRetryAnalyzer() instanceof FlakyRetryAnalyzer;
+            final boolean isFlakyTest = testNGMethod != null && testNGMethod.getRetryAnalyzer(result) != null && testNGMethod.getRetryAnalyzer(result) instanceof FlakyRetryAnalyzer;
             if (!isFlakyTest) {
                 hasFailed = true;
             }

--- a/util/src/test/java/org/killbill/billing/api/AbortAfterFirstFailureListener.java
+++ b/util/src/test/java/org/killbill/billing/api/AbortAfterFirstFailureListener.java
@@ -51,7 +51,7 @@ public class AbortAfterFirstFailureListener implements IInvokedMethodListener {
 
         if (testResult.getStatus() == ITestResult.FAILURE) {
             // Don't skip other tests with the current test method is flaky
-            final boolean isFlakyTest = method.getTestMethod().getRetryAnalyzer() != null && method.getTestMethod().getRetryAnalyzer() instanceof FlakyRetryAnalyzer;
+            final boolean isFlakyTest = method.getTestMethod().getRetryAnalyzer(testResult) != null && method.getTestMethod().getRetryAnalyzer(testResult) instanceof FlakyRetryAnalyzer;
             if (!isFlakyTest) {
                 synchronized (this) {
                     logger.warn("!!! Test failure, all other tests will be skipped: {} !!!", testResult);

--- a/util/src/test/java/org/killbill/billing/api/FlakyInvokedMethodListener.java
+++ b/util/src/test/java/org/killbill/billing/api/FlakyInvokedMethodListener.java
@@ -35,7 +35,7 @@ public class FlakyInvokedMethodListener implements IInvokedMethodListener {
             return;
         }
 
-        final IRetryAnalyzer retryAnalyzer = testResult.getMethod().getRetryAnalyzer();
+        final IRetryAnalyzer retryAnalyzer = testResult.getMethod().getRetryAnalyzer(testResult);
         if (retryAnalyzer != null &&
             retryAnalyzer instanceof FlakyRetryAnalyzer &&
             !((FlakyRetryAnalyzer) retryAnalyzer).shouldRetry()) {


### PR DESCRIPTION
Note that in order to use a more recent JVM, plugins must be re-compiled to relax the `(&(osgi.ee=JavaSE)(version=1.8))` requirement.

/cc @andrenpaes 