### PR TITLE
Test for unnecessary repairs with fixes

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java
@@ -143,7 +143,8 @@ public class Item {
 
     public Item[] split(final LocalDate splitDate) {
 
-        Preconditions.checkState(action == ItemAction.ADD);
+        // Relax this pre-condition to allow splitting from 'merge' phase as well.
+        //Preconditions.checkState(action == ItemAction.ADD);
         Preconditions.checkState(currentRepairedAmount.compareTo(BigDecimal.ZERO) == 0);
         Preconditions.checkState(adjustedAmount.compareTo(BigDecimal.ZERO) == 0);
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
@@ -70,7 +70,7 @@ public class ItemsNodeInterval extends NodeInterval {
     public ItemsNodeInterval[] split(final LocalDate splitDate) {
 
         Preconditions.checkState(splitDate.compareTo(start) > 0 && splitDate.compareTo(end) < 0,
-                                 String.format("Unexpected item split with startDate='%s' and endDate='%s'", start, end));
+                                 String.format("Unexpected item split with startDate='%s' and endDate='%s', splitDate='%s'", start, end, splitDate));
 
         Preconditions.checkState(leftChild == null);
         Preconditions.checkState(rightSibling == null);

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -185,7 +185,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final LocalDate proposedItem1StartPeriod = new LocalDate(2014, 5, 17);
         final LocalDate proposedItem1EndPeriod = new LocalDate(2014, 6, 17);
-        final LocalDate proposedItem2StartPeriod = existingItem1EndPeriod;
+        final LocalDate proposedItem2StartPeriod = proposedItem1EndPeriod;
         final LocalDate proposedItem2EndPeriod = new LocalDate(2014, 7, 17);
         final LocalDate proposedItem3StartPeriod = proposedItem2EndPeriod;
         final LocalDate proposedItem3EndPeriod = new LocalDate(2014, 8, 17);
@@ -1397,7 +1397,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         verifyResult(tree.getView(), expectedResult);
     }
 
-    private void printTree(final SubscriptionItemTree tree) throws IOException {
+    private void printTree(final SubscriptionItemTree tree) {
         System.out.println(TreePrinter.print(tree.getRoot()));
     }
 


### PR DESCRIPTION
The test `TestSubscriptionItemTree#testWithBCDChange4` should now pass as expecting and all invoice tests pass but `ci` still unhappy because of `TestWithAccountBCDUpdate#testAccountBCDChangeWithNoOptimization`, and I was not sure what the status was.

Note: There is more work to properly implement a generic tree where we can split and rebalance arbitrary items at arbitrary levels. I have some thoughts but this would require a good amount of bandwidth...