### PR TITLE
add index on invoice_billing_events.{tenant_record_id, account_record_id}

### DIFF
--- a/invoice/src/main/resources/org/killbill/billing/invoice/ddl.sql
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/ddl.sql
@@ -250,3 +250,4 @@ CREATE TABLE invoice_billing_events (
     PRIMARY KEY(record_id)
 ) /*! CHARACTER SET utf8 COLLATE utf8_bin */;
 CREATE UNIQUE INDEX invoice_billing_events_invoice_id ON invoice_billing_events(invoice_id);
+CREATE INDEX invoice_billing_events_tenant_account_record_id ON invoice_billing_events(tenant_record_id, account_record_id);

--- a/invoice/src/main/resources/org/killbill/billing/invoice/migration/V20211119130300__invoice_billing_events_index.sql
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/migration/V20211119130300__invoice_billing_events_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX invoice_billing_events_tenant_account_record_id ON invoice_billing_events(tenant_record_id, account_record_id);


### PR DESCRIPTION
## Motivation
Accessing records by the `tenant_record_id` and `account_record_id` is a common pattern, but the `invoice_billing_events` table is inconsistent with other tables and does not have an index on these columns.

## Change
Add a migration file and update the ddl to add a new composite index on the `tenant_record_id` and `account_record_id` columns for the `invoice_billing_events` table.