### PR TITLE
Add handling to prevent voiding a repaired invoice. See #1464

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationVoidInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationVoidInvoice.java
@@ -21,6 +21,7 @@ package org.killbill.billing.beatrix.integration;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -29,13 +30,20 @@ import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Entitlement;
+import org.killbill.billing.entitlement.api.Entitlement.EntitlementActionPolicy;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceApiException;
+import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
+import org.killbill.billing.invoice.model.CreditAdjInvoiceItem;
 import org.killbill.billing.payment.api.Payment;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.subscription.api.user.DefaultSubscriptionBase;
@@ -45,6 +53,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class TestIntegrationVoidInvoice extends TestIntegrationBase {
@@ -128,5 +137,69 @@ public class TestIntegrationVoidInvoice extends TestIntegrationBase {
         assertEquals(invoices.size(), 3);
         assertEquals(invoices.get(1).getStatus(), InvoiceStatus.VOID);
         assertEquals(invoices.get(2).getStatus(), InvoiceStatus.VOID);
+    }
+
+    @Test(groups = "slow")
+    public void testVoidRepairedInvoice() throws Exception {
+
+        final DateTime initialDate = new DateTime(2013, 6, 15, 0, 0, 0, 0, testTimeZone);
+        final LocalDate startDate = initialDate.toLocalDate();
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        assertNotNull(account);
+
+        add_AUTO_PAY_OFF_Tag(account.getId(), ObjectType.ACCOUNT);
+
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial");
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE);
+        final InvoiceItem inputCredit = new CreditAdjInvoiceItem(null, account.getId(), startDate, "credit invoice", new BigDecimal("20.00"), account.getCurrency(), null);
+        invoiceUserApi.insertCredits(account.getId(), startDate, ImmutableList.of(inputCredit), true, null, callContext);
+        assertListenerStatus();
+
+        final BigDecimal accountBalance1 = invoiceUserApi.getAccountBalance(account.getId(), callContext);
+        final BigDecimal accountCBA1 = invoiceUserApi.getAccountCBA(account.getId(), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CREATE, NextEvent.INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null), null, startDate, startDate, false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Entitlement bpEntitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
+        assertListenerStatus();
+
+        final Invoice invoice2 = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                            new ExpectedInvoiceItemCheck(new LocalDate(2013, 6, 15), new LocalDate(2013, 7, 15), InvoiceItemType.RECURRING, new BigDecimal("19.95")),
+                                                             new ExpectedInvoiceItemCheck(new LocalDate(2013, 6, 15), new LocalDate(2013, 6, 15), InvoiceItemType.CBA_ADJ, new BigDecimal("-19.95")));
+
+
+        // 2013-07-01
+        clock.addDays(16);
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE);
+        bpEntitlement.cancelEntitlementWithPolicyOverrideBillingPolicy(EntitlementActionPolicy.IMMEDIATE, BillingActionPolicy.IMMEDIATE, ImmutableList.<PluginProperty>of(), callContext);
+        assertListenerStatus();
+
+        final BigDecimal accountBalance2 = invoiceUserApi.getAccountBalance(account.getId(), callContext);
+        final BigDecimal accountCBA2 = invoiceUserApi.getAccountCBA(account.getId(), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
+        invoiceUserApi.voidInvoice(invoice2.getId(), callContext);
+        assertListenerStatus();
+
+        final BigDecimal accountBalance3 = invoiceUserApi.getAccountBalance(account.getId(), callContext);
+        final BigDecimal accountCBA3 = invoiceUserApi.getAccountCBA(account.getId(), callContext);
+
+        /* This lead to the following:
+        2021-09-02T22:54:14.875+0000 [main] WARN org.killbill.billing.invoice.InvoiceDispatcher - Illegal invoicing state detected for accountId='6f1e5365-7a0e-40fe-bc11-203df1cb52e5', dryRunArguments='null', parking account
+{cause=java.lang.IllegalStateException: Missing cancelledItem for cancelItem=REPAIR_ADJ{startDate='2013-07-01', endDate='2013-07-15', amount='-9.31', linkedItemId='0e920939-008d-49db-b8d1-4e91aec71f0f'}, code=4, formattedMsg='ILLEGAL INVOICING STATE'}
+	at org.killbill.billing.invoice.generator.InvoicePruner.getFullyRepairedItemsClosure(InvoicePruner.java:95)
+	at org.killbill.billing.invoice.generator.FixedAndRecurringInvoiceItemGenerator.generateItems(FixedAndRecurringInvoiceItemGenerator.java:97)
+	at org.killbill.billing.invoice.generator.DefaultInvoiceGenerator.generateInvoice(DefaultInvoiceGenerator.java:101)
+	at org.killbill.billing.invoice.InvoiceDispatcher.generateKillBillInvoice(InvoiceDispatcher.java:700)
+	at org.killbill.billing.invoice.InvoiceDispatcher.processAccountWithLockAndInputTargetDate(InvoiceDispatcher.java:591)
+         */
+        invoiceUserApi.triggerInvoiceGeneration(account.getId(), clock.getUTCToday(), callContext);
+
+
+        checkNoMoreInvoiceToGenerate(account.getId());
+
     }
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationVoidInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationVoidInvoice.java
@@ -185,9 +185,7 @@ public class TestIntegrationVoidInvoice extends TestIntegrationBase {
             invoiceUserApi.voidInvoice(invoice2.getId(), callContext);
             Assert.fail("Should fail to void a repaired invoice");
         } catch (final RuntimeException e) {
-            if (!e.getMessage().contains("because it contains items being repaired")) {
-                throw e;
-            }
+            assertTrue(e.getMessage().contains("because it contains items being repaired"));
         }
 
         // Void the invoice where the REPAIR_ADJ occurred first

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceHardening.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceHardening.java
@@ -310,11 +310,7 @@ public class TestWithInvoiceHardening extends TestIntegrationBase {
         busHandler.waitAndIgnoreEvents(3000);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
-        invoiceUserApi.voidInvoice(firstInvoice.getId(), callContext);
-        assertListenerStatus();
-
-        busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
-        invoiceUserApi.voidInvoice(secondInvoice.getId(), callContext);
+        invoiceUserApi.voidInvoice(fourthInvoice.getId(), callContext);
         assertListenerStatus();
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
@@ -322,8 +318,13 @@ public class TestWithInvoiceHardening extends TestIntegrationBase {
         assertListenerStatus();
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
-        invoiceUserApi.voidInvoice(fourthInvoice.getId(), callContext);
+        invoiceUserApi.voidInvoice(secondInvoice.getId(), callContext);
         assertListenerStatus();
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
+        invoiceUserApi.voidInvoice(firstInvoice.getId(), callContext);
+        assertListenerStatus();
+
 
         // This remove the __PARK__ tag and fixes the state !
         busHandler.pushExpectedEvents(NextEvent.TAG, NextEvent.NULL_INVOICE);

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.java
@@ -25,6 +25,7 @@ import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.util.audit.ChangeType;
+import org.killbill.billing.util.dao.CounterMappings;
 import org.killbill.billing.util.entity.dao.Audited;
 import org.killbill.billing.util.entity.dao.EntitySqlDao;
 import org.killbill.commons.jdbi.binder.SmartBindBean;
@@ -32,6 +33,7 @@ import org.killbill.commons.jdbi.template.KillBillSqlDaoStringTemplate;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.unstable.BindIn;
 
 @KillBillSqlDaoStringTemplate
 public interface InvoiceItemSqlDao extends EntitySqlDao<InvoiceItemModelDao, InvoiceItem> {
@@ -62,4 +64,7 @@ public interface InvoiceItemSqlDao extends EntitySqlDao<InvoiceItemModelDao, Inv
 
     @SqlQuery
     BigDecimal getAccountCBA(@SmartBindBean final InternalTenantContext context);
+
+    @SqlQuery
+    Iterable<CounterMappings> getRepairMap(@BindIn("ids") final Iterable<String> invoiceIds, @SmartBindBean final InternalTenantContext context);
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceModelDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceModelDao.java
@@ -58,6 +58,7 @@ public class InvoiceModelDao extends EntityModelDaoBase implements EntityModelDa
     private InvoiceModelDao parentInvoice;
 
     private boolean isWrittenOff;
+    private boolean isRepaired;
 
     public InvoiceModelDao() { /* For the DAO mapper */ }
 
@@ -72,6 +73,7 @@ public class InvoiceModelDao extends EntityModelDaoBase implements EntityModelDa
         this.currency = currency;
         this.migrated = migrated;
         this.isWrittenOff = false;
+        this.isRepaired = false;
         this.status = status;
         this.isParentInvoice = isParentInvoice;
     }
@@ -204,6 +206,19 @@ public class InvoiceModelDao extends EntityModelDaoBase implements EntityModelDa
 
     public void setIsWrittenOff(final boolean isWrittenOff) {
         this.isWrittenOff = isWrittenOff;
+    }
+
+    public boolean isRepaired() {
+        return isRepaired;
+    }
+
+    // Make BeanInspector happy when invoked from EntityHistoryBinder
+    public boolean getIsRepaired() {
+        return isRepaired;
+    }
+
+    public void setRepaired(final boolean repaired) {
+        this.isRepaired = repaired;
     }
 
     public void setStatus(final InvoiceStatus status) {

--- a/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.sql.stg
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.sql.stg
@@ -116,16 +116,19 @@ and <accountRecordIdField("ii.")> = :accountRecordId
 
 getRepairMap(ids) ::= <<
   SELECT
-  i1.invoice_id the_key
-  , count(i1.invoice_id) the_count
-  FROM <tableName()> i1
-  JOIN <tableName()> i2 on i1.account_record_id = i2.account_record_id and i2.type = 'REPAIR_ADJ' and i2.linked_item_id = i1.id
+  ii1.invoice_id the_key
+  , count(ii1.invoice_id) the_count
+  FROM <tableName()> ii1
+  JOIN <tableName()> ii2 on ii1.account_record_id = ii2.account_record_id and ii2.type = 'REPAIR_ADJ' and ii2.linked_item_id = ii1.id
+  JOIN invoices i on i.id = ii2.invoice_id
   WHERE
-  i1.invoice_id in (<ids>)
-  and i2.id is not null
-  <AND_CHECK_TENANT("i1.")>
-  <AND_CHECK_TENANT("i2.")>
-  group by i1.invoice_id
+  ii1.invoice_id in (<ids>)
+  and i.status = 'COMMITTED'
+  and ii2.id is not null
+  <AND_CHECK_TENANT("ii1.")>
+  <AND_CHECK_TENANT("ii2.")>
+  <AND_CHECK_TENANT("i.")>
+  group by ii1.invoice_id
   ;
 >>
 

--- a/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.sql.stg
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.sql.stg
@@ -113,3 +113,19 @@ and <accountRecordIdField("ii.")> = :accountRecordId
 <AND_CHECK_TENANT("ii.")>
 ;
 >>
+
+getRepairMap(ids) ::= <<
+  SELECT
+  i1.invoice_id the_key
+  , count(i1.invoice_id) the_count
+  FROM <tableName()> i1
+  JOIN <tableName()> i2 on i1.account_record_id = i2.account_record_id and i2.type = 'REPAIR_ADJ' and i2.linked_item_id = i1.id
+  WHERE
+  i1.invoice_id in (<ids>)
+  and i2.id is not null
+  <AND_CHECK_TENANT("i1.")>
+  <AND_CHECK_TENANT("i2.")>
+  group by i1.invoice_id
+  ;
+>>
+

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceItemSqlDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceItemSqlDao.java
@@ -27,6 +27,7 @@ import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.InvoiceTestSuiteWithEmbeddedDB;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.invoice.model.RepairAdjInvoiceItem;
 import org.killbill.billing.util.dao.CounterMappings;
 import org.testng.Assert;
@@ -98,52 +99,81 @@ public class TestInvoiceItemSqlDao extends InvoiceTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow")
     public void testRepairMap()  {
-        final InvoiceItemSqlDao dao = dbi.onDemand(InvoiceItemSqlDao.class);
+        final InvoiceSqlDao invoiceSqlDao = dbi.onDemand(InvoiceSqlDao.class);
+        final InvoiceItemSqlDao invoiceItemSqlDao = dbi.onDemand(InvoiceItemSqlDao.class);
 
         final UUID accountId = UUID.randomUUID();
 
         // 1 REPAIR against 1st invoice
-        final UUID invoiceId1 = UUID.randomUUID();
+        final InvoiceModelDao invoice1 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoice1, internalCallContext);
         final UUID invoiceItemId1 = UUID.randomUUID();
-        final InvoiceItemModelDao item1 = new InvoiceItemModelDao(invoiceItemId1, null, InvoiceItemType.RECURRING, invoiceId1, accountId, null, null, null, "description",
+        final InvoiceItemModelDao item1 = new InvoiceItemModelDao(invoiceItemId1, null, InvoiceItemType.RECURRING, invoice1.getId(), accountId, null, null, null, "description",
                                                                   null, null, null, null, null, new LocalDate(), null, BigDecimal.TEN, null, Currency.USD, null);
-        dao.create(item1, internalCallContext);
+        invoiceItemSqlDao.create(item1, internalCallContext);
 
+        final InvoiceModelDao invoiceRepair1 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoiceRepair1, internalCallContext);
         final UUID repairId1 = UUID.randomUUID();
-        final InvoiceItemModelDao repair1 = new InvoiceItemModelDao( repairId1, null, InvoiceItemType.REPAIR_ADJ, UUID.randomUUID(), accountId, null, null, null, "description",
-                                                            null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item1.getId());
-        dao.create(repair1, internalCallContext);
+        final InvoiceItemModelDao repair1 = new InvoiceItemModelDao( repairId1, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair1.getId(), accountId, null, null, null, "description",
+                                                                     null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item1.getId());
+        invoiceItemSqlDao.create(repair1, internalCallContext);
 
 
         // 2 REPAIRs against 2nd invoice
-        final UUID invoiceId2 = UUID.randomUUID();
+        final InvoiceModelDao invoice2 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoice2, internalCallContext);
         final UUID invoiceItemId2 = UUID.randomUUID();
-        final InvoiceItemModelDao item2 = new InvoiceItemModelDao(invoiceItemId2, null, InvoiceItemType.RECURRING, invoiceId2, accountId, null, null, null, "description",
+        final InvoiceItemModelDao item2 = new InvoiceItemModelDao(invoiceItemId2, null, InvoiceItemType.RECURRING, invoice2.getId(), accountId, null, null, null, "description",
                                                                   null, null, null, null, null, new LocalDate(), null, BigDecimal.TEN, null, Currency.USD, null);
-        dao.create(item2, internalCallContext);
+        invoiceItemSqlDao.create(item2, internalCallContext);
 
+        final InvoiceModelDao invoiceRepair2a = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoiceRepair2a, internalCallContext);
         final UUID repairId2a = UUID.randomUUID();
-        final InvoiceItemModelDao repair2a = new InvoiceItemModelDao( repairId2a, null, InvoiceItemType.REPAIR_ADJ, UUID.randomUUID(), accountId, null, null, null, "description",
+        final InvoiceItemModelDao repair2a = new InvoiceItemModelDao( repairId2a, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair2a.getId(), accountId, null, null, null, "description",
                                                                       null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item2.getId());
-        dao.create(repair2a, internalCallContext);
+        invoiceItemSqlDao.create(repair2a, internalCallContext);
 
+        final InvoiceModelDao invoiceRepair2b = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoiceRepair2b, internalCallContext);
         final UUID repairId2b = UUID.randomUUID();
-        final InvoiceItemModelDao repair2b = new InvoiceItemModelDao( repairId2b, null, InvoiceItemType.REPAIR_ADJ, UUID.randomUUID(), accountId, null, null, null, "description",
+        final InvoiceItemModelDao repair2b = new InvoiceItemModelDao( repairId2b, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair2b.getId(), accountId, null, null, null, "description",
                                                                       null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item2.getId());
-        dao.create(repair2b, internalCallContext);
+        invoiceItemSqlDao.create(repair2b, internalCallContext);
 
 
         // 0 REPAIR against 3rd invoice
-        final UUID invoiceId3 = UUID.randomUUID();
+        final InvoiceModelDao invoice3 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoice3, internalCallContext);
         final UUID invoiceItemId3 = UUID.randomUUID();
-        final InvoiceItemModelDao item3 = new InvoiceItemModelDao(invoiceItemId3, null, InvoiceItemType.RECURRING, invoiceId3, accountId, null, null, null, "description",
+        final InvoiceItemModelDao item3 = new InvoiceItemModelDao(invoiceItemId3, null, InvoiceItemType.RECURRING, invoice3.getId(), accountId, null, null, null, "description",
                                                                   null, null, null, null, null, new LocalDate(), null, BigDecimal.TEN, null, Currency.USD, null);
-        dao.create(item3, internalCallContext);
+        invoiceItemSqlDao.create(item3, internalCallContext);
 
-        final Iterable<CounterMappings> repairedMapRes = dao.getRepairMap(ImmutableList.of(invoiceId1.toString(), invoiceId2.toString(), invoiceId3.toString()), internalCallContext);
+        //////
+
+        // 1 REPAIR against 4th invoice (VOID)
+        final InvoiceModelDao invoice4 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoice4, internalCallContext);
+        final UUID invoiceItemId4 = UUID.randomUUID();
+        final InvoiceItemModelDao item4 = new InvoiceItemModelDao(invoiceItemId4, null, InvoiceItemType.RECURRING, invoice4.getId(), accountId, null, null, null, "description",
+                                                                  null, null, null, null, null, new LocalDate(), null, BigDecimal.TEN, null, Currency.USD, null);
+        invoiceItemSqlDao.create(item4, internalCallContext);
+
+        final InvoiceModelDao invoiceRepair4 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.VOID);
+        invoiceSqlDao.create(invoiceRepair4, internalCallContext);
+        final UUID repairId4 = UUID.randomUUID();
+        final InvoiceItemModelDao repair4 = new InvoiceItemModelDao( repairId4, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair4.getId(), accountId, null, null, null, "description",
+                                                                     null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item4.getId());
+        invoiceItemSqlDao.create(repair4, internalCallContext);
+
+
+
+        final Iterable<CounterMappings> repairedMapRes = invoiceItemSqlDao.getRepairMap(ImmutableList.of(invoice1.getId().toString(), invoice2.getId().toString(), invoice3.getId().toString(), invoice4.getId().toString()), internalCallContext);
         final Map<String, Integer> repairedMap = CounterMappings.toMap(repairedMapRes);
         Assert.assertEquals(repairedMap.size(), 2);
-        Assert.assertEquals(repairedMap.get(invoiceId1.toString()), Integer.valueOf(1));
-        Assert.assertEquals(repairedMap.get(invoiceId2.toString()), Integer.valueOf(2));
+        Assert.assertEquals(repairedMap.get(invoice1.getId().toString()), Integer.valueOf(1));
+        Assert.assertEquals(repairedMap.get(invoice2.getId().toString()), Integer.valueOf(2));
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/dao/CounterMappings.java
+++ b/util/src/main/java/org/killbill/billing/util/dao/CounterMappings.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.dao;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class CounterMappings {
+
+    private final String key;
+    private final Integer total;
+
+    public CounterMappings(final String key, final Integer count) {
+        this.key = key;
+        this.total = count;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Integer getTotal() {
+        return total;
+    }
+
+    public static Map<String, Integer> toMap(final Iterable<CounterMappings> mappings) {
+        final Map<String, Integer> result = new LinkedHashMap<String, Integer>();
+        for (final CounterMappings mapping : mappings) {
+            result.put(mapping.getKey(), mapping.getTotal());
+        }
+        return result;
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/dao/CounterMappingsMapper.java
+++ b/util/src/main/java/org/killbill/billing/util/dao/CounterMappingsMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.dao;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+public class CounterMappingsMapper extends MapperBase implements ResultSetMapper<CounterMappings> {
+
+    @Override
+    public CounterMappings map(final int index, final ResultSet r, final StatementContext ctx) throws SQLException {
+        final String key = r.getString("the_key");
+        final Integer total = r.getInt("the_count");
+        return new CounterMappings(key, total);
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/glue/IDBISetup.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/IDBISetup.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.killbill.billing.lifecycle.ServiceFinder;
 import org.killbill.billing.util.broadcast.dao.BroadcastModelDao;
 import org.killbill.billing.util.dao.AuditLogModelDaoMapper;
+import org.killbill.billing.util.dao.CounterMappingsMapper;
 import org.killbill.billing.util.dao.EntityHistoryModelDaoMapperFactory;
 import org.killbill.billing.util.dao.RecordIdIdMappingsMapper;
 import org.killbill.billing.util.entity.Entity;
@@ -93,6 +94,7 @@ public class IDBISetup {
         return ImmutableList.<ResultSetMapper>builder()
                 .add(new AuditLogModelDaoMapper())
                 .add(new RecordIdIdMappingsMapper())
+                .add(new CounterMappingsMapper())
                 .add(new DatabaseSchemaSqlDao.ColumnInfoMapper())
                 .build();
     }


### PR DESCRIPTION
The change prevents voiding invoices that have items repaired in subsequent invoices and leading to a broken state.

After this change, the void operation would be rejected, and the user would have to first void the invoice repairing the original target invoice.

Notes:

- There is currently no good information provided to help the user understanding what to void first
- There is a possibility to create a cascade of invoices to void, as each of those could have repair elements on a subsequent one - this can become problematic for larger accounts
- There is also a possibility that we cannot void the subsequent invoice with the repair items on it as it was paid -- we disallow voiding paid invoices.
