### PR TITLE
Work for 1503

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationDryRunInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationDryRunInvoice.java
@@ -20,6 +20,7 @@ package org.killbill.billing.beatrix.integration;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -49,6 +50,8 @@ import org.killbill.billing.subscription.api.user.DefaultSubscriptionBase;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.tc.util.Assert;
 
 import static com.tc.util.Assert.fail;
 import static org.testng.Assert.assertEquals;
@@ -59,6 +62,45 @@ public class TestIntegrationDryRunInvoice extends TestIntegrationBase {
     private static final DryRunArguments DRY_RUN_UPCOMING_INVOICE_ARG = new TestDryRunArguments(DryRunType.UPCOMING_INVOICE);
     private static final DryRunArguments DRY_RUN_TARGET_DATE_ARG = new TestDryRunArguments(DryRunType.TARGET_DATE);
 
+
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1503")
+    public void testForIssue_1503() throws Exception {
+        clock.setTime(new DateTime("2021-04-01T3:56:02"));
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+        assertNotNull(account);
+
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("Blowdart", BillingPeriod.MONTHLY, "notrial", null);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), "Something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        final Entitlement bp = entitlementApi.getEntitlementForId(entitlementId, callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2021, 4, 1), new LocalDate(2021, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("29.95")));
+
+        bp.cancelEntitlementWithDate(new LocalDate(2021, 6, 1), true, ImmutableList.<PluginProperty>of(), callContext);
+
+        // We see one recurring from 2021-5-1 -> 2021-6-1
+        final Invoice dryRunInvoice1 = invoiceUserApi.triggerDryRunInvoiceGeneration(bp.getAccountId(), new LocalDate(2021, 5, 1), DRY_RUN_TARGET_DATE_ARG, callContext);
+        invoiceChecker.checkInvoiceNoAudits(dryRunInvoice1, ImmutableList.of(new ExpectedInvoiceItemCheck(new LocalDate(2021, 5, 1), new LocalDate(2021, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("29.95"))));
+
+        // From any date > 2021-5-1, we should see nothing
+        Set<LocalDate> nextDates = ImmutableSet.of(new LocalDate(2021, 6, 1), /* cancelation date */
+                                                   new LocalDate(2021, 6, 3),
+                                                   new LocalDate(2021, 7, 1));
+
+        for (LocalDate targetDate : nextDates) {
+            try {
+                invoiceUserApi.triggerDryRunInvoiceGeneration(bp.getAccountId(), targetDate, DRY_RUN_TARGET_DATE_ARG, callContext);
+                Assert.fail(String.format("Should not have received an invoice for date %s", targetDate));
+            } catch(final InvoiceApiException e) {
+                assertEquals(e.getCode(), ErrorCode.INVOICE_NOTHING_TO_DO.getCode());
+            }
+        }
+
+    }
     //
     // Basic test with one subscription that verifies the behavior of using invoice dryRun api with no date
     //

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -494,7 +494,7 @@ public class InvoiceDispatcher {
             if (prev != null && prev.compareTo(cur) == 0) {
                 continue;
             }
-            if (cur.compareTo(targetDate) >= 0) {
+            if (cur.compareTo(targetDate) > 0) {
                 break;
             }
 
@@ -526,12 +526,17 @@ public class InvoiceDispatcher {
             prev = cur;
         }
 
-        pluginProperties = new LinkedList<PluginProperty>();
-        pluginProperties.add(new PluginProperty(DRY_RUN_CUR_DATE_PROP, targetDate, false));
-        pluginProperties.add(new PluginProperty(DRY_RUN_TARGET_DATE_PROP, targetDate, false));
-        final InvoiceWithFutureNotifications invoiceWithFutureNotifications = processAccountWithLockAndInputTargetDate(accountId, targetDate, billingEvents, accountInvoices, dryRunInfo, false, pluginProperties, context);
-        final Invoice targetInvoice = invoiceWithFutureNotifications != null ? invoiceWithFutureNotifications.getInvoice() : null;
-        return targetInvoice != null ? targetInvoice : additionalInvoice;
+        final boolean isTargetDateAlignedOnLastTransition = prev != null && prev.compareTo(targetDate) == 0;
+        if (isTargetDateAlignedOnLastTransition) {
+            return additionalInvoice;
+        } else { /* The provided targetDate does not coincide with any transition, so we try it and return what we find if there is anything or default to previous transition  */
+            pluginProperties = new LinkedList<PluginProperty>();
+            pluginProperties.add(new PluginProperty(DRY_RUN_CUR_DATE_PROP, targetDate, false));
+            pluginProperties.add(new PluginProperty(DRY_RUN_TARGET_DATE_PROP, targetDate, false));
+            final InvoiceWithFutureNotifications invoiceWithFutureNotifications = processAccountWithLockAndInputTargetDate(accountId, targetDate, billingEvents, accountInvoices, dryRunInfo, false, pluginProperties, context);
+            final Invoice targetInvoice = invoiceWithFutureNotifications != null ? invoiceWithFutureNotifications.getInvoice() : null;
+            return targetInvoice != null ? targetInvoice : additionalInvoice;
+        }
     }
 
     private void parkAccount(final UUID accountId, final InternalCallContext context) {


### PR DESCRIPTION
Fix is in https://github.com/killbill/killbill/pull/1526/commits/988b5773a8cdba3f0a280683e68bb9b7e546901c

The goal is keep the dryRun (`targetDate`) behavior where we only return the last invoice for that invoice dry Run *as if everything prior that had been invoiced up to date*. So in order to also allow for a random targetDate not aligned on billing boundaries, the code need to check for that as well.
