### PR TITLE
Account BCD update feature pass 1

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,5 +14,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-account</artifactId>

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-account</artifactId>

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-account</artifactId>

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-account</artifactId>

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-account</artifactId>

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-account</artifactId>

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-account</artifactId>

--- a/account/pom.xml
+++ b/account/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-account</artifactId>

--- a/account/src/main/java/org/killbill/billing/account/dao/AccountModelDao.java
+++ b/account/src/main/java/org/killbill/billing/account/dao/AccountModelDao.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -139,12 +140,7 @@ public class AccountModelDao extends EntityModelDaoBase implements TimeZoneAware
 
         setCurrency(currentAccount.getCurrency());
 
-        if (currentAccount.getBillingCycleDayLocal() == DEFAULT_BILLING_CYCLE_DAY_LOCAL && // There is *not* already a BCD set
-            billingCycleDayLocal != DEFAULT_BILLING_CYCLE_DAY_LOCAL) {  // and the proposed date is not 0
-            setBillingCycleDayLocal(billingCycleDayLocal);
-        } else {
-            setBillingCycleDayLocal(currentAccount.getBillingCycleDayLocal());
-        }
+        // Note: the caller is responsible for setting the BCD
 
         // Set all updatable fields with the new values if non null, otherwise defaults to the current values
         setEmail(email != null ? email : currentAccount.getEmail());
@@ -173,7 +169,9 @@ public class AccountModelDao extends EntityModelDaoBase implements TimeZoneAware
         }
     }
 
-    public void validateAccountUpdateInput(final AccountModelDao currentAccount, final boolean ignoreNullInput) {
+    public void validateAccountUpdateInput(final AccountModelDao currentAccount,
+                                           final boolean ignoreNullInput,
+                                           final boolean allowAccountBCDUpdate) {
         //
         // We don't allow update on the following fields:
         //
@@ -199,8 +197,9 @@ public class AccountModelDao extends EntityModelDaoBase implements TimeZoneAware
         }
 
         if ((ignoreNullInput || (billingCycleDayLocal != DEFAULT_BILLING_CYCLE_DAY_LOCAL)) &&
+            !allowAccountBCDUpdate && // BCD update is disallowed
             currentAccount.getBillingCycleDayLocal() != DEFAULT_BILLING_CYCLE_DAY_LOCAL && // There is already a BCD set
-            !currentAccount.getBillingCycleDayLocal().equals(billingCycleDayLocal)) { // and it does not match we we have
+            !currentAccount.getBillingCycleDayLocal().equals(billingCycleDayLocal)) { // and it does not match what we have
             throw new IllegalArgumentException(String.format("Killbill doesn't support updating the account BCD: new=%s, current=%s", billingCycleDayLocal, currentAccount.getBillingCycleDayLocal()));
         }
 

--- a/account/src/main/java/org/killbill/billing/account/glue/DefaultAccountModule.java
+++ b/account/src/main/java/org/killbill/billing/account/glue/DefaultAccountModule.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014 Groupon, Inc
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -32,12 +33,17 @@ import org.killbill.billing.glue.AccountModule;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.audit.dao.AuditDao;
 import org.killbill.billing.util.audit.dao.DefaultAuditDao;
+import org.killbill.billing.util.features.KillbillFeatures;
 import org.killbill.billing.util.glue.KillBillModule;
 
 public class DefaultAccountModule extends KillBillModule implements AccountModule {
 
     public DefaultAccountModule(final KillbillConfigSource configSource) {
         super(configSource);
+    }
+
+    public DefaultAccountModule(final KillbillConfigSource configSource, final KillbillFeatures killbillFeatures) {
+        super(configSource, killbillFeatures);
     }
 
     private void installConfig() {
@@ -62,6 +68,10 @@ public class DefaultAccountModule extends KillBillModule implements AccountModul
         bind(AccountService.class).to(DefaultAccountService.class).asEagerSingleton();
     }
 
+    private void installKillBillFeatures() {
+        bind(KillbillFeatures.class).toInstance(killbillFeatures);
+    }
+
     @Override
     protected void configure() {
         installConfig();
@@ -69,5 +79,6 @@ public class DefaultAccountModule extends KillBillModule implements AccountModul
         installAccountService();
         installAccountUserApi();
         installInternalApi();
+        installKillBillFeatures();
     }
 }

--- a/account/src/test/java/org/killbill/billing/account/dao/TestAccountDao.java
+++ b/account/src/test/java/org/killbill/billing/account/dao/TestAccountDao.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the

--- a/account/src/test/java/org/killbill/billing/account/dao/TestAccountModelDao.java
+++ b/account/src/test/java/org/killbill/billing/account/dao/TestAccountModelDao.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.dao;
+
+import org.killbill.billing.account.AccountTestSuiteNoDB;
+import org.killbill.billing.account.AccountTestUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestAccountModelDao extends AccountTestSuiteNoDB {
+
+    @Test(groups = "fast")
+    public void testShouldBeAbleToUpdateBCD() {
+        final AccountModelDao currentAccount = AccountTestUtils.createTestAccount(17);
+        final AccountModelDao newAccount = AccountTestUtils.createTestAccount(20);
+        newAccount.setExternalKey(currentAccount.getExternalKey());
+
+        try {
+            newAccount.validateAccountUpdateInput(currentAccount, true, false);
+            Assert.fail("Should not be a able to update the BCD");
+        } catch (final IllegalArgumentException e) {
+            // Expected
+        }
+
+        newAccount.validateAccountUpdateInput(currentAccount, true, true);
+    }
+}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-internal-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-internal-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-internal-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-internal-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-internal-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-internal-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-internal-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-internal-api</artifactId>

--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-beatrix</artifactId>

--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-beatrix</artifactId>

--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-beatrix</artifactId>

--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-beatrix</artifactId>

--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-beatrix</artifactId>

--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-beatrix</artifactId>

--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-beatrix</artifactId>

--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-beatrix</artifactId>

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/BeatrixIntegrationModule.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/BeatrixIntegrationModule.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2018 Groupon, Inc
- * Copyright 2014-2018 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -84,25 +85,28 @@ public class BeatrixIntegrationModule extends KillBillModule {
     private final InvoiceConfig invoiceConfig;
 
     public BeatrixIntegrationModule(final KillbillConfigSource configSource, final ClockMock clock) {
-        this(configSource, clock, null);
+        this(configSource, clock, null, new KillbillFeatures());
     }
 
-    public BeatrixIntegrationModule(final KillbillConfigSource configSource, final ClockMock clock, @Nullable final InvoiceConfig invoiceConfig) {
-        super(configSource);
+    public BeatrixIntegrationModule(final KillbillConfigSource configSource,
+                                    final ClockMock clock,
+                                    @Nullable final InvoiceConfig invoiceConfig,
+                                    final KillbillFeatures killbillFeatures) {
+        super(configSource, killbillFeatures);
         this.clock = clock;
         this.invoiceConfig = invoiceConfig;
     }
 
     @Override
     protected void configure() {
-        install(new GuicyKillbillTestWithEmbeddedDBModule(true, configSource, clock));
+        install(new GuicyKillbillTestWithEmbeddedDBModule(true, configSource, clock, killbillFeatures));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
         install(new EventModule(configSource));
         install(new CallContextModule(configSource));
         install(new TagStoreModule(configSource));
         install(new CustomFieldModule(configSource));
-        install(new DefaultAccountModule(configSource));
+        install(new DefaultAccountModule(configSource, killbillFeatures));
         install(new CatalogModule(configSource));
         install(new DefaultSubscriptionModule(configSource));
         install(new DefaultEntitlementModule(configSource));
@@ -151,6 +155,7 @@ public class BeatrixIntegrationModule extends KillBillModule {
                 bind(InvoiceOptimizer.class).to(InvoiceOptimizerNoop.class).asEagerSingleton();
             }
         }
+
         protected void installInvoiceGenerator() {
             bind(InvoiceGenerator.class).to(DefaultInvoiceGenerator.class).asEagerSingleton();
         }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegration.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegration.java
@@ -939,7 +939,7 @@ public class TestIntegration extends TestIntegrationBase {
         // We check there is no more recurring for Refurbish-Maintenance
         expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 4, 1), new LocalDate(2016, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("29.95")));
 
-        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addMonths(1);
         assertListenerStatus();
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -137,6 +137,7 @@ import org.killbill.billing.util.callcontext.UserType;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.config.definition.PaymentConfig;
 import org.killbill.billing.util.dao.NonEntityDao;
+import org.killbill.billing.util.features.KillbillFeatures;
 import org.killbill.billing.util.nodes.KillbillNodesApi;
 import org.killbill.billing.util.tag.ControlTagType;
 import org.killbill.bus.api.PersistentBus;
@@ -337,6 +338,7 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
     protected NotificationQueueService notificationQueueService;
 
     protected ConfigurableInvoiceConfig invoiceConfig;
+    protected KillbillFeatures killbillFeatures = new KillbillFeatures();
 
     @Override
     protected void assertListenerStatus() {
@@ -351,7 +353,7 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
         final InvoiceConfig defaultInvoiceConfig = new ConfigurationObjectFactory(skifeConfigSource).build(InvoiceConfig.class);
         invoiceConfig = new ConfigurableInvoiceConfig(defaultInvoiceConfig);
-        final Injector g = Guice.createInjector(Stage.PRODUCTION, new BeatrixIntegrationModule(configSource, clock, invoiceConfig));
+        final Injector g = Guice.createInjector(Stage.PRODUCTION, new BeatrixIntegrationModule(configSource, clock, invoiceConfig, killbillFeatures));
         g.injectMembers(this);
     }
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithAccountBCDUpdate.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithAccountBCDUpdate.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.Period;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.account.api.DefaultMutableAccountData;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
+import org.killbill.billing.util.features.KillbillFeatures;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestWithAccountBCDUpdate extends TestIntegrationBase {
+
+    @BeforeClass(groups = "slow")
+    public void beforeClass() throws Exception {
+        if (hasFailed()) {
+            return;
+        }
+
+        this.killbillFeatures = Mockito.spy(KillbillFeatures.class);
+        Mockito.when(killbillFeatures.allowAccountBCDUpdate()).thenReturn(true);
+
+        super.beforeClass();
+    }
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.putAll(DEFAULT_BEATRIX_PROPERTIES);
+        allExtraProperties.put(KillbillFeatures.PROP_FEATURE_INVOICE_OPTIMIZATION, "true");
+        allExtraProperties.put("org.killbill.cache.disabled", "account-bcd");
+        return getConfigSource(null, allExtraProperties);
+    }
+
+    @BeforeMethod(groups = "slow")
+    public void beforeMethod() throws Exception {
+        if (hasFailed()) {
+            return;
+        }
+        super.beforeMethod();
+
+        invoiceConfig.setMaxInvoiceLimit(new Period(InvoiceConfig.DEFAULT_NULL_PERIOD));
+    }
+
+    @Test(groups = "slow")
+    public void testAccountBCDChangeWithNoOptimization() throws Exception {
+        final Account account = setupScenario();
+
+        // 2016-7-17: BCD alignment. We repair earliest period and generate trailing pro-ration.
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.addDays(27);
+        assertListenerStatus();
+
+        final List<ExpectedInvoiceItemCheck> expectedInvoices = new ArrayList<ExpectedInvoiceItemCheck>();
+        List<Invoice> invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, callContext);
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 5, 17), new LocalDate(2016, 6, 17), InvoiceItemType.RECURRING, new BigDecimal("249.95")));
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 7, 20), new LocalDate(2016, 8, 17), InvoiceItemType.RECURRING, new BigDecimal("225.76")));
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 5, 17), new LocalDate(2016, 5, 20), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-25")));
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 5, 20), new LocalDate(2016, 6, 17), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-225.76")));
+        invoiceChecker.checkInvoice(invoices.get(4).getId(), callContext, expectedInvoices);
+        expectedInvoices.clear();
+    }
+
+    private Account setupScenario() throws Exception {
+        final DateTime initialDate = new DateTime(2016, 4, 17, 0, 13, 42, 0, testTimeZone);
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(17));
+        assertNotNull(account);
+
+        assertEquals(accountUserApi.getAccountById(account.getId(), callContext).getBillCycleDayLocal(), (Integer) 17);
+
+        // BP creation
+        final String productName = "Shotgun";
+        final BillingPeriod term = BillingPeriod.MONTHLY;
+        final DefaultEntitlement baseEntitlement = createBaseEntitlementAndCheckForCompletion(account.getId(), "bundleKey", productName, ProductCategory.BASE, term, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+
+        final List<ExpectedInvoiceItemCheck> expectedInvoices = new ArrayList<ExpectedInvoiceItemCheck>();
+        List<Invoice> invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, callContext);
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 4, 17), null, InvoiceItemType.FIXED, BigDecimal.ZERO));
+        invoiceChecker.checkInvoice(invoices.get(0).getId(), callContext, expectedInvoices);
+        expectedInvoices.clear();
+
+        // 2016-4-20: (BP still in TRIAL)
+        clock.addDays(3);
+
+        // Set next BCD to be the 20
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE);
+        accountUserApi.updateAccount(account.getId(), new DefaultMutableAccountData(null, null, null, 0, null, null, null, 20, null, null, null, null, null, null, null, null, null, null, null, null, null, false), callContext);
+        assertListenerStatus();
+        assertEquals(accountUserApi.getAccountById(account.getId(), callContext).getBillCycleDayLocal(), (Integer) 20);
+
+        // 2016-5-17: PHASE change
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.addDays(27);
+        assertListenerStatus();
+
+        // Leading pro-ration to the new BCD
+        invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, callContext);
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 5, 17), new LocalDate(2016, 5, 20), InvoiceItemType.RECURRING, new BigDecimal("25")));
+        invoiceChecker.checkInvoice(invoices.get(1).getId(), callContext, expectedInvoices);
+        expectedInvoices.clear();
+
+        // 2016-5-20: BCD alignment
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.addDays(3);
+        assertListenerStatus();
+
+        // Regular invoice (20th -> 20th)
+        invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, callContext);
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 5, 20), new LocalDate(2016, 6, 20), InvoiceItemType.RECURRING, new BigDecimal("249.95")));
+        invoiceChecker.checkInvoice(invoices.get(2).getId(), callContext, expectedInvoices);
+        expectedInvoices.clear();
+
+        // 2016-6-20
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.addMonths(1);
+        assertListenerStatus();
+
+        // Regular invoice (20th -> 20th)
+        invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, callContext);
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2016, 6, 20), new LocalDate(2016, 7, 20), InvoiceItemType.RECURRING, new BigDecimal("249.95")));
+        invoiceChecker.checkInvoice(invoices.get(3).getId(), callContext, expectedInvoices);
+        expectedInvoices.clear();
+
+        // Move the BCD back to the 17 -- no repair happens upon the BCD change
+        accountUserApi.updateAccount(account.getId(), new DefaultMutableAccountData(null, null, null, 0, null, null, null, 17, null, null, null, null, null, null, null, null, null, null, null, null, null, false), callContext);
+        assertListenerStatus();
+        assertEquals(accountUserApi.getAccountById(account.getId(), callContext).getBillCycleDayLocal(), (Integer) 17);
+
+        return account;
+    }
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -1,6 +1,8 @@
 /*
- * Copyright 2014-2019 Groupon, Inc
- * Copyright 2014-2019 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -81,7 +83,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
 
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("Blowdart", BillingPeriod.MONTHLY, "notrial", null);
-        UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
         invoiceChecker.checkInvoice(account.getId(), 1, callContext,
@@ -121,7 +123,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
                                     new ExpectedInvoiceItemCheck(new LocalDate(2020, 3, 1), new LocalDate(2020, 4, 1), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-29.95")),
                                     new ExpectedInvoiceItemCheck(new LocalDate(2020, 3, 1), new LocalDate(2020, 3, 1), InvoiceItemType.CBA_ADJ, new BigDecimal("20.00")));
 
-        DryRunArguments dryRun = new TestDryRunArguments(DryRunType.TARGET_DATE);
+        final DryRunArguments dryRun = new TestDryRunArguments(DryRunType.TARGET_DATE);
 
         // Issue a first dry-run on 2020-03-02
         // We should not see the items that were repaired a month prior now because of the cutoff date
@@ -136,9 +138,9 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         // Issue a series of dry-run starting on 2020-04-01
         DateTime nextDate = clock.getUTCNow().plusMonths(1);
         for (int i = 0; i < 5; i++) {
-            Invoice invoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(nextDate, testTimeZone), dryRun, callContext);
+            final Invoice invoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(nextDate, testTimeZone), dryRun, callContext);
             // Filter to eliminate CBA
-            int actualRecurring = Iterables.size(Iterables.filter(invoice.getInvoiceItems(), new Predicate<InvoiceItem>() {
+            final int actualRecurring = Iterables.size(Iterables.filter(invoice.getInvoiceItems(), new Predicate<InvoiceItem>() {
                 @Override
                 public boolean apply(final InvoiceItem invoiceItem) {
                     return invoiceItem.getInvoiceItemType() == InvoiceItemType.RECURRING;
@@ -165,7 +167,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
 
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("Blowdart", BillingPeriod.MONTHLY, "notrial", null);
-        UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
         invoiceChecker.checkInvoice(account.getId(), 1, callContext,
@@ -209,7 +211,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
 
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
         final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("blowdart-in-arrear-monthly-notrial");
-        UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
         // 2020-02-01
@@ -253,7 +255,6 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
                                     new ExpectedInvoiceItemCheck(new LocalDate(2020, 4, 1), new LocalDate(2020, 4, 1), InvoiceItemType.CBA_ADJ, new BigDecimal("200.00")));
     }
 
-
     @Test(groups = "slow")
     public void testRecurringInArrear2() throws Exception {
 
@@ -264,11 +265,9 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
         assertNotNull(account);
 
-
-
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
         final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("blowdart-in-arrear-monthly-notrial");
-        UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
         // 2020-02-01
@@ -278,7 +277,6 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
 
         invoiceChecker.checkInvoice(account.getId(), 1, callContext,
                                     new ExpectedInvoiceItemCheck(new LocalDate(2020, 1, 1), new LocalDate(2020, 2, 1), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
-
 
         // Cancel in the past (previous period)
         final Entitlement entitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
@@ -293,8 +291,6 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         assertListenerStatus();
     }
 
-
-
     @Test(groups = "slow")
     public void testRecurringInArrear3() throws Exception {
 
@@ -307,7 +303,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
 
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
         final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("blowdart-in-arrear-monthly-notrial");
-        UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
         // 2020-03-01
@@ -334,7 +330,6 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         invoiceChecker.checkInvoice(account.getId(), 3, callContext,
                                     new ExpectedInvoiceItemCheck(new LocalDate(2020, 4, 1), new LocalDate(2020, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
 
-
     }
 
     private Invoice getCurrentDraftInvoice(final UUID accountId, final int nbTries) {
@@ -349,14 +344,13 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
             }
             try {
                 Thread.sleep(100);
-            } catch (InterruptedException e) {
+            } catch (final InterruptedException e) {
                 Assert.fail(e.getMessage());
             }
         }
         Assert.fail("Failed to find draft invoice for account");
         return null;
     }
-
 
     @Test(groups = "slow")
     public void testRecurringInArrear4() throws Exception {
@@ -373,7 +367,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
 
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
         final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("blowdart-in-arrear-monthly-notrial");
-        UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
         // 2021-02-01
@@ -385,8 +379,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         assertListenerStatus();
 
         invoiceChecker.checkInvoice(account.getId(), 1, callContext,
-                                                      new ExpectedInvoiceItemCheck(new LocalDate(2021, 1, 1), new LocalDate(2021, 2, 1), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
-
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2021, 1, 1), new LocalDate(2021, 2, 1), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
 
         // 2021-03-01
         clock.addMonths(1);
@@ -397,8 +390,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         assertListenerStatus();
 
         invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                              new ExpectedInvoiceItemCheck(new LocalDate(2021, 2, 1), new LocalDate(2021, 3, 1), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
-
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2021, 2, 1), new LocalDate(2021, 3, 1), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
 
         // 2021-04-01
         clock.addMonths(1);
@@ -409,9 +401,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         assertListenerStatus();
 
         invoiceChecker.checkInvoice(account.getId(), 3, callContext,
-                                              new ExpectedInvoiceItemCheck(new LocalDate(2021, 3, 1), new LocalDate(2021, 4, 1), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
-
-
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2021, 3, 1), new LocalDate(2021, 4, 1), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
 
         // Cancel on 2021-04-30
         final Entitlement entitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
@@ -419,12 +409,10 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         entitlement.cancelEntitlementWithDate(new LocalDate(2021, 4, 30), true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
-
         // 2021-05-01
         busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL);
         clock.addMonths(1);
         assertListenerStatus();
-
 
         invoice = getCurrentDraftInvoice(account.getId(), 10);
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -442,9 +430,6 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         clock.addMonths(1);
         assertListenerStatus();
     }
-
-
-
 
     @Test(groups = "slow")
     public void testUsageInArrear() throws Exception {
@@ -507,6 +492,5 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-3", "tracking-4"), internalCallContext);
 
     }
-
 }
 

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -200,8 +200,8 @@
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>load-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -215,7 +215,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.LoadCatalog</Main-Class>
@@ -235,8 +235,8 @@
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -250,7 +250,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.CreateCatalogSchema</Main-Class>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-catalog</artifactId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-catalog</artifactId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-catalog</artifactId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-catalog</artifactId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-catalog</artifactId>
@@ -200,8 +200,8 @@
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>load-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -215,7 +215,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.LoadCatalog</Main-Class>
@@ -235,8 +235,8 @@
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -250,7 +250,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.CreateCatalogSchema</Main-Class>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-catalog</artifactId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-catalog</artifactId>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-catalog</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-currency</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-currency</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-currency</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-currency</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-currency</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-currency</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-currency</artifactId>

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-currency</artifactId>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-entitlement</artifactId>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-entitlement</artifactId>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-entitlement</artifactId>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-entitlement</artifactId>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-entitlement</artifactId>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-entitlement</artifactId>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-entitlement</artifactId>

--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-entitlement</artifactId>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-invoice</artifactId>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-invoice</artifactId>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-invoice</artifactId>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-invoice</artifactId>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-invoice</artifactId>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-invoice</artifactId>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-invoice</artifactId>

--- a/invoice/pom.xml
+++ b/invoice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-invoice</artifactId>

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -189,7 +189,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                          !Objects.equals(changedField.getOldValue(), changedField.getNewValue()) &&
                                                          !"0".equals(changedField.getOldValue())) {
                                                          final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "AccountBCDChange", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-                                                         dispatcher.processAccountBCDChange(event.getAccountId(), Integer.parseInt(changedField.getNewValue()), context);
+                                                         dispatcher.processAccountBCDChange(event.getAccountId(), context);
                                                          return;
                                                      }
                                                  }

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java
@@ -143,7 +143,8 @@ public class Item {
 
     public Item[] split(final LocalDate splitDate) {
 
-        Preconditions.checkState(action == ItemAction.ADD);
+        // Relax this pre-condition to allow splitting from 'merge' phase as well.
+        //Preconditions.checkState(action == ItemAction.ADD);
         Preconditions.checkState(currentRepairedAmount.compareTo(BigDecimal.ZERO) == 0);
         Preconditions.checkState(adjustedAmount.compareTo(BigDecimal.ZERO) == 0);
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
@@ -70,7 +70,7 @@ public class ItemsNodeInterval extends NodeInterval {
     public ItemsNodeInterval[] split(final LocalDate splitDate) {
 
         Preconditions.checkState(splitDate.compareTo(start) > 0 && splitDate.compareTo(end) < 0,
-                                 String.format("Unexpected item split with startDate='%s' and endDate='%s'", start, end));
+                                 String.format("Unexpected item split with startDate='%s' and endDate='%s', splitDate='%s'", start, end, splitDate));
 
         Preconditions.checkState(leftChild == null);
         Preconditions.checkState(rightSibling == null);

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
@@ -1,7 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2015 Groupon, Inc
- * Copyright 2014-2015 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -56,12 +57,12 @@ public class ItemsNodeInterval extends NodeInterval {
         this.items = items;
     }
 
-    public ItemsNodeInterval(final ItemsNodeInterval parent, final Item item) {
+    public ItemsNodeInterval(final NodeInterval parent, final Item item) {
         super(parent, item.getStartDate(), item.getEndDate());
         this.items = new ItemsInterval(this, item);
     }
 
-    public ItemsNodeInterval(final ItemsNodeInterval parent, final LocalDate startDate, final LocalDate endDate) {
+    public ItemsNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate) {
         super(parent, startDate, endDate);
         this.items = new ItemsInterval(this);
     }
@@ -75,12 +76,12 @@ public class ItemsNodeInterval extends NodeInterval {
         Preconditions.checkState(rightSibling == null);
 
         final List<Item> rawItems = items.getItems();
-        Preconditions.checkState(rawItems.size() == 1);
+        Preconditions.checkState(rawItems.size() == 1, "Interval should have a single item: " + rawItems);
 
         final Item[] splitItems = rawItems.get(0).split(splitDate);
 
-        final ItemsNodeInterval split1 = new ItemsNodeInterval((ItemsNodeInterval) this.parent, splitItems[0]);
-        final ItemsNodeInterval split2 = new ItemsNodeInterval((ItemsNodeInterval) this.parent, splitItems[1]);
+        final ItemsNodeInterval split1 = new ItemsNodeInterval(this.parent, splitItems[0]);
+        final ItemsNodeInterval split2 = new ItemsNodeInterval(this.parent, splitItems[1]);
         final ItemsNodeInterval[] result = new ItemsNodeInterval[2];
         result[0] = split1;
         result[1] = split2;
@@ -341,9 +342,6 @@ public class ItemsNodeInterval extends NodeInterval {
         }
     }
 
-
-
-
     //
     // This is not strictly necessary -- just there to add a layer of sanity on what our tree contains
     //
@@ -444,7 +442,7 @@ public class ItemsNodeInterval extends NodeInterval {
                         curDepth = depth;
                     }
                     generator.writeObject(node);
-                } catch (IOException e) {
+                } catch (final IOException e) {
                     throw new RuntimeException("Failed to deserialize tree", e);
                 }
             }

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java
@@ -166,11 +166,15 @@ public class NodeInterval {
 
             // newNode starts before cur element, try to insert before
             if (newNode.getStart().compareTo(curChild.getStart()) < 0) {
+                if (newNode.getEnd().compareTo(curChild.getStart()) > 0) {
+                    // newNode will need to be split so it can be inserted
+                    final NodeInterval[] newNodes = ((ItemsNodeInterval) newNode).split(curChild.getStart());
+                    curChild.getParent().addNode(newNodes[0], callback);
+                    curChild.getParent().addNode(newNodes[1], callback);
+                    return true;
+                }
 
                 // We have not implemented all cases so adding preconditions
-                Preconditions.checkState(newNode.getEnd().compareTo(curChild.getStart()) <= 0,
-                                         "Failed to insert new node %s, end date overlaps with right child %s", newNode, curChild);
-
                 Preconditions.checkState(prevChild == null || newNode.getStart().compareTo(prevChild.getEnd()) >= 0,
                                          "Failed to insert new node %s, start date overlaps with left child %s", newNode, prevChild);
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/SubscriptionItemTree.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/SubscriptionItemTree.java
@@ -1,7 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2017 Groupon, Inc
- * Copyright 2014-2017 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -47,19 +48,19 @@ public class SubscriptionItemTree {
     private final UUID targetInvoiceId;
     private final UUID subscriptionId;
 
-    private ItemsNodeInterval root =new ItemsNodeInterval();
+    private ItemsNodeInterval root = new ItemsNodeInterval();
     private boolean isBuilt = false;
     private boolean isMerged = false;
 
     private static final Comparator<InvoiceItem> INVOICE_ITEM_COMPARATOR = new Comparator<InvoiceItem>() {
         @Override
         public int compare(final InvoiceItem o1, final InvoiceItem o2) {
-            int startDateComp = o1.getStartDate().compareTo(o2.getStartDate());
+            final int startDateComp = o1.getStartDate().compareTo(o2.getStartDate());
             if (startDateComp != 0) {
                 return startDateComp;
             }
-            int itemTypeComp =  (o1.getInvoiceItemType().ordinal()<o2.getInvoiceItemType().ordinal() ? -1 :
-                                 (o1.getInvoiceItemType().ordinal()==o2.getInvoiceItemType().ordinal() ? 0 : 1));
+            final int itemTypeComp = (o1.getInvoiceItemType().ordinal() < o2.getInvoiceItemType().ordinal() ? -1 :
+                                      (o1.getInvoiceItemType().ordinal() == o2.getInvoiceItemType().ordinal() ? 0 : 1));
             if (itemTypeComp != 0) {
                 return itemTypeComp;
             }
@@ -133,7 +134,6 @@ public class SubscriptionItemTree {
         pendingItemAdj.clear();
 
         root.buildForExistingItems(items, targetInvoiceId);
-
 
         isBuilt = true;
     }
@@ -217,11 +217,11 @@ public class SubscriptionItemTree {
 
         final List<InvoiceItem> tmp = new LinkedList<InvoiceItem>();
         tmp.addAll(remainingIgnoredItems);
-        for (final Item item: items) {
+        for (final Item item : items) {
             if (item != null) {
                 tmp.add(item.toInvoiceItem());
             }
-        };
+        }
 
         final List<InvoiceItem> result = Ordering.<InvoiceItem>from(INVOICE_ITEM_COMPARATOR).sortedCopy(tmp);
         checkItemsListState(result);
@@ -233,7 +233,7 @@ public class SubscriptionItemTree {
 
         LocalDate prevRecurringEndDate = null;
         LocalDate prevRepairEndDate = null;
-        for (InvoiceItem cur : orderedList) {
+        for (final InvoiceItem cur : orderedList) {
             switch (cur.getInvoiceItemType()) {
                 case FIXED:
                     break;

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
@@ -33,6 +33,8 @@ import org.killbill.billing.invoice.tree.NodeInterval.WalkCallback;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Preconditions;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -50,13 +52,28 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
             this.id = UUID.randomUUID();
         }
 
-        public DummyNodeInterval(final DummyNodeInterval parent, final LocalDate startDate, final LocalDate endDate) {
+        public DummyNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate) {
             super(parent, startDate, endDate);
             this.id = UUID.randomUUID();
         }
 
         public UUID getId() {
             return id;
+        }
+
+        @Override
+        public ItemsNodeInterval[] split(final LocalDate splitDate) {
+            Preconditions.checkState(splitDate.compareTo(start) > 0 && splitDate.compareTo(end) < 0,
+                                     String.format("Unexpected item split with startDate='%s' and endDate='%s'", start, end));
+            Preconditions.checkState(leftChild == null);
+            Preconditions.checkState(rightSibling == null);
+
+            final DummyNodeInterval split1 = new DummyNodeInterval(this.parent, this.start, splitDate);
+            final DummyNodeInterval split2 = new DummyNodeInterval(this.parent, splitDate, this.end);
+            final DummyNodeInterval[] result = new DummyNodeInterval[2];
+            result[0] = split1;
+            result[1] = split2;
+            return result;
         }
 
         @Override

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
@@ -38,7 +38,6 @@ import com.google.common.base.Preconditions;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
@@ -77,6 +76,15 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
         }
 
         @Override
+        public String toString() {
+            final StringBuffer sb = new StringBuffer("DummyNodeInterval{");
+            sb.append("start=").append(start);
+            sb.append(", end=").append(end);
+            sb.append('}');
+            return sb.toString();
+        }
+
+        @Override
         public boolean equals(final Object o) {
             if (this == o) {
                 return true;
@@ -87,10 +95,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
             final DummyNodeInterval that = (DummyNodeInterval) o;
 
-            if (id != null ? !id.equals(that.id) : that.id != null) {
-                return false;
-            }
-            return true;
+            return id != null ? id.equals(that.id) : that.id == null;
         }
 
         @Override
@@ -181,15 +186,27 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
 
-        final DummyNodeInterval firstChild = createNodeInterval("2014-01-03", "2014-01-07");
-        root.addNode(firstChild, CALLBACK);
+        final DummyNodeInterval secondChildLevel1 = createNodeInterval("2014-01-03", "2014-01-07");
+        root.addNode(secondChildLevel1, CALLBACK);
 
-        try {
-            final DummyNodeInterval newNode = createNodeInterval("2014-01-01", "2014-01-04");
-            root.addNode(newNode, CALLBACK);
-            fail("Should fail to insert node");
-        } catch (final IllegalStateException e) {
-        }
+        final DummyNodeInterval newNode = createNodeInterval("2014-01-01", "2014-01-04");
+        root.addNode(newNode, CALLBACK);
+
+        // Newly created node "split" from newNode
+        final DummyNodeInterval firstChildLevel1 = (DummyNodeInterval) top.getLeftChild();
+        assertEquals(firstChildLevel1.getStart(), new LocalDate("2014-01-01"));
+        assertEquals(firstChildLevel1.getEnd(), new LocalDate("2014-01-03"));
+
+        // Newly created node "split" from newNode
+        final DummyNodeInterval firstChildLevel2 = (DummyNodeInterval) secondChildLevel1.getLeftChild();
+        assertEquals(firstChildLevel2.getStart(), new LocalDate("2014-01-03"));
+        assertEquals(firstChildLevel2.getEnd(), new LocalDate("2014-01-04"));
+
+        checkNode(top, 2, root, firstChildLevel1, null);
+        checkNode(firstChildLevel1, 0, top, null, secondChildLevel1);
+        checkNode(secondChildLevel1, 1, top, firstChildLevel2, null);
+
+        checkNode(firstChildLevel2, 0, secondChildLevel1, null, null);
     }
 
     @Test(groups = "fast")
@@ -199,17 +216,30 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
 
-        final DummyNodeInterval firstChild = createNodeInterval("2014-01-01", "2014-01-07");
-        root.addNode(firstChild, CALLBACK);
-        final DummyNodeInterval secondChild = createNodeInterval("2014-01-12", "2014-01-15");
-        root.addNode(secondChild, CALLBACK);
+        final DummyNodeInterval firstChildLevel1 = createNodeInterval("2014-01-01", "2014-01-07");
+        root.addNode(firstChildLevel1, CALLBACK);
+        final DummyNodeInterval thirdChildLevel1 = createNodeInterval("2014-01-12", "2014-01-15");
+        root.addNode(thirdChildLevel1, CALLBACK);
 
-        try {
-            final DummyNodeInterval newNode = createNodeInterval("2014-01-07", "2014-01-13");
-            root.addNode(newNode, CALLBACK);
-            fail("Should fail to insert node");
-        } catch (final IllegalStateException e) {
-        }
+        final DummyNodeInterval newNode = createNodeInterval("2014-01-07", "2014-01-13");
+        root.addNode(newNode, CALLBACK);
+
+        // Newly created node "split" from newNode
+        final DummyNodeInterval secondChildLevel1 = (DummyNodeInterval) firstChildLevel1.getRightSibling();
+        assertEquals(secondChildLevel1.getStart(), new LocalDate("2014-01-07"));
+        assertEquals(secondChildLevel1.getEnd(), new LocalDate("2014-01-12"));
+
+        // Newly created node "split" from newNode
+        final DummyNodeInterval firstChildLevel2 = (DummyNodeInterval) thirdChildLevel1.getLeftChild();
+        assertEquals(firstChildLevel2.getStart(), new LocalDate("2014-01-12"));
+        assertEquals(firstChildLevel2.getEnd(), new LocalDate("2014-01-13"));
+
+        checkNode(top, 3, root, firstChildLevel1, null);
+        checkNode(firstChildLevel1, 0, top, null, secondChildLevel1);
+        checkNode(secondChildLevel1, 0, top, null, thirdChildLevel1);
+        checkNode(thirdChildLevel1, 1, top, firstChildLevel2, null);
+
+        checkNode(firstChildLevel2, 0, thirdChildLevel1, null, null);
     }
 
     @Test(groups = "fast")
@@ -219,17 +249,30 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
 
-        final DummyNodeInterval firstChild = createNodeInterval("2014-01-01", "2014-01-07");
-        root.addNode(firstChild, CALLBACK);
-        final DummyNodeInterval secondChild = createNodeInterval("2014-01-12", "2014-01-15");
-        root.addNode(secondChild, CALLBACK);
+        final DummyNodeInterval firstChildLevel1 = createNodeInterval("2014-01-01", "2014-01-07");
+        root.addNode(firstChildLevel1, CALLBACK);
+        final DummyNodeInterval thirdChildLevel1 = createNodeInterval("2014-01-12", "2014-01-15");
+        root.addNode(thirdChildLevel1, CALLBACK);
 
-        try {
-            final DummyNodeInterval newNode = createNodeInterval("2014-01-06", "2014-01-12");
-            root.addNode(newNode, CALLBACK);
-            fail("Should fail to insert node");
-        } catch (final IllegalStateException e) {
-        }
+        final DummyNodeInterval newNode = createNodeInterval("2014-01-06", "2014-01-12");
+        root.addNode(newNode, CALLBACK);
+
+        // Newly created node "split" from newNode
+        final DummyNodeInterval firstChildLevel2 = (DummyNodeInterval) firstChildLevel1.getLeftChild();
+        assertEquals(firstChildLevel2.getStart(), new LocalDate("2014-01-06"));
+        assertEquals(firstChildLevel2.getEnd(), new LocalDate("2014-01-07"));
+
+        // Newly created node "split" from newNode
+        final DummyNodeInterval secondChildLevel1 = (DummyNodeInterval) firstChildLevel1.getRightSibling();
+        assertEquals(secondChildLevel1.getStart(), new LocalDate("2014-01-07"));
+        assertEquals(secondChildLevel1.getEnd(), new LocalDate("2014-01-12"));
+
+        checkNode(top, 3, root, firstChildLevel1, null);
+        checkNode(firstChildLevel1, 1, top, firstChildLevel2, secondChildLevel1);
+        checkNode(secondChildLevel1, 0, top, null, thirdChildLevel1);
+        checkNode(thirdChildLevel1, 0, top, null, null);
+
+        checkNode(firstChildLevel2, 0, firstChildLevel1, null, null);
     }
 
     @Test(groups = "fast")
@@ -239,17 +282,30 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
 
-        final DummyNodeInterval firstChild = createNodeInterval("2014-01-01", "2014-01-07");
-        root.addNode(firstChild, CALLBACK);
-        final DummyNodeInterval secondChild = createNodeInterval("2014-01-12", "2014-01-15");
-        root.addNode(secondChild, CALLBACK);
+        final DummyNodeInterval firstChildLevel1 = createNodeInterval("2014-01-01", "2014-01-07");
+        root.addNode(firstChildLevel1, CALLBACK);
+        final DummyNodeInterval secondChildLevel1 = createNodeInterval("2014-01-12", "2014-01-15");
+        root.addNode(secondChildLevel1, CALLBACK);
 
-        try {
-            final DummyNodeInterval newNode = createNodeInterval("2014-01-14", "2014-01-18");
-            root.addNode(newNode, CALLBACK);
-            fail("Should fail to insert node");
-        } catch (final IllegalStateException e) {
-        }
+        final DummyNodeInterval newNode = createNodeInterval("2014-01-14", "2014-01-18");
+        root.addNode(newNode, CALLBACK);
+
+        // Newly created node "split" from newNode
+        final DummyNodeInterval firstChildLevel2 = (DummyNodeInterval) secondChildLevel1.getLeftChild();
+        assertEquals(firstChildLevel2.getStart(), new LocalDate("2014-01-14"));
+        assertEquals(firstChildLevel2.getEnd(), new LocalDate("2014-01-15"));
+
+        // Newly created node "split" from newNode
+        final DummyNodeInterval thirdChildLevel1 = (DummyNodeInterval) secondChildLevel1.getRightSibling();
+        assertEquals(thirdChildLevel1.getStart(), new LocalDate("2014-01-15"));
+        assertEquals(thirdChildLevel1.getEnd(), new LocalDate("2014-01-18"));
+
+        checkNode(top, 3, root, firstChildLevel1, null);
+        checkNode(firstChildLevel1, 0, top, null, secondChildLevel1);
+        checkNode(secondChildLevel1, 1, top, firstChildLevel2, thirdChildLevel1);
+        checkNode(thirdChildLevel1, 0, top, null, null);
+
+        checkNode(firstChildLevel2, 0, secondChildLevel1, null, null);
     }
 
     @Test(groups = "fast")

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
@@ -1,7 +1,10 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -22,6 +25,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.joda.time.LocalDate;
+import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
 import org.killbill.billing.invoice.tree.NodeInterval.AddNodeCallback;
 import org.killbill.billing.invoice.tree.NodeInterval.BuildNodeCallback;
 import org.killbill.billing.invoice.tree.NodeInterval.SearchCallback;
@@ -34,9 +38,9 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class TestNodeInterval /* extends InvoiceTestSuiteNoDB  */ {
+public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
-    private AddNodeCallback CALLBACK = new DummyAddNodeCallback();
+    private final AddNodeCallback CALLBACK = new DummyAddNodeCallback();
 
     public static class DummyNodeInterval extends ItemsNodeInterval {
 
@@ -90,8 +94,6 @@ public class TestNodeInterval /* extends InvoiceTestSuiteNoDB  */ {
             return true;
         }
     }
-
-
 
     @Test(groups = "fast")
     public void testAddExistingItemSimple() {
@@ -212,7 +214,6 @@ public class TestNodeInterval /* extends InvoiceTestSuiteNoDB  */ {
         } catch (final IllegalStateException e) {
         }
     }
-
 
     @Test(groups = "fast")
     public void testAddOverlapNode4() {
@@ -406,7 +407,6 @@ public class TestNodeInterval /* extends InvoiceTestSuiteNoDB  */ {
         root.addNode(firstChildLevel1, CALLBACK);
         root.addNode(secondChildLevel1, CALLBACK);
 
-
         final DummyNodeInterval firstChildLevel2 = createNodeInterval("2014-01-01", "2014-01-03");
         final DummyNodeInterval secondChildLevel2 = createNodeInterval("2014-01-04", "2014-01-10");
         final DummyNodeInterval thirdChildLevel2 = createNodeInterval("2014-01-11", "2014-01-20");
@@ -461,7 +461,6 @@ public class TestNodeInterval /* extends InvoiceTestSuiteNoDB  */ {
         final DummyNodeInterval secondChildLevel1 = createNodeInterval("2014-01-21", "2014-01-31");
         root.addNode(firstChildLevel1, CALLBACK);
         root.addNode(secondChildLevel1, CALLBACK);
-
 
         final DummyNodeInterval firstChildLevel2 = createNodeInterval("2014-01-21", "2014-01-23");
         final DummyNodeInterval secondChildLevel2 = createNodeInterval("2014-01-24", "2014-01-25");
@@ -526,5 +525,4 @@ public class TestNodeInterval /* extends InvoiceTestSuiteNoDB  */ {
     private DummyNodeInterval createNodeInterval(final String startDate, final String endDate) {
         return createNodeInterval(new LocalDate(startDate), new LocalDate(endDate));
     }
-
 }

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -185,7 +185,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final LocalDate proposedItem1StartPeriod = new LocalDate(2014, 5, 17);
         final LocalDate proposedItem1EndPeriod = new LocalDate(2014, 6, 17);
-        final LocalDate proposedItem2StartPeriod = existingItem1EndPeriod;
+        final LocalDate proposedItem2StartPeriod = proposedItem1EndPeriod;
         final LocalDate proposedItem2EndPeriod = new LocalDate(2014, 7, 17);
         final LocalDate proposedItem3StartPeriod = proposedItem2EndPeriod;
         final LocalDate proposedItem3EndPeriod = new LocalDate(2014, 8, 17);
@@ -1397,7 +1397,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         verifyResult(tree.getView(), expectedResult);
     }
 
-    private void printTree(final SubscriptionItemTree tree) throws IOException {
+    private void printTree(final SubscriptionItemTree tree) {
         System.out.println(TreePrinter.print(tree.getRoot()));
     }
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -125,6 +125,102 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
+    public void testWithBCDChange3() {
+        final LocalDate existingItem1StartPeriod = new LocalDate(2014, 5, 17);
+        final LocalDate existingItem1EndPeriod = new LocalDate(2014, 6, 17);
+        final LocalDate existingItem2StartPeriod = existingItem1EndPeriod;
+        final LocalDate existingItem2EndPeriod = new LocalDate(2014, 7, 17);
+
+        final LocalDate proposedItem1StartPeriod = new LocalDate(2014, 5, 17);
+        final LocalDate proposedItem1EndPeriod = new LocalDate(2014, 5, 20);
+        final LocalDate proposedItem2StartPeriod = proposedItem1EndPeriod;
+        final LocalDate proposedItem2EndPeriod = new LocalDate(2014, 6, 20);
+        final LocalDate proposedItem3StartPeriod = proposedItem2EndPeriod;
+        final LocalDate proposedItem3EndPeriod = new LocalDate(2014, 7, 20);
+        final LocalDate proposedItem4StartPeriod = proposedItem3EndPeriod;
+        final LocalDate proposedItem4EndPeriod = new LocalDate(2014, 8, 17);
+
+        final BigDecimal monthlyRate = new BigDecimal("10.00");
+        final BigDecimal fullAmount = monthlyRate;
+
+        final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem1StartPeriod, existingItem1EndPeriod, fullAmount, monthlyRate, currency);
+        final InvoiceItem item2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem2StartPeriod, existingItem2EndPeriod, fullAmount, monthlyRate, currency);
+
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        tree.addItem(item1);
+        tree.addItem(item2);
+        tree.build();
+
+        tree.flatten(true);
+
+        final InvoiceItem proposed1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem1StartPeriod, proposedItem1EndPeriod, new BigDecimal("1"), monthlyRate, currency);
+        final InvoiceItem proposed2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem2StartPeriod, proposedItem2EndPeriod, fullAmount, monthlyRate, currency);
+        final InvoiceItem proposed3 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem3StartPeriod, proposedItem3EndPeriod, fullAmount, monthlyRate, currency);
+        final InvoiceItem proposed4 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem4StartPeriod, proposedItem4EndPeriod, new BigDecimal("7"), monthlyRate, currency);
+
+        tree.mergeProposedItem(proposed1);
+        tree.mergeProposedItem(proposed2);
+        tree.mergeProposedItem(proposed3);
+        tree.mergeProposedItem(proposed4);
+        tree.buildForMerge();
+
+        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final InvoiceItem expected1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem2EndPeriod, proposedItem3EndPeriod, new BigDecimal("1"), monthlyRate, currency);
+        expectedResult.add(expected1);
+        final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem3EndPeriod, proposedItem4EndPeriod, new BigDecimal("7"), monthlyRate, currency);
+        expectedResult.add(expected2);
+        verifyResult(tree.getView(), expectedResult);
+    }
+
+    @Test(groups = "fast")
+    public void testWithBCDChange4() {
+        final LocalDate existingItem1StartPeriod = new LocalDate(2014, 5, 17);
+        final LocalDate existingItem1EndPeriod = new LocalDate(2014, 5, 20);
+        final LocalDate existingItem2StartPeriod = existingItem1EndPeriod;
+        final LocalDate existingItem2EndPeriod = new LocalDate(2014, 6, 20);
+        final LocalDate existingItem3StartPeriod = existingItem2EndPeriod;
+        final LocalDate existingItem3EndPeriod = new LocalDate(2014, 7, 20);
+        final LocalDate existingItem4StartPeriod = existingItem3EndPeriod;
+        final LocalDate existingItem4EndPeriod = new LocalDate(2014, 8, 17);
+
+        final LocalDate proposedItem1StartPeriod = new LocalDate(2014, 5, 17);
+        final LocalDate proposedItem1EndPeriod = new LocalDate(2014, 6, 17);
+        final LocalDate proposedItem2StartPeriod = existingItem1EndPeriod;
+        final LocalDate proposedItem2EndPeriod = new LocalDate(2014, 7, 17);
+        final LocalDate proposedItem3StartPeriod = proposedItem2EndPeriod;
+        final LocalDate proposedItem3EndPeriod = new LocalDate(2014, 8, 17);
+
+        final BigDecimal monthlyRate = new BigDecimal("10.00");
+        final BigDecimal fullAmount = monthlyRate;
+
+        final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem1StartPeriod, existingItem1EndPeriod, new BigDecimal("1"), monthlyRate, currency);
+        final InvoiceItem item2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem2StartPeriod, existingItem2EndPeriod, fullAmount, monthlyRate, currency);
+        final InvoiceItem item3 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem3StartPeriod, existingItem3EndPeriod, fullAmount, monthlyRate, currency);
+        final InvoiceItem item4 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem4StartPeriod, existingItem4EndPeriod, new BigDecimal("7"), monthlyRate, currency);
+
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        tree.addItem(item1);
+        tree.addItem(item2);
+        tree.addItem(item3);
+        tree.addItem(item4);
+        tree.build();
+
+        tree.flatten(true);
+
+        final InvoiceItem proposed1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem1StartPeriod, proposedItem1EndPeriod, fullAmount, monthlyRate, currency);
+        final InvoiceItem proposed2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem2StartPeriod, proposedItem2EndPeriod, fullAmount, monthlyRate, currency);
+        final InvoiceItem proposed3 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem3StartPeriod, proposedItem3EndPeriod, fullAmount, monthlyRate, currency);
+
+        tree.mergeProposedItem(proposed1);
+        tree.mergeProposedItem(proposed2);
+        tree.mergeProposedItem(proposed3);
+        tree.buildForMerge();
+
+        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        verifyResult(tree.getView(), expectedResult);
+    }
+
+    @Test(groups = "fast")
     public void testAnnualToNewAnnualWithLaterDate() {
 
         final LocalDate startAnnual1 = new LocalDate(2015, 1, 1);

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -1,7 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -36,7 +37,6 @@ import org.killbill.billing.invoice.model.RepairAdjInvoiceItem;
 import org.killbill.billing.util.jackson.ObjectMapper;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -45,12 +45,6 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    static {
-        OBJECT_MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
-    }
 
     private final UUID invoiceId = UUID.randomUUID();
     private final UUID accountId = UUID.randomUUID();
@@ -61,11 +55,8 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
     private final String phaseName = "my-phase";
     private final Currency currency = Currency.USD;
 
-
-
     @Test(groups = "fast")
     public void testWithBCDChange() {
-
         final LocalDate startPeriod = new LocalDate(2014, 5, 1);
         final LocalDate endPeriod = new LocalDate(2014, 6, 1);
         final LocalDate bcdChange = new LocalDate(2014, 5, 15);
@@ -73,7 +64,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final BigDecimal monthlyRate = new BigDecimal("10.00");
         final BigDecimal fullAmount = monthlyRate;
-        final BigDecimal halfAmount =  new BigDecimal("5.00");
+        final BigDecimal halfAmount = new BigDecimal("5.00");
 
         final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startPeriod, endPeriod, fullAmount, monthlyRate, currency);
         final InvoiceItem item2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endPeriod, newEndPeriod, halfAmount, monthlyRate, currency);
@@ -157,17 +148,13 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed2);
         tree.buildForMerge();
 
-
         final InvoiceItem expected1 = new RepairAdjInvoiceItem(invoiceId, accountId, startBlock, endBlock, new BigDecimal("-6.85"), currency, annual.getId());
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endDate, newEndDate, new BigDecimal("7.79"), yearlyAmount, currency);
-
 
         final List<InvoiceItem> expectedResult = Lists.newLinkedList();
         expectedResult.addAll(ImmutableList.of(expected1, expected2));
         verifyResult(tree.getView(), expectedResult);
     }
-
-
 
     @Test(groups = "fast")
     public void testAnnualWithBlocking2() {
@@ -201,14 +188,10 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed2);
         tree.buildForMerge();
 
-
         final List<InvoiceItem> expectedResult = Lists.newLinkedList();
         expectedResult.addAll(ImmutableList.of());
         verifyResult(tree.getView(), expectedResult);
     }
-
-
-
 
     @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/1205")
     public void testBlockUnblock() {
@@ -575,7 +558,6 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
     }
 
-
     @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/664")
     public void testDoubleBillingOnDifferentInvoices() {
         final LocalDate startDate1 = new LocalDate(2012, 5, 1);
@@ -638,7 +620,6 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         } catch (final IllegalStateException e) {
         }
     }
-
 
     @Test(groups = "fast")
     public void testMergeWithNoExisting() {
@@ -1030,8 +1011,6 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         verifyResult(tree.getView(), expectedResult);
     }
 
-
-
     @Test(groups = "fast")
     public void testRepairWithFullItemAdjustment() {
 
@@ -1062,8 +1041,6 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final List<InvoiceItem> expectedResult = Lists.newLinkedList();
         verifyResult(tree.getView(), expectedResult);
     }
-
-
 
     @Test(groups = "fast")
     public void testMergeMonthlyToAnnualWithNoProRation() {
@@ -1269,10 +1246,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         verifyResult(tree.getView(), expectedResult);
     }
 
-
-
-
-    @Test(groups = "fast", description="https://github.com/killbill/killbill/issues/1251")
+    @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/1251")
     public void testRecuring$0PriceNoCatalogEffectiveDate() {
         final LocalDate startDate = new LocalDate(2019, 11, 1);
         final LocalDate endDate = new LocalDate(2019, 12, 1);
@@ -1293,12 +1267,6 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         verifyResult(tree.getView(), expectedResult);
     }
 
-    private void printTreeJSON(final SubscriptionItemTree tree) throws IOException {
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        tree.getRoot().jsonSerializeTree(OBJECT_MAPPER, outputStream);
-        System.out.println(outputStream.toString("UTF-8"));
-    }
-
     private void printTree(final SubscriptionItemTree tree) throws IOException {
         System.out.println(TreePrinter.print(tree.getRoot()));
     }
@@ -1309,5 +1277,4 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
             assertTrue(result.get(i).matches(expectedResult.get(i)));
         }
     }
-
 }

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -88,7 +88,41 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         verifyResult(tree.getView(), expectedResult);
     }
 
+    @Test(groups = "fast")
+    public void testWithBCDChange2() {
+        final LocalDate existingItemStartPeriod = new LocalDate(2014, 6, 20);
+        final LocalDate existingItemEndPeriod = new LocalDate(2014, 7, 20);
 
+        final LocalDate proposedItem1StartPeriod = new LocalDate(2014, 6, 17);
+        final LocalDate proposedItem1EndPeriod = new LocalDate(2014, 7, 17);
+        final LocalDate proposedItem2StartPeriod = proposedItem1EndPeriod;
+        final LocalDate proposedItem2EndPeriod = new LocalDate(2014, 8, 17);
+
+        final BigDecimal monthlyRate = new BigDecimal("10.00");
+        final BigDecimal fullAmount = monthlyRate;
+
+        final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItemStartPeriod, existingItemEndPeriod, fullAmount, monthlyRate, currency);
+
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        tree.addItem(item1);
+        tree.build();
+
+        tree.flatten(true);
+
+        final InvoiceItem proposed1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem1StartPeriod, proposedItem1EndPeriod, fullAmount, monthlyRate, currency);
+        final InvoiceItem proposed2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem2StartPeriod, proposedItem2EndPeriod, fullAmount, monthlyRate, currency);
+
+        tree.mergeProposedItem(proposed1);
+        tree.mergeProposedItem(proposed2);
+        tree.buildForMerge();
+
+        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final InvoiceItem expected1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem1StartPeriod, existingItemStartPeriod, new BigDecimal("1"), monthlyRate, currency);
+        expectedResult.add(expected1);
+        final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItemEndPeriod, proposedItem2EndPeriod, new BigDecimal("9.03"), monthlyRate, currency);
+        expectedResult.add(expected2);
+        verifyResult(tree.getView(), expectedResult);
+    }
 
     @Test(groups = "fast")
     public void testAnnualToNewAnnualWithLaterDate() {

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestTreePrinter.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestTreePrinter.java
@@ -1,6 +1,7 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -63,7 +64,7 @@ public class TestTreePrinter extends InvoiceTestSuiteNoDB {
         node11.rightSibling = node12;
         node12.leftChild = node23;
 
-        final SortedMap<XY, ItemsNodeInterval> coords = TreePrinter.buildCoordinates(root);
+        final SortedMap<XY, NodeInterval> coords = TreePrinter.buildCoordinates(root);
         Assert.assertEquals(coords.size(), 4);
         Assert.assertEquals(coords.get(new XY(0, 0)), root);
         Assert.assertEquals(coords.get(new XY(-1, -1)), node11);
@@ -74,7 +75,7 @@ public class TestTreePrinter extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testComplexMultiLevelTree() throws Exception {
-        Map<XY, ItemsNodeInterval> coords = TreePrinter.buildCoordinates(root);
+        Map<XY, NodeInterval> coords = TreePrinter.buildCoordinates(root);
         Assert.assertEquals(coords.size(), 1);
         Assert.assertEquals(coords.get(new XY(0, 0)), root);
 

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jaxrs</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jaxrs</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jaxrs</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jaxrs</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jaxrs</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jaxrs</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jaxrs</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-jaxrs</artifactId>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-junction</artifactId>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-junction</artifactId>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-junction</artifactId>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-junction</artifactId>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-junction</artifactId>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-junction</artifactId>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-junction</artifactId>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-junction</artifactId>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -220,8 +220,8 @@
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -235,7 +235,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.overdue.CreateOverdueConfigSchema</Main-Class>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-overdue</artifactId>
@@ -220,8 +220,8 @@
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -235,7 +235,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.overdue.CreateOverdueConfigSchema</Main-Class>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-overdue</artifactId>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-overdue</artifactId>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-overdue</artifactId>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-overdue</artifactId>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-overdue</artifactId>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-overdue</artifactId>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-overdue</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-payment</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-payment</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-payment</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-payment</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-payment</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-payment</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-payment</artifactId>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-payment</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.144.59</version>
     </parent>
     <artifactId>killbill</artifactId>
-    <version>0.22.26-SNAPSHOT</version>
+    <version>0.22.26</version>
     <packaging>pom</packaging>
     <name>killbill</name>
     <description>Library for managing recurring subscriptions and the associated billing</description>
@@ -51,7 +51,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>killbill-0.22.26</tag>
         <url>http://github.com/killbill/killbill/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.144.51</version>
     </parent>
     <artifactId>killbill</artifactId>
-    <version>0.22.23-SNAPSHOT</version>
+    <version>0.22.23</version>
     <packaging>pom</packaging>
     <name>killbill</name>
     <description>Library for managing recurring subscriptions and the associated billing</description>
@@ -51,7 +51,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>killbill-0.22.23</tag>
         <url>http://github.com/killbill/killbill/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.144.59</version>
     </parent>
     <artifactId>killbill</artifactId>
-    <version>0.22.26</version>
+    <version>0.22.27-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>killbill</name>
     <description>Library for managing recurring subscriptions and the associated billing</description>
@@ -51,7 +51,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill.git</developerConnection>
-        <tag>killbill-0.22.26</tag>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.58</version>
+        <version>0.144.59</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.22.26-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.144.51</version>
     </parent>
     <artifactId>killbill</artifactId>
-    <version>0.22.25</version>
+    <version>0.22.26-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>killbill</name>
     <description>Library for managing recurring subscriptions and the associated billing</description>
@@ -51,7 +51,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill.git</developerConnection>
-        <tag>killbill-0.22.25</tag>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.144.51</version>
     </parent>
     <artifactId>killbill</artifactId>
-    <version>0.22.25-SNAPSHOT</version>
+    <version>0.22.25</version>
     <packaging>pom</packaging>
     <name>killbill</name>
     <description>Library for managing recurring subscriptions and the associated billing</description>
@@ -51,7 +51,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>killbill-0.22.25</tag>
         <url>http://github.com/killbill/killbill/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.144.51</version>
     </parent>
     <artifactId>killbill</artifactId>
-    <version>0.22.24</version>
+    <version>0.22.25-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>killbill</name>
     <description>Library for managing recurring subscriptions and the associated billing</description>
@@ -51,7 +51,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill.git</developerConnection>
-        <tag>killbill-0.22.24</tag>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.144.51</version>
     </parent>
     <artifactId>killbill</artifactId>
-    <version>0.22.23</version>
+    <version>0.22.24-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>killbill</name>
     <description>Library for managing recurring subscriptions and the associated billing</description>
@@ -51,7 +51,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill.git</developerConnection>
-        <tag>killbill-0.22.23</tag>
+        <tag>HEAD</tag>
         <url>http://github.com/killbill/killbill/tree/master</url>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version>0.144.51</version>
     </parent>
     <artifactId>killbill</artifactId>
-    <version>0.22.24-SNAPSHOT</version>
+    <version>0.22.24</version>
     <packaging>pom</packaging>
     <name>killbill</name>
     <description>Library for managing recurring subscriptions and the associated billing</description>
@@ -51,7 +51,7 @@
     <scm>
         <connection>scm:git:git://github.com/killbill/killbill.git</connection>
         <developerConnection>scm:git:git@github.com:killbill/killbill.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>killbill-0.22.24</tag>
         <url>http://github.com/killbill/killbill/tree/master</url>
     </scm>
     <issueManagement>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killbill</artifactId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killbill</artifactId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killbill</artifactId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killbill</artifactId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killbill</artifactId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killbill</artifactId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killbill</artifactId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killbill</artifactId>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killpay</artifactId>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killpay</artifactId>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killpay</artifactId>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killpay</artifactId>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killpay</artifactId>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killpay</artifactId>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killpay</artifactId>

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-profiles</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles-killpay</artifactId>

--- a/profiles/pom.xml
+++ b/profiles/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles</artifactId>

--- a/profiles/pom.xml
+++ b/profiles/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles</artifactId>

--- a/profiles/pom.xml
+++ b/profiles/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles</artifactId>

--- a/profiles/pom.xml
+++ b/profiles/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles</artifactId>

--- a/profiles/pom.xml
+++ b/profiles/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles</artifactId>

--- a/profiles/pom.xml
+++ b/profiles/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles</artifactId>

--- a/profiles/pom.xml
+++ b/profiles/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles</artifactId>

--- a/profiles/pom.xml
+++ b/profiles/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-profiles</artifactId>

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-subscription</artifactId>

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-subscription</artifactId>

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-subscription</artifactId>

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-subscription</artifactId>

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-subscription</artifactId>

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-subscription</artifactId>

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-subscription</artifactId>

--- a/subscription/pom.xml
+++ b/subscription/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-subscription</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-tenant</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-tenant</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-tenant</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-tenant</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-tenant</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-tenant</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-tenant</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-tenant</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-usage</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-usage</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-usage</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-usage</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-usage</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-usage</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-usage</artifactId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-usage</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23-SNAPSHOT</version>
+        <version>0.22.23</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24</version>
+        <version>0.22.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.23</version>
+        <version>0.22.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25</version>
+        <version>0.22.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.25-SNAPSHOT</version>
+        <version>0.22.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26</version>
+        <version>0.22.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.26-SNAPSHOT</version>
+        <version>0.22.26</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>killbill-util</name>
     <properties>
+        <killbill.features.account.allowBCDUpdate>false</killbill.features.account.allowBCDUpdate>
         <killbill.features.bus.optimization>false</killbill.features.bus.optimization>
         <killbill.features.invoice.optimization>false</killbill.features.invoice.optimization>
         <main.basedir>${project.parent.basedir}</main.basedir>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill</artifactId>
-        <version>0.22.24-SNAPSHOT</version>
+        <version>0.22.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>killbill-util</artifactId>

--- a/util/src/main/java-templates/org/killbill/billing/util/features/KillbillFeatures.java
+++ b/util/src/main/java-templates/org/killbill/billing/util/features/KillbillFeatures.java
@@ -19,20 +19,24 @@ package org.killbill.billing.util.features;
 
 import com.google.common.base.MoreObjects;
 
-public final class KillbillFeatures {
+public class KillbillFeatures {
 
     public static final String PROP_FEATURE_INVOICE_OPTIMIZATION = "killbill.features.invoice.optimization";
     public static final String PROP_FEATURE_BUS_OPTIMIZATION = "killbill.features.bus.optimization";
+    public static final String PROP_FEATURE_ALLOW_ACCOUNT_BCD_UPDATE = "killbill.features.account.allowBCDUpdate";
 
     private static final String FEATURE_INVOICE_OPTIMIZATION = "${killbill.features.invoice.optimization}";
     private static final String FEATURE_BUS_OPTIMIZATION = "${killbill.features.bus.optimization}";
+    private static final String FEATURE_ALLOW_ACCOUNT_BCD_UPDATE = "${killbill.features.account.allowBCDUpdate}";
 
     private final boolean isInvoiceOptimizationOn;
     private final boolean isBusOptimizationOn;
+    private final boolean allowAccountBCDUpdate;
 
     public KillbillFeatures() {
         this.isInvoiceOptimizationOn = Boolean.valueOf(MoreObjects.<String>firstNonNull(FEATURE_INVOICE_OPTIMIZATION, "false"));
         this.isBusOptimizationOn = Boolean.valueOf(MoreObjects.<String>firstNonNull(FEATURE_BUS_OPTIMIZATION, "false"));
+        this.allowAccountBCDUpdate = Boolean.valueOf(MoreObjects.<String>firstNonNull(FEATURE_ALLOW_ACCOUNT_BCD_UPDATE, "false"));
     }
 
     public boolean isInvoiceOptimizationOn() {
@@ -41,5 +45,9 @@ public final class KillbillFeatures {
 
     public boolean isBusOptimizationOn() {
         return isBusOptimizationOn;
+    }
+
+    public boolean allowAccountBCDUpdate() {
+        return allowAccountBCDUpdate;
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/cache/CacheControllerDispatcherProvider.java
+++ b/util/src/main/java/org/killbill/billing/util/cache/CacheControllerDispatcherProvider.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2017 Groupon, Inc
- * Copyright 2014-2017 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -28,6 +29,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 import org.killbill.billing.util.cache.Cachable.CacheType;
+import org.killbill.billing.util.config.definition.CacheConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,29 +42,40 @@ public class CacheControllerDispatcherProvider implements Provider<CacheControll
 
     private final CacheManager cacheManager;
     private final Set<BaseCacheLoader> cacheLoaders;
+    private final CacheConfig cacheConfig;
 
     @Inject
     public CacheControllerDispatcherProvider(final CacheManager cacheManager,
-                                             final Set<BaseCacheLoader> cacheLoaders) {
+                                             final Set<BaseCacheLoader> cacheLoaders,
+                                             final CacheConfig cacheConfig) {
         this.cacheManager = cacheManager;
         this.cacheLoaders = cacheLoaders;
+        this.cacheConfig = cacheConfig;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public CacheControllerDispatcher get() {
         final Map<CacheType, CacheController<Object, Object>> cacheControllers = new LinkedHashMap<CacheType, CacheController<Object, Object>>();
         for (final BaseCacheLoader cacheLoader : cacheLoaders) {
             final CacheType cacheType = cacheLoader.getCacheType();
 
-            final Cache cache = cacheManager.getCache(cacheType.getCacheName(), cacheType.getKeyType(), cacheType.getValueType());
-            if (cache == null) {
-                logger.warn("Cache for cacheName='{}' not configured", cacheLoader.getCacheType().getCacheName());
-                continue;
-            }
-            Preconditions.checkState(!cache.isClosed(), "Cache '%s' should not be closed", cacheType.getCacheName());
+            final CacheController<Object, Object> cacheController;
+            if (cacheConfig.getDisabledCaches() != null && cacheConfig.getDisabledCaches().contains(cacheType.getCacheName())) {
+                logger.info("Disabling cache for cacheName='{}'", cacheLoader.getCacheType().getCacheName());
+                cacheController = new NoOpCacheController(cacheLoader);
+            } else {
+                final Cache cache = cacheManager.getCache(cacheType.getCacheName(), cacheType.getKeyType(), cacheType.getValueType());
+                if (cache == null) {
+                    logger.warn("Cache for cacheName='{}' not configured", cacheLoader.getCacheType().getCacheName());
+                    continue;
+                }
+                Preconditions.checkState(!cache.isClosed(), "Cache '%s' should not be closed", cacheType.getCacheName());
 
-            final CacheController<Object, Object> killBillCacheController = new KillBillCacheController<Object, Object>(cache, cacheLoader);
-            cacheControllers.put(cacheType, killBillCacheController);
+                cacheController = new KillBillCacheController<Object, Object>(cache, cacheLoader);
+            }
+
+            cacheControllers.put(cacheType, cacheController);
         }
 
         return new CacheControllerDispatcher(cacheControllers);

--- a/util/src/main/java/org/killbill/billing/util/cache/NoOpCacheController.java
+++ b/util/src/main/java/org/killbill/billing/util/cache/NoOpCacheController.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.cache;
+
+import java.util.List;
+
+import org.killbill.billing.util.cache.Cachable.CacheType;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+
+// No support to turn off a cache in Ehcache 3 / JCache (JSR 107) unfortunately
+public class NoOpCacheController<K, V> implements CacheController<K, V> {
+
+    private final BaseCacheLoader<K, V> baseCacheLoader;
+
+    public NoOpCacheController(final BaseCacheLoader<K, V> baseCacheLoader) {
+        this.baseCacheLoader = baseCacheLoader;
+    }
+
+    @Override
+    public List<K> getKeys() {
+        return ImmutableList.<K>of();
+    }
+
+    @Override
+    public boolean isKeyInCache(final K key) {
+        return false;
+    }
+
+    @Override
+    public V get(final K key, final CacheLoaderArgument cacheLoaderArgument) {
+        if (key == null) {
+            return null;
+        }
+
+        final V value = computeValue(key, cacheLoaderArgument);
+        if (BaseCacheLoader.EMPTY_VALUE_PLACEHOLDER.equals(value)) {
+            return null;
+        } else {
+            return value;
+        }
+    }
+
+    @Override
+    public boolean remove(final K key) {
+        return false;
+    }
+
+    @Override
+    public void remove(final Function<K, Boolean> keyMatcher) {
+    }
+
+    @Override
+    public void putIfAbsent(final K key, final V value) {
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public void removeAll() {
+    }
+
+    @Override
+    public CacheType getCacheType() {
+        return baseCacheLoader.getCacheType();
+    }
+
+    private V computeValue(final K key, final CacheLoaderArgument cacheLoaderArgument) {
+        final V value;
+        try {
+            value = baseCacheLoader.compute(key, cacheLoaderArgument);
+        } catch (final Exception e) {
+            // Remove noisy log (might be expected, see https://github.com/killbill/killbill/issues/842)
+            //logger.warn("Unable to compute cached value for key='{}' and cacheLoaderArgument='{}'", key, cacheLoaderArgument, e);
+            throw new RuntimeException(e);
+        }
+        return value;
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/config/definition/CacheConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/CacheConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.config.definition;
+
+import java.util.Set;
+
+import org.skife.config.Config;
+import org.skife.config.DefaultNull;
+import org.skife.config.Description;
+
+public interface CacheConfig extends KillbillConfig {
+
+    @Config("org.killbill.cache.disabled")
+    @DefaultNull
+    @Description("Caches to be disabled")
+    public Set<String> getDisabledCaches();
+}

--- a/util/src/main/java/org/killbill/billing/util/glue/CacheModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/CacheModule.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2014-2019 Groupon, Inc
- * Copyright 2014-2019 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -39,6 +40,7 @@ import org.killbill.billing.util.cache.TenantKVCacheLoader;
 import org.killbill.billing.util.cache.TenantOverdueConfigCacheLoader;
 import org.killbill.billing.util.cache.TenantRecordIdCacheLoader;
 import org.killbill.billing.util.cache.TenantStateMachineConfigCacheLoader;
+import org.killbill.billing.util.config.definition.CacheConfig;
 import org.killbill.billing.util.config.definition.EhCacheConfig;
 import org.killbill.billing.util.config.definition.RedisCacheConfig;
 import org.redisson.api.RedissonClient;
@@ -58,6 +60,9 @@ public class CacheModule extends KillBillModule {
 
     @Override
     protected void configure() {
+        final CacheConfig cacheConfig = new ConfigurationObjectFactory(skifeConfigSource).build(CacheConfig.class);
+        bind(CacheConfig.class).toInstance(cacheConfig);
+
         final EhCacheConfig ehCacheConfig = new ConfigurationObjectFactory(skifeConfigSource).build(EhCacheConfig.class);
         bind(EhCacheConfig.class).toInstance(ehCacheConfig);
 

--- a/util/src/main/java/org/killbill/billing/util/glue/KillBillModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillBillModule.java
@@ -1,6 +1,8 @@
 /*
- * Copyright 2014 Groupon, Inc
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -32,9 +34,13 @@ public abstract class KillBillModule extends AbstractModule {
     protected final KillbillFeatures killbillFeatures;
 
     public KillBillModule(final KillbillConfigSource configSource) {
+        this(configSource, new KillbillFeatures());
+    }
+
+    public KillBillModule(final KillbillConfigSource configSource, final KillbillFeatures killbillFeatures) {
         this.configSource = configSource;
         this.skifeConfigSource = new KillbillSkifeConfigSource(configSource);
-        this.killbillFeatures = new KillbillFeatures();
+        this.killbillFeatures = killbillFeatures;
     }
 
     private static final class KillbillSkifeConfigSource implements ConfigSource {

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestModule.java
@@ -29,6 +29,7 @@ import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.features.KillbillFeatures;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.killbill.clock.Clock;
 import org.killbill.clock.ClockMock;
@@ -40,7 +41,11 @@ public class GuicyKillbillTestModule extends KillBillModule {
     private final ClockMock clock;
 
     public GuicyKillbillTestModule(final KillbillConfigSource configSource, final ClockMock clock) {
-        super(configSource);
+        this(configSource, clock, new KillbillFeatures());
+    }
+
+    public GuicyKillbillTestModule(final KillbillConfigSource configSource, final ClockMock clock, final KillbillFeatures killbillFeatures) {
+        super(configSource, killbillFeatures);
         this.clock = clock;
 
         internalCallContext = new MutableInternalCallContext(InternalCallContextFactory.INTERNAL_TENANT_RECORD_ID,

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestWithEmbeddedDBModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestWithEmbeddedDBModule.java
@@ -22,6 +22,7 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.platform.test.PlatformDBTestingHelper;
 import org.killbill.billing.platform.test.config.TestKillbillConfigSource;
 import org.killbill.billing.platform.test.glue.TestPlatformModuleWithEmbeddedDB;
+import org.killbill.billing.util.features.KillbillFeatures;
 import org.killbill.billing.util.glue.GlobalLockerModule;
 import org.killbill.billing.util.glue.IDBISetup;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
@@ -42,11 +43,11 @@ public class GuicyKillbillTestWithEmbeddedDBModule extends GuicyKillbillTestModu
     private final boolean withOSGI;
 
     public GuicyKillbillTestWithEmbeddedDBModule(final KillbillConfigSource configSource, final ClockMock clock) {
-        this(false, configSource, clock);
+        this(false, configSource, clock, new KillbillFeatures());
     }
 
-    public GuicyKillbillTestWithEmbeddedDBModule(final boolean withOSGI, final KillbillConfigSource configSource, final ClockMock clock) {
-        super(configSource, clock);
+    public GuicyKillbillTestWithEmbeddedDBModule(final boolean withOSGI, final KillbillConfigSource configSource, final ClockMock clock, final KillbillFeatures killbillFeatures) {
+        super(configSource, clock, killbillFeatures);
         this.withOSGI = withOSGI;
     }
 


### PR DESCRIPTION
See individual commits.

☕ Invoice bug fix: ☕
* c6c569d98d097301824604ac323b16cd6032df15: remove a precondition and implement a split in the tree. I would recommend re-reading the `addNode` implementation and the modified test cases, before looking at the diff.
* 978fdf6bdf74beaca2cad014831a53475548514f: new test to highlight what the above enables.

🍺 New features: 🍺 
* 9fa48f06dc6f879832cea2d5e792c6c0472401b0: ability to disable select caches via the new property `org.killbill.cache.disabled`.
* cf6d24b3504ee28393285c53e78f2e13674b851f: new feature to allow account BCD updates (get familiar with `TestWithAccountBCDUpdate#setupScenario`, more tests coming up using that exact scenario).

🍸 _Trivial_ changes: 🍸 
* 07cd841ed20e658a2cb8242fcbb814d4571b3d6f
* 377169c115510c831af56b1b5fd3024430dd4111
* 31da803bee5a6e8b9a00d2dc22a3c1cc4a101e5f
* 4cbbad8fbd8bcd965850632fa7fb142d00302502: not _that_ trivial technically, as the `@Override` broke the `testAddOverlapNode3` test. Fixed subsequently: the test wasn't testing what we thought it was testing anyways (the state exception came from the `DummyNodeInterval` relying on the `super` implementation and missing items, not from the `addNode` insertion).
* bc2a52e3eccb357c6cec9b222514a8f59d421cc0