### PR TITLE
profiles: Fix flakiness in test around CTD

### DIFF
--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
@@ -233,7 +233,7 @@ public class TestTag extends TestJaxrsBase {
     public void testTagsPagination() throws Exception {
         final Account account = createAccount();
         for (int i = 0; i < 5; i++) {
-            final TagDefinition tagDefinition = new TagDefinition(null, false, UUID.randomUUID().toString().substring(0, 5), UUID.randomUUID().toString(), ImmutableList.<ObjectType>of(ObjectType.ACCOUNT), null);
+            final TagDefinition tagDefinition = new TagDefinition(null, false, "td-" + i, UUID.randomUUID().toString(), ImmutableList.<ObjectType>of(ObjectType.ACCOUNT), null);
             final UUID tagDefinitionId = tagDefinitionApi.createTagDefinition(tagDefinition, requestOptions).getId();
             accountApi.createAccountTags(account.getAccountId(), ImmutableList.<UUID>of(tagDefinitionId), requestOptions);
         }


### PR DESCRIPTION
I have seen the issue on CI as reported here: `https://github.com/killbill/killbill/pull/1541#issuecomment-991453841`

The issue is that when we commit an invoice, setting the CTD happens after the transaction (incl the INVOICE event) for committed,
so we need to poll for the CTD value to be correctly reflected.