### PR TITLE
payment: Introduce a new property to allow updating a payment method

### DIFF
--- a/payment/src/main/java/org/killbill/billing/payment/config/MultiTenantPaymentConfig.java
+++ b/payment/src/main/java/org/killbill/billing/payment/config/MultiTenantPaymentConfig.java
@@ -170,6 +170,11 @@ public class MultiTenantPaymentConfig extends MultiTenantConfigBase implements P
     }
 
     @Override
+    public boolean isAllowedToOverwritePaymentMethodId() {
+        return staticConfig.isAllowedToOverwritePaymentMethodId();
+    }
+
+    @Override
     protected Class<? extends KillbillConfig> getConfigClass() {
         return PaymentConfig.class;
     }

--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/control/ControlPluginRunner.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/control/ControlPluginRunner.java
@@ -128,7 +128,7 @@ public class ControlPluginRunner {
             if (prevResult.getAdjustedPaymentMethodId() != null) {
                 // We only allow setting the paymentMethodId but disallow overwriting an existing paymentMethodId for a given Payment - See #1097
                 // unless the property isAllowedToOverwritePaymentMethodId was explicitly configured to allow this
-                if (paymentConfig.isAllowedToOverwritePaymentMethodId() || paymentMethodId != null) {
+                if (!paymentConfig.isAllowedToOverwritePaymentMethodId() && paymentMethodId != null) {
                     throw new PaymentControlApiException(String.format("Not allowed to overwrite paymentMethodId '%s' for payment '%s'",
                                                                        paymentMethodId, paymentId));
                 }

--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/control/ControlPluginRunner.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/control/ControlPluginRunner.java
@@ -43,6 +43,7 @@ import org.killbill.billing.payment.retry.DefaultFailureCallResult;
 import org.killbill.billing.payment.retry.DefaultOnSuccessPaymentControlResult;
 import org.killbill.billing.payment.retry.DefaultPriorPaymentControlResult;
 import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.config.definition.PaymentConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,10 +52,13 @@ public class ControlPluginRunner {
     private static final Logger log = LoggerFactory.getLogger(ControlPluginRunner.class);
 
     private final OSGIServiceRegistration<PaymentControlPluginApi> paymentControlPluginRegistry;
+    private final PaymentConfig paymentConfig;
 
     @Inject
-    public ControlPluginRunner(final OSGIServiceRegistration<PaymentControlPluginApi> paymentControlPluginRegistry) {
+    public ControlPluginRunner(final OSGIServiceRegistration<PaymentControlPluginApi> paymentControlPluginRegistry,
+                              final PaymentConfig paymentConfig) {
         this.paymentControlPluginRegistry = paymentControlPluginRegistry;
+        this.paymentConfig = paymentConfig;
     }
 
     public PriorPaymentControlResult executePluginPriorCalls(final Account account,
@@ -122,12 +126,12 @@ public class ControlPluginRunner {
             }
 
             if (prevResult.getAdjustedPaymentMethodId() != null) {
-                // We only allow setting the paymentMethodId but disallow overwriting an existing paymentMethodId for a given Payment. See #1097
-                if (paymentMethodId != null) {
+                // We only allow setting the paymentMethodId but disallow overwriting an existing paymentMethodId for a given Payment - See #1097
+                // unless the property isAllowedToOverwritePaymentMethodId was explicitly configured to allow this
+                if (paymentConfig.isAllowedToOverwritePaymentMethodId() || paymentMethodId != null) {
                     throw new PaymentControlApiException(String.format("Not allowed to overwrite paymentMethodId '%s' for payment '%s'",
                                                                        paymentMethodId, paymentId));
                 }
-
                 inputPaymentMethodId = prevResult.getAdjustedPaymentMethodId();
             }
             if (prevResult.getAdjustedPluginName() != null) {

--- a/payment/src/test/java/org/killbill/billing/payment/PaymentTestSuiteNoDB.java
+++ b/payment/src/test/java/org/killbill/billing/payment/PaymentTestSuiteNoDB.java
@@ -163,6 +163,7 @@ public abstract class PaymentTestSuiteNoDB extends GuicyKillbillTestSuiteNoDB {
         paymentExecutors.initialize();
         ((MockPaymentDao) paymentDao).reset();
         Profiling.resetPerThreadProfilingData();
+        clock.resetDeltaFromReality();
     }
 
     @AfterMethod(groups = "fast")

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/control/TestControlPluginRunner.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/control/TestControlPluginRunner.java
@@ -50,7 +50,7 @@ public class TestControlPluginRunner extends PaymentTestSuiteNoDB {
         final ImmutableList<String> paymentControlPluginNames = ImmutableList.<String>of("not-registered");
         final ImmutableList<PluginProperty> pluginProperties = ImmutableList.<PluginProperty>of();
 
-        final ControlPluginRunner controlPluginRunner = new ControlPluginRunner(new DefaultPaymentControlProviderPluginRegistry());
+        final ControlPluginRunner controlPluginRunner = new ControlPluginRunner(new DefaultPaymentControlProviderPluginRegistry(), paymentConfig);
         final PriorPaymentControlResult paymentControlResult = controlPluginRunner.executePluginPriorCalls(account,
                                                                                                            paymentMethodId,
                                                                                                            null,
@@ -89,7 +89,7 @@ public class TestControlPluginRunner extends PaymentTestSuiteNoDB {
         final ImmutableList<String> paymentControlPluginNames = ImmutableList.<String>of("not-registered");
         final ImmutableList<PluginProperty> pluginProperties = ImmutableList.<PluginProperty>of();
 
-        final ControlPluginRunner controlPluginRunner = new ControlPluginRunner(new DefaultPaymentControlProviderPluginRegistry());
+        final ControlPluginRunner controlPluginRunner = new ControlPluginRunner(new DefaultPaymentControlProviderPluginRegistry(), paymentConfig);
         final PriorPaymentControlResult paymentControlResult = controlPluginRunner.executePluginPriorCalls(null,
                 null,
                 null,

--- a/util/src/main/java/org/killbill/billing/util/config/definition/PaymentConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/PaymentConfig.java
@@ -129,4 +129,10 @@ public interface PaymentConfig extends KillbillConfig {
     @Default("50")
     @Description("Maximum number of times the system will retry to grab global lock (with a 100ms wait each time)")
     int getMaxGlobalLockRetries();
+
+    @Config("org.killbill.payment.method.overwrite")
+    @Default("false")
+    @Description("Ability to overwrite an existing payment method from a control plugin")
+    boolean isAllowedToOverwritePaymentMethodId();
+
 }


### PR DESCRIPTION
By default, we only allow *setting* a new payment method from a payment control plugin.

When this new property is set to true, we allow overwriting whatever value it already had.

This needs to be used with caution, as we could have multiple updates from multiple plugins leading to a non deterministic state, or we could attempt to update a payment method for an existing `Payment` and it is not clear what the end state would be. See #1097

Also, (attempt) to fix the test instability shown below in https://github.com/killbill/killbill/pull/1559/commits/deba7f7bc43835f8e536ee08aef04dcb00a05d41