### PR TITLE
invoice: Fix a ILLEGAL INVOICING STATE in repair + adj use case. See …

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationDryRunInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationDryRunInvoice.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.api.TestApiListener.NextEvent;
@@ -42,15 +41,20 @@ import org.killbill.billing.invoice.api.DryRunArguments;
 import org.killbill.billing.invoice.api.DryRunType;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceApiException;
+import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.subscription.api.user.DefaultSubscriptionBase;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 import static com.tc.util.Assert.fail;
+import static org.killbill.billing.ErrorCode.INVOICE_NOTHING_TO_DO;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -62,6 +66,62 @@ public class TestIntegrationDryRunInvoice extends TestIntegrationBase {
     //
     // Basic test with one subscription that verifies the behavior of using invoice dryRun api with no date
     //
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1505")
+    public void testForIssue_1505() throws Exception {
+        clock.setTime(new DateTime("2021-09-20T3:56:02"));
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(10));
+        assertNotNull(account);
+
+        // Start subscription in the past on 2021-08-10
+        final LocalDate billingStartDate = new LocalDate(2021, 8, 10);
+
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("Blowdart", BillingPeriod.MONTHLY, "notrial", null);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", billingStartDate, billingStartDate, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        final Entitlement bp = entitlementApi.getEntitlementForId(entitlementId, callContext);
+        assertListenerStatus();
+
+        final Invoice firstInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                                 new ExpectedInvoiceItemCheck(new LocalDate(2021, 8, 10), new LocalDate(2021, 9, 10), InvoiceItemType.RECURRING, new BigDecimal("29.95")));
+
+        final Invoice secondInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                                  new ExpectedInvoiceItemCheck(new LocalDate(2021, 9, 10), new LocalDate(2021, 10, 10), InvoiceItemType.RECURRING, new BigDecimal("29.95")));
+
+        final InvoiceItem recurringItem = Iterables.tryFind(secondInvoice.getInvoiceItems(), new Predicate<InvoiceItem>() {
+            @Override
+            public boolean apply(final InvoiceItem input) {
+                return input.getInvoiceItemType() == InvoiceItemType.RECURRING;
+            }
+        }).orNull();
+        Assert.assertNotNull(recurringItem);
+
+        // Full item adjustment for the RECURRING from second invoice
+        busHandler.pushExpectedEvents(NextEvent.INVOICE_ADJUSTMENT);
+        invoiceUserApi.insertInvoiceItemAdjustment(account.getId(), secondInvoice.getId(), recurringItem.getId(), clock.getUTCToday(), "", "", null, callContext);
+        assertListenerStatus();
+
+        // Cancel Subscription on 2021-09-20
+        busHandler.pushExpectedEvents(NextEvent.CANCEL, NextEvent.BLOCK, NextEvent.INVOICE);
+        bp.cancelEntitlementWithDate(new LocalDate(2021, 9, 10), true, ImmutableList.<PluginProperty>of(), callContext);
+        assertListenerStatus();
+
+        // We see a third Invoice generated with a $0 REPAIR_ADJ item
+        final Invoice thirdInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                                 new ExpectedInvoiceItemCheck(new LocalDate(2021, 9, 10), new LocalDate(2021, 10, 10), InvoiceItemType.REPAIR_ADJ, BigDecimal.ZERO));
+
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE);
+        try {
+            invoiceUserApi.triggerInvoiceGeneration(account.getId(), clock.getUTCToday(), callContext);
+            Assert.fail("Should not generate an invoice");
+        } catch (final InvoiceApiException e) {
+            assertEquals(e.getCode(), INVOICE_NOTHING_TO_DO.getCode());
+        } finally {
+            assertListenerStatus();
+        }
+    }
+
     @Test(groups = "slow")
     public void testDryRunWithNoTargetDate() throws Exception {
         final int billingDay = 14;
@@ -268,7 +328,7 @@ public class TestIntegrationDryRunInvoice extends TestIntegrationBase {
             invoiceUserApi.triggerDryRunInvoiceGeneration(createdEntitlement.getAccountId(), futureDate.minusDays(1), dryRunSubscriptionActionArg, callContext);
             fail("Should fail to trigger dryRun invoice prior subscription starts");
         } catch (final InvoiceApiException e) {
-            assertEquals(e.getCode(), ErrorCode.INVOICE_NOTHING_TO_DO.getCode());
+            assertEquals(e.getCode(), INVOICE_NOTHING_TO_DO.getCode());
         }
 
         // Second, on the startDate
@@ -388,7 +448,6 @@ public class TestIntegrationDryRunInvoice extends TestIntegrationBase {
         assertEquals(dryRunInvoice.getTargetDate(), new LocalDate(2014, 3, 1));
         invoiceChecker.checkInvoiceNoAudits(dryRunInvoice, expectedInvoices);
         expectedInvoices.clear();
-
 
         expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2014, 4, 1), new LocalDate(2014, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("249.95")));
         dryRunInvoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(2014, 4, 1), DRY_RUN_TARGET_DATE_ARG, callContext);
@@ -620,8 +679,6 @@ public class TestIntegrationDryRunInvoice extends TestIntegrationBase {
                                     new ExpectedInvoiceItemCheck(new LocalDate(2017, 12, 25), new LocalDate(2017, 12, 25), InvoiceItemType.CBA_ADJ, new BigDecimal("-56.44")));
 
     }
-
-
 
     @Test(groups = "slow", description = "See https://github.com/killbill/killbill/issues/1313")
     public void testDryRunTargetDatesWith_AUTO_INVOICING_REUSE_DRAFT() throws Exception {

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -35,6 +35,7 @@ import org.killbill.billing.invoice.model.ItemAdjInvoiceItem;
 import org.killbill.billing.invoice.model.RecurringInvoiceItem;
 import org.killbill.billing.invoice.model.RepairAdjInvoiceItem;
 import org.killbill.billing.util.jackson.ObjectMapper;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -436,6 +437,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.build();
     }
 
+
     @Test(groups = "fast")
     public void testInvalidRepair() {
         final LocalDate startDate = new LocalDate(2014, 1, 1);
@@ -447,23 +449,22 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem tooEarlyRepair = new RepairAdjInvoiceItem(invoiceId, accountId, startDate.minusDays(1), endDate, rate.negate(), currency, initial.getId());
         final InvoiceItem tooLateRepair = new RepairAdjInvoiceItem(invoiceId, accountId, startDate, endDate.plusDays(1), rate.negate(), currency, initial.getId());
 
+        List<InvoiceItem> result;
         SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
         tree.addItem(initial);
         tree.addItem(tooEarlyRepair);
-        try {
-            tree.build();
-            fail();
-        } catch (final IllegalStateException e) {
-        }
+        tree.build();
+
+        result  = tree.getView();
+        Assert.assertEquals(result.size(), 0);
 
         tree = new SubscriptionItemTree(subscriptionId, invoiceId);
         tree.addItem(initial);
         tree.addItem(tooLateRepair);
-        try {
-            tree.build();
-            fail();
-        } catch (final IllegalStateException e) {
-        }
+        tree.build();
+        result  = tree.getView();
+        Assert.assertEquals(result.size(), 0);
+
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
…#1505

It seems like we had some logic long time ago to remove cancelling pair of items on the same interval (i.e a RECURRING item fully REPAIRED) but this was removed in https://github.com/killbill/killbill/commit/789ed9ff15 and yet the comments and logic in the code would still refer to [this mechanism](https://github.com/killbill/killbill/blob/killbill-0.22.27/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java#L178).

For most cases where we have a full repair, we rely on the `InvoicePruner` to remove both the RECURRING and its fully REPAIRED item prior we even enter the tree, as shown in [here](https://github.com/killbill/killbill/blob/killbill-0.22.27/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoicePruner.java#L206).

However, the scenario we have here is one where we have a fully adjusted RECURRING item, and then an additional $0 `REPAIR_ADJ` item and in such a scenario,
the `InvoicePruner` will keep both the `ITEM_ADJ` and the `REPAIR_ADJ`, leading to a case that is not handled once we are in the tree - or rather a case that triggers a precondition.
Removing the precondition would lead to keep generating more $0 `REPAIR_ADJ` on every run, not a good thing...

The initial attempt to fix this issue was to extend the code in `InvoicePruner` and it can be made to work, but it slightly changes the behavior for an edge case scenario where the system tries to be smart about incorrect `RECURRING` items - see TestFixedAndRecurringInvoiceItemGenerator#testItemPartiallyRepairedAndPartiallyAdjusted. It is debatable whether we really care about keeping the behavior we have, but in order to minimize disruption, I gave up on this implementation.

Instead, I added some logic to harden the cases where we have canceling pairs of RECURRING item fully REPAIRED inside the interval tree to support this use case.

I had to change a a unit test that would also expect a case where we have unexpected RECURRING items on disk to fail, to instead return 0 items (ignore it).

إِنْ شَاءَ ٱللَّٰهُ