### PR TITLE
Incremental work for 1464

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationVoidInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationVoidInvoice.java
@@ -139,7 +139,7 @@ public class TestIntegrationVoidInvoice extends TestIntegrationBase {
         assertEquals(invoices.get(2).getStatus(), InvoiceStatus.VOID);
     }
 
-    @Test(groups = "slow")
+    @Test(groups = "slow", enabled=false)
     public void testVoidRepairedInvoice() throws Exception {
 
         final DateTime initialDate = new DateTime(2013, 6, 15, 0, 0, 0, 0, testTimeZone);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationVoidInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationVoidInvoice.java
@@ -139,7 +139,7 @@ public class TestIntegrationVoidInvoice extends TestIntegrationBase {
         assertEquals(invoices.get(2).getStatus(), InvoiceStatus.VOID);
     }
 
-    @Test(groups = "slow", enabled=false)
+    @Test(groups = "slow")
     public void testVoidRepairedInvoice() throws Exception {
 
         final DateTime initialDate = new DateTime(2013, 6, 15, 0, 0, 0, 0, testTimeZone);
@@ -192,7 +192,6 @@ public class TestIntegrationVoidInvoice extends TestIntegrationBase {
         busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
         invoiceUserApi.voidInvoice(invoice3.getId(), callContext);
         assertListenerStatus();
-
 
         // NOW check we allow voiding the invoice2
         busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceHardening.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceHardening.java
@@ -216,7 +216,7 @@ public class TestWithInvoiceHardening extends TestIntegrationBase {
 
 
 
-    @Test(groups = "slow")
+    @Test(groups = "slow", enabled = false)
     public void testFixParkedAccountByVoidingInvoices() throws Exception {
 
         final DateTimeZone testTimeZone = DateTimeZone.UTC;

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceHardening.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceHardening.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.beatrix.integration;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 import javax.inject.Inject;
@@ -37,7 +38,9 @@ import org.killbill.billing.entitlement.api.BlockingState;
 import org.killbill.billing.entitlement.api.BlockingStateType;
 import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
 import org.killbill.billing.invoice.InvoiceDispatcher.FutureAccountNotifications;
+import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceApiException;
+import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.invoice.dao.InvoiceDao;
@@ -50,8 +53,11 @@ import org.killbill.billing.util.tag.ControlTagType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 import static org.killbill.billing.ErrorCode.INVOICE_NOTHING_TO_DO;
 import static org.testng.Assert.assertEquals;
@@ -214,9 +220,39 @@ public class TestWithInvoiceHardening extends TestIntegrationBase {
 
     }
 
+    private void deleteUsedCredit(final UUID accountId, final BigDecimal targetAmount) throws InvoiceApiException {
+        final List<Invoice> allInvoices = invoiceUserApi.getInvoicesByAccount(accountId, false, false, callContext);
+        final Iterable<InvoiceItem> allItems = Iterables.concat(Iterables.transform(allInvoices, new Function<Invoice, List<InvoiceItem>>() {
+
+            @Override
+            public List<InvoiceItem> apply(final Invoice input) {
+                return input.getInvoiceItems();
+            }
+        }));
+        final InvoiceItem usedCredit = Iterables.tryFind(allItems, new Predicate<InvoiceItem>() {
+            @Override
+            public boolean apply(final InvoiceItem input) {
+                return input.getInvoiceItemType() == InvoiceItemType.CBA_ADJ &&
+                       input.getAmount().compareTo(targetAmount) == 0;
+            }
+        }).orNull();
+        Assert.assertNotNull(usedCredit);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
+        invoiceUserApi.deleteCBA(accountId, usedCredit.getInvoiceId(), usedCredit.getId(), callContext);
+        assertListenerStatus();
 
 
-    @Test(groups = "slow", enabled = false)
+    }
+
+    //
+    // Complicated scenario where we want to test that given some bad data
+    //  1/ leading the account to be parked and
+    //  2/ leading the system to have both generated and used some credit
+    //  we are able using our 'void' and credit 'deletion api' to come back to a good state, i.e
+    //  credit was reclaimed, and account is back into a good state
+    //
+    @Test(groups = "slow")
     public void testFixParkedAccountByVoidingInvoices() throws Exception {
 
         final DateTimeZone testTimeZone = DateTimeZone.UTC;
@@ -248,7 +284,6 @@ public class TestWithInvoiceHardening extends TestIntegrationBase {
         //
         // Simulate some bad data on disk
         //
-
         // Invoice 1: RECURRING 2019-4-27 -> 2019-5-27
         final InvoiceModelDao firstInvoice = new InvoiceModelDao(UUID.randomUUID(), clock.getUTCNow(), account.getId(), null, new LocalDate(2019, 4, 27), new LocalDate(2019, 4, 27), account.getCurrency(), false, InvoiceStatus.COMMITTED, false);
         final UUID initialRecuringItemId = UUID.randomUUID();
@@ -309,6 +344,22 @@ public class TestWithInvoiceHardening extends TestIntegrationBase {
         tagUserApi.removeTag(account.getId(), ObjectType.ACCOUNT, ControlTagType.AUTO_INVOICING_OFF.getId(), callContext);
         busHandler.waitAndIgnoreEvents(3000);
 
+        // <! end of setup>
+        //
+        // We need to first VOID invoices that have REPAIR items otherwsie VOID operation on invoices being repaired would fail
+        // However, in order to VOID such REPAIR invoices for which (system) credit was generated, we need to ensure there is enough
+        // credit available on the account, hence the step of manually reclaiming credit before each operation.
+        //
+
+        deleteUsedCredit(account.getId(), new BigDecimal("-23.96"));
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
+        invoiceUserApi.voidInvoice(secondInvoice.getId(), callContext);
+        assertListenerStatus();
+
+        deleteUsedCredit(account.getId(), new BigDecimal("-5.99"));
+        deleteUsedCredit(account.getId(), new BigDecimal("-3.99"));
+
         busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
         invoiceUserApi.voidInvoice(fourthInvoice.getId(), callContext);
         assertListenerStatus();
@@ -317,9 +368,6 @@ public class TestWithInvoiceHardening extends TestIntegrationBase {
         invoiceUserApi.voidInvoice(thirdInvoice.getId(), callContext);
         assertListenerStatus();
 
-        busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
-        invoiceUserApi.voidInvoice(secondInvoice.getId(), callContext);
-        assertListenerStatus();
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
         invoiceUserApi.voidInvoice(firstInvoice.getId(), callContext);

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -772,8 +772,10 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                 final InternalCallContext internalCallContext = internalCallContextFactory.createInternalCallContext(invoiceId, ObjectType.INVOICE, context);
 
                 final InvoiceModelDao rawInvoice = dao.getById(invoiceId, internalCallContext);
-                checkInvoiceNotRepaired(rawInvoice);
-                checkInvoiceDoesContainGeneratedCredit(rawInvoice);
+                if (rawInvoice.getStatus() == InvoiceStatus.COMMITTED) {
+                    checkInvoiceNotRepaired(rawInvoice);
+                    checkInvoiceDoesContainGeneratedCredit(rawInvoice);
+                }
 
                 final Invoice currentInvoice = new DefaultInvoice(rawInvoice, getCatalogSafelyForPrettyNames(internalCallContext));
                 checkInvoiceNotPaid(currentInvoice);

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -1144,7 +1144,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
 
                     // In case this is a credit invoice (pure credit, or mixed), we allow to 'delete' credit generation
                     if (creditItem != null) { /* Credit Invoice */
-                        final BigDecimal accountCBA = cbaDao.getAccountCBAFromTransaction(entitySqlDaoWrapperFactory, context);
+                            final BigDecimal accountCBA = cbaDao.getAccountCBAFromTransaction(entitySqlDaoWrapperFactory, context);
                         // If we don't have enough credit left on the account, we reclaim what is necessary
                         if (accountCBA.compareTo(cbaItem.getAmount()) < 0) {
                             final BigDecimal amountToReclaim = cbaItem.getAmount().subtract(accountCBA);
@@ -1161,8 +1161,8 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                         final InvoiceItemModelDao itemAdj = new InvoiceItemModelDao(context.getCreatedDate(), InvoiceItemType.ITEM_ADJ, invoice.getId(), invoice.getAccountId(),
                                                                                     null, null, null, null, null, null, null, null, context.getCreatedDate().toLocalDate(),
                                                                                     null, cbaItem.getAmount(), null, cbaItem.getCurrency(), creditItem.getId());
-                        // createInvoiceItemFromTransaction
                         invoiceIds.add(invoice.getId());
+                        // We use createAndRefresh instead of createInvoiceItemFromTransaction to bypass the validation on the ITEM_ADJ
                         createAndRefresh(invoiceItemSqlDao, itemAdj, context);
                     } else /* System generated credit, e.g Repair invoice */ {
                         // TODO Add missing error https://github.com/killbill/killbill/issues/1501

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.java
@@ -65,6 +65,10 @@ public interface InvoiceItemSqlDao extends EntitySqlDao<InvoiceItemModelDao, Inv
     @SqlQuery
     BigDecimal getAccountCBA(@SmartBindBean final InternalTenantContext context);
 
+
+    @SqlQuery
+    List<InvoiceItemModelDao> getConsumedCBAItems(@SmartBindBean final InternalTenantContext context);
+
     @SqlQuery
     Iterable<CounterMappings> getRepairMap(@BindIn("ids") final Iterable<String> invoiceIds, @SmartBindBean final InternalTenantContext context);
 }

--- a/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.sql.stg
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.sql.stg
@@ -114,6 +114,22 @@ and <accountRecordIdField("ii.")> = :accountRecordId
 ;
 >>
 
+getConsumedCBAItems() ::= <<
+  SELECT <allTableFields("ii.")>
+  FROM <tableName()> ii
+  JOIN invoices i ON i.id = ii.invoice_id
+  WHERE
+  i.status = 'COMMITTED'
+  and ii.type = 'CBA_ADJ'
+  and ii.amount \< 0
+  and <accountRecordIdField("i.")> = :accountRecordId
+  and <accountRecordIdField("ii.")> = :accountRecordId
+  <AND_CHECK_TENANT("i.")>
+  <AND_CHECK_TENANT("ii.")>
+  order by <recordIdField("ii.")> DESC
+  ;
+>>
+
 getRepairMap(ids) ::= <<
   SELECT
   ii1.invoice_id the_key

--- a/invoice/src/test/java/org/killbill/billing/invoice/api/user/TestDefaultInvoiceUserApi.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/api/user/TestDefaultInvoiceUserApi.java
@@ -460,7 +460,7 @@ public class TestDefaultInvoiceUserApi extends InvoiceTestSuiteWithEmbeddedDB {
             final InvoiceItem externalCharge = new ExternalChargeInvoiceItem(invoiceId, accountId, null, "description", clock.getUTCToday(), clock.getUTCToday(), BigDecimal.TEN, accountCurrency, null);
             invoiceUserApi.insertExternalCharges(accountId, clock.getUTCToday(), ImmutableList.<InvoiceItem>of(externalCharge), true, null, callContext).get(0);
             Assert.fail("Should not allow to add items to a VOIDed invoice");
-        } catch (final Exception ignore) {
+        } catch (final IllegalStateException ignore) {
             // No check because of  https://github.com/killbill/killbill/issues/1501
         }
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/api/user/TestDefaultInvoiceUserApi.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/api/user/TestDefaultInvoiceUserApi.java
@@ -602,22 +602,20 @@ public class TestDefaultInvoiceUserApi extends InvoiceTestSuiteWithEmbeddedDB {
 
         latestInvoice1 = invoiceUserApi.getInvoice(items1.get(0).getInvoiceId(), callContext);
         Assert.assertEquals(latestInvoice1.getBalance().compareTo(BigDecimal.ZERO), 0);
-        // {EXTERNAL_CHARGE 50.0, CREDIT_ADJ -200.0, CBA_ADJ 200.0}
-        // + new items {CBA_ADJ -100.0, ITEM_ADJ 100.0}
-        Assert.assertEquals(latestInvoice1.getInvoiceItems().size(), 5);
+        Assert.assertEquals(latestInvoice1.getInvoiceItems().size(), 3);
 
         Assert.assertNotNull(Iterables.tryFind(latestInvoice1.getInvoiceItems(), new Predicate<InvoiceItem>() {
             @Override
             public boolean apply(final InvoiceItem invoiceItem) {
-                return InvoiceItemType.CBA_ADJ == invoiceItem.getInvoiceItemType() && invoiceItem.getAmount().compareTo(new BigDecimal("-100.0")) == 0;
+                return InvoiceItemType.CBA_ADJ == invoiceItem.getInvoiceItemType() && invoiceItem.getAmount().compareTo(BigDecimal.ZERO) == 0;
             }
         }).orNull());
         Assert.assertNotNull(Iterables.tryFind(latestInvoice1.getInvoiceItems(), new Predicate<InvoiceItem>() {
             @Override
             public boolean apply(final InvoiceItem invoiceItem) {
-                return InvoiceItemType.ITEM_ADJ == invoiceItem.getInvoiceItemType() &&
-                       invoiceItem.getAmount().compareTo(new BigDecimal("100.0")) == 0 &&
-                       invoiceItem.getLinkedItemId().equals(itemCredit.getId());
+                return InvoiceItemType.CREDIT_ADJ == invoiceItem.getInvoiceItemType() &&
+                       // Original credit amount - CBA gen (we just deleted)
+                       invoiceItem.getAmount().compareTo(new BigDecimal("-100.00")) == 0;
             }
         }).orNull());
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDao.java
@@ -1764,13 +1764,13 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         invoiceDao.deleteCBA(accountId, invoice.getId(), creditBalanceAdjInvoiceItem1.getId(), context);
 
         final InvoiceModelDao res = invoiceDao.getById(invoice.getId(), context);
-        Assert.assertEquals(res.getInvoiceItems().size(), 3);
+        Assert.assertEquals(res.getInvoiceItems().size(), 2);
         Assert.assertEquals(InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(res).compareTo(BigDecimal.TEN), 0);
         Assert.assertEquals(InvoiceModelDaoHelper.getCBAAmount(res).compareTo(BigDecimal.ZERO), 0);
         final InvoiceItemModelDao cbaAdj = Iterables.tryFind(res.getInvoiceItems(), new Predicate<InvoiceItemModelDao>() {
             @Override
             public boolean apply(final InvoiceItemModelDao input) {
-                return input.getType() == InvoiceItemType.CBA_ADJ && input.getAmount().compareTo(creditBalanceAdjInvoiceItem1.getAmount().negate()) == 0;
+                return input.getType() == InvoiceItemType.CBA_ADJ && input.getAmount().compareTo(BigDecimal.ZERO) == 0;
             }
         }).orNull();
         Assert.assertNotNull(cbaAdj);

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceItemSqlDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceItemSqlDao.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.invoice.dao;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -25,10 +26,8 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.InvoiceTestSuiteWithEmbeddedDB;
-import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
-import org.killbill.billing.invoice.model.RepairAdjInvoiceItem;
 import org.killbill.billing.util.dao.CounterMappings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -74,7 +73,6 @@ public class TestInvoiceItemSqlDao extends InvoiceTestSuiteWithEmbeddedDB {
     public void testWithOrWithoutCatalogEffectiveDate() throws Exception {
         final InvoiceItemSqlDao dao = dbi.onDemand(InvoiceItemSqlDao.class);
 
-
         // No catalogEffectiveDate
         final UUID invoiceItemId1 = UUID.randomUUID();
         dao.create(new InvoiceItemModelDao(invoiceItemId1, null, InvoiceItemType.FIXED, UUID.randomUUID(), UUID.randomUUID(), null, null, null, "description",
@@ -82,7 +80,6 @@ public class TestInvoiceItemSqlDao extends InvoiceTestSuiteWithEmbeddedDB {
 
         InvoiceItemModelDao result1 = dao.getById(invoiceItemId1.toString(), internalCallContext);
         Assert.assertNull(result1.getCatalogEffectiveDate());
-
 
         // With catalogEffectiveDate
         final UUID invoiceItemId2 = UUID.randomUUID();
@@ -95,10 +92,8 @@ public class TestInvoiceItemSqlDao extends InvoiceTestSuiteWithEmbeddedDB {
         Assert.assertTrue(result2.getCatalogEffectiveDate().compareTo(catalogEffectiveDate) == 0);
     }
 
-
-
     @Test(groups = "slow")
-    public void testRepairMap()  {
+    public void testRepairMap() {
         final InvoiceSqlDao invoiceSqlDao = dbi.onDemand(InvoiceSqlDao.class);
         final InvoiceItemSqlDao invoiceItemSqlDao = dbi.onDemand(InvoiceItemSqlDao.class);
 
@@ -115,10 +110,9 @@ public class TestInvoiceItemSqlDao extends InvoiceTestSuiteWithEmbeddedDB {
         final InvoiceModelDao invoiceRepair1 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
         invoiceSqlDao.create(invoiceRepair1, internalCallContext);
         final UUID repairId1 = UUID.randomUUID();
-        final InvoiceItemModelDao repair1 = new InvoiceItemModelDao( repairId1, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair1.getId(), accountId, null, null, null, "description",
-                                                                     null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item1.getId());
+        final InvoiceItemModelDao repair1 = new InvoiceItemModelDao(repairId1, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair1.getId(), accountId, null, null, null, "description",
+                                                                    null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item1.getId());
         invoiceItemSqlDao.create(repair1, internalCallContext);
-
 
         // 2 REPAIRs against 2nd invoice
         final InvoiceModelDao invoice2 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
@@ -131,17 +125,16 @@ public class TestInvoiceItemSqlDao extends InvoiceTestSuiteWithEmbeddedDB {
         final InvoiceModelDao invoiceRepair2a = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
         invoiceSqlDao.create(invoiceRepair2a, internalCallContext);
         final UUID repairId2a = UUID.randomUUID();
-        final InvoiceItemModelDao repair2a = new InvoiceItemModelDao( repairId2a, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair2a.getId(), accountId, null, null, null, "description",
-                                                                      null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item2.getId());
+        final InvoiceItemModelDao repair2a = new InvoiceItemModelDao(repairId2a, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair2a.getId(), accountId, null, null, null, "description",
+                                                                     null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item2.getId());
         invoiceItemSqlDao.create(repair2a, internalCallContext);
 
         final InvoiceModelDao invoiceRepair2b = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
         invoiceSqlDao.create(invoiceRepair2b, internalCallContext);
         final UUID repairId2b = UUID.randomUUID();
-        final InvoiceItemModelDao repair2b = new InvoiceItemModelDao( repairId2b, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair2b.getId(), accountId, null, null, null, "description",
-                                                                      null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item2.getId());
+        final InvoiceItemModelDao repair2b = new InvoiceItemModelDao(repairId2b, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair2b.getId(), accountId, null, null, null, "description",
+                                                                     null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item2.getId());
         invoiceItemSqlDao.create(repair2b, internalCallContext);
-
 
         // 0 REPAIR against 3rd invoice
         final InvoiceModelDao invoice3 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
@@ -164,16 +157,58 @@ public class TestInvoiceItemSqlDao extends InvoiceTestSuiteWithEmbeddedDB {
         final InvoiceModelDao invoiceRepair4 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.VOID);
         invoiceSqlDao.create(invoiceRepair4, internalCallContext);
         final UUID repairId4 = UUID.randomUUID();
-        final InvoiceItemModelDao repair4 = new InvoiceItemModelDao( repairId4, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair4.getId(), accountId, null, null, null, "description",
-                                                                     null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item4.getId());
+        final InvoiceItemModelDao repair4 = new InvoiceItemModelDao(repairId4, null, InvoiceItemType.REPAIR_ADJ, invoiceRepair4.getId(), accountId, null, null, null, "description",
+                                                                    null, null, null, null, null, new LocalDate(), null, BigDecimal.ONE, null, Currency.USD, item4.getId());
         invoiceItemSqlDao.create(repair4, internalCallContext);
-
-
 
         final Iterable<CounterMappings> repairedMapRes = invoiceItemSqlDao.getRepairMap(ImmutableList.of(invoice1.getId().toString(), invoice2.getId().toString(), invoice3.getId().toString(), invoice4.getId().toString()), internalCallContext);
         final Map<String, Integer> repairedMap = CounterMappings.toMap(repairedMapRes);
         Assert.assertEquals(repairedMap.size(), 2);
         Assert.assertEquals(repairedMap.get(invoice1.getId().toString()), Integer.valueOf(1));
         Assert.assertEquals(repairedMap.get(invoice2.getId().toString()), Integer.valueOf(2));
+    }
+
+    @Test(groups = "slow")
+    public void testConsumedCBAItems() {
+        final InvoiceSqlDao invoiceSqlDao = dbi.onDemand(InvoiceSqlDao.class);
+        final InvoiceItemSqlDao invoiceItemSqlDao = dbi.onDemand(InvoiceItemSqlDao.class);
+
+        final UUID accountId = UUID.randomUUID();
+
+        final InvoiceModelDao invoice1 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoice1, internalCallContext);
+
+        final UUID cbaInv1Item1Id = UUID.randomUUID();
+        final InvoiceItemModelDao cbaInv1Item1 = new InvoiceItemModelDao(cbaInv1Item1Id, null, InvoiceItemType.CBA_ADJ, invoice1.getId(), accountId, null, null, null, "description",
+                                                                         null, null, null, null, null, new LocalDate(), null, new BigDecimal("-5.43"), null, Currency.USD, null);
+        invoiceItemSqlDao.create(cbaInv1Item1, internalCallContext);
+
+        final UUID cbaInv1Item2Id = UUID.randomUUID();
+        final InvoiceItemModelDao cbaInv1Item2 = new InvoiceItemModelDao(cbaInv1Item2Id, null, InvoiceItemType.CBA_ADJ, invoice1.getId(), accountId, null, null, null, "description",
+                                                                         null, null, null, null, null, new LocalDate(), null, new BigDecimal("-7.25"), null, Currency.USD, null);
+        invoiceItemSqlDao.create(cbaInv1Item2, internalCallContext);
+
+
+        final InvoiceModelDao invoice2 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.DRAFT);
+        invoiceSqlDao.create(invoice2, internalCallContext);
+
+        final UUID cbaInv2Item1Id = UUID.randomUUID();
+        final InvoiceItemModelDao cbaInv2Item1 = new InvoiceItemModelDao(cbaInv2Item1Id, null, InvoiceItemType.CBA_ADJ, invoice2.getId(), accountId, null, null, null, "description",
+                                                                         null, null, null, null, null, new LocalDate(), null, new BigDecimal("-4.43"), null, Currency.USD, null);
+        invoiceItemSqlDao.create(cbaInv2Item1, internalCallContext);
+
+        final InvoiceModelDao invoice3 = new InvoiceModelDao(accountId, new LocalDate(), new LocalDate(), Currency.USD, false, InvoiceStatus.COMMITTED);
+        invoiceSqlDao.create(invoice3, internalCallContext);
+
+        final UUID cbaInv3Item1Id = UUID.randomUUID();
+        final InvoiceItemModelDao cbaInv3Item1 = new InvoiceItemModelDao(cbaInv3Item1Id, null, InvoiceItemType.CBA_ADJ, invoice3.getId(), accountId, null, null, null, "description",
+                                                                         null, null, null, null, null, new LocalDate(), null, new BigDecimal("-9.83"), null, Currency.USD, null);
+        invoiceItemSqlDao.create(cbaInv3Item1, internalCallContext);
+
+        final List<InvoiceItemModelDao> cbasConsumed = invoiceItemSqlDao.getConsumedCBAItems(internalCallContext);
+        Assert.assertEquals(cbasConsumed.size(), 3);
+        Assert.assertEquals(cbasConsumed.get(0).getAmount().compareTo(cbaInv3Item1.getAmount()), 0);
+        Assert.assertEquals(cbasConsumed.get(1).getAmount().compareTo(cbaInv1Item2.getAmount()), 0);
+        Assert.assertEquals(cbasConsumed.get(2).getAmount().compareTo(cbaInv1Item1.getAmount()), 0);
     }
 }


### PR DESCRIPTION
This PR contains a series of fixes related to VOIDing invoices. This goes beyond what was originally tracked in #1464.


* New constraints:
  * af237a904 Add constraints to not add items on a VOIDed invoice 
  * d474c1f06544e Add constraints to avoid VOIDing an invoice with credit generation items; however, we relaxed the constraint in b02b4dd10ca9d to allow VOIDing an invoice with credit generation items when such credit was not consumed, i.e when there is enough CBA left on the account. This was added because otherwise we could end up in a situation where part or all of such credit could have been consumed and it would lead to consuming credit that does not exist (inconsistent state).
  * d474c1f06544e Also contains a new contraint preventing VOIDing invoices that have `REPAIR_ADJ` items point to them. 
* 14a13b837a76 and 3b35f13ca4b345 are a rework of the InvoiceUserApi#deleteCBA (see details in the commit messages). The latest impl. will *update* the amount of the `CBA_ADJ` to remove gen/used credits. Although this is not a VOID scenario per-say, it was added to adjust our credit deletion logic with new VOID constraints (e.g Allow to delete credit generation generated through api).





     