### PR TITLE
Fix for #1472

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.kill-bill.billing</groupId>
             <artifactId>killbill-platform-server</artifactId>
             <classifier>classes</classifier>
+            <exclusions>
+                <exclusion>
+                    <artifactId>metrics-guice</artifactId>
+                    <groupId>com.palominolabs.metrics</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>

--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/control/CompletionControlOperation.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/control/CompletionControlOperation.java
@@ -18,9 +18,11 @@
 package org.killbill.billing.payment.core.sm.control;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.killbill.automaton.OperationException;
 import org.killbill.automaton.OperationResult;
+import org.killbill.billing.account.api.Account;
 import org.killbill.billing.control.plugin.api.PaymentApiType;
 import org.killbill.billing.control.plugin.api.PaymentControlContext;
 import org.killbill.billing.payment.api.Payment;
@@ -74,7 +76,10 @@ public class CompletionControlOperation extends OperationControlCallback {
             @Override
             public PluginDispatcherReturnType<OperationResult> doOperation() throws OperationException {
                 final PaymentTransactionModelDao transaction = paymentStateContext.getPaymentTransactionModelDao();
-                final PaymentControlContext updatedPaymentControlContext = new DefaultPaymentControlContext(paymentStateContext.getAccount(),
+                final Account account = paymentStateContext.getAccount();
+
+                final UUID accountId = account != null ? account.getId() : null;
+                final PaymentControlContext updatedPaymentControlContext = new DefaultPaymentControlContext(accountId,
                                                                                                             paymentStateContext.getPaymentMethodId(),
                                                                                                             null,
                                                                                                             paymentStateControlContext.getAttemptId(),

--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/control/ControlPluginRunner.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/control/ControlPluginRunner.java
@@ -85,7 +85,9 @@ public class ControlPluginRunner {
         BigDecimal inputAmount = amount;
         Currency inputCurrency = currency;
         Iterable<PluginProperty> inputPluginProperties = pluginProperties;
-        PaymentControlContext inputPaymentControlContext = new DefaultPaymentControlContext(account,
+
+        final UUID accountId = account != null ? account.getId() : null;
+        PaymentControlContext inputPaymentControlContext = new DefaultPaymentControlContext(accountId,
                                                                                             paymentMethodId,
                                                                                             pluginName,
                                                                                             paymentAttemptId,
@@ -136,7 +138,8 @@ public class ControlPluginRunner {
             if (prevResult.isAborted()) {
                 throw new PaymentControlApiAbortException(controlPluginName);
             }
-            inputPaymentControlContext = new DefaultPaymentControlContext(account,
+
+            inputPaymentControlContext = new DefaultPaymentControlContext(accountId,
                                                                           inputPaymentMethodId,
                                                                           controlPluginName,
                                                                           paymentAttemptId,
@@ -179,7 +182,8 @@ public class ControlPluginRunner {
                                                                      final Iterable<PluginProperty> pluginProperties,
                                                                      final CallContext callContext) {
 
-        final PaymentControlContext inputPaymentControlContext = new DefaultPaymentControlContext(account,
+        final UUID accountId = account != null ? account.getId() : null;
+        final PaymentControlContext inputPaymentControlContext = new DefaultPaymentControlContext(accountId,
                                                                                                   paymentMethodId,
                                                                                                   pluginName,
                                                                                                   paymentAttemptId,
@@ -244,7 +248,8 @@ public class ControlPluginRunner {
                                                                      final Iterable<PluginProperty> pluginProperties,
                                                                      final CallContext callContext) {
 
-        final PaymentControlContext inputPaymentControlContext = new DefaultPaymentControlContext(account,
+        final UUID accountId = account != null ? account.getId() : null;
+        final PaymentControlContext inputPaymentControlContext = new DefaultPaymentControlContext(accountId,
                                                                                                   paymentMethodId,
                                                                                                   pluginName,
                                                                                                   paymentAttemptId,
@@ -298,7 +303,6 @@ public class ControlPluginRunner {
 
     public static class DefaultPaymentControlContext extends DefaultCallContext implements PaymentControlContext {
 
-        private final Account account;
         private final UUID paymentMethodId;
         private final String pluginName;
         private final UUID attemptId;
@@ -315,8 +319,8 @@ public class ControlPluginRunner {
         private final Currency processedCurrency;
         private final boolean isApiPayment;
 
-        public DefaultPaymentControlContext(final Account account,
-                                            final UUID paymentMethodId,
+        public DefaultPaymentControlContext(@Nullable final UUID accountId,
+                                            @Nullable final UUID paymentMethodId,
                                             @Nullable String pluginName,
                                             final UUID attemptId,
                                             @Nullable final UUID paymentId,
@@ -332,8 +336,9 @@ public class ControlPluginRunner {
                                             @Nullable final Currency processedCurrency,
                                             final boolean isApiPayment,
                                             final CallContext callContext) {
-            super(account.getId(), callContext.getTenantId(), callContext.getUserName(), callContext.getCallOrigin(), callContext.getUserType(), callContext.getReasonCode(), callContext.getComments(), callContext.getUserToken(), callContext.getCreatedDate(), callContext.getUpdatedDate());
-            this.account = account;
+
+            super(accountId, callContext.getTenantId(), callContext.getUserName(), callContext.getCallOrigin(), callContext.getUserType(), callContext.getReasonCode(), callContext.getComments(), callContext.getUserToken(), callContext.getCreatedDate(), callContext.getUpdatedDate());
+
             this.paymentMethodId = paymentMethodId;
             this.pluginName = pluginName;
             this.attemptId = attemptId;
@@ -349,11 +354,6 @@ public class ControlPluginRunner {
             this.processedAmount = processedAmount;
             this.processedCurrency = processedCurrency;
             this.isApiPayment = isApiPayment;
-        }
-
-        @Override
-        public UUID getAccountId() {
-            return account.getId();
         }
 
         @Override
@@ -433,7 +433,7 @@ public class ControlPluginRunner {
         @Override
         public String toString() {
             return "DefaultPaymentControlContext{" +
-                   "account=" + account +
+                   "accountId=" + accountId +
                    ", paymentMethodId=" + paymentMethodId +
                    ", pluginName=" + pluginName +
                    ", attemptId=" + attemptId +

--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/control/OperationControlCallback.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/control/OperationControlCallback.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.core.sm.control;
 
 import java.util.List;
+import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -26,6 +27,7 @@ import org.killbill.automaton.Operation.OperationCallback;
 import org.killbill.automaton.OperationException;
 import org.killbill.automaton.OperationResult;
 import org.killbill.billing.ErrorCode;
+import org.killbill.billing.account.api.Account;
 import org.killbill.billing.control.plugin.api.OnFailurePaymentControlResult;
 import org.killbill.billing.control.plugin.api.OnSuccessPaymentControlResult;
 import org.killbill.billing.control.plugin.api.PaymentApiType;
@@ -85,8 +87,10 @@ public abstract class OperationControlCallback extends OperationCallbackBase<Pay
 
             @Override
             public PluginDispatcherReturnType<OperationResult> doOperation() throws OperationException {
+                final Account account = paymentStateContext.getAccount();
+                final UUID accountId = account != null ? account.getId() : null;
 
-                final PaymentControlContext paymentControlContext = new DefaultPaymentControlContext(paymentStateContext.getAccount(),
+                final PaymentControlContext paymentControlContext = new DefaultPaymentControlContext(accountId,
                                                                                                      paymentStateContext.getPaymentMethodId(),
                                                                                                      null,
                                                                                                      paymentStateControlContext.getAttemptId(),
@@ -122,7 +126,8 @@ public abstract class OperationControlCallback extends OperationCallbackBase<Pay
                     final PaymentTransaction transaction = ((PaymentStateControlContext) paymentStateContext).getCurrentTransaction();
 
                     success = transaction.getTransactionStatus() == TransactionStatus.SUCCESS || transaction.getTransactionStatus() == TransactionStatus.PENDING;
-                    final PaymentControlContext updatedPaymentControlContext = new DefaultPaymentControlContext(paymentStateContext.getAccount(),
+
+                    final PaymentControlContext updatedPaymentControlContext = new DefaultPaymentControlContext(accountId,
                                                                                                                 paymentStateContext.getPaymentMethodId(),
                                                                                                                 null,
                                                                                                                 paymentStateControlContext.getAttemptId(),

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/control/TestControlPluginRunner.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/control/TestControlPluginRunner.java
@@ -76,4 +76,41 @@ public class TestControlPluginRunner extends PaymentTestSuiteNoDB {
         Assert.assertEquals(paymentControlResult.getAdjustedPluginProperties(), pluginProperties);
         Assert.assertFalse(paymentControlResult.isAborted());
     }
+
+    // This tests the PSP notification processing case
+    @Test(groups = "fast")
+    public void testPriorCallWithNullAccountAndPaymentMethodId() throws Exception {
+        final UUID paymentId = UUIDs.randomUUID();
+        final String paymentExternalKey = UUIDs.randomUUID().toString();
+        final UUID paymentTransactionId = UUIDs.randomUUID();
+        final String paymentTransactionExternalKey = UUIDs.randomUUID().toString();
+        final BigDecimal amount = BigDecimal.ONE;
+        final Currency currency = Currency.USD;
+        final ImmutableList<String> paymentControlPluginNames = ImmutableList.<String>of("not-registered");
+        final ImmutableList<PluginProperty> pluginProperties = ImmutableList.<PluginProperty>of();
+
+        final ControlPluginRunner controlPluginRunner = new ControlPluginRunner(new DefaultPaymentControlProviderPluginRegistry());
+        final PriorPaymentControlResult paymentControlResult = controlPluginRunner.executePluginPriorCalls(null,
+                null,
+                null,
+                null,
+                paymentId,
+                paymentExternalKey,
+                paymentTransactionId,
+                paymentTransactionExternalKey,
+                PaymentApiType.PAYMENT_TRANSACTION,
+                TransactionType.AUTHORIZE,
+                null,
+                amount,
+                currency,
+                null,
+                null,
+                true,
+                paymentControlPluginNames,
+                pluginProperties,
+                callContext);
+
+        Assert.assertNotNull(paymentControlResult);
+    }
+
 }

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -79,6 +79,7 @@
         <dependency>
             <groupId>com.palominolabs.metrics</groupId>
             <artifactId>metrics-guice</artifactId>
+            <version>3.2.2</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -51,6 +51,7 @@
         <dependency>
             <groupId>com.palominolabs.metrics</groupId>
             <artifactId>metrics-guice</artifactId>
+            <version>3.2.2</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Will be required when we upgrade metrics-guice to 3.1.3 -->


### PR DESCRIPTION
Changes the DefaultPaymentControlContext constructor signature to accept an account id instead
of a full account. This allows to build a CallContext even if the
account is null (e.g. when processing a PSP notification).

Fixes #1472