### PR TITLE
Re-implement NodeInterval#addNode in a generic way

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationInvoiceWithRepairLogic.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationInvoiceWithRepairLogic.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
-import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.api.TestApiListener.NextEvent;
@@ -1324,35 +1323,9 @@ public class TestIntegrationInvoiceWithRepairLogic extends TestIntegrationBase {
         assertListenerStatus();
 
         invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                    new ExpectedInvoiceItemCheck(new LocalDate(2016, 9, 8), new LocalDate(2016, 10, 8), InvoiceItemType.RECURRING, new BigDecimal("19.95")),
-                                    new ExpectedInvoiceItemCheck(new LocalDate(2016, 9, 9), new LocalDate(2016, 10, 8), InvoiceItemType.REPAIR_ADJ, BigDecimal.ZERO));
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2016, 9, 8), new LocalDate(2016, 9, 9), InvoiceItemType.RECURRING, new BigDecimal("0.66")));
 
-
-        // Interestingly uncommenting this shows a double billing detected, so the scenario is not really well supported...
-        /*
-        2021-08-27T22:55:03.730+0000 [main] INFO org.killbill.billing.junction.plumbing.billing.DefaultInternalBillingApi - Computed billing events for accountId='39464ada-d3bc-4bd9-89d0-f54d8f8635af'
-DefaultBillingEvent{type=CREATE, effectiveDate=2016-09-08T00:00:00.000Z, planPhaseName=pistol-monthly-notrial-evergreen, subscriptionId=559a2298-2a70-4c6a-aece-e4032c018ace, totalOrdering=1}
-2021-08-27T22:55:03.785+0000 [main] WARN org.killbill.billing.invoice.InvoiceDispatcher - Illegal invoicing state detected for accountId='39464ada-d3bc-4bd9-89d0-f54d8f8635af', dryRunArguments='null', parking account
-{cause=java.lang.IllegalStateException: Double billing detected: addItemsCancelled=[3fd5f966-d96d-4f2a-bd27-99ffbd95f363], addItemsToBeCancelled=[d41d3557-1b03-46de-b36c-1c74825824a3], code=4, formattedMsg='ILLEGAL INVOICING STATE accountItemTree=AccountItemTree{subscriptionItemTree={559a2298-2a70-4c6a-aece-e4032c018ace=SubscriptionItemTree{targetInvoiceId=1c861c8f-6d1b-40a6-bb47-26ac8da9c319, subscriptionId=559a2298-2a70-4c6a-aece-e4032c018ace, root=ItemsNodeInterval{items=ItemsInterval{items=[]}}, isBuilt=false, isMerged=false, items=[], existingIgnoredItems=[], remainingIgnoredItems=[], pendingItemAdj=[]}}}'}
-	at org.killbill.billing.invoice.generator.FixedAndRecurringInvoiceItemGenerator.generateItems(FixedAndRecurringInvoiceItemGenerator.java:127)
-	at org.killbill.billing.invoice.generator.DefaultInvoiceGenerator.generateInvoice(DefaultInvoiceGenerator.java:101)
-	at org.killbill.billing.invoice.InvoiceDispatcher.generateKillBillInvoice(InvoiceDispatcher.java:700)
-	at org.killbill.billing.invoice.InvoiceDispatcher.processAccountWithLockAndInputTargetDate(InvoiceDispatcher.java:591)
-	at org.killbill.billing.invoice.InvoiceDispatcher.processAccountInternal(InvoiceDispatcher.java:364)
-	at org.killbill.billing.invoice.InvoiceDispatcher.processAccount(InvoiceDispatcher.java:317)
-	at org.killbill.billing.invoice.api.user.DefaultInvoiceUserApi.triggerInvoiceGeneration(DefaultInvoiceUserApi.java:287)
-	at org.killbill.billing.invoice.api.user.DefaultInvoiceUserApi$$EnhancerByGuice$$3a4ad754.CGLIB$triggerInvoiceGeneration$5(<generated>)
-	at org.killbill.billing.invoice.api.user.DefaultInvoiceUserApi$$EnhancerByGuice$$3a4ad754$$FastClassByGuice$$b79ca568.invoke(<generated>)
-	at com.google.inject.internal.cglib.proxy.$MethodProxy.invokeSuper(MethodProxy.java:228)
-	at com.google.inject.internal.InterceptorStackCallback$InterceptedMethodInvocation.proceed(InterceptorStackCallback.java:76)
-	at org.killbill.billing.util.glue.KillbillApiAopModule$ProfilingMethodInterceptor$1.execute(KillbillApiAopModule.java:76)
-	at org.killbill.commons.profiling.Profiling.executeWithProfiling(Profiling.java:35)
-	at org.killbill.billing.util.glue.KillbillApiAopModule$ProfilingMethodInterceptor.invoke(KillbillApiAopModule.java:92)
-	at com.google.inject.internal.InterceptorStackCallback$InterceptedMethodInvocation.proceed(InterceptorStackCallback.java:78)
-	at com.google.inject.internal.InterceptorStackCallback.intercept(InterceptorStackCallback.java:54)
-....
-         */
-        //checkNoMoreInvoiceToGenerate(account);
+        checkNoMoreInvoiceToGenerate(account);
     }
 
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationInvoiceWithRepairLogic.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationInvoiceWithRepairLogic.java
@@ -1328,6 +1328,47 @@ public class TestIntegrationInvoiceWithRepairLogic extends TestIntegrationBase {
         checkNoMoreInvoiceToGenerate(account);
     }
 
+    // This is a beatrix level test matching our invoice TestFixedAndRecurringInvoiceItemGenerator#testOverlappingItems
+    @Test(groups = "slow")
+    public void testOverlappingItems() throws Exception {
 
+        final DateTime initialDate = new DateTime(2016, 1, 1, 0, 0, 0, 0, testTimeZone);
+        final LocalDate startDate = initialDate.toLocalDate();
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+        assertNotNull(account);
+
+        add_AUTO_INVOICING_OFF_Tag(account.getId(), ObjectType.ACCOUNT);
+        add_AUTO_PAY_OFF_Tag(account.getId(), ObjectType.ACCOUNT);
+
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial");
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CREATE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null), null, startDate, startDate, false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Entitlement bpEntitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
+        assertListenerStatus();
+
+
+        final InvoiceModelDao existingBadInvoice = new InvoiceModelDao(UUID.randomUUID(), clock.getUTCNow(), account.getId(), null, startDate, startDate, Currency.USD, false, InvoiceStatus.COMMITTED, false);
+        final InvoiceItemModelDao wrongRecurring = new InvoiceItemModelDao(initialDate, InvoiceItemType.RECURRING, existingBadInvoice.getId(), existingBadInvoice.getAccountId(),
+                                                                           bpEntitlement.getBundleId(), entitlementId, "", "Pistol", "pistol-monthly-notrial", "pistol-monthly-notrial-evergreen", null,
+                                                                           null, new LocalDate(2016, 1, 1), new LocalDate(2016, 1, 30), new BigDecimal("18.66"), new BigDecimal("19.95"), account.getCurrency(), null);
+        existingBadInvoice.addInvoiceItem(wrongRecurring);
+        busHandler.pushExpectedEvents(NextEvent.INVOICE);
+        insertInvoiceItems(existingBadInvoice);
+        assertListenerStatus();
+
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE);
+        remove_AUTO_INVOICING_OFF_Tag(account.getId(), ObjectType.ACCOUNT);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2016, 1, 1), new LocalDate(2016, 2, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")),
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2016, 1, 1), new LocalDate(2016, 1, 30), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-18.66")));
+
+        checkNoMoreInvoiceToGenerate(account);
+    }
 
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationInvoiceWithRepairLogic.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationInvoiceWithRepairLogic.java
@@ -1382,4 +1382,54 @@ public class TestIntegrationInvoiceWithRepairLogic extends TestIntegrationBase {
         checkNoMoreInvoiceToGenerate(account);
     }
 
+
+    // This is a beatrix level test matching our invoice TestDefaultInvoiceGenerator#testRegressionFor170
+    @Test(groups = "slow")
+    public void testRegressionFor170() throws Exception {
+
+        final DateTime initialDate = new DateTime(2013, 6, 15, 0, 0, 0, 0, testTimeZone);
+        final LocalDate startDate = initialDate.toLocalDate();
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        assertNotNull(account);
+
+        add_AUTO_PAY_OFF_Tag(account.getId(), ObjectType.ACCOUNT);
+
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial");
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CREATE, NextEvent.INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null), null, startDate, startDate, false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Entitlement bpEntitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
+        assertListenerStatus();
+
+        final Invoice invoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                            new ExpectedInvoiceItemCheck(new LocalDate(2013, 6, 15), new LocalDate(2013, 7, 15), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+
+        add_AUTO_INVOICING_OFF_Tag(account.getId(), ObjectType.ACCOUNT);
+
+        final UUID linkedItemId = invoice.getInvoiceItems().get(0).getId();
+        final InvoiceModelDao repairInvoice = new InvoiceModelDao(UUID.randomUUID(), clock.getUTCNow(), account.getId(), null, startDate, startDate, Currency.USD, false, InvoiceStatus.COMMITTED, false);
+        final InvoiceItemModelDao wrongRepair = new InvoiceItemModelDao(repairInvoice.getCreatedDate(), InvoiceItemType.REPAIR_ADJ, repairInvoice.getId(), repairInvoice.getAccountId(),
+                                                                       bpEntitlement.getBundleId(), bpEntitlement.getBaseEntitlementId(), null, null, null, null, null,
+                                                                       null, new LocalDate(2013, 6, 21), new LocalDate(2013, 6, 26),  new BigDecimal("-3.33"), new BigDecimal("19.95"), account.getCurrency(), linkedItemId);
+        repairInvoice.addInvoiceItem(wrongRepair);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT, NextEvent.INVOICE);
+        insertInvoiceItems(repairInvoice);
+        assertListenerStatus();
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE);
+        remove_AUTO_INVOICING_OFF_Tag(account.getId(), ObjectType.ACCOUNT);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2013, 6, 15), new LocalDate(2013, 7, 15), InvoiceItemType.RECURRING, new BigDecimal("19.95")),
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2013, 6, 15), new LocalDate(2013, 6, 21), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-3.99")),
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2013, 6, 26), new LocalDate(2013, 7, 15), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-12.63")));
+
+
+        checkNoMoreInvoiceToGenerate(account);
+
+    }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import org.joda.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public class NodeInterval {
@@ -180,33 +179,6 @@ public class NodeInterval {
         return insertNode(this, prevChild, null, newNode, callback);
     }
 
-    @VisibleForTesting
-    void removeChild(final NodeInterval toBeRemoved) {
-        NodeInterval prevChild = null;
-        NodeInterval curChild = leftChild;
-        while (curChild != null) {
-            if (curChild.isSame(toBeRemoved)) {
-                if (prevChild == null) {
-                    if (curChild.getLeftChild() == null) {
-                        leftChild = curChild.getRightSibling();
-                    } else {
-                        leftChild = curChild.getLeftChild();
-                        adjustRightMostChildSibling(curChild);
-                    }
-                } else {
-                    if (curChild.getLeftChild() == null) {
-                        prevChild.rightSibling = curChild.getRightSibling();
-                    } else {
-                        prevChild.rightSibling = curChild.getLeftChild();
-                        adjustRightMostChildSibling(curChild);
-                    }
-                }
-                break;
-            }
-            prevChild = curChild;
-            curChild = curChild.getRightSibling();
-        }
-    }
 
     private void adjustRightMostChildSibling(final NodeInterval curNode) {
         NodeInterval tmpChild = curNode.getLeftChild();
@@ -217,39 +189,7 @@ public class NodeInterval {
         }
         preTmpChild.rightSibling = curNode.getRightSibling();
     }
-
-    /**
-     * Return the first node satisfying the date and match callback.
-     *
-     * @param targetDate target date for possible match nodes whose interval comprises that date
-     * @param callback   custom logic to decide if a given node is a match
-     * @return the found node or null if there is nothing.
-     */
-    @VisibleForTesting
-    NodeInterval findNode(final LocalDate targetDate, final SearchCallback callback) {
-
-        Preconditions.checkNotNull(callback);
-        Preconditions.checkNotNull(targetDate);
-
-        if (targetDate.compareTo(getStart()) < 0 || targetDate.compareTo(getEnd()) > 0) {
-            return null;
-        }
-
-        NodeInterval curChild = leftChild;
-        while (curChild != null) {
-            if (curChild.getStart().compareTo(targetDate) <= 0 && curChild.getEnd().compareTo(targetDate) >= 0) {
-                if (callback.isMatch(curChild)) {
-                    return curChild;
-                }
-                final NodeInterval result = curChild.findNode(targetDate, callback);
-                if (result != null) {
-                    return result;
-                }
-            }
-            curChild = curChild.getRightSibling();
-        }
-        return null;
-    }
+    
 
     /**
      * Return the first node satisfying the date and match callback.

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java
@@ -19,13 +19,12 @@
 
 package org.killbill.billing.invoice.tree;
 
-import java.util.List;
+import javax.annotation.Nullable;
 
 import org.joda.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 public class NodeInterval {
 
@@ -81,6 +80,21 @@ public class NodeInterval {
         return;
     }
 
+    private static boolean insertNode(final NodeInterval parentNode, @Nullable final NodeInterval prevNode, @Nullable final NodeInterval nextNode, final NodeInterval newNode, final AddNodeCallback callback) {
+        if (!callback.shouldInsertNode(parentNode, (ItemsNodeInterval) newNode)) {
+            return false;
+        }
+        newNode.parent = parentNode;
+        if (prevNode == null) {
+            parentNode.leftChild = newNode;
+        } else {
+            prevNode.rightSibling = newNode;
+        }
+        newNode.rightSibling = nextNode;
+        return true;
+    }
+
+
     /**
      * Add a new node in the tree.
      *
@@ -95,6 +109,7 @@ public class NodeInterval {
 
         // Recursion: we've found a node matching that interval
         if (!isRoot() && newNode.getStart().compareTo(start) == 0 && newNode.getEnd().compareTo(end) == 0) {
+            // Case I.a
             return callback.onExistingNode(this, (ItemsNodeInterval) newNode);
         }
 
@@ -103,124 +118,32 @@ public class NodeInterval {
 
         newNode.parent = this;
         if (leftChild == null) {
-            if (callback.shouldInsertNode(this, (ItemsNodeInterval) newNode)) {
-                leftChild = newNode;
-                return true;
-            } else {
-                return false;
-            }
+            return insertNode(this, null, null, newNode, callback);
         }
 
         NodeInterval prevChild = null;
         NodeInterval curChild = leftChild;
         while (curChild != null) {
-            // newNode is contained (i.e. fits into curChild interval), we go deeper in the tree
-            if (curChild.isThisItemContaining(newNode)) {
-                return curChild.addNode(newNode, callback);
-            }
-
-            // newNode overlaps (i.e. curChild is contained in newNode), we have to rebalance:
-            // we go through the left child and all of its right siblings, "push" down the ones that
-            // are contained, and insert the newNode (along maybe with right siblings that aren't contained).
-            //
-            // For example, before:
-            //       A
-            //      /
-            //      B
-            //     /
-            //     Cde
-            //
-            //     A: [2014-01-01,2014-02-01]
-            //
-            //     B: [2014-01-01,2014-02-01]
-            //
-            //     C: [2014-01-01,2014-01-03]
-            //     d: [2014-01-03,2014-01-05]
-            //     e: [2014-01-16,2014-01-17]
-            //
-            // After inserting F [2014-01-01,2014-01-07]:
-            //        A
-            //       /
-            //       B
-            //      /
-            //      Fe
-            //     /
-            //     Cd
-            //
-            //     A: [2014-01-01,2014-02-01]
-            //
-            //     B: [2014-01-01,2014-02-01]
-            //
-            //     F: [2014-01-01,2014-01-07]
-            //     e: [2014-01-16,2014-01-17]
-            //
-            //     C: [2014-01-01,2014-01-03]
-            //     d: [2014-01-03,2014-01-05]
-            //
-            if (curChild.isThisItemEncompassed(newNode)) {
-                if (rebalance(newNode)) {
-                    // Return from the recursion
-                    return callback.shouldInsertNode(this, (ItemsNodeInterval) newNode);
-                }
-            }
-
-            // newNode starts before cur element, try to insert before
             if (newNode.getStart().compareTo(curChild.getStart()) < 0) {
-                if (newNode.getEnd().compareTo(curChild.getStart()) > 0) {
-                    // newNode will need to be split so it can be inserted
+                if (newNode.getEnd().compareTo(curChild.getStart()) <= 0) {
+                    return insertNode(this, prevChild, curChild, newNode, callback);
+                } else {
                     final NodeInterval[] newNodes = ((ItemsNodeInterval) newNode).split(curChild.getStart());
                     curChild.getParent().addNode(newNodes[0], callback);
-                    curChild.getParent().addNode(newNodes[1], callback);
-                    return true;
+                    return curChild.getParent().addNode(newNodes[1], callback);
                 }
-
-                // We have not implemented all cases so adding preconditions
-                Preconditions.checkState(prevChild == null || newNode.getStart().compareTo(prevChild.getEnd()) >= 0,
-                                         "Failed to insert new node %s, start date overlaps with left child %s", newNode, prevChild);
-
-                if (callback.shouldInsertNode(this, (ItemsNodeInterval) newNode)) {
-                    newNode.rightSibling = curChild;
-                    if (prevChild == null) {
-                        leftChild = newNode;
-                    } else {
-                        prevChild.rightSibling = newNode;
-                    }
-                    return true;
-                } else {
-                    return false;
-                }
-
+            } else if (curChild.isThisItemContaining(newNode)) {
+                return curChild.addNode(newNode, callback);
             } else if (newNode.getStart().compareTo(curChild.getEnd()) < 0) {
-
-                Preconditions.checkState(newNode.getStart().compareTo(curChild.getStart()) >= 0,
-                                         "Failed to insert new node %s, start date is prior last child start date %s", newNode, curChild);
-
-                // newNode will need to be split so it can be inserted
                 final NodeInterval[] newNodes = ((ItemsNodeInterval) newNode).split(curChild.getEnd());
                 curChild.getParent().addNode(newNodes[0], callback);
-                curChild.getParent().addNode(newNodes[1], callback);
-                return true;
+                return curChild.getParent().addNode(newNodes[1], callback);
+            } else {
+                prevChild = curChild;
+                curChild = curChild.rightSibling;
             }
-            prevChild = curChild;
-            curChild = curChild.rightSibling;
         }
-
-        if (newNode.getStart().compareTo(prevChild.getEnd()) < 0) {
-            final NodeInterval[] newNodes = ((ItemsNodeInterval) newNode).split(prevChild.getEnd());
-            prevChild.getParent().addNode(newNodes[0], callback);
-            prevChild.getParent().addNode(newNodes[1], callback);
-            return true;
-        }
-
-        Preconditions.checkState(newNode.getStart().compareTo(prevChild.getEnd()) >= 0,
-                                 "Failed to insert new node %s, start date overlaps with left child %s", newNode, prevChild);
-
-        if (callback.shouldInsertNode(this, (ItemsNodeInterval) newNode)) {
-            prevChild.rightSibling = newNode;
-            return true;
-        } else {
-            return false;
-        }
+        return insertNode(this, prevChild, null, newNode, callback);
     }
 
     public void removeChild(final NodeInterval toBeRemoved) {
@@ -457,73 +380,6 @@ public class NodeInterval {
         }
         sb.append('}');
         return sb.toString();
-    }
-
-    /**
-     * Since items may be added out of order, there is no guarantee that we don't suddenly have a new node
-     * whose interval encompasses current node(s). In which case we need to rebalance the tree.
-     *
-     * @param newNode node that triggered a rebalance operation
-     */
-    boolean rebalance(final NodeInterval newNode) {
-
-        NodeInterval prevRebalanced = null;
-        NodeInterval curChild = leftChild;
-        final List<NodeInterval> toBeRebalanced = Lists.newLinkedList();
-        do {
-            if (curChild.isThisItemEncompassed(newNode)) {
-                toBeRebalanced.add(curChild);
-            } else if (curChild.isThisItemOverlapedLeft(newNode)) {
-                final LocalDate splitDate = newNode.getEnd();
-                // Split curChild and rebalance (under newNode) the left part
-                final NodeInterval curChildRightSibling = curChild.rightSibling;
-                curChild.rightSibling = null;
-                final NodeInterval[] curNodes = ((ItemsNodeInterval) curChild).split(splitDate);
-                curNodes[0].rightSibling = curNodes[1];
-                curNodes[1].rightSibling = curChildRightSibling;
-                toBeRebalanced.add(curNodes[0]);
-
-                Preconditions.checkState(curChild.leftChild == null,
-                                         "Splitting a node (curChild=%s) during rebalance with children, not implemented", curChild);
-            } else if (curChild.isThisItemOverlapedRight(newNode)) {
-                // We could implement this -- fairly symmetrical to previous case, but cannot convince myself this is valid use case
-                // The caller, addNode(), should have already split 'newNode' prior we see a need of rebalancing on a subsequent sibling from curChild
-                Preconditions.checkState(!curChild.isThisItemOverlapedRight(newNode),
-                                         "Failed to rebalance new node %s, new Node overlaps on the right with cur child %s", newNode, curChild);
-            } else {
-                if (toBeRebalanced.size() > 0) {
-                    break;
-                }
-                prevRebalanced = curChild;
-            }
-            curChild = curChild.rightSibling;
-        } while (curChild != null);
-
-        if (toBeRebalanced.isEmpty()) {
-            return false;
-        }
-
-        newNode.parent = this;
-        final NodeInterval lastNodeToRebalance = toBeRebalanced.get(toBeRebalanced.size() - 1);
-        newNode.rightSibling = lastNodeToRebalance.rightSibling;
-        lastNodeToRebalance.rightSibling = null;
-        if (prevRebalanced == null) {
-            leftChild = newNode;
-        } else {
-            prevRebalanced.rightSibling = newNode;
-        }
-
-        NodeInterval prev = null;
-        for (final NodeInterval cur : toBeRebalanced) {
-            cur.parent = newNode;
-            if (prev == null) {
-                newNode.leftChild = cur;
-            } else {
-                prev.rightSibling = cur;
-            }
-            prev = cur;
-        }
-        return true;
     }
 
     private void computeRootInterval(final NodeInterval newNode) {

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestDefaultInvoiceGenerator.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestDefaultInvoiceGenerator.java
@@ -950,34 +950,27 @@ public class TestDefaultInvoiceGenerator extends InvoiceTestSuiteNoDB {
 
         final InvoiceWithMetadata invoiceWithMetadata = generator.generateInvoice(account, events, new AccountInvoices(null, existingInvoices), null, targetDate, currency, null, internalCallContext);
         final Invoice invoice = invoiceWithMetadata.getInvoice();
-        assertEquals(invoice.getNumberOfItems(), 7);
+        assertEquals(invoice.getNumberOfItems(), 5);
         assertEquals(invoice.getInvoiceItems().get(0).getInvoiceItemType(), InvoiceItemType.RECURRING);
-        assertEquals(invoice.getInvoiceItems().get(0).getStartDate(), new LocalDate(2013, 6, 15));
-        assertEquals(invoice.getInvoiceItems().get(0).getEndDate(), new LocalDate(2013, 7, 15));
+        assertEquals(invoice.getInvoiceItems().get(0).getStartDate(), new LocalDate(2013, 6, 21));
+        assertEquals(invoice.getInvoiceItems().get(0).getEndDate(), new LocalDate(2013, 6, 26));
+        assertTrue(repairAmount.negate().compareTo(invoice.getInvoiceItems().get(0).getAmount()) == 0);
 
-        assertEquals(invoice.getInvoiceItems().get(1).getInvoiceItemType(), InvoiceItemType.REPAIR_ADJ);
-        assertEquals(invoice.getInvoiceItems().get(1).getStartDate(), new LocalDate(2013, 6, 15));
-        assertEquals(invoice.getInvoiceItems().get(1).getEndDate(), new LocalDate(2013, 6, 21));
+        assertEquals(invoice.getInvoiceItems().get(1).getInvoiceItemType(), InvoiceItemType.RECURRING);
+        assertEquals(invoice.getInvoiceItems().get(1).getStartDate(), new LocalDate(2013, 7, 15));
+        assertEquals(invoice.getInvoiceItems().get(1).getEndDate(), new LocalDate(2013, 8, 15));
 
-        assertEquals(invoice.getInvoiceItems().get(2).getInvoiceItemType(), InvoiceItemType.REPAIR_ADJ);
-        assertEquals(invoice.getInvoiceItems().get(2).getStartDate(), new LocalDate(2013, 6, 26));
-        assertEquals(invoice.getInvoiceItems().get(2).getEndDate(), new LocalDate(2013, 7, 15));
+        assertEquals(invoice.getInvoiceItems().get(2).getInvoiceItemType(), InvoiceItemType.RECURRING);
+        assertEquals(invoice.getInvoiceItems().get(2).getStartDate(), new LocalDate(2013, 8, 15));
+        assertEquals(invoice.getInvoiceItems().get(2).getEndDate(), new LocalDate(2013, 9, 15));
 
         assertEquals(invoice.getInvoiceItems().get(3).getInvoiceItemType(), InvoiceItemType.RECURRING);
-        assertEquals(invoice.getInvoiceItems().get(3).getStartDate(), new LocalDate(2013, 7, 15));
-        assertEquals(invoice.getInvoiceItems().get(3).getEndDate(), new LocalDate(2013, 8, 15));
+        assertEquals(invoice.getInvoiceItems().get(3).getStartDate(), new LocalDate(2013, 9, 15));
+        assertEquals(invoice.getInvoiceItems().get(3).getEndDate(), new LocalDate(2013, 10, 15));
 
         assertEquals(invoice.getInvoiceItems().get(4).getInvoiceItemType(), InvoiceItemType.RECURRING);
-        assertEquals(invoice.getInvoiceItems().get(4).getStartDate(), new LocalDate(2013, 8, 15));
-        assertEquals(invoice.getInvoiceItems().get(4).getEndDate(), new LocalDate(2013, 9, 15));
-
-        assertEquals(invoice.getInvoiceItems().get(5).getInvoiceItemType(), InvoiceItemType.RECURRING);
-        assertEquals(invoice.getInvoiceItems().get(5).getStartDate(), new LocalDate(2013, 9, 15));
-        assertEquals(invoice.getInvoiceItems().get(5).getEndDate(), new LocalDate(2013, 10, 15));
-
-        assertEquals(invoice.getInvoiceItems().get(6).getInvoiceItemType(), InvoiceItemType.RECURRING);
-        assertEquals(invoice.getInvoiceItems().get(6).getStartDate(), new LocalDate(2013, 10, 15));
-        assertEquals(invoice.getInvoiceItems().get(6).getEndDate(), new LocalDate(2013, 11, 15));
+        assertEquals(invoice.getInvoiceItems().get(4).getStartDate(), new LocalDate(2013, 10, 15));
+        assertEquals(invoice.getInvoiceItems().get(4).getEndDate(), new LocalDate(2013, 11, 15));
 
         // Add newly generated invoice to existing invoices
         existingInvoices.add(invoice);

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestFixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestFixedAndRecurringInvoiceItemGenerator.java
@@ -589,14 +589,11 @@ public class TestFixedAndRecurringInvoiceItemGenerator extends InvoiceTestSuiteN
                                                                                                      account.getCurrency(),
                                                                                                      new HashMap<UUID, SubscriptionFutureNotificationDates>(),
                                                                                                      null, internalCallContext).getItems();
-        assertEquals(generatedItems.size(), 2);
+        assertEquals(generatedItems.size(), 1);
         assertTrue(generatedItems.get(0) instanceof RecurringInvoiceItem);
-        assertEquals(generatedItems.get(0).getStartDate(), new LocalDate("2016-01-01"));
+        assertEquals(generatedItems.get(0).getStartDate(), new LocalDate("2016-01-30"));
         assertEquals(generatedItems.get(0).getEndDate(), new LocalDate("2016-02-01"));
-        assertEquals(generatedItems.get(0).getAmount().compareTo(amount), 0);
-        assertTrue(generatedItems.get(1) instanceof RepairAdjInvoiceItem);
-        assertEquals(generatedItems.get(1).getAmount().compareTo(amount.negate()), 0);
-        assertEquals(generatedItems.get(1).getLinkedItemId(), invoice.getInvoiceItems().get(0).getId());
+        assertEquals(generatedItems.get(0).getAmount().compareTo(new BigDecimal("0.65")), 0);
     }
 
     @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/664")

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
@@ -148,36 +148,6 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
         checkNode(thirdChildLevel2, 0, thirdChildLevel1, null, null);
     }
 
-    @Test(groups = "fast")
-    public void testAddExistingItemWithRebalance() {
-        final DummyNodeInterval root = new DummyNodeInterval();
-
-        final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
-        root.addNode(top, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel2 = createNodeInterval("2014-01-01", "2014-01-03");
-        final DummyNodeInterval secondChildLevel2 = createNodeInterval("2014-01-03", "2014-01-5");
-        final DummyNodeInterval thirdChildLevel2 = createNodeInterval("2014-01-16", "2014-01-17");
-        root.addNode(firstChildLevel2, CALLBACK);
-        root.addNode(secondChildLevel2, CALLBACK);
-        root.addNode(thirdChildLevel2, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel1 = createNodeInterval("2014-01-01", "2014-01-07");
-        final DummyNodeInterval secondChildLevel1 = createNodeInterval("2014-01-08", "2014-01-15");
-        final DummyNodeInterval thirdChildLevel1 = createNodeInterval("2014-01-16", "2014-02-01");
-        root.addNode(firstChildLevel1, CALLBACK);
-        root.addNode(secondChildLevel1, CALLBACK);
-        root.addNode(thirdChildLevel1, CALLBACK);
-
-        checkNode(top, 3, root, firstChildLevel1, null);
-        checkNode(firstChildLevel1, 2, top, firstChildLevel2, secondChildLevel1);
-        checkNode(secondChildLevel1, 0, top, null, thirdChildLevel1);
-        checkNode(thirdChildLevel1, 1, top, thirdChildLevel2, null);
-
-        checkNode(firstChildLevel2, 0, firstChildLevel1, null, secondChildLevel2);
-        checkNode(secondChildLevel2, 0, firstChildLevel1, null, null);
-        checkNode(thirdChildLevel2, 0, thirdChildLevel1, null, null);
-    }
 
     @Test(groups = "fast")
     public void testAddOverlapNode1() {
@@ -573,44 +543,6 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
             @Override
             public void onCurrentNode(final int depth, final NodeInterval curNode, final NodeInterval parent) {
                 Assert.assertEquals(curNode, expectedNodesAfterRemoval.remove(0));
-            }
-        });
-    }
-
-    @Test(groups = "fast")
-    public void testRebalanceWithSplits() {
-        final DummyNodeInterval root = new DummyNodeInterval();
-
-        final DummyNodeInterval firstChildLevel1 = createNodeInterval("2021-05-17", "2021-05-20");
-        root.addNode(firstChildLevel1, CALLBACK);
-        final DummyNodeInterval secondChildLevel1 = createNodeInterval("2021-05-20", "2021-06-20");
-        root.addNode(secondChildLevel1, CALLBACK);
-
-
-        final DummyNodeInterval newNode = createNodeInterval("2021-05-17", "2021-06-17");
-        root.addNode(newNode, CALLBACK);
-
-        final List<NodeInterval> expectedNodes = new ArrayList<NodeInterval>();
-        expectedNodes.add(root);
-        expectedNodes.add(newNode);
-        expectedNodes.add(firstChildLevel1);
-        final DummyNodeInterval secondChildLevel1Split1 = createNodeInterval("2021-05-20", "2021-06-17");
-        secondChildLevel1Split1.parent = newNode;
-        expectedNodes.add(secondChildLevel1Split1);
-
-        final DummyNodeInterval secondChildLevel1Split2 = createNodeInterval("2021-06-17", "2021-06-20");
-        secondChildLevel1Split2.parent = newNode.parent;
-        expectedNodes.add(secondChildLevel1Split2);
-
-        System.out.println(TreePrinter.print(root));
-
-        root.walkTree(new WalkCallback() {
-            @Override
-            public void onCurrentNode(final int depth, final NodeInterval curNode, final NodeInterval parent) {
-                final NodeInterval expectedNode = expectedNodes.remove(0);
-                if (!curNode.isRoot()) {
-                    Assert.assertTrue(curNode.isSame(expectedNode));
-                }
             }
         });
     }

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
@@ -19,7 +19,6 @@
 
 package org.killbill.billing.invoice.tree;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -28,15 +27,12 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
 import org.killbill.billing.invoice.tree.NodeInterval.AddNodeCallback;
 import org.killbill.billing.invoice.tree.NodeInterval.BuildNodeCallback;
-import org.killbill.billing.invoice.tree.NodeInterval.SearchCallback;
 import org.killbill.billing.invoice.tree.NodeInterval.WalkCallback;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Preconditions;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class TestNodeInterval extends InvoiceTestSuiteNoDB {
@@ -327,57 +323,6 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    public void testSearch() {
-        final DummyNodeInterval root = new DummyNodeInterval();
-
-        final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
-        root.addNode(top, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel1 = createNodeInterval("2014-01-01", "2014-01-07");
-        final DummyNodeInterval secondChildLevel1 = createNodeInterval("2014-01-08", "2014-01-15");
-        final DummyNodeInterval thirdChildLevel1 = createNodeInterval("2014-01-16", "2014-02-01");
-        root.addNode(firstChildLevel1, CALLBACK);
-        root.addNode(secondChildLevel1, CALLBACK);
-        root.addNode(thirdChildLevel1, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel2 = createNodeInterval("2014-01-01", "2014-01-03");
-        final DummyNodeInterval secondChildLevel2 = createNodeInterval("2014-01-03", "2014-01-5");
-        final DummyNodeInterval thirdChildLevel2 = createNodeInterval("2014-01-16", "2014-01-17");
-        root.addNode(firstChildLevel2, CALLBACK);
-        root.addNode(secondChildLevel2, CALLBACK);
-        root.addNode(thirdChildLevel2, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel3 = createNodeInterval("2014-01-01", "2014-01-02");
-        final DummyNodeInterval secondChildLevel3 = createNodeInterval("2014-01-03", "2014-01-04");
-        root.addNode(firstChildLevel3, CALLBACK);
-        root.addNode(secondChildLevel3, CALLBACK);
-
-        final NodeInterval search1 = root.findNode(new LocalDate("2014-01-04"), new SearchCallback() {
-            @Override
-            public boolean isMatch(final NodeInterval curNode) {
-                return curNode instanceof DummyNodeInterval && ((DummyNodeInterval) curNode).getId().equals(secondChildLevel3.getId());
-            }
-        });
-        checkInterval(search1, secondChildLevel3);
-
-        final NodeInterval search2 = root.findNode(new SearchCallback() {
-            @Override
-            public boolean isMatch(final NodeInterval curNode) {
-                return curNode instanceof DummyNodeInterval && ((DummyNodeInterval) curNode).getId().equals(thirdChildLevel2.getId());
-            }
-        });
-        checkInterval(search2, thirdChildLevel2);
-
-        final NodeInterval nullSearch = root.findNode(new SearchCallback() {
-            @Override
-            public boolean isMatch(final NodeInterval curNode) {
-                return curNode instanceof DummyNodeInterval && "foo".equals(((DummyNodeInterval) curNode).getId().toString());
-            }
-        });
-        assertNull(nullSearch);
-    }
-
-    @Test(groups = "fast")
     public void testWalkTree() {
         final DummyNodeInterval root = new DummyNodeInterval();
 
@@ -438,114 +383,6 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
         }
     }
 
-    @Test(groups = "fast")
-    public void testRemoveLeftChildWithGrandChildren() {
-        final DummyNodeInterval root = new DummyNodeInterval();
-
-        final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
-        root.addNode(top, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel1 = createNodeInterval("2014-01-01", "2014-01-20");
-        final DummyNodeInterval secondChildLevel1 = createNodeInterval("2014-01-21", "2014-01-31");
-        root.addNode(firstChildLevel1, CALLBACK);
-        root.addNode(secondChildLevel1, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel2 = createNodeInterval("2014-01-01", "2014-01-03");
-        final DummyNodeInterval secondChildLevel2 = createNodeInterval("2014-01-04", "2014-01-10");
-        final DummyNodeInterval thirdChildLevel2 = createNodeInterval("2014-01-11", "2014-01-20");
-        root.addNode(firstChildLevel2, CALLBACK);
-        root.addNode(secondChildLevel2, CALLBACK);
-        root.addNode(thirdChildLevel2, CALLBACK);
-
-        // Let's verify we get it right prior removing the node
-        final List<NodeInterval> expectedNodes = new ArrayList<NodeInterval>();
-        expectedNodes.add(root);
-        expectedNodes.add(top);
-        expectedNodes.add(firstChildLevel1);
-        expectedNodes.add(firstChildLevel2);
-        expectedNodes.add(secondChildLevel2);
-        expectedNodes.add(thirdChildLevel2);
-        expectedNodes.add(secondChildLevel1);
-
-        root.walkTree(new WalkCallback() {
-            @Override
-            public void onCurrentNode(final int depth, final NodeInterval curNode, final NodeInterval parent) {
-                Assert.assertEquals(curNode, expectedNodes.remove(0));
-            }
-        });
-
-        // Remove node and verify again
-        top.removeChild(firstChildLevel1);
-
-        final List<NodeInterval> expectedNodesAfterRemoval = new ArrayList<NodeInterval>();
-        expectedNodesAfterRemoval.add(root);
-        expectedNodesAfterRemoval.add(top);
-        expectedNodesAfterRemoval.add(firstChildLevel2);
-        expectedNodesAfterRemoval.add(secondChildLevel2);
-        expectedNodesAfterRemoval.add(thirdChildLevel2);
-        expectedNodesAfterRemoval.add(secondChildLevel1);
-
-        root.walkTree(new WalkCallback() {
-            @Override
-            public void onCurrentNode(final int depth, final NodeInterval curNode, final NodeInterval parent) {
-                Assert.assertEquals(curNode, expectedNodesAfterRemoval.remove(0));
-            }
-        });
-    }
-
-    @Test(groups = "fast")
-    public void testRemoveMiddleChildWithGrandChildren() {
-        final DummyNodeInterval root = new DummyNodeInterval();
-
-        final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
-        root.addNode(top, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel1 = createNodeInterval("2014-01-01", "2014-01-20");
-        final DummyNodeInterval secondChildLevel1 = createNodeInterval("2014-01-21", "2014-01-31");
-        root.addNode(firstChildLevel1, CALLBACK);
-        root.addNode(secondChildLevel1, CALLBACK);
-
-        final DummyNodeInterval firstChildLevel2 = createNodeInterval("2014-01-21", "2014-01-23");
-        final DummyNodeInterval secondChildLevel2 = createNodeInterval("2014-01-24", "2014-01-25");
-        final DummyNodeInterval thirdChildLevel2 = createNodeInterval("2014-01-26", "2014-01-31");
-        root.addNode(firstChildLevel2, CALLBACK);
-        root.addNode(secondChildLevel2, CALLBACK);
-        root.addNode(thirdChildLevel2, CALLBACK);
-
-        // Original List without removing node:
-        final List<NodeInterval> expectedNodes = new ArrayList<NodeInterval>();
-        expectedNodes.add(root);
-        expectedNodes.add(top);
-        expectedNodes.add(firstChildLevel1);
-        expectedNodes.add(secondChildLevel1);
-        expectedNodes.add(firstChildLevel2);
-        expectedNodes.add(secondChildLevel2);
-        expectedNodes.add(thirdChildLevel2);
-
-        root.walkTree(new WalkCallback() {
-            @Override
-            public void onCurrentNode(final int depth, final NodeInterval curNode, final NodeInterval parent) {
-                Assert.assertEquals(curNode, expectedNodes.remove(0));
-            }
-        });
-
-        top.removeChild(secondChildLevel1);
-
-        final List<NodeInterval> expectedNodesAfterRemoval = new ArrayList<NodeInterval>();
-        expectedNodesAfterRemoval.add(root);
-        expectedNodesAfterRemoval.add(top);
-        expectedNodesAfterRemoval.add(firstChildLevel1);
-        expectedNodesAfterRemoval.add(firstChildLevel2);
-        expectedNodesAfterRemoval.add(secondChildLevel2);
-        expectedNodesAfterRemoval.add(thirdChildLevel2);
-
-        root.walkTree(new WalkCallback() {
-            @Override
-            public void onCurrentNode(final int depth, final NodeInterval curNode, final NodeInterval parent) {
-                Assert.assertEquals(curNode, expectedNodesAfterRemoval.remove(0));
-            }
-        });
-    }
 
     private void checkInterval(final NodeInterval real, final NodeInterval expected) {
         assertEquals(real.getStart(), expected.getStart());

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -1344,8 +1344,20 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(correctInitialItem);
         tree.buildForMerge();
 
-        final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, wrongStartDate, endDate, BigDecimal.ZERO, Currency.USD, wrongInitialItem.getId());
-        final List<InvoiceItem> expectedResult = ImmutableList.<InvoiceItem>of(correctInitialItem, repair);
+        final InvoiceItem expected = new RecurringInvoiceItem(invoiceId,
+                                                                accountId,
+                                                                bundleId,
+                                                                subscriptionId,
+                                                                productName,
+                                                                planName,
+                                                                phaseName,
+                                                                null,
+                                                                correctStartDate,
+                                                                wrongStartDate,
+                                                                new BigDecimal("0.40"),
+                                                                rate,
+                                                                currency);
+        final List<InvoiceItem> expectedResult = ImmutableList.<InvoiceItem>of(expected);
         verifyResult(tree.getView(), expectedResult);
 
     }

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -500,7 +500,6 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem expected3 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, repairDate2, endDate, amount3, rate3, currency);
         expectedResult.add(expected3);
 
-        // First test with items in order
         SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
         tree.addItem(initial);
         tree.addItem(newItem1);
@@ -510,23 +509,6 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.build();
         verifyResult(tree.getView(), expectedResult);
 
-        tree = new SubscriptionItemTree(subscriptionId, invoiceId);
-        tree.addItem(repair2);
-        tree.addItem(newItem1);
-        tree.addItem(newItem2);
-        tree.addItem(repair1);
-        tree.addItem(initial);
-        tree.build();
-        verifyResult(tree.getView(), expectedResult);
-
-        tree = new SubscriptionItemTree(subscriptionId, invoiceId);
-        tree.addItem(repair1);
-        tree.addItem(newItem1);
-        tree.addItem(initial);
-        tree.addItem(repair2);
-        tree.addItem(newItem2);
-        tree.build();
-        verifyResult(tree.getView(), expectedResult);
     }
 
     @Test(groups = "fast")

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -429,26 +429,11 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, "someelse", "someelse", "someelse", null, repairDate, endDate, amount2, rate2, currency);
         expectedResult.add(expected2);
 
-        // First test with items in order
         SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
         tree.addItem(initial);
         tree.addItem(newItem);
         tree.addItem(repair);
         tree.build();
-        verifyResult(tree.getView(), expectedResult);
-        tree = new SubscriptionItemTree(subscriptionId, invoiceId);
-        tree.addItem(repair);
-        tree.addItem(newItem);
-        tree.addItem(initial);
-        tree.build();
-        verifyResult(tree.getView(), expectedResult);
-
-        tree = new SubscriptionItemTree(subscriptionId, invoiceId);
-        tree.addItem(repair);
-        tree.addItem(initial);
-        tree.addItem(newItem);
-        tree.build();
-        verifyResult(tree.getView(), expectedResult);
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
**Overview**

The method `NodeInterval#addNode` required to construct our invoice item tree based on `existing` and then `proposed` items was initially implemented  with simple use cases where various invoice items represented as `NodeInterval` were not supposed to overlap.

Starting from [this commit](https://github.com/killbill/killbill/commit/ba81d9b53173f0b09ace71cdbef018f05f914a56), we introduced the ability to split `NodeInterval` and because the tree was not generic we added preconditions in a lot of places to deal with non implemented use cases.

Then, more recently we had to implement [more cases](https://github.com/killbill/killbill/commit/c6c569d98d097301824604ac323b16cd6032df15), and then the logic to split started [to leak into the code where we were rebalancing items](https://github.com/killbill/killbill/pull/1484/commits/07eb86f3fbf2fd132886c07d8e79ba254afcc681), and not only we were left with a lot of cases to implement, but it also became clear this was not the right implementation.

This PR re-implements this whole method in a much simpler and generic way. However, by doing so, it changes the way the tree is constructed and this led to some changes in a few tests:
* All high level `profile`, `beatrix`, and `integration-tests` were left untouched 🎉 
* A few invoice unit tests had to be modified, and those will be detailed below.

The main code change is encapsulated in this https://github.com/killbill/killbill/pull/1493/commits/6338109f8cdc7f21eccdc4d9ac1aad79382db232 along with this https://github.com/killbill/killbill/pull/1493/commits/51e87c300db4d30851d7a615b6194efe3d5eedbf for more documentation. Probably easier to read the [code of the one resulting method](https://github.com/killbill/killbill/blob/invoice-tree-fix/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java#L107) ☕ 

**Invoice Unit Tests**

* https://github.com/killbill/killbill/pull/1493/commits/7876bae255d703f1380b23087ee82720319fde2c: Remove invalid test cases (node rebalancing don't exist anymore)
* https://github.com/killbill/killbill/pull/1493/commits/abd65eb042e499ad8ec44ebb01b1a02e781bdf90: An edge case scenario with a partial invoice item adjustment led to a different behavior. Adding a beatrix level test to reproduce the issue with old behavior showed that code was unstable and would lead to a 'double invoicing' exception. With new behavior, it produces a fine result and no exception. 🎉 
* The following are all edge cases where we have existing invalid recurring items and some invoice code running to make to repair and re-invoicing. New beatrix tests have been introduced first with the old behavior, and then by ingesting the data from this old behavior with the desire effect of showing that new behavior would lead a no-op. 🎉 
  * https://github.com/killbill/killbill/pull/1493/commits/47cad58d1c26ade31031634317ab1235fe1ffe2a
  * https://github.com/killbill/killbill/pull/1493/commits/4207ad2f26f25ed5b57481eaec95f428312d5dd0
* Finally there are some invoice unit tests that allowed for inserting some items into the tree out of sequence that would now produce different results. Because the use cases don't make sense in a real scenario, such assertions have been removed:
  * https://github.com/killbill/killbill/pull/1493/commits/dd3e1c64774906ecda080b114f11ed84ad2b1e17
  * https://github.com/killbill/killbill/pull/1493/commits/9b30fb3bd9d041daac77e1102c2c43bd1294e2d2

**Risks**

Because we change the way we construct our invoice item tree, there is a certain amount of risk with folks having old data. However we have seen that none of our high level tests were modified (and we have some fairly complicated use cases at this level) so for most real use cases this should not be an issue; for edge cases, we have also spent great amount of efforts showing that everything will be correctly handled (no-op) or lead to a better result.

Happy review! 🍻 



