### PR TITLE
invoice, junction. Enables api invoicing when AUTO_INVOICING_OFF is s…

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/DefaultInvoiceGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/DefaultInvoiceGenerator.java
@@ -82,7 +82,7 @@ public class DefaultInvoiceGenerator implements InvoiceGenerator {
                                                final Currency targetCurrency,
                                                final boolean isDryRun,
                                                final InternalCallContext context) throws InvoiceApiException {
-        if ((events == null)  || events.isAccountAutoInvoiceOff()) {
+        if (events == null) {
             return new InvoiceWithMetadata(null, ImmutableSet.of(), ImmutableMap.<UUID, SubscriptionFutureNotificationDates>of(), false, context);
         }
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestDefaultInvoiceGenerator.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestDefaultInvoiceGenerator.java
@@ -989,28 +989,6 @@ public class TestDefaultInvoiceGenerator extends InvoiceTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    public void testAutoInvoiceOffAccount() throws Exception {
-        final MockBillingEventSet events = new MockBillingEventSet();
-        events.setAccountInvoiceOff(true);
-
-        final SubscriptionBase sub = createSubscription();
-        final LocalDate startDate = invoiceUtil.buildDate(2011, 9, 1);
-
-        final Plan plan = new MockPlan();
-        final BigDecimal rate1 = TEN;
-        final PlanPhase phase = createMockMonthlyPlanPhase(rate1);
-
-        final BillingEvent event = createBillingEvent(sub.getId(), sub.getBundleId(), startDate, plan, phase, 1);
-        events.add(event);
-
-        final LocalDate targetDate = invoiceUtil.buildDate(2011, 10, 3);
-        final UUID accountId = UUID.randomUUID();
-        final InvoiceWithMetadata invoiceWithMetadata = generator.generateInvoice(account, events, new AccountInvoices(), null, targetDate, Currency.USD, false, internalCallContext);
-
-        assertNull(invoiceWithMetadata.getInvoice());
-    }
-
-    @Test(groups = "fast")
     public void testAutoInvoiceOffWithCredits() throws CatalogApiException, InvoiceApiException {
         final Currency currency = Currency.USD;
         final List<Invoice> invoices = new ArrayList<Invoice>();

--- a/junction/src/main/java/org/killbill/billing/junction/plumbing/billing/DefaultInternalBillingApi.java
+++ b/junction/src/main/java/org/killbill/billing/junction/plumbing/billing/DefaultInternalBillingApi.java
@@ -106,17 +106,10 @@ public class DefaultInternalBillingApi implements BillingInternalApi {
         final Set<UUID> skippedSubscriptions = new HashSet<UUID>();
         final DefaultBillingEventSet result;
 
-        if (found_AUTO_INVOICING_OFF) {
-            result = new DefaultBillingEventSet(true, found_INVOICING_DRAFT, found_INVOICING_REUSE_DRAFT); // billing is off, we are done
-            log.info("Account is AUTO_INVOICING_OFF: no billing event for accountId='{}'", accountId);
-            return result;
-        }
-
         final Map<UUID, List<SubscriptionBase>> subscriptionsForAccount = subscriptionApi.getSubscriptionsForAccount(fullCatalog, context);
-
         final List<SubscriptionBaseBundle> bundles = subscriptionApi.getBundlesForAccount(accountId, context);
         final ImmutableAccountData account = accountApi.getImmutableAccountDataById(accountId, context);
-        result = new DefaultBillingEventSet(false, found_INVOICING_DRAFT, found_INVOICING_REUSE_DRAFT);
+        result = new DefaultBillingEventSet(found_AUTO_INVOICING_OFF, found_INVOICING_DRAFT, found_INVOICING_REUSE_DRAFT);
         addBillingEventsForBundles(bundles, account, dryRunArguments, context, result, skippedSubscriptions, subscriptionsForAccount, fullCatalog, tagsForAccount);
         if (result.isEmpty()) {
             log.info("No billing event for accountId='{}'", accountId);

--- a/junction/src/test/java/org/killbill/billing/junction/plumbing/billing/TestBillingApi.java
+++ b/junction/src/test/java/org/killbill/billing/junction/plumbing/billing/TestBillingApi.java
@@ -232,7 +232,7 @@ public class TestBillingApi extends JunctionTestSuiteNoDB {
         final BillingEventSet events = billingInternalApi.getBillingEventsForAccountAndUpdateAccountBCD(account.getId(), null, internalCallContext);
 
         assertEquals(events.isAccountAutoInvoiceOff(), true);
-        assertEquals(events.size(), 0);
+        assertEquals(events.size(), 1);
     }
 
     @Test(groups = "fast")

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
@@ -978,7 +978,8 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList("notrial");
 
-        callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CREATION,
+        callbackServlet.pushExpectedEvents(ExtBusEventType.ACCOUNT_CHANGE, /* BCD Update */
+                                           ExtBusEventType.SUBSCRIPTION_CREATION,
                                            ExtBusEventType.SUBSCRIPTION_CREATION,
                                            ExtBusEventType.ENTITLEMENT_CREATION); // Note that the BCD isn't set
         final Subscription subscriptionJson = subscriptionApi.createSubscription(input,


### PR DESCRIPTION
…et. See #1476

Prior to this, any invoicing attempt would abort if AUTO_INVOICING_OFF was set -- this included dry-run operations.

With this fix, we now allow invoice generation through api even if AUTO_INVOICING_OFF is set. This reflects the true
nature of the tag, i.e to disable 'auto' invoicing from system bus events or notifications.