### PR TITLE
Fix 1469 killbill usage amount should be a floating point

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions.java
@@ -158,8 +158,8 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
-        recordUsageData(entitlementId, "t1", "liter", new LocalDate(2018, 1, 1), 10L, callContext);
-        recordUsageData(entitlementId, "t2", "liter", new LocalDate(2018, 1, 23), 10L, callContext);
+        recordUsageData(entitlementId, "t1", "liter", new LocalDate(2018, 1, 1), BigDecimal.valueOf(10L), callContext);
+        recordUsageData(entitlementId, "t2", "liter", new LocalDate(2018, 1, 23), BigDecimal.valueOf(10L), callContext);
 
         // Catalog v2 with price increase is on 2018-04-01 but because we have an effectiveDateForExistingSubscriptions set to 2018-05-01
         // we don't see any change until 5-1
@@ -174,7 +174,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t1", "t2"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t3", "liter", new LocalDate(2018, 2, 15), 20L, callContext);
+        recordUsageData(entitlementId, "t3", "liter", new LocalDate(2018, 2, 15), BigDecimal.valueOf(20L), callContext);
         // 2018-3-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -185,7 +185,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t3"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t4", "liter", new LocalDate(2018, 3, 18), 20L, callContext);
+        recordUsageData(entitlementId, "t4", "liter", new LocalDate(2018, 3, 18), BigDecimal.valueOf(20L), callContext);
         // 2018-4-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -196,7 +196,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t4"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t5", "liter", new LocalDate(2018, 4, 28), 20L, callContext);
+        recordUsageData(entitlementId, "t5", "liter", new LocalDate(2018, 4, 28), BigDecimal.valueOf(20L), callContext);
 
         // 2018-5-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -209,7 +209,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
 
 
         // effectiveDateForExistingSubscriptions set to 2018-05-01 should kick-in and we should see the price increase for the period 2018-05-01 -> 2018-6-1
-        recordUsageData(entitlementId, "t6", "liter", new LocalDate(2018, 5, 22), 20L, callContext);
+        recordUsageData(entitlementId, "t6", "liter", new LocalDate(2018, 5, 22), BigDecimal.valueOf(20L), callContext);
 
         // 2018-6-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -222,7 +222,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
 
 
 
-        recordUsageData(entitlementId, "t7", "liter", new LocalDate(2018, 6, 29), 20L, callContext);
+        recordUsageData(entitlementId, "t7", "liter", new LocalDate(2018, 6, 29), BigDecimal.valueOf(20L), callContext);
 
         // 2018-7-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -235,7 +235,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
 
 
 
-        recordUsageData(entitlementId, "t8", "liter", new LocalDate(2018, 7, 13), 20L, callContext);
+        recordUsageData(entitlementId, "t8", "liter", new LocalDate(2018, 7, 13), BigDecimal.valueOf(20L), callContext);
 
         // Catalog v3 with price increase is on 2018-07-01 but because we have an effectiveDateForExistingSubscriptions set to 2018-08-01
         // we don't see any change until 8-1
@@ -249,7 +249,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t8"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t9", "liter", new LocalDate(2018, 8, 13), 20L, callContext);
+        recordUsageData(entitlementId, "t9", "liter", new LocalDate(2018, 8, 13), BigDecimal.valueOf(20L), callContext);
 
         // Check we see the new price for catalog version v3
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions2.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions2.java
@@ -25,23 +25,16 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
-import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
-import org.killbill.billing.catalog.api.ProductCategory;
-import org.killbill.billing.catalog.api.VersionedCatalog;
-import org.killbill.billing.entitlement.api.DefaultEntitlement;
 import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.platform.api.KillbillConfigSource;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
-import static org.testng.Assert.assertNotNull;
 
 public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestIntegrationBase {
 
@@ -69,8 +62,8 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestI
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
-        recordUsageData(entitlementId, "t1", "liter", new LocalDate(2018, 1, 1), 10L, callContext);
-        recordUsageData(entitlementId, "t2", "liter", new LocalDate(2018, 1, 23), 10L, callContext);
+        recordUsageData(entitlementId, "t1", "liter", new LocalDate(2018, 1, 1), BigDecimal.valueOf(10L), callContext);
+        recordUsageData(entitlementId, "t2", "liter", new LocalDate(2018, 1, 23), BigDecimal.valueOf(10L), callContext);
 
         // Catalog v2 with price increase is on 2018-04-01 but because we have an effectiveDateForExistingSubscriptions set to 2018-05-01
         // we don't see any change until 5-1
@@ -85,7 +78,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestI
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t1", "t2"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t3", "liter", new LocalDate(2018, 2, 15), 20L, callContext);
+        recordUsageData(entitlementId, "t3", "liter", new LocalDate(2018, 2, 15), BigDecimal.valueOf(20L), callContext);
         // 2018-3-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -96,7 +89,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestI
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t3"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t4", "liter", new LocalDate(2018, 3, 18), 20L, callContext);
+        recordUsageData(entitlementId, "t4", "liter", new LocalDate(2018, 3, 18), BigDecimal.valueOf(20L), callContext);
         // 2018-4-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -107,7 +100,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestI
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t4"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t5", "liter", new LocalDate(2018, 4, 28), 20L, callContext);
+        recordUsageData(entitlementId, "t5", "liter", new LocalDate(2018, 4, 28), BigDecimal.valueOf(20L), callContext);
 
         // 2018-5-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -119,7 +112,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestI
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t5"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t6", "liter", new LocalDate(2018, 5, 22), 20L, callContext);
+        recordUsageData(entitlementId, "t6", "liter", new LocalDate(2018, 5, 22), BigDecimal.valueOf(20L), callContext);
 
         // 2018-6-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -132,7 +125,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestI
 
 
 
-        recordUsageData(entitlementId, "t7", "liter", new LocalDate(2018, 6, 29), 20L, callContext);
+        recordUsageData(entitlementId, "t7", "liter", new LocalDate(2018, 6, 29), BigDecimal.valueOf(20L), callContext);
 
         // 2018-7-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -145,7 +138,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestI
 
 
 
-        recordUsageData(entitlementId, "t8", "liter", new LocalDate(2018, 7, 13), 20L, callContext);
+        recordUsageData(entitlementId, "t8", "liter", new LocalDate(2018, 7, 13), BigDecimal.valueOf(20L), callContext);
 
         // Catalog v3 with price increase is on 2018-07-01 but because we have an effectiveDateForExistingSubscriptions set to 2018-08-01
         // we don't see any change until 8-1
@@ -159,7 +152,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions2 extends TestI
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t8"), internalCallContext);
 
 
-        recordUsageData(entitlementId, "t9", "liter", new LocalDate(2018, 8, 13), 20L, callContext);
+        recordUsageData(entitlementId, "t9", "liter", new LocalDate(2018, 8, 13), BigDecimal.valueOf(20L), callContext);
 
         // Check we see the new price for catalog version v3
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEvents.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEvents.java
@@ -27,11 +27,8 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
-import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
-import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.catalog.api.VersionedCatalog;
-import org.killbill.billing.entitlement.api.DefaultEntitlement;
 import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
 import org.killbill.billing.entitlement.api.Subscription;
 import org.killbill.billing.entitlement.api.SubscriptionEvent;
@@ -44,8 +41,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
-import static org.testng.Assert.assertNotNull;
 
 public class TestCatalogWithEvents extends TestIntegrationBase {
 
@@ -72,8 +67,8 @@ public class TestCatalogWithEvents extends TestIntegrationBase {
         final UUID subscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null), UUID.randomUUID().toString(), clock.getUTCToday(), clock.getUTCToday(), false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
-        recordUsageData(subscriptionId, "t1", "liter", new LocalDate(2020, 1, 1), 10L, callContext);
-        recordUsageData(subscriptionId, "t2", "liter", new LocalDate(2020, 1, 23), 10L, callContext);
+        recordUsageData(subscriptionId, "t1", "liter", new LocalDate(2020, 1, 1), BigDecimal.valueOf(10L), callContext);
+        recordUsageData(subscriptionId, "t2", "liter", new LocalDate(2020, 1, 23), BigDecimal.valueOf(10L), callContext);
 
         // 2020-2-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1053,10 +1053,10 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
                                    final String trackingId,
                                    final String unitType,
                                    final LocalDate startDate,
-                                   final BigDecimal amount, // FIXME-1469 change to correct BigDecimal implementation
+                                   final BigDecimal amount,
                                    final CallContext context) throws UsageApiException {
         final List<UsageRecord> usageRecords = new ArrayList<>();
-        usageRecords.add(new UsageRecord(startDate, amount));
+        usageRecords.add(new UsageRecord(startDate, amount.longValue())); /* FIXME-1469 : API backward compat */
         final List<UnitUsageRecord> unitUsageRecords = new ArrayList<>();
         unitUsageRecords.add(new UnitUsageRecord(unitType, usageRecords));
         final SubscriptionUsageRecord record = new SubscriptionUsageRecord(subscriptionId, trackingId, unitUsageRecords);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1053,11 +1053,11 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
                                    final String trackingId,
                                    final String unitType,
                                    final LocalDate startDate,
-                                   final Long amount, // FIXME-1469 change to correct BigDecimal implementation
+                                   final BigDecimal amount, // FIXME-1469 change to correct BigDecimal implementation
                                    final CallContext context) throws UsageApiException {
-        final List<UsageRecord> usageRecords = new ArrayList<UsageRecord>();
-        usageRecords.add(new UsageRecord(startDate, new BigDecimal(amount)));
-        final List<UnitUsageRecord> unitUsageRecords = new ArrayList<UnitUsageRecord>();
+        final List<UsageRecord> usageRecords = new ArrayList<>();
+        usageRecords.add(new UsageRecord(startDate, amount));
+        final List<UnitUsageRecord> unitUsageRecords = new ArrayList<>();
         unitUsageRecords.add(new UnitUsageRecord(unitType, usageRecords));
         final SubscriptionUsageRecord record = new SubscriptionUsageRecord(subscriptionId, trackingId, unitUsageRecords);
         usageUserApi.recordRolledUpUsage(record, context);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1049,9 +1049,14 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         T apply(F input) throws E;
     }
 
-    protected void recordUsageData(final UUID subscriptionId, final String trackingId, final String unitType, final LocalDate startDate, final Long amount, final CallContext context) throws UsageApiException {
+    protected void recordUsageData(final UUID subscriptionId,
+                                   final String trackingId,
+                                   final String unitType,
+                                   final LocalDate startDate,
+                                   final Long amount, // FIXME-1469 change to correct BigDecimal implementation
+                                   final CallContext context) throws UsageApiException {
         final List<UsageRecord> usageRecords = new ArrayList<UsageRecord>();
-        usageRecords.add(new UsageRecord(startDate, amount));
+        usageRecords.add(new UsageRecord(startDate, new BigDecimal(amount)));
         final List<UnitUsageRecord> unitUsageRecords = new ArrayList<UnitUsageRecord>();
         unitUsageRecords.add(new UnitUsageRecord(unitType, usageRecords));
         final SubscriptionUsageRecord record = new SubscriptionUsageRecord(subscriptionId, trackingId, unitUsageRecords);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithBCDUpdate.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithBCDUpdate.java
@@ -825,8 +825,8 @@ public class TestWithBCDUpdate extends TestIntegrationBase {
         assertNull(bpSubscription.getSubscriptionBase().getChargedThroughDate());
 
         // Record usage for first month
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 5), 100L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 5), BigDecimal.valueOf(100L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // 2012-05-01
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -855,8 +855,8 @@ public class TestWithBCDUpdate extends TestIntegrationBase {
                                     new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2012, 5, 5), InvoiceItemType.USAGE, BigDecimal.ZERO));
 
         // Record usage for second month
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 5), 100L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 4), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 5), BigDecimal.valueOf(100L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 4), BigDecimal.valueOf(100L), callContext);
 
         // 2012-06-01
         busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -440,8 +440,8 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         // AO subscription
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2021, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2021, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2021, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2021, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // 2020-05-01
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -463,8 +463,8 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
                                                  new ExpectedInvoiceItemCheck(new LocalDate(2021, 5, 1), new LocalDate(2021, 6, 1), InvoiceItemType.USAGE, BigDecimal.ZERO));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of(), internalCallContext);
 
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2021, 6, 1), 50L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2021, 6, 16), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2021, 6, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2021, 6, 16), BigDecimal.valueOf(300L), callContext);
 
         // We have 2 conflicting properties (on purpose) for this test that will lead to re-invoice the usage on month 2021-04-01 -> 2021-05-01:
         // - org.killbill.invoice.maxInvoiceLimit= 1 -> meaning usage code does not see such invoice

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -505,8 +505,8 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         // AO subscription
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2021, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2021, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2021, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2021, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // 2020-05-01
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -528,8 +528,8 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
                                                  new ExpectedInvoiceItemCheck(new LocalDate(2021, 5, 1), new LocalDate(2021, 6, 1), InvoiceItemType.USAGE, BigDecimal.ZERO));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of(), internalCallContext);
 
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2021, 6, 1), 50L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2021, 6, 16), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2021, 6, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2021, 6, 16), BigDecimal.valueOf(300L), callContext);
 
         // 2020-07-01
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -541,8 +541,8 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-3", "tracking-4"), internalCallContext);
 
 
-        recordUsageData(aoSubscription.getId(), "tracking-5", "bullets", new LocalDate(2021, 7, 2), 40L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-6", "bullets", new LocalDate(2021, 7, 18), 310L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-5", "bullets", new LocalDate(2021, 7, 2), BigDecimal.valueOf(40L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-6", "bullets", new LocalDate(2021, 7, 18), BigDecimal.valueOf(310L), callContext);
 
         // 2020-08-01
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -837,13 +837,13 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         assertListenerStatus();
 
         // Generate some usage data for past months
-        recordUsageData(sub2.getId(), "tracking-old-1", "hours", new LocalDate(2020, 9, 19), 1L, callContext);
-        recordUsageData(sub2.getId(), "tracking-old-2", "hours", new LocalDate(2020, 10, 19), 1L, callContext);
-        recordUsageData(sub2.getId(), "tracking-old-3", "hours", new LocalDate(2020, 11, 19), 1L, callContext);
-        recordUsageData(sub2.getId(), "tracking-old-4", "hours", new LocalDate(2020, 12, 19), 1L, callContext);
+        recordUsageData(sub2.getId(), "tracking-old-1", "hours", new LocalDate(2020, 9, 19), BigDecimal.valueOf(1L), callContext);
+        recordUsageData(sub2.getId(), "tracking-old-2", "hours", new LocalDate(2020, 10, 19), BigDecimal.valueOf(1L), callContext);
+        recordUsageData(sub2.getId(), "tracking-old-3", "hours", new LocalDate(2020, 11, 19), BigDecimal.valueOf(1L), callContext);
+        recordUsageData(sub2.getId(), "tracking-old-4", "hours", new LocalDate(2020, 12, 19), BigDecimal.valueOf(1L), callContext);
 
         // Generate usage data for this month
-        recordUsageData(sub2.getId(), "tracking-1", "hours", new LocalDate(2021, 1, 19), 1L, callContext);
+        recordUsageData(sub2.getId(), "tracking-1", "hours", new LocalDate(2021, 1, 19), BigDecimal.valueOf(1L), callContext);
 
         // 2021-02-01
         // (Hum... Interestingly, there is no future notification set on the 1st although sub2#BCD is the 1st...)
@@ -876,13 +876,13 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         Thread.sleep(1000);
 
 
-        recordUsageData(sub2.getId(), "tracking-2-a", "hours", new LocalDate(2021, 2, 15), 1L, callContext);
+        recordUsageData(sub2.getId(), "tracking-2-a", "hours", new LocalDate(2021, 2, 15), BigDecimal.valueOf(1L), callContext);
 
         // 2021-03-01
         clock.addDays(14);
         Thread.sleep(1000);
 
-        recordUsageData(sub2.getId(), "tracking-2-b", "hours", new LocalDate(2021, 2, 25), 1L, callContext);
+        recordUsageData(sub2.getId(), "tracking-2-b", "hours", new LocalDate(2021, 2, 25), BigDecimal.valueOf(1L), callContext);
 
 
         invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2021, 3, 31), callContext);
@@ -908,7 +908,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         Thread.sleep(1000);
 
 
-        recordUsageData(sub2.getId(), "tracking-3", "hours", new LocalDate(2021, 3, 15), 1L, callContext);
+        recordUsageData(sub2.getId(), "tracking-3", "hours", new LocalDate(2021, 3, 15), BigDecimal.valueOf(1L), callContext);
 
         // 2021-04-01
         clock.addDays(17);
@@ -937,7 +937,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         clock.addDays(14);
         Thread.sleep(1000);
 
-        recordUsageData(sub2.getId(), "tracking-4", "hours", new LocalDate(2021, 4, 15), 1L, callContext);
+        recordUsageData(sub2.getId(), "tracking-4", "hours", new LocalDate(2021, 4, 15), BigDecimal.valueOf(1L), callContext);
 
         // 2021-05-01
         clock.addDays(16);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
@@ -65,7 +65,6 @@ import org.killbill.billing.platform.api.KillbillService.KILLBILL_SERVICES;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.notificationq.api.NotificationEventWithMetadata;
 import org.killbill.notificationq.api.NotificationQueue;
-import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
 import org.killbill.queue.retry.RetryNotificationEvent;
 import org.killbill.queue.retry.RetryableService;
@@ -468,15 +467,15 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpEntitlement.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2017, 6, 18), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2017, 7, 25), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2017, 6, 18), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2017, 7, 25), BigDecimal.valueOf(100L), callContext);
 
 
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2017, 8, 18), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2017, 9, 25), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2017, 8, 18), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2017, 9, 25), BigDecimal.valueOf(100L), callContext);
 
 
-        Invoice dryRunInvoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(2018, 8, 15), new TestDryRunArguments(DryRunType.TARGET_DATE), callContext);
+        final Invoice dryRunInvoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(2018, 8, 15), new TestDryRunArguments(DryRunType.TARGET_DATE), callContext);
         assertEquals(dryRunInvoice.getInvoiceItems().size(), 16);
 
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithUsagePlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithUsagePlugin.java
@@ -115,14 +115,14 @@ public class TestWithUsagePlugin extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        testUsagePluginApi.recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        testUsagePluginApi.recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        testUsagePluginApi.recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        testUsagePluginApi.recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // Wrong subscription - should be ignored...
-        testUsagePluginApi.recordUsageData(UUID.randomUUID(), "tracking-3", "bullets", new LocalDate(2012, 4, 5), 100L, callContext);
+        testUsagePluginApi.recordUsageData(UUID.randomUUID(), "tracking-3", "bullets", new LocalDate(2012, 4, 5), BigDecimal.valueOf(100L), callContext);
 
         // Wrong unit - should be ignored...
-        testUsagePluginApi.recordUsageData(aoSubscription.getId(), "tracking-3", "bullets2", new LocalDate(2012, 4, 6), 200L, callContext);
+        testUsagePluginApi.recordUsageData(aoSubscription.getId(), "tracking-3", "bullets2", new LocalDate(2012, 4, 6), BigDecimal.valueOf(200L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);
@@ -215,7 +215,7 @@ public class TestWithUsagePlugin extends TestIntegrationBase {
             return result;
         }
 
-        public void recordUsageData(final UUID subscriptionId, final String trackingId, final String unitType, final LocalDate startDate, final Long amount, final CallContext context) throws UsageApiException {
+        public void recordUsageData(final UUID subscriptionId, final String trackingId, final String unitType, final LocalDate startDate, final BigDecimal amount, final CallContext context) throws UsageApiException {
 
             List<RawUsageRecord> record = usageData.get(startDate);
             if (record == null) {

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestInArrearWithCatalogVersions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestInArrearWithCatalogVersions.java
@@ -68,8 +68,8 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
-        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 1), 143L, callContext);
-        recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 18), 57L, callContext);
+        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 1), BigDecimal.valueOf(143L), callContext);
+        recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 18), BigDecimal.valueOf(57L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -79,10 +79,10 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
                                                          new ExpectedInvoiceItemCheck(new LocalDate(2016, 4, 1), new LocalDate(2016, 5, 1), InvoiceItemType.USAGE, new BigDecimal("300.00")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t1", "t2"), internalCallContext);
 
-        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 2), 100L, callContext); // -> Uses v1 : $150
+        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 2), BigDecimal.valueOf(100L), callContext); // -> Uses v1 : $150
 
         // Catalog change with new price on 2016-05-08
-        recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 10), 100L, callContext); // -> Uses v2 : $250
+        recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 10), BigDecimal.valueOf(100L), callContext); // -> Uses v2 : $250
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -113,8 +113,8 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec1), null, null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
-        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 1), 143L, callContext);
-        recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 18), 57L, callContext);
+        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 1), BigDecimal.valueOf(143L), callContext);
+        recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 18), BigDecimal.valueOf(57L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -124,7 +124,7 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
                                                          new ExpectedInvoiceItemCheck(new LocalDate(2016, 4, 1), new LocalDate(2016, 5, 1), InvoiceItemType.USAGE, new BigDecimal("300.00")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t1", "t2"), internalCallContext);
 
-        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 2), 100L, callContext); // -> Uses v1 : $150
+        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 2), BigDecimal.valueOf(100L), callContext); // -> Uses v1 : $150
 
         final Entitlement bp = entitlementApi.getEntitlementForId(entitlementId, callContext);
 
@@ -141,7 +141,7 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
                                                  new ExpectedInvoiceItemCheck(new LocalDate(2016, 5, 1), new LocalDate(2016, 5, 7), InvoiceItemType.USAGE, new BigDecimal("150.00")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t3"), internalCallContext);
 
-        recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 10), 100L, callContext); // -> Uses special plan : $100
+        recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 10), BigDecimal.valueOf(100L), callContext); // -> Uses special plan : $100
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addDays(23);
@@ -172,8 +172,8 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
-        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 5), 1L, callContext);
-        recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 5), 99L, callContext);
+        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 5), BigDecimal.valueOf(1L), callContext);
+        recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 5), BigDecimal.valueOf(99L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -183,9 +183,9 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
                                                          new ExpectedInvoiceItemCheck(new LocalDate(2016, 4, 1), new LocalDate(2016, 5, 1), InvoiceItemType.USAGE, new BigDecimal("150.00")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t1", "t2"), internalCallContext);
 
-        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 1), 100L, callContext);
-        recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 2), 900L, callContext);
-        recordUsageData(entitlementId, "t5", "kilowatt-hour", new LocalDate(2016, 5, 3), 200L, callContext); // Move to tier 2.
+        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 1), BigDecimal.valueOf(100L), callContext);
+        recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 2), BigDecimal.valueOf(900L), callContext);
+        recordUsageData(entitlementId, "t5", "kilowatt-hour", new LocalDate(2016, 5, 3), BigDecimal.valueOf(200L), callContext); // Move to tier 2.
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -203,10 +203,10 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
         removeUsageData(entitlementId, "kilowatt-hour", new LocalDate(2016, 5, 3));
 
         //
-        recordUsageData(entitlementId, "t6", "kilowatt-hour", new LocalDate(2016, 6, 5), 100L, callContext);
-        recordUsageData(entitlementId, "t7", "kilowatt-hour", new LocalDate(2016, 6, 8), 900L, callContext);
-        recordUsageData(entitlementId, "t8", "kilowatt-hour", new LocalDate(2016, 6, 12), 50L, callContext); // Move to tier 2.
-        recordUsageData(entitlementId, "t9", "kilowatt-hour", new LocalDate(2016, 6, 13), 50L, callContext);
+        recordUsageData(entitlementId, "t6", "kilowatt-hour", new LocalDate(2016, 6, 5), BigDecimal.valueOf(100L), callContext);
+        recordUsageData(entitlementId, "t7", "kilowatt-hour", new LocalDate(2016, 6, 8), BigDecimal.valueOf(900L), callContext);
+        recordUsageData(entitlementId, "t8", "kilowatt-hour", new LocalDate(2016, 6, 12), BigDecimal.valueOf(50L), callContext); // Move to tier 2.
+        recordUsageData(entitlementId, "t9", "kilowatt-hour", new LocalDate(2016, 6, 13), BigDecimal.valueOf(50L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -249,8 +249,8 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
-        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 5), 1L, callContext);
-        recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 5), 99L, callContext);
+        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 5), BigDecimal.valueOf(1L), callContext);
+        recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 5), BigDecimal.valueOf(99L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addMonths(1);
@@ -262,12 +262,12 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
 
         final Entitlement bp = entitlementApi.getEntitlementForId(entitlementId, callContext);
 
-        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 2), 100L, callContext);
+        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 2), BigDecimal.valueOf(100L), callContext);
 
         // Update subscription BCD
         bp.updateBCD(9, new LocalDate(2016, 5, 9), callContext);
 
-        recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 10), 10L, callContext);
+        recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 10), BigDecimal.valueOf(10L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.BCD_CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.addDays(9);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUnknownUsageUnits.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUnknownUsageUnits.java
@@ -68,8 +68,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         subscriptionChecker.checkSubscriptionCreated(bpSubscription.getId(), internalCallContext);
 
         // Record known usage for April
-        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);
@@ -87,8 +87,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceConfig.setShouldParkAccountsWithUnknownUsage(true);
 
         // Record known consumable usage but unknown capacity usage for May
-        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-1", new LocalDate(2012, 5, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-4", "bandwidth-type-2", new LocalDate(2012, 5, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-1", new LocalDate(2012, 5, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-4", "bandwidth-type-2", new LocalDate(2012, 5, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.TAG);
         clock.addMonths(1);
@@ -118,8 +118,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-3", "tracking-4"), internalCallContext);
 
         // Record known capacity usage but unknown consumable usage for June
-        recordUsageData(bpSubscription.getId(), "tracking-5", "server-hourly-type-2", new LocalDate(2012, 6, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-6", "bandwidth-type-1", new LocalDate(2012, 6, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-5", "server-hourly-type-2", new LocalDate(2012, 6, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-6", "bandwidth-type-1", new LocalDate(2012, 6, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.TAG);
         clock.addMonths(1);
@@ -153,8 +153,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceConfig.setShouldParkAccountsWithUnknownUsage(false);
 
         // Record unknown usage for July
-        recordUsageData(bpSubscription.getId(), "tracking-7", "server-hourly-type-3", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-8", "bandwidth-type-3", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-7", "server-hourly-type-3", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-8", "bandwidth-type-3", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE);
         clock.addMonths(1);
@@ -179,7 +179,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         assertListenerStatus();
 
         // Record unknown usage for August (the unit has been retired)
-        recordUsageData(bpSubscription.getId(), "tracking-9", "server-hourly-type-1", new LocalDate(2012, 8, 1), 99L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-9", "server-hourly-type-1", new LocalDate(2012, 8, 1), BigDecimal.valueOf(99L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.TAG);
         clock.addMonths(1);
@@ -189,8 +189,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         Assert.assertTrue(parkedAccountsManager.isParked(internalCallContext));
 
         // Record retroactively additional known usage for August
-        recordUsageData(bpSubscription.getId(), "tracking-10", "server-hourly-type-2", new LocalDate(2012, 8, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-11", "bandwidth-type-2", new LocalDate(2012, 8, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-10", "server-hourly-type-2", new LocalDate(2012, 8, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-11", "bandwidth-type-2", new LocalDate(2012, 8, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.BLOCK);
         entitlementApi.pause(bpSubscription.getBundleId(), new LocalDate(2012, 8, 1), ImmutableList.<PluginProperty>of(), callContext);
@@ -239,8 +239,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         subscriptionChecker.checkSubscriptionCreated(bpSubscription.getId(), internalCallContext);
 
         // Record known usage for April
-        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);
@@ -253,8 +253,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-1", "tracking-2"), internalCallContext);
 
         // Record known usage for May
-        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-1", new LocalDate(2012, 5, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-4", "bandwidth-type-1", new LocalDate(2012, 5, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-1", new LocalDate(2012, 5, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-4", "bandwidth-type-1", new LocalDate(2012, 5, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addMonths(1);
@@ -267,8 +267,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-3", "tracking-4"), internalCallContext);
 
         // Record known usage for June
-        recordUsageData(bpSubscription.getId(), "tracking-5", "server-hourly-type-1", new LocalDate(2012, 6, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-6", "bandwidth-type-1", new LocalDate(2012, 6, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-5", "server-hourly-type-1", new LocalDate(2012, 6, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-6", "bandwidth-type-1", new LocalDate(2012, 6, 15), BigDecimal.valueOf(100L), callContext);
 
         // Trigger a future change plan on the same plan, to force the new catalog version at the next billing cycle (Catalog-v4.xml)
         bpSubscription.changePlanWithDate(new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("server-monthly")), new LocalDate("2012-07-01"), null, callContext);
@@ -286,8 +286,8 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-5", "tracking-6"), internalCallContext);
 
         // Record known and unknown usage for July (server-hourly-type-1 doesn't exist anymore)
-        recordUsageData(bpSubscription.getId(), "tracking-7", "server-hourly-type-1", new LocalDate(2012, 7, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-8", "bandwidth-type-1", new LocalDate(2012, 7, 15), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-7", "server-hourly-type-1", new LocalDate(2012, 7, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-8", "bandwidth-type-1", new LocalDate(2012, 7, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.TAG);
         clock.addMonths(1);
@@ -313,9 +313,9 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         subscriptionChecker.checkSubscriptionCreated(bpSubscription.getId(), internalCallContext);
 
         // Record known and unknown usage for April
-        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), 100L, callContext);
-        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-2", new LocalDate(2012, 4, 20), 100L, callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-2", new LocalDate(2012, 4, 20), BigDecimal.valueOf(100L), callContext);
 
         // Strict mode if off by default
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
@@ -80,8 +80,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // 2012-05-01
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -93,8 +93,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
                                                          new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.USAGE, new BigDecimal("5.90")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-1", "tracking-2"), internalCallContext);
 
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 1), 50L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 5, 16), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 5, 16), BigDecimal.valueOf(300L), callContext);
 
         // 2012-05-16
         clock.addDays(15);
@@ -136,17 +136,17 @@ public class TestUsageInArrear extends TestIntegrationBase {
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
         // This point should be taken into account
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
         // This point should not be taken into account as it is past cancellation date
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         aoSubscription.cancelEntitlementWithDate(new LocalDate(2012, 4, 1), true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
 
-        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                                         new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 4, 1), InvoiceItemType.USAGE, new BigDecimal("2.95")));
+        final Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                               new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 4, 1), InvoiceItemType.USAGE, new BigDecimal("2.95")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-1"), internalCallContext);
 
         assertListenerStatus();
@@ -176,8 +176,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // 2012-05-01
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -189,8 +189,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
                                                          new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.USAGE, new BigDecimal("5.90")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-1", "tracking-2"), internalCallContext);
 
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 1), 50L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 1), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 1), BigDecimal.valueOf(300L), callContext);
 
         // 2012-05-16
         clock.addDays(15);
@@ -231,8 +231,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // 2012-05-01
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -245,9 +245,9 @@ public class TestUsageInArrear extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-1", "tracking-2"), internalCallContext);
 
         // Billed on 2012-06-01
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 1), 50L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(50L), callContext);
         // Billed on 2012-07-01
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 1), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 1), BigDecimal.valueOf(300L), callContext);
 
         // 2012-05-16
         clock.addDays(15);
@@ -303,8 +303,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);
@@ -324,8 +324,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
                                                  new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2012, 6, 1), InvoiceItemType.USAGE, BigDecimal.ZERO));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of(), internalCallContext);
 
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 6, 1), 50L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 16), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 6, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 16), BigDecimal.valueOf(300L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addMonths(1);
@@ -336,14 +336,14 @@ public class TestUsageInArrear extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-3", "tracking-4"), internalCallContext);
 
         // Should be ignored because this is outside of optimization range (org.killbill.invoice.readMaxRawUsagePreviousPeriod = 2) => we will only look for items > 2012-7-1 - 2 months = 2012-5-1
-        recordUsageData(aoSubscription.getId(), "tracking-5", "bullets", new LocalDate(2012, 4, 30), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-5", "bullets", new LocalDate(2012, 4, 30), BigDecimal.valueOf(100L), callContext);
 
         // Should be invoiced from past period
-        recordUsageData(aoSubscription.getId(), "tracking-6", "bullets", new LocalDate(2012, 5, 1), 199L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-6", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(199L), callContext);
 
         // New usage for this past period
-        recordUsageData(aoSubscription.getId(), "tracking-7", "bullets", new LocalDate(2012, 7, 1), 50L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-8", "bullets", new LocalDate(2012, 7, 16), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-7", "bullets", new LocalDate(2012, 7, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-8", "bullets", new LocalDate(2012, 7, 16), BigDecimal.valueOf(300L), callContext);
 
         // Remove old data, should be ignored by the system because readMaxRawUsagePreviousPeriod = 2, so:
         // * Last endDate invoiced is 2012-7-1 => Anything 2 period prior that will be ignored => Anything prior 2012-5-1 should be ignored
@@ -364,7 +364,7 @@ public class TestUsageInArrear extends TestIntegrationBase {
         for (int i = 0; i < 8; i++) {
 
             final String trackingId = "tracking-" + (9 + i);
-            recordUsageData(aoSubscription.getId(), trackingId, "bullets", startDate.plusDays(15), 350L, callContext);
+            recordUsageData(aoSubscription.getId(), trackingId, "bullets", startDate.plusDays(15), BigDecimal.valueOf(350L), callContext);
 
             busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
             clock.addMonths(1);
@@ -407,8 +407,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
                                                                                         new LocalDate(2012, 4, 1),
                                                                                         NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "t1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "t2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "t1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "t2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // Trigger future invoice
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -439,8 +439,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(thirdInvoice, ImmutableSet.of(), internalCallContext);
 
         // Add usage data
-        recordUsageData(aoSubscription.getId(), "u1", "slugs", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "u2", "slugs", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "u1", "slugs", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "u2", "slugs", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // Trigger future invoice
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -477,8 +477,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "t1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "t2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "t1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "t2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);
@@ -488,11 +488,11 @@ public class TestUsageInArrear extends TestIntegrationBase {
                                                          new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.USAGE, new BigDecimal("5.90")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("t1", "t2"), internalCallContext);
 
-        recordUsageData(aoSubscription.getId(), "t3", "bullets", new LocalDate(2012, 5, 3), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "t4", "bullets", new LocalDate(2012, 5, 5), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "t3", "bullets", new LocalDate(2012, 5, 3), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "t4", "bullets", new LocalDate(2012, 5, 5), BigDecimal.valueOf(100L), callContext);
 
         // This one should be ignored
-        recordUsageData(aoSubscription.getId(), "t5", "bullets", new LocalDate(2012, 5, 29), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "t5", "bullets", new LocalDate(2012, 5, 29), BigDecimal.valueOf(100L), callContext);
 
         clock.addDays(27);
         busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -526,8 +526,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         Assert.assertNull(bpSubscription.getSubscriptionBase().getChargedThroughDate());
 
         // Record usage for first month
-        recordUsageData(bpSubscription.getId(), "xxx-1", "stones", new LocalDate(2012, 4, 5), 85L, callContext);
-        recordUsageData(bpSubscription.getId(), "xxx-2", "stones", new LocalDate(2012, 4, 15), 150L, callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-1", "stones", new LocalDate(2012, 4, 5), BigDecimal.valueOf(85L), callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-2", "stones", new LocalDate(2012, 4, 15), BigDecimal.valueOf(150L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addMonths(1);
@@ -554,8 +554,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         assertEquals(subscriptionBaseInternalApiApi.getSubscriptionFromId(bpSubscription.getId(), internalCallContext).getChargedThroughDate().compareTo(secondExpectedCTD), 0);
 
         // Record usage for third month (verify invoicing resumes)
-        recordUsageData(bpSubscription.getId(), "xxx-3", "stones", new LocalDate(2012, 6, 5), 25L, callContext);
-        recordUsageData(bpSubscription.getId(), "xxx-4", "stones", new LocalDate(2012, 6, 15), 50L, callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-3", "stones", new LocalDate(2012, 6, 5), BigDecimal.valueOf(25L), callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-4", "stones", new LocalDate(2012, 6, 15), BigDecimal.valueOf(50L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addMonths(1);
@@ -647,8 +647,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         Assert.assertNull(bpSubscription.getSubscriptionBase().getChargedThroughDate());
 
         // Record usage for first month
-        recordUsageData(bpSubscription.getId(), "xxx-1", "stones", new LocalDate(2012, 4, 5), 85L, callContext);
-        recordUsageData(bpSubscription.getId(), "xxx-2", "stones", new LocalDate(2012, 4, 15), 150L, callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-1", "stones", new LocalDate(2012, 4, 5), BigDecimal.valueOf(85L), callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-2", "stones", new LocalDate(2012, 4, 15), BigDecimal.valueOf(150L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT_ERROR);
         invoiceUserApi.triggerInvoiceGeneration(account.getId(),
@@ -703,8 +703,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 18), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 18), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);
@@ -753,8 +753,8 @@ public class TestUsageInArrear extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
@@ -587,23 +587,23 @@ public class TestUsageInArrear extends TestIntegrationBase {
         subscriptionChecker.checkSubscriptionCreated(bp2.getId(), internalCallContext);
 
         final List<UsageRecord> bp1StoneRecords1 = new ArrayList();
-        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 5), BigDecimal.valueOf(5L)));
-        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 15), BigDecimal.valueOf(10L)));
-        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 16), BigDecimal.valueOf(15L)));
+        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 5), BigDecimal.valueOf(5L).longValue() /* FIXME-1469 : API backward compat */));
+        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 15), BigDecimal.valueOf(10L).longValue() /* FIXME-1469 : API backward compat */));
+        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 16), BigDecimal.valueOf(15L).longValue() /* FIXME-1469 : API backward compat */));
         final SubscriptionUsageRecord bp1UsageRecord1 = new SubscriptionUsageRecord(bp1.getId(), "bp1-tracking-1", ImmutableList.of(new UnitUsageRecord("stones", bp1StoneRecords1)));
         recordUsageData(bp1UsageRecord1, callContext);
 
         final List<UsageRecord> bp1StoneRecords2 = new ArrayList();
-        bp1StoneRecords2.add(new UsageRecord(new LocalDate(2012, 4, 23), BigDecimal.valueOf(10L)));
+        bp1StoneRecords2.add(new UsageRecord(new LocalDate(2012, 4, 23), BigDecimal.valueOf(10L).longValue() /* FIXME-1469 : API backward compat */));
         // Outside of range for this period -> Its tracking ID spreads across 2 invoices
-        bp1StoneRecords2.add(new UsageRecord(new LocalDate(2012, 5, 1), BigDecimal.valueOf(101L)));
+        bp1StoneRecords2.add(new UsageRecord(new LocalDate(2012, 5, 1), BigDecimal.valueOf(101L).longValue() /* FIXME-1469 : API backward compat */));
         final SubscriptionUsageRecord bp1UsageRecord2 = new SubscriptionUsageRecord(bp1.getId(), "bp1-tracking-2", ImmutableList.of(new UnitUsageRecord("stones", bp1StoneRecords2)));
         recordUsageData(bp1UsageRecord2, callContext);
 
         final List<UsageRecord> bp2StoneRecords = new ArrayList();
-        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 5), BigDecimal.valueOf(85L)));
-        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 15), BigDecimal.valueOf(150L)));
-        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 16), BigDecimal.valueOf(39L)));
+        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 5), BigDecimal.valueOf(85L).longValue() /* FIXME-1469 : API backward compat */));
+        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 15), BigDecimal.valueOf(150L).longValue() /* FIXME-1469 : API backward compat */));
+        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 16), BigDecimal.valueOf(39L).longValue() /* FIXME-1469 : API backward compat */));
         final SubscriptionUsageRecord bp2UsageRecord = new SubscriptionUsageRecord(bp2.getId(), "bp2-tracking-1", ImmutableList.of(new UnitUsageRecord("stones", bp2StoneRecords)));
         recordUsageData(bp2UsageRecord, callContext);
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
@@ -587,23 +587,23 @@ public class TestUsageInArrear extends TestIntegrationBase {
         subscriptionChecker.checkSubscriptionCreated(bp2.getId(), internalCallContext);
 
         final List<UsageRecord> bp1StoneRecords1 = new ArrayList();
-        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 5), 5L));
-        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 15), 10L));
-        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 16), 15L));
+        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 5), BigDecimal.valueOf(5L)));
+        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 15), BigDecimal.valueOf(10L)));
+        bp1StoneRecords1.add(new UsageRecord(new LocalDate(2012, 4, 16), BigDecimal.valueOf(15L)));
         final SubscriptionUsageRecord bp1UsageRecord1 = new SubscriptionUsageRecord(bp1.getId(), "bp1-tracking-1", ImmutableList.of(new UnitUsageRecord("stones", bp1StoneRecords1)));
         recordUsageData(bp1UsageRecord1, callContext);
 
         final List<UsageRecord> bp1StoneRecords2 = new ArrayList();
-        bp1StoneRecords2.add(new UsageRecord(new LocalDate(2012, 4, 23), 10L));
+        bp1StoneRecords2.add(new UsageRecord(new LocalDate(2012, 4, 23), BigDecimal.valueOf(10L)));
         // Outside of range for this period -> Its tracking ID spreads across 2 invoices
-        bp1StoneRecords2.add(new UsageRecord(new LocalDate(2012, 5, 1), 101L));
+        bp1StoneRecords2.add(new UsageRecord(new LocalDate(2012, 5, 1), BigDecimal.valueOf(101L)));
         final SubscriptionUsageRecord bp1UsageRecord2 = new SubscriptionUsageRecord(bp1.getId(), "bp1-tracking-2", ImmutableList.of(new UnitUsageRecord("stones", bp1StoneRecords2)));
         recordUsageData(bp1UsageRecord2, callContext);
 
         final List<UsageRecord> bp2StoneRecords = new ArrayList();
-        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 5), 85L));
-        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 15), 150L));
-        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 16), 39L));
+        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 5), BigDecimal.valueOf(85L)));
+        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 15), BigDecimal.valueOf(150L)));
+        bp2StoneRecords.add(new UsageRecord(new LocalDate(2012, 4, 16), BigDecimal.valueOf(39L)));
         final SubscriptionUsageRecord bp2UsageRecord = new SubscriptionUsageRecord(bp2.getId(), "bp2-tracking-1", ImmutableList.of(new UnitUsageRecord("stones", bp2StoneRecords)));
         recordUsageData(bp2UsageRecord, callContext);
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestWithoutZeroUsageItems.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestWithoutZeroUsageItems.java
@@ -186,7 +186,7 @@ public class TestWithoutZeroUsageItems extends TestIntegrationBase {
         invoiceForPreviousBehavior.addInvoiceItem(new InvoiceItemModelDao(UUID.randomUUID(), clock.getUTCNow(), InvoiceItemType.USAGE, invoiceForPreviousBehavior.getId(), account.getId(), null, aoSubscription.getBundleId(), aoSubscription.getId(), "",
                                                                           "Bullets", "bullets-usage-in-arrear", "bullets-usage-in-arrear-evergreen", "bullets-usage-in-arrear-usage", catalogEffectiveDate,
                                                                           new LocalDate(2012, 5, 1), new LocalDate(2012, 6, 1),
-                                                                          BigDecimal.ZERO, BigDecimal.ZERO, Currency.USD, null, 0, "{\"tier\":1,\"tierUnit\":\"bullets\",\"tierPrice\":2.95,\"tierBlockSize\":100,\"quantity\":0,\"amount\":5.90}"));
+                                                                          BigDecimal.ZERO, BigDecimal.ZERO, Currency.USD, null, BigDecimal.ZERO, "{\"tier\":1,\"tierUnit\":\"bullets\",\"tierPrice\":2.95,\"tierBlockSize\":100,\"quantity\":0,\"amount\":5.90}"));
         busHandler.pushExpectedEvents(NextEvent.INVOICE);
         insertInvoiceItems(invoiceForPreviousBehavior);
         assertListenerStatus();

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestWithoutZeroUsageItems.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestWithoutZeroUsageItems.java
@@ -98,8 +98,8 @@ public class TestWithoutZeroUsageItems extends TestIntegrationBase {
         Assert.assertNull(bpSubscription.getSubscriptionBase().getChargedThroughDate());
 
         // Record usage for first month
-        recordUsageData(bpSubscription.getId(), "xxx-1", "stones", new LocalDate(2012, 4, 5), 85L, callContext);
-        recordUsageData(bpSubscription.getId(), "xxx-2", "stones", new LocalDate(2012, 4, 15), 150L, callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-1", "stones", new LocalDate(2012, 4, 5), BigDecimal.valueOf(85L), callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-2", "stones", new LocalDate(2012, 4, 15), BigDecimal.valueOf(150L), callContext);
 
         // 2012-5-1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -123,8 +123,8 @@ public class TestWithoutZeroUsageItems extends TestIntegrationBase {
         assertEquals(subscriptionBaseInternalApiApi.getSubscriptionFromId(bpSubscription.getId(), internalCallContext).getChargedThroughDate().compareTo(secondExpectedCTD), 0);
 
         // Record usage for third month (verify invoicing resumes)
-        recordUsageData(bpSubscription.getId(), "xxx-3", "stones", new LocalDate(2012, 6, 5), 25L, callContext);
-        recordUsageData(bpSubscription.getId(), "xxx-4", "stones", new LocalDate(2012, 6, 15), 50L, callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-3", "stones", new LocalDate(2012, 6, 5), BigDecimal.valueOf(25L), callContext);
+        recordUsageData(bpSubscription.getId(), "xxx-4", "stones", new LocalDate(2012, 6, 15), BigDecimal.valueOf(50L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addMonths(1);
@@ -161,8 +161,8 @@ public class TestWithoutZeroUsageItems extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);
@@ -192,8 +192,8 @@ public class TestWithoutZeroUsageItems extends TestIntegrationBase {
         assertListenerStatus();
 
 
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 6, 1), 50L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 16), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 6, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 16), BigDecimal.valueOf(300L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addMonths(1);
@@ -204,14 +204,14 @@ public class TestWithoutZeroUsageItems extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-3", "tracking-4"), internalCallContext);
 
         // Should be ignored because this is outside of optimization range (org.killbill.invoice.readMaxRawUsagePreviousPeriod = 2) => we will only look for items > 2012-7-1 - 2 months = 2012-5-1
-        recordUsageData(aoSubscription.getId(), "tracking-5", "bullets", new LocalDate(2012, 4, 30), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-5", "bullets", new LocalDate(2012, 4, 30), BigDecimal.valueOf(100L), callContext);
 
         // Should be invoiced from past period
-        recordUsageData(aoSubscription.getId(), "tracking-6", "bullets", new LocalDate(2012, 5, 1), 199L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-6", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(199L), callContext);
 
         // New usage for this past period
-        recordUsageData(aoSubscription.getId(), "tracking-7", "bullets", new LocalDate(2012, 7, 1), 50L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-8", "bullets", new LocalDate(2012, 7, 16), 300L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-7", "bullets", new LocalDate(2012, 7, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-8", "bullets", new LocalDate(2012, 7, 16), BigDecimal.valueOf(300L), callContext);
 
         // Remove old data, should be ignored by the system because readMaxRawUsagePreviousPeriod = 2, so:
         // * Last endDate invoiced is 2012-7-1 => Anything 2 period prior that will be ignored => Anything prior 2012-5-1 should be ignored
@@ -253,17 +253,17 @@ public class TestWithoutZeroUsageItems extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Pellets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "pellets", new LocalDate(2012, 4, 1), 99L, callContext);
-        recordUsageData(aoSubscription.getId(), "tracking-2", "pellets", new LocalDate(2012, 4, 15), 100L, callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "pellets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-2", "pellets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addDays(30);
         assertListenerStatus();
 
         // Code will generate a $0 USAGE with a non null quantity
-        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                                         new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2013, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("2399.95")),
-                                                         new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.USAGE, new BigDecimal("0.00")));
+        final Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                               new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2013, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("2399.95")),
+                                                               new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.USAGE, new BigDecimal("0.00")));
         invoiceChecker.checkTrackingIds(curInvoice, ImmutableSet.of("tracking-1", "tracking-2"), internalCallContext);
 
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -274,7 +274,10 @@ public class InvoicePluginDispatcher {
                                           immutableField("rate", existingItem, existingItem != null ? existingItem.getRate() : null, additionalInvoiceItem.getRate(), invoicePlugin),
                                           immutableField("currency", existingItem, existingItem != null ? existingItem.getCurrency() : null, additionalInvoiceItem.getCurrency(), invoicePlugin),
                                           immutableField("linkedItemId", existingItem, existingItem != null ? existingItem.getLinkedItemId() : null, additionalInvoiceItem.getLinkedItemId(), invoicePlugin),
-                                          immutableField("quantity", existingItem, existingItem != null ? BigDecimal.valueOf(existingItem.getQuantity())/* FIXME-1469 : API backward compat */ : null, BigDecimal.valueOf(additionalInvoiceItem.getQuantity())/* FIXME-1469 : API backward compat */, invoicePlugin),
+                                          immutableField("quantity", existingItem,
+                                                         (existingItem == null || existingItem.getQuantity() == null) ? null : BigDecimal.valueOf(existingItem.getQuantity()) /* FIXME-1469 : API backward compat*/,
+                                                         additionalInvoiceItem.getQuantity() == null ? null : BigDecimal.valueOf(additionalInvoiceItem.getQuantity())/* FIXME-1469 : API backward compat */,
+                                                         invoicePlugin),
                                           mutableField("itemDetails", existingItem != null ? existingItem.getItemDetails() : null, additionalInvoiceItem.getItemDetails(), invoicePlugin),
                                           immutableField("invoiceItemType", existingItem, existingItem != null ? existingItem.getInvoiceItemType() : null, additionalInvoiceItem.getInvoiceItemType(), invoicePlugin));
         switch (tmp.getInvoiceItemType()) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.invoice;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -273,7 +274,7 @@ public class InvoicePluginDispatcher {
                                           immutableField("rate", existingItem, existingItem != null ? existingItem.getRate() : null, additionalInvoiceItem.getRate(), invoicePlugin),
                                           immutableField("currency", existingItem, existingItem != null ? existingItem.getCurrency() : null, additionalInvoiceItem.getCurrency(), invoicePlugin),
                                           immutableField("linkedItemId", existingItem, existingItem != null ? existingItem.getLinkedItemId() : null, additionalInvoiceItem.getLinkedItemId(), invoicePlugin),
-                                          immutableField("quantity", existingItem, existingItem != null ? existingItem.getQuantity() : null, additionalInvoiceItem.getQuantity(), invoicePlugin),
+                                          immutableField("quantity", existingItem, existingItem != null ? BigDecimal.valueOf(existingItem.getQuantity())/* FIXME-1469 : API backward compat */ : null, BigDecimal.valueOf(additionalInvoiceItem.getQuantity())/* FIXME-1469 : API backward compat */, invoicePlugin),
                                           mutableField("itemDetails", existingItem != null ? existingItem.getItemDetails() : null, additionalInvoiceItem.getItemDetails(), invoicePlugin),
                                           immutableField("invoiceItemType", existingItem, existingItem != null ? existingItem.getInvoiceItemType() : null, additionalInvoiceItem.getInvoiceItemType(), invoicePlugin));
         switch (tmp.getInvoiceItemType()) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -146,7 +146,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                 creditItem.getAmount().negate(),
                                                 creditItem.getRate(),
                                                 creditItem.getCurrency(),
-                                                BigDecimal.valueOf(creditItem.getQuantity()), /* FIXME-1469 : API backward compat */
+                                                creditItem.getQuantity() == null ? null : BigDecimal.valueOf(creditItem.getQuantity()), /* FIXME-1469 : API backward compat */
                                                 creditItem.getItemDetails());
             }
         });
@@ -614,7 +614,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                                            inputItem.getRate(),
                                                                            accountCurrency,
                                                                            inputItem.getLinkedItemId(),
-                                                                           BigDecimal.valueOf(inputItem.getQuantity()), /* FIXME-1469 : API backward compat */
+                                                                           inputItem.getQuantity() == null ? null : BigDecimal.valueOf(inputItem.getQuantity()), /* FIXME-1469 : API backward compat */
                                                                            inputItem.getItemDetails());
 
                             break;
@@ -630,7 +630,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                                       inputItem.getAmount().negate(),
                                                                       inputItem.getRate(),
                                                                       inputItem.getCurrency(),
-                                                                      BigDecimal.valueOf(inputItem.getQuantity()), /* FIXME-1469 : API backward compat */
+                                                                      inputItem.getQuantity() == null ? null : BigDecimal.valueOf(inputItem.getQuantity()), /* FIXME-1469 : API backward compat */
                                                                       inputItem.getItemDetails());
                             break;
                         case TAX:

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -146,7 +146,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                 creditItem.getAmount().negate(),
                                                 creditItem.getRate(),
                                                 creditItem.getCurrency(),
-                                                creditItem.getQuantity(),
+                                                BigDecimal.valueOf(creditItem.getQuantity()), /* FIXME-1469 : API backward compat */
                                                 creditItem.getItemDetails());
             }
         });
@@ -614,7 +614,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                                            inputItem.getRate(),
                                                                            accountCurrency,
                                                                            inputItem.getLinkedItemId(),
-                                                                           inputItem.getQuantity(),
+                                                                           BigDecimal.valueOf(inputItem.getQuantity()), /* FIXME-1469 : API backward compat */
                                                                            inputItem.getItemDetails());
 
                             break;
@@ -630,7 +630,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                                       inputItem.getAmount().negate(),
                                                                       inputItem.getRate(),
                                                                       inputItem.getCurrency(),
-                                                                      inputItem.getQuantity(),
+                                                                      BigDecimal.valueOf(inputItem.getQuantity()), /* FIXME-1469 : API backward compat */
                                                                       inputItem.getItemDetails());
                             break;
                         case TAX:

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemModelDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemModelDao.java
@@ -25,7 +25,6 @@ import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.util.UUIDs;
-import org.killbill.billing.util.catalog.CatalogDateHelper;
 import org.killbill.billing.util.dao.TableName;
 import org.killbill.billing.util.entity.dao.EntityModelDao;
 import org.killbill.billing.util.entity.dao.EntityModelDaoBase;
@@ -49,7 +48,7 @@ public class InvoiceItemModelDao extends EntityModelDaoBase implements EntityMod
     private BigDecimal rate;
     private Currency currency;
     private UUID linkedItemId;
-    private Integer quantity;
+    private BigDecimal quantity;
     private String itemDetails;
     private DateTime catalogEffectiveDate;
 
@@ -58,7 +57,7 @@ public class InvoiceItemModelDao extends EntityModelDaoBase implements EntityMod
     public InvoiceItemModelDao(final UUID id, final DateTime createdDate, final InvoiceItemType type, final UUID invoiceId, final UUID accountId,
                                final UUID childAccountId, final UUID bundleId, final UUID subscriptionId, final String description, final String productName,
                                final String planName, final String phaseName, final String usageName, final DateTime catalogEffectiveDate, final LocalDate startDate, final LocalDate endDate,
-                               final BigDecimal amount, final BigDecimal rate, final Currency currency, final UUID linkedItemId, final Integer quantity,
+                               final BigDecimal amount, final BigDecimal rate, final Currency currency, final UUID linkedItemId, final BigDecimal quantity,
                                final String itemDetails) {
 
         super(id, createdDate, createdDate);
@@ -244,11 +243,11 @@ public class InvoiceItemModelDao extends EntityModelDaoBase implements EntityMod
         this.linkedItemId = linkedItemId;
     }
 
-    public Integer getQuantity() {
+    public BigDecimal getQuantity() {
         return quantity;
     }
 
-    public void setQuantity(final Integer quantity) {
+    public void setQuantity(final BigDecimal quantity) {
         this.quantity = quantity;
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemModelDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemModelDao.java
@@ -104,7 +104,7 @@ public class InvoiceItemModelDao extends EntityModelDaoBase implements EntityMod
         this(invoiceItem.getId(), invoiceItem.getCreatedDate(), invoiceItem.getInvoiceItemType(), invoiceItem.getInvoiceId(), invoiceItem.getAccountId(), invoiceItem.getChildAccountId(), invoiceItem.getBundleId(),
              invoiceItem.getSubscriptionId(), invoiceItem.getDescription(), invoiceItem.getProductName(), invoiceItem.getPlanName(), invoiceItem.getPhaseName(), invoiceItem.getUsageName(), invoiceItem.getCatalogEffectiveDate(),
              invoiceItem.getStartDate(), invoiceItem.getEndDate(),
-             invoiceItem.getAmount(), invoiceItem.getRate(), invoiceItem.getCurrency(), invoiceItem.getLinkedItemId(), invoiceItem.getQuantity(), invoiceItem.getItemDetails());
+             invoiceItem.getAmount(), invoiceItem.getRate(), invoiceItem.getCurrency(), invoiceItem.getLinkedItemId(), BigDecimal.valueOf(invoiceItem.getQuantity())/* FIXME-1469 : API backward compat */, invoiceItem.getItemDetails());
     }
 
     public InvoiceItemType getType() {

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemModelDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemModelDao.java
@@ -104,7 +104,7 @@ public class InvoiceItemModelDao extends EntityModelDaoBase implements EntityMod
         this(invoiceItem.getId(), invoiceItem.getCreatedDate(), invoiceItem.getInvoiceItemType(), invoiceItem.getInvoiceId(), invoiceItem.getAccountId(), invoiceItem.getChildAccountId(), invoiceItem.getBundleId(),
              invoiceItem.getSubscriptionId(), invoiceItem.getDescription(), invoiceItem.getProductName(), invoiceItem.getPlanName(), invoiceItem.getPhaseName(), invoiceItem.getUsageName(), invoiceItem.getCatalogEffectiveDate(),
              invoiceItem.getStartDate(), invoiceItem.getEndDate(),
-             invoiceItem.getAmount(), invoiceItem.getRate(), invoiceItem.getCurrency(), invoiceItem.getLinkedItemId(), BigDecimal.valueOf(invoiceItem.getQuantity())/* FIXME-1469 : API backward compat */, invoiceItem.getItemDetails());
+             invoiceItem.getAmount(), invoiceItem.getRate(), invoiceItem.getCurrency(), invoiceItem.getLinkedItemId(), (invoiceItem.getQuantity() == null ? null : BigDecimal.valueOf(invoiceItem.getQuantity())/* FIXME-1469 : API backward compat */), invoiceItem.getItemDetails());
     }
 
     public InvoiceItemType getType() {

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceWithMetadata.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceWithMetadata.java
@@ -96,7 +96,7 @@ public class InvoiceWithMetadata {
                     public boolean apply(final InvoiceItem invoiceItem) {
                         return invoiceItem.getInvoiceItemType() != InvoiceItemType.USAGE ||
                                invoiceItem.getAmount().compareTo(BigDecimal.ZERO) != 0 ||
-                               (invoiceItem.getQuantity() != null &&  invoiceItem.getQuantity() > 0);
+                               (invoiceItem.getQuantity() != null &&  invoiceItem.getQuantity().compareTo(BigDecimal.ZERO) > 0);
                     }
                 });
                 final ImmutableList<InvoiceItem> filteredItems = ImmutableList.copyOf(resultingItems);

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceWithMetadata.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceWithMetadata.java
@@ -96,7 +96,9 @@ public class InvoiceWithMetadata {
                     public boolean apply(final InvoiceItem invoiceItem) {
                         return invoiceItem.getInvoiceItemType() != InvoiceItemType.USAGE ||
                                invoiceItem.getAmount().compareTo(BigDecimal.ZERO) != 0 ||
-                               (invoiceItem.getQuantity() != null &&  invoiceItem.getQuantity().compareTo(BigDecimal.ZERO) > 0);
+                                /* FIXME-1469 : API backward compat */
+                               // (invoiceItem.getQuantity() != null &&  invoiceItem.getQuantity().compareTo(BigDecimal.ZERO) > 0);
+                               (invoiceItem.getQuantity() != null &&  invoiceItem.getQuantity() > 0);
                     }
                 });
                 final ImmutableList<InvoiceItem> filteredItems = ImmutableList.copyOf(resultingItems);

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/AdjInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/AdjInvoiceItem.java
@@ -44,7 +44,7 @@ public abstract class AdjInvoiceItem extends InvoiceItemBase {
 
     AdjInvoiceItem(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId,
                    final LocalDate startDate, final LocalDate endDate, @Nullable final String description,
-                   final BigDecimal amount, @Nullable final BigDecimal rate, final Currency currency, @Nullable final UUID reversingId, @Nullable final Integer quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
+                   final BigDecimal amount, @Nullable final BigDecimal rate, final Currency currency, @Nullable final UUID reversingId, @Nullable final BigDecimal quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
         super(id, createdDate, invoiceId, accountId, null, null, description, startDate, endDate, amount, rate, currency, reversingId, quantity, itemDetails, invoiceItemType);
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/CreditAdjInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/CreditAdjInvoiceItem.java
@@ -44,7 +44,7 @@ public class CreditAdjInvoiceItem extends AdjInvoiceItem {
     }
 
     public CreditAdjInvoiceItem(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId, final LocalDate date,
-                                @Nullable final String description, final BigDecimal amount, @Nullable final BigDecimal rate, final Currency currency, @Nullable final Integer quantity, @Nullable final String itemDetails) {
+                                @Nullable final String description, final BigDecimal amount, @Nullable final BigDecimal rate, final Currency currency, @Nullable final BigDecimal quantity, @Nullable final String itemDetails) {
         super(id, createdDate, invoiceId, accountId, date, date, description, amount, rate, currency, null, quantity, itemDetails, InvoiceItemType.CREDIT_ADJ);
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/ExternalChargeInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/ExternalChargeInvoiceItem.java
@@ -54,7 +54,7 @@ public class ExternalChargeInvoiceItem extends InvoiceItemCatalogBase {
 
     public ExternalChargeInvoiceItem(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId, final UUID bundleId, final UUID subscriptionId,
                                      final String productName, final String planName, final String phaseName, final String prettyProductName, final String prettyPlanName, final String prettyPhaseName, @Nullable final String description, final LocalDate startDate, final LocalDate endDate,
-                                     final BigDecimal amount, final BigDecimal rate, final Currency currency, @Nullable final UUID linkedItemId, @Nullable final Integer quantity, @Nullable final String itemDetails) {
+                                     final BigDecimal amount, final BigDecimal rate, final Currency currency, @Nullable final UUID linkedItemId, @Nullable final BigDecimal quantity, @Nullable final String itemDetails) {
         super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, null, null, prettyProductName, prettyPlanName, prettyPhaseName, null, startDate, endDate, amount, rate, currency, linkedItemId, quantity, itemDetails, InvoiceItemType.EXTERNAL_CHARGE);
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/ExternalChargeInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/ExternalChargeInvoiceItem.java
@@ -82,7 +82,7 @@ public class ExternalChargeInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              i.getQuantity(),
+              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/ExternalChargeInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/ExternalChargeInvoiceItem.java
@@ -82,7 +82,7 @@ public class ExternalChargeInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
+              i.getQuantity() == null ? null : BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/FixedPriceInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/FixedPriceInvoiceItem.java
@@ -19,7 +19,6 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
-import java.util.Date;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -47,7 +46,7 @@ public class FixedPriceInvoiceItem extends InvoiceItemCatalogBase {
     public FixedPriceInvoiceItem(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId, final UUID bundleId,
                                  final UUID subscriptionId, final String productName, final String planName, final String phaseName, final DateTime catalogEffectiveDate,
                                  final String prettyProductName, final String prettyPlanName, final String prettyPhaseName,
-                                 @Nullable final String description, final LocalDate date, final BigDecimal amount, final Currency currency, @Nullable final Integer quantity, @Nullable final String itemDetails) {
+                                 @Nullable final String description, final LocalDate date, final BigDecimal amount, final Currency currency, @Nullable final BigDecimal quantity, @Nullable final String itemDetails) {
         super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, null, catalogEffectiveDate, prettyProductName, prettyPlanName, prettyPhaseName,
               null, date, null, amount, null, currency, null, quantity, itemDetails, InvoiceItemType.FIXED);
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/FixedPriceInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/FixedPriceInvoiceItem.java
@@ -75,7 +75,7 @@ public class FixedPriceInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              i.getQuantity(),
+              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/FixedPriceInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/FixedPriceInvoiceItem.java
@@ -75,7 +75,7 @@ public class FixedPriceInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
+              i.getQuantity() == null ? null : BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemBase.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemBase.java
@@ -55,7 +55,7 @@ public abstract class InvoiceItemBase extends EntityBase implements InvoiceItem 
     protected final UUID linkedItemId;
 
     /* Usage details */
-    protected final Integer quantity;
+    protected final BigDecimal quantity;
     protected final String itemDetails;
 
     public InvoiceItemBase(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId, @Nullable final UUID bundleId,
@@ -67,7 +67,7 @@ public abstract class InvoiceItemBase extends EntityBase implements InvoiceItem 
     public InvoiceItemBase(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId, @Nullable final UUID bundleId,
                            @Nullable final UUID subscriptionId, @Nullable final String description,
                            final LocalDate startDate, final LocalDate endDate, final BigDecimal amount, final BigDecimal rate, final Currency currency, final UUID reversedItemId,
-                           @Nullable final Integer quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
+                           @Nullable final BigDecimal quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
         this(id, createdDate, invoiceId, accountId, null, bundleId, subscriptionId, description, startDate, endDate, amount, rate, currency, reversedItemId, quantity, itemDetails, invoiceItemType);
     }
 
@@ -80,7 +80,7 @@ public abstract class InvoiceItemBase extends EntityBase implements InvoiceItem 
     private InvoiceItemBase(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId, @Nullable final UUID childAccountId, @Nullable final UUID bundleId,
                             @Nullable final UUID subscriptionId, @Nullable final String description,
                             @Nullable final LocalDate startDate, final LocalDate endDate, final BigDecimal amount, final BigDecimal rate, final Currency currency,
-                            final UUID reversedItemId, @Nullable final Integer quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
+                            final UUID reversedItemId, @Nullable final BigDecimal quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
         super(id, createdDate, createdDate);
         this.invoiceId = invoiceId;
         this.accountId = accountId;
@@ -195,7 +195,7 @@ public abstract class InvoiceItemBase extends EntityBase implements InvoiceItem 
     }
 
     @Override
-    public Integer getQuantity() {
+    public BigDecimal getQuantity() {
         return quantity;
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemBase.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemBase.java
@@ -196,7 +196,7 @@ public abstract class InvoiceItemBase extends EntityBase implements InvoiceItem 
 
     @Override
     public Integer getQuantity() {
-        return quantity.intValue();
+        return quantity == null ? null : quantity.intValue();
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemBase.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemBase.java
@@ -195,8 +195,8 @@ public abstract class InvoiceItemBase extends EntityBase implements InvoiceItem 
     }
 
     @Override
-    public BigDecimal getQuantity() {
-        return quantity;
+    public Integer getQuantity() {
+        return quantity.intValue();
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemCatalogBase.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemCatalogBase.java
@@ -18,14 +18,12 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
-import java.util.Date;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.joda.time.Seconds;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
@@ -54,7 +52,7 @@ public class InvoiceItemCatalogBase extends InvoiceItemBase implements InvoiceIt
                                   @Nullable final UUID subscriptionId, @Nullable final String description,
                                   @Nullable final String productName, @Nullable final String planName, @Nullable final String phaseName, @Nullable final String usageName, @Nullable final DateTime catalogEffectiveDate,
                                   final LocalDate startDate, final LocalDate endDate, final BigDecimal amount, final BigDecimal rate, final Currency currency, @Nullable final UUID linkedItemId,
-                                  @Nullable final Integer quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
+                                  @Nullable final BigDecimal quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
         this(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, usageName, catalogEffectiveDate, null, null, null, null, startDate, endDate, amount, rate, currency, linkedItemId, quantity, itemDetails, invoiceItemType);
     }
 
@@ -63,7 +61,7 @@ public class InvoiceItemCatalogBase extends InvoiceItemBase implements InvoiceIt
                                   @Nullable final String productName, @Nullable final String planName, @Nullable final String phaseName, @Nullable final String usageName, @Nullable final DateTime catalogEffectiveDate,
                                   @Nullable final String prettyProductName, @Nullable final String prettyPlanName, @Nullable final String prettyPhaseName, @Nullable final String prettyUsageName,
                                   final LocalDate startDate, final LocalDate endDate, final BigDecimal amount, final BigDecimal rate, final Currency currency, @Nullable final UUID linkedItemId,
-                                  @Nullable final Integer quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
+                                  @Nullable final BigDecimal quantity, @Nullable final String itemDetails, final InvoiceItemType invoiceItemType) {
         super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, startDate, endDate, amount, rate, currency, linkedItemId, quantity, itemDetails, invoiceItemType);
         this.productName = productName;
         this.planName = planName;

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemFactory.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemFactory.java
@@ -19,7 +19,6 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -38,7 +37,6 @@ import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.dao.InvoiceItemModelDao;
-import org.killbill.billing.util.catalog.CatalogDateHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +75,7 @@ public class InvoiceItemFactory {
         final BigDecimal rate = invoiceItemModelDao.getRate();
         final Currency currency = invoiceItemModelDao.getCurrency();
         final UUID linkedItemId = invoiceItemModelDao.getLinkedItemId();
-        final Integer quantity = invoiceItemModelDao.getQuantity();
+        final BigDecimal quantity = invoiceItemModelDao.getQuantity();
         final String itemDetails = invoiceItemModelDao.getItemDetails();
 
         final InvoiceItemType type = invoiceItemModelDao.getType();

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/ItemAdjInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/ItemAdjInvoiceItem.java
@@ -46,7 +46,7 @@ public class ItemAdjInvoiceItem extends AdjInvoiceItem {
     }
 
     public ItemAdjInvoiceItem(final UUID id, @Nullable final DateTime createdDate, final UUID invoiceId, final UUID accountId, final LocalDate startDate,
-                              @Nullable final String description, final BigDecimal amount, @Nullable final BigDecimal rate, final Currency currency, final UUID linkedItemId, @Nullable final Integer quantity, @Nullable final String itemDetails) {
+                              @Nullable final String description, final BigDecimal amount, @Nullable final BigDecimal rate, final Currency currency, final UUID linkedItemId, @Nullable final BigDecimal quantity, @Nullable final String itemDetails) {
         super(id, createdDate, invoiceId, accountId, startDate, startDate, description, amount, rate, currency, linkedItemId, quantity, itemDetails, InvoiceItemType.ITEM_ADJ);
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/ParentInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/ParentInvoiceItem.java
@@ -18,7 +18,6 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
-import java.util.Date;
 import java.util.UUID;
 
 import javax.annotation.Nullable;

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/RecurringInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/RecurringInvoiceItem.java
@@ -81,7 +81,7 @@ public class RecurringInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
+              i.getQuantity() == null ? null : BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/RecurringInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/RecurringInvoiceItem.java
@@ -19,7 +19,6 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
-import java.util.Date;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -53,7 +52,7 @@ public class RecurringInvoiceItem extends InvoiceItemCatalogBase {
                                 final String productName, final String planName, final String phaseName, final DateTime catalogEffectiveDate,
                                 final String prettyProductName, final String prettyPlanName, final String prettyPhaseName,
                                 @Nullable final String description, final LocalDate startDate, final LocalDate endDate,
-                                final BigDecimal amount, final BigDecimal rate, final Currency currency, @Nullable final Integer quantity, @Nullable final String itemDetails) {
+                                final BigDecimal amount, final BigDecimal rate, final Currency currency, @Nullable final BigDecimal quantity, @Nullable final String itemDetails) {
         super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, null, catalogEffectiveDate, prettyProductName, prettyPlanName, prettyPhaseName, null, startDate, endDate, amount, rate, currency, null, quantity, itemDetails, InvoiceItemType.RECURRING);
 
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/RecurringInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/RecurringInvoiceItem.java
@@ -81,7 +81,7 @@ public class RecurringInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              i.getQuantity(),
+              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/TaxInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/TaxInvoiceItem.java
@@ -70,7 +70,7 @@ public class TaxInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
+              i.getQuantity() == null ? null : BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/TaxInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/TaxInvoiceItem.java
@@ -18,7 +18,6 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
-import java.util.Date;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -71,7 +70,7 @@ public class TaxInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              i.getQuantity(),
+              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
@@ -77,7 +77,7 @@ public class UsageInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
+              i.getQuantity() == null ? null : BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
@@ -77,7 +77,7 @@ public class UsageInvoiceItem extends InvoiceItemCatalogBase {
               i.getRate(),
               i.getCurrency(),
               i.getLinkedItemId(),
-              i.getQuantity(),
+              BigDecimal.valueOf(i.getQuantity()), /* FIXME-1469 : API backward compat */
               i.getItemDetails(),
               i.getInvoiceItemType());
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
@@ -18,7 +18,6 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
-import java.util.Date;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -43,7 +42,7 @@ public class UsageInvoiceItem extends InvoiceItemCatalogBase {
 
     public UsageInvoiceItem(final UUID invoiceId, final UUID accountId, @Nullable final UUID bundleId, @Nullable final UUID subscriptionId,
                             final String productName, final String planName, final String phaseName, final String usageName, final DateTime catalogEffectiveDate,
-                            final LocalDate startDate, final LocalDate endDate, final BigDecimal amount, final BigDecimal rate, final Currency currency, @Nullable final Integer quantity, @Nullable final String itemDetails) {
+                            final LocalDate startDate, final LocalDate endDate, final BigDecimal amount, final BigDecimal rate, final Currency currency, @Nullable final BigDecimal quantity, @Nullable final String itemDetails) {
         this(UUIDs.randomUUID(), null, invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, catalogEffectiveDate, null, null, null, null, startDate, endDate, null, amount, rate, currency, quantity, itemDetails);
     }
 
@@ -51,7 +50,7 @@ public class UsageInvoiceItem extends InvoiceItemCatalogBase {
                      final UUID subscriptionId, final String productName, final String planName, final String phaseName, final String usageName, final DateTime catalogEffectiveDate,
                      final String prettyProductName, final String prettyPlanName, final String prettyPhaseName, final String prettyUsageName,
                      final LocalDate startDate, final LocalDate endDate, @Nullable final String description, final BigDecimal amount, final BigDecimal rate,
-                     final Currency currency, @Nullable final Integer quantity, @Nullable final String itemDetails) {
+                     final Currency currency, @Nullable final BigDecimal quantity, @Nullable final String itemDetails) {
         super(id, createdDate, invoiceId, accountId, bundleId, subscriptionId, description, productName, planName, phaseName, usageName, catalogEffectiveDate, prettyProductName, prettyPlanName, prettyPhaseName, prettyUsageName, startDate, endDate, amount, rate, currency, null, quantity, itemDetails, InvoiceItemType.USAGE);
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/template/formatters/DefaultInvoiceItemFormatter.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/template/formatters/DefaultInvoiceItemFormatter.java
@@ -18,7 +18,6 @@ package org.killbill.billing.invoice.template.formatters;
 
 import java.math.BigDecimal;
 import java.text.NumberFormat;
-import java.util.Date;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.UUID;
@@ -204,7 +203,7 @@ public class DefaultInvoiceItemFormatter implements InvoiceItemFormatter {
     }
 
     @Override
-    public Integer getQuantity() { return item.getQuantity(); }
+    public BigDecimal getQuantity() { return item.getQuantity(); }
 
     @Override
     public String getItemDetails() { return item.getItemDetails(); }

--- a/invoice/src/main/java/org/killbill/billing/invoice/template/formatters/DefaultInvoiceItemFormatter.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/template/formatters/DefaultInvoiceItemFormatter.java
@@ -203,7 +203,7 @@ public class DefaultInvoiceItemFormatter implements InvoiceItemFormatter {
     }
 
     @Override
-    public BigDecimal getQuantity() { return item.getQuantity(); }
+    public Integer getQuantity() { return item.getQuantity(); }
 
     @Override
     public String getItemDetails() { return item.getItemDetails(); }

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalCapacityUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalCapacityUsageInArrear.java
@@ -133,13 +133,7 @@ public class ContiguousIntervalCapacityUsageInArrear extends ContiguousIntervalU
                     allUnitAmountToZero = ro.getAmount().compareTo(BigDecimal.ZERO) > 0 ? false : allUnitAmountToZero;
 
                     if (!perUnitTypeDetailTierLevel.contains(ro.getUnitType())) {
-                        // FIXME-1469 change to correct BigDecimal implementation
-                        toBeBilledDetails.add(new UsageInArrearTierUnitDetail(
-                                tierNum,
-                                ro.getUnitType(),
-                                curTierPrice,
-                                ro.getAmount().longValue()) // FIXME-1469 change to correct BigDecimal implementation
-                        );
+                        toBeBilledDetails.add(new UsageInArrearTierUnitDetail(tierNum, ro.getUnitType(), curTierPrice, ro.getAmount()));
                         perUnitTypeDetailTierLevel.add(ro.getUnitType());
                     }
                 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalCapacityUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalCapacityUsageInArrear.java
@@ -130,10 +130,16 @@ public class ContiguousIntervalCapacityUsageInArrear extends ContiguousIntervalU
                     complies = false;
                 } else {
 
-                    allUnitAmountToZero = ro.getAmount() > 0 ? false : allUnitAmountToZero;
+                    allUnitAmountToZero = ro.getAmount().compareTo(BigDecimal.ZERO) > 0 ? false : allUnitAmountToZero;
 
                     if (!perUnitTypeDetailTierLevel.contains(ro.getUnitType())) {
-                        toBeBilledDetails.add(new UsageInArrearTierUnitDetail(tierNum, ro.getUnitType(), curTierPrice, ro.getAmount()));
+                        // FIXME-1469 change to correct BigDecimal implementation
+                        toBeBilledDetails.add(new UsageInArrearTierUnitDetail(
+                                tierNum,
+                                ro.getUnitType(),
+                                curTierPrice,
+                                ro.getAmount().longValue()) // FIXME-1469 change to correct BigDecimal implementation
+                        );
                         perUnitTypeDetailTierLevel.add(ro.getUnitType());
                     }
                 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalCapacityUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalCapacityUsageInArrear.java
@@ -129,11 +129,12 @@ public class ContiguousIntervalCapacityUsageInArrear extends ContiguousIntervalU
                 if (tierLimit.getMax() != (double) -1 && ro.getAmount().doubleValue() > tierLimit.getMax()) {
                     complies = false;
                 } else {
-
-                    allUnitAmountToZero = ro.getAmount().compareTo(BigDecimal.ZERO) > 0 ? false : allUnitAmountToZero;
+                    /* FIXME-1469 : API backward compat */
+                    // allUnitAmountToZero = ro.getAmount().compareTo(BigDecimal.ZERO) > 0 ? false : allUnitAmountToZero;
+                    allUnitAmountToZero = ro.getAmount() <= 0 && allUnitAmountToZero;
 
                     if (!perUnitTypeDetailTierLevel.contains(ro.getUnitType())) {
-                        toBeBilledDetails.add(new UsageInArrearTierUnitDetail(tierNum, ro.getUnitType(), curTierPrice, ro.getAmount()));
+                        toBeBilledDetails.add(new UsageInArrearTierUnitDetail(tierNum, ro.getUnitType(), curTierPrice, BigDecimal.valueOf(ro.getAmount())) /* FIXME-1469 : API backward compat */);
                         perUnitTypeDetailTierLevel.add(ro.getUnitType());
                     }
                 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalConsumableUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalConsumableUsageInArrear.java
@@ -98,11 +98,7 @@ public class ContiguousIntervalConsumableUsageInArrear extends ContiguousInterva
 
                     for (UsageConsumableInArrearTierUnitAggregate toBeBilledUsageDetail : ((UsageConsumableInArrearAggregate) toBeBilledUsageDetails).getTierDetails()) {
                         final String itemDetails = toJson(toBeBilledUsageDetail);
-                        // See https://github.com/killbill/killbill/issues/1325
-                        // Our current sql schema limits to an int value ...
-                        // FIXME-1469 change this to BigDecimal :
-                        // final Integer quantity = toBeBilledUsageDetail.getQuantity() <= Integer.MAX_VALUE ? toBeBilledUsageDetail.getQuantity().intValue() : -1;
-                        final Integer quantity = toBeBilledUsageDetail.getQuantity().intValue();
+                        final BigDecimal quantity = toBeBilledUsageDetail.getQuantity();
                         final InvoiceItem item = new UsageInvoiceItem(invoiceId, accountId, getBundleId(), getSubscriptionId(), getProductName(), getPlanName(),
                                                                       getPhaseName(), usage.getName(), catalogEffectiveDate, startDate, endDate, toBeBilledUsageDetail.getAmount(), toBeBilledUsageDetail.getTierPrice(), getCurrency(), quantity, itemDetails);
                         result.add(item);
@@ -160,7 +156,7 @@ public class ContiguousIntervalConsumableUsageInArrear extends ContiguousInterva
                 final UsageConsumableInArrearTierUnitAggregate targetTierUnitDetail = fromJson(bi.getItemDetails(), new TypeReference<UsageConsumableInArrearTierUnitAggregate>() {});
                 if (targetTierUnitDetail.getTierUnit().equals(unitType)) {
                     // See https://github.com/killbill/killbill/issues/1325
-                    final BigDecimal quantity = BigDecimal.valueOf(bi.getQuantity());
+                    final BigDecimal quantity = bi.getQuantity();
                     UsageConsumableInArrearTierUnitAggregate usageUnitAggregate = new UsageConsumableInArrearTierUnitAggregate(
                             targetTierUnitDetail.getTier(), targetTierUnitDetail.getTierUnit(), bi.getRate(),
                             targetTierUnitDetail.getTierBlockSize(),

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalConsumableUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalConsumableUsageInArrear.java
@@ -157,7 +157,7 @@ public class ContiguousIntervalConsumableUsageInArrear extends ContiguousInterva
                 if (targetTierUnitDetail.getTierUnit().equals(unitType)) {
                     // See https://github.com/killbill/killbill/issues/1325
                     /* FIXME-1469 : API backward compat */
-                    final BigDecimal quantity = BigDecimal.valueOf(bi.getQuantity());
+                    final BigDecimal quantity = bi.getQuantity() == null ? null : BigDecimal.valueOf(bi.getQuantity());
                     UsageConsumableInArrearTierUnitAggregate usageUnitAggregate = new UsageConsumableInArrearTierUnitAggregate(
                             targetTierUnitDetail.getTier(), targetTierUnitDetail.getTierUnit(), bi.getRate(),
                             targetTierUnitDetail.getTierBlockSize(),

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalConsumableUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalConsumableUsageInArrear.java
@@ -156,7 +156,8 @@ public class ContiguousIntervalConsumableUsageInArrear extends ContiguousInterva
                 final UsageConsumableInArrearTierUnitAggregate targetTierUnitDetail = fromJson(bi.getItemDetails(), new TypeReference<UsageConsumableInArrearTierUnitAggregate>() {});
                 if (targetTierUnitDetail.getTierUnit().equals(unitType)) {
                     // See https://github.com/killbill/killbill/issues/1325
-                    final BigDecimal quantity = bi.getQuantity();
+                    /* FIXME-1469 : API backward compat */
+                    final BigDecimal quantity = BigDecimal.valueOf(bi.getQuantity());
                     UsageConsumableInArrearTierUnitAggregate usageUnitAggregate = new UsageConsumableInArrearTierUnitAggregate(
                             targetTierUnitDetail.getTier(), targetTierUnitDetail.getTierUnit(), bi.getRate(),
                             targetTierUnitDetail.getTierBlockSize(),
@@ -193,9 +194,9 @@ public class ContiguousIntervalConsumableUsageInArrear extends ContiguousInterva
 
         switch (usage.getTierBlockPolicy()) {
             case ALL_TIERS:
-                return computeToBeBilledConsumableInArrearWith_ALL_TIERS(startDate, endDate, tieredBlocks, previousUsage, roUnit.getAmount());
+                return computeToBeBilledConsumableInArrearWith_ALL_TIERS(startDate, endDate, tieredBlocks, previousUsage, BigDecimal.valueOf(roUnit.getAmount()) /* FIXME-1469 : API backward compat */);
             case TOP_TIER:
-                return Arrays.asList(computeToBeBilledConsumableInArrearWith_TOP_TIER(tieredBlocks, previousUsage, roUnit.getAmount().longValue() /* FIXME-1469 change to correct BigDecimal implementation */));
+                return Arrays.asList(computeToBeBilledConsumableInArrearWith_TOP_TIER(tieredBlocks, previousUsage, roUnit.getAmount() /* FIXME-1469 change to correct BigDecimal implementation */));
             default:
                 throw new IllegalStateException("Unknown TierBlockPolicy " + usage.getTierBlockPolicy());
         }

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
@@ -455,7 +455,7 @@ public abstract class ContiguousIntervalUsageInArrear {
                     if (prevRawUsage.getDate().compareTo(prevDate) >= 0 &&
                         (prevRawUsage.getDate().compareTo(curDate) < 0 || isUsageForCancellationDay)) {
                         final BigDecimal currentAmount = perRangeUnitToAmount.get(prevRawUsage.getUnitType());
-                        final BigDecimal updatedAmount = computeUpdatedAmount(currentAmount, prevRawUsage.getAmount());
+                        final BigDecimal updatedAmount = computeUpdatedAmount(currentAmount, BigDecimal.valueOf(prevRawUsage.getAmount()));
                         perRangeUnitToAmount.put(prevRawUsage.getUnitType(), updatedAmount);
                         trackingIds.add(new TrackingRecordId(prevRawUsage.getTrackingId(), invoiceId, prevRawUsage.getSubscriptionId(), prevRawUsage.getUnitType(), prevRawUsage.getDate()));
                         prevRawUsage = null;
@@ -483,7 +483,7 @@ public abstract class ContiguousIntervalUsageInArrear {
 
                         final BigDecimal currentAmount = perRangeUnitToAmount.get(curRawUsage.getUnitType());
                         // FIXME-1469 : API backward compat
-                        final BigDecimal updatedAmount = computeUpdatedAmount(currentAmount, curRawUsage.getAmount());
+                        final BigDecimal updatedAmount = computeUpdatedAmount(currentAmount, BigDecimal.valueOf(curRawUsage.getAmount()));
                         perRangeUnitToAmount.put(curRawUsage.getUnitType(), updatedAmount);
                         trackingIds.add(new TrackingRecordId(curRawUsage.getTrackingId(), invoiceId, curRawUsage.getSubscriptionId(), curRawUsage.getUnitType(), curRawUsage.getDate()));
                     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
@@ -482,6 +482,7 @@ public abstract class ContiguousIntervalUsageInArrear {
                         }
 
                         final BigDecimal currentAmount = perRangeUnitToAmount.get(curRawUsage.getUnitType());
+                        // FIXME-1469 : API backward compat
                         final BigDecimal updatedAmount = computeUpdatedAmount(currentAmount, curRawUsage.getAmount());
                         perRangeUnitToAmount.put(curRawUsage.getUnitType(), updatedAmount);
                         trackingIds.add(new TrackingRecordId(curRawUsage.getTrackingId(), invoiceId, curRawUsage.getSubscriptionId(), curRawUsage.getUnitType(), curRawUsage.getDate()));

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
@@ -439,9 +439,9 @@ public abstract class ContiguousIntervalUsageInArrear {
             if (prevDate != null) {
 
                 // Allocate and initialize new perRangeUnitToAmount for this interval and populate with rawSubscriptionUsage items
-                final Map<String, Long> perRangeUnitToAmount = new HashMap<String, Long>();
+                final Map<String, BigDecimal> perRangeUnitToAmount = new HashMap<>();
                 for (String unitType : unitTypes) {
-                    perRangeUnitToAmount.put(unitType, 0L);
+                    perRangeUnitToAmount.put(unitType, BigDecimal.ZERO);
                 }
 
                 // Start consuming prevRawUsage element if it exists and falls into the range
@@ -454,8 +454,8 @@ public abstract class ContiguousIntervalUsageInArrear {
 
                     if (prevRawUsage.getDate().compareTo(prevDate) >= 0 &&
                         (prevRawUsage.getDate().compareTo(curDate) < 0 || isUsageForCancellationDay)) {
-                        final Long currentAmount = perRangeUnitToAmount.get(prevRawUsage.getUnitType());
-                        final Long updatedAmount = computeUpdatedAmount(currentAmount, prevRawUsage.getAmount());
+                        final BigDecimal currentAmount = perRangeUnitToAmount.get(prevRawUsage.getUnitType());
+                        final BigDecimal updatedAmount = computeUpdatedAmount(currentAmount, prevRawUsage.getAmount());
                         perRangeUnitToAmount.put(prevRawUsage.getUnitType(), updatedAmount);
                         trackingIds.add(new TrackingRecordId(prevRawUsage.getTrackingId(), invoiceId, prevRawUsage.getSubscriptionId(), prevRawUsage.getUnitType(), prevRawUsage.getDate()));
                         prevRawUsage = null;
@@ -481,8 +481,8 @@ public abstract class ContiguousIntervalUsageInArrear {
                             break;
                         }
 
-                        final Long currentAmount = perRangeUnitToAmount.get(curRawUsage.getUnitType());
-                        final Long updatedAmount = computeUpdatedAmount(currentAmount, curRawUsage.getAmount());
+                        final BigDecimal currentAmount = perRangeUnitToAmount.get(curRawUsage.getUnitType());
+                        final BigDecimal updatedAmount = computeUpdatedAmount(currentAmount, curRawUsage.getAmount());
                         perRangeUnitToAmount.put(curRawUsage.getUnitType(), updatedAmount);
                         trackingIds.add(new TrackingRecordId(curRawUsage.getTrackingId(), invoiceId, curRawUsage.getSubscriptionId(), curRawUsage.getUnitType(), curRawUsage.getDate()));
                     }
@@ -491,7 +491,7 @@ public abstract class ContiguousIntervalUsageInArrear {
                 // If we did find some usage for that date range, let's populate the result
                 if (!perRangeUnitToAmount.isEmpty()) {
                     final List<RolledUpUnit> rolledUpUnits = new ArrayList<RolledUpUnit>(perRangeUnitToAmount.size());
-                    for (final Entry<String, Long> entry : perRangeUnitToAmount.entrySet()) {
+                    for (final Entry<String, BigDecimal> entry : perRangeUnitToAmount.entrySet()) {
                         final String unitType = entry.getKey();
                         // Sanity check: https://github.com/killbill/killbill/issues/1275
                         if (!allSeenUnitTypes.get(curTransition.getTargetBillingEvent()).contains(unitType)) {
@@ -534,7 +534,7 @@ public abstract class ContiguousIntervalUsageInArrear {
         final LocalDate endDate = endTransition.getDate();
         for (String unitType : unitTypes) {
             final List<RolledUpUnit> emptyRolledUptUnits = new ArrayList<RolledUpUnit>();
-            emptyRolledUptUnits.add(new DefaultRolledUpUnit(unitType, 0L));
+            emptyRolledUptUnits.add(new DefaultRolledUpUnit(unitType, BigDecimal.ZERO));
             final DefaultRolledUpUsageWithMetadata defaultForUnit = new DefaultRolledUpUsageWithMetadata(getSubscriptionId(), startDate, endDate, emptyRolledUptUnits,
                                                                                                          initialTransition.getTargetBillingEvent().getCatalogEffectiveDate());
             result.add(defaultForUnit);
@@ -549,15 +549,14 @@ public abstract class ContiguousIntervalUsageInArrear {
      * @param newAmount
      * @return
      */
-    private Long computeUpdatedAmount(@Nullable Long currentAmount, @Nullable Long newAmount) {
-
-        currentAmount = currentAmount == null ? (Long) 0L : currentAmount;
-        newAmount = newAmount == null ? (Long) 0L : newAmount;
+    private BigDecimal computeUpdatedAmount(@Nullable BigDecimal currentAmount, @Nullable BigDecimal newAmount) {
+        currentAmount = currentAmount == null ? BigDecimal.ZERO : currentAmount;
+        newAmount = newAmount == null ? BigDecimal.ZERO : newAmount;
 
         if (usage.getUsageType() == UsageType.CAPACITY) {
-            return Math.max(currentAmount, newAmount);
+            return currentAmount.max(newAmount);
         } else /* UsageType.CONSUMABLE */ {
-            return currentAmount + newAmount;
+            return currentAmount.add(newAmount);
         }
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/DefaultRolledUpUnit.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/DefaultRolledUpUnit.java
@@ -17,14 +17,16 @@
 
 package org.killbill.billing.invoice.usage;
 
+import java.math.BigDecimal;
+
 import org.killbill.billing.usage.api.RolledUpUnit;
 
 public class DefaultRolledUpUnit implements RolledUpUnit {
 
     private final String unitType;
-    private final Long amount;
+    private final BigDecimal amount;
 
-    public DefaultRolledUpUnit(final String unitType, final Long amount) {
+    public DefaultRolledUpUnit(final String unitType, final BigDecimal amount) {
         this.unitType = unitType;
         this.amount = amount;
     }
@@ -35,7 +37,7 @@ public class DefaultRolledUpUnit implements RolledUpUnit {
     }
 
     @Override
-    public Long getAmount() {
+    public BigDecimal getAmount() {
         return amount;
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/DefaultRolledUpUnit.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/DefaultRolledUpUnit.java
@@ -37,8 +37,8 @@ public class DefaultRolledUpUnit implements RolledUpUnit {
     }
 
     @Override
-    public BigDecimal getAmount() {
-        return amount;
+    public Long getAmount() {
+        return amount.longValue();
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/details/UsageConsumableInArrearTierUnitAggregate.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/details/UsageConsumableInArrearTierUnitAggregate.java
@@ -30,7 +30,7 @@ public class UsageConsumableInArrearTierUnitAggregate extends UsageInArrearTierU
     private final long tierBlockSize;
     private BigDecimal amount;
 
-    public UsageConsumableInArrearTierUnitAggregate(int tier, String tierUnit, BigDecimal tierPrice, Long tierBlockSize, Long quantity) {
+    public UsageConsumableInArrearTierUnitAggregate(int tier, String tierUnit, BigDecimal tierPrice, Long tierBlockSize, BigDecimal quantity) {
         this(tier, tierUnit, tierPrice, tierBlockSize, quantity, computeAmount(tierPrice, quantity));
     }
 
@@ -39,7 +39,7 @@ public class UsageConsumableInArrearTierUnitAggregate extends UsageInArrearTierU
                                                     @JsonProperty("tierUnit") String tierUnit,
                                                     @JsonProperty("tierPrice") BigDecimal tierPrice,
                                                     @JsonProperty("tierBlockSize") Long tierBlockSize,
-                                                    @JsonProperty("quantity") Long quantity,
+                                                    @JsonProperty("quantity") BigDecimal quantity,
                                                     @JsonProperty("amount") BigDecimal amount) {
         super(tier, tierUnit, tierPrice, quantity);
         this.amount = amount;
@@ -58,7 +58,7 @@ public class UsageConsumableInArrearTierUnitAggregate extends UsageInArrearTierU
         return tierPrice;
     }
 
-    public Long getQuantity() {
+    public BigDecimal getQuantity() {
         return quantity;
     }
 
@@ -74,12 +74,12 @@ public class UsageConsumableInArrearTierUnitAggregate extends UsageInArrearTierU
         return tierBlockSize;
     }
 
-    public void updateQuantityAndAmount(final Long additionalQuantity) {
-        this.quantity = quantity + additionalQuantity;
+    public void updateQuantityAndAmount(final BigDecimal additionalQuantity) {
+        this.quantity = quantity.add(additionalQuantity);
         this.amount = computeAmount(tierPrice, quantity);
     }
 
-    private static BigDecimal computeAmount(final BigDecimal targetTierPrice, final Long targetQuantity) {
-        return targetTierPrice.multiply(BigDecimal.valueOf(targetQuantity));
+    private static BigDecimal computeAmount(final BigDecimal targetTierPrice, final BigDecimal targetQuantity) {
+        return targetTierPrice.multiply(targetQuantity);
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/details/UsageInArrearTierUnitDetail.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/details/UsageInArrearTierUnitDetail.java
@@ -29,13 +29,13 @@ public class UsageInArrearTierUnitDetail {
     protected final int tier;
     protected final String tierUnit;
     protected final BigDecimal tierPrice;
-    protected Long quantity;
+    protected BigDecimal quantity;
 
     @JsonCreator
     public UsageInArrearTierUnitDetail(@JsonProperty("tier") int tier,
                                        @JsonProperty("tierUnit") String tierUnit,
                                        @JsonProperty("tierPrice") BigDecimal tierPrice,
-                                       @JsonProperty("quantity") Long quantity) {
+                                       @JsonProperty("quantity") BigDecimal quantity) {
         this.tier = tier;
         this.tierUnit = tierUnit;
         this.tierPrice = tierPrice;
@@ -54,7 +54,7 @@ public class UsageInArrearTierUnitDetail {
         return tierPrice;
     }
 
-    public Long getQuantity() {
+    public BigDecimal getQuantity() {
         return quantity;
     }
 }

--- a/invoice/src/main/resources/org/killbill/billing/invoice/ddl.sql
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/ddl.sql
@@ -68,7 +68,7 @@ CREATE TABLE invoice_items (
     rate numeric(15,9) NULL,
     currency varchar(3) NOT NULL,
     linked_item_id varchar(36),
-    quantity int,
+    quantity decimal(18, 9),
     item_details text,
     created_by varchar(50) NOT NULL,
     created_date datetime NOT NULL,

--- a/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalCapacityInArrear.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalCapacityInArrear.java
@@ -137,30 +137,30 @@ public class TestContiguousIntervalCapacityInArrear extends TestUsageInArrearBas
                                                                                                                                                  Collections.<Usage>emptyList(), catalogEffectiveDate)
                                                                                                                          );
         // Tier 1 (both units from tier 1)
-        UsageCapacityInArrearAggregate result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", 100L),
-                                                                                                                                          new DefaultRolledUpUnit("unit2", 1000L),
-                                                                                                                                          new DefaultRolledUpUnit("unit3", 50L)));
+        UsageCapacityInArrearAggregate result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", BigDecimal.valueOf(100L)),
+                                                                                                                                          new DefaultRolledUpUnit("unit2", BigDecimal.valueOf(1000L)),
+                                                                                                                                          new DefaultRolledUpUnit("unit3", BigDecimal.valueOf(50L))));
         assertEquals(result.getTierDetails().size(), 3);
         assertTrue(result.getAmount().compareTo(BigDecimal.TEN) == 0);
 
         // Tier 2 (only one unit from tier 1)
-        result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", 100L),
-                                                                                                           new DefaultRolledUpUnit("unit2", 1001L)));
+        result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", BigDecimal.valueOf(100L)),
+                                                                                                           new DefaultRolledUpUnit("unit2", BigDecimal.valueOf(1001L))));
         assertTrue(result.getAmount().compareTo(new BigDecimal("20.0")) == 0);
 
         // Tier 2 (only one unit from tier 1)
-        result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", 101L),
-                                                                                                           new DefaultRolledUpUnit("unit2", 1000L)));
+        result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", BigDecimal.valueOf(101L)),
+                                                                                                           new DefaultRolledUpUnit("unit2", BigDecimal.valueOf(1000L))));
         assertTrue(result.getAmount().compareTo(new BigDecimal("20.0")) == 0);
 
         // Tier 2 (both units from tier 2)
-        result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", 101L),
-                                                                                                           new DefaultRolledUpUnit("unit2", 1001L)));
+        result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", BigDecimal.valueOf(101L)),
+                                                                                                           new DefaultRolledUpUnit("unit2", BigDecimal.valueOf(1001L))));
         assertTrue(result.getAmount().compareTo(new BigDecimal("20.0")) == 0);
 
         // Tier 3 (only one unit from tier 3)
-        result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", 10L),
-                                                                                                           new DefaultRolledUpUnit("unit2", 2001L)));
+        result = intervalCapacityInArrear.computeToBeBilledCapacityInArrear(ImmutableList.<RolledUpUnit>of(new DefaultRolledUpUnit("unit1", BigDecimal.valueOf(10L)),
+                                                                                                           new DefaultRolledUpUnit("unit2", BigDecimal.valueOf(2001L))));
         assertTrue(result.getAmount().compareTo(new BigDecimal("30.0")) == 0);
     }
 
@@ -178,18 +178,18 @@ public class TestContiguousIntervalCapacityInArrear extends TestUsageInArrearBas
         // First period: startDate - firstBCDDate
         //
         // 2 items for unit1
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "unit1", 130L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "unit1", 271L, "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "unit1", BigDecimal.valueOf(130L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "unit1", BigDecimal.valueOf(271L), "tracking-2"));
         // 1 items for unit2
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 24), "unit2", 10L, "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 24), "unit2", BigDecimal.valueOf(10L), "tracking-1"));
 
         //
         // Second period: firstBCDDate - endDate
         //
         // 1 items unit1
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 04, 15), "unit1", 199L, "tracking-4"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 04, 15), "unit1", BigDecimal.valueOf(199L), "tracking-4"));
         // 1 items unit2
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 04, 15), "unit2", 20L, "tracking-5"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 04, 15), "unit2", BigDecimal.valueOf(20L), "tracking-5"));
 
         final DefaultUnit unit1 = new DefaultUnit().setName("unit1");
         final DefaultLimit limit1 = new DefaultLimit().setUnit(unit1).setMax((double) -1);
@@ -258,8 +258,8 @@ public class TestContiguousIntervalCapacityInArrear extends TestUsageInArrearBas
 
         // Case 1
         List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 99L, "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(99L), "tracking-2"));
 
         List<InvoiceItem> result = produceInvoiceItems(rawUsageRecords, usageDetailMode, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
@@ -283,8 +283,8 @@ public class TestContiguousIntervalCapacityInArrear extends TestUsageInArrearBas
 
         // Case 2
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-2"));
         result = produceInvoiceItems(rawUsageRecords, usageDetailMode, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
         assertEquals(result.get(0).getAmount().compareTo(BigDecimal.TEN), 0, String.format("%s != 10.0", result.get(0).getAmount()));
@@ -308,8 +308,8 @@ public class TestContiguousIntervalCapacityInArrear extends TestUsageInArrearBas
 
         // Case 3
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 75L, "tracking-3"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-3"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(75L), "tracking-3"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-3"));
         result = produceInvoiceItems(rawUsageRecords, usageDetailMode, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
         assertEquals(result.get(0).getAmount().compareTo(new BigDecimal("100.0")), 0, String.format("%s != 100.0", result.get(0).getAmount()));
@@ -341,8 +341,8 @@ public class TestContiguousIntervalCapacityInArrear extends TestUsageInArrearBas
         final UsageInArrearTierUnitDetail existingBarUsageTier2 = new UsageInArrearTierUnitDetail(2, "BAR", BigDecimal.TEN, 200L);
 
         List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 60L, "tracking-1")); // tier 3
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 200L, "tracking-1")); // tier 2
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(60L), "tracking-1")); // tier 3
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(200L), "tracking-1")); // tier 2
 
         final List<UsageInArrearTierUnitDetail> existingUsage = ImmutableList.of(existingFooUsageTier1, existingBarUsageTier2);
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalCapacityInArrear.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalCapacityInArrear.java
@@ -337,8 +337,8 @@ public class TestContiguousIntervalCapacityInArrear extends TestUsageInArrearBas
     public void testMultipleItemsAndTiersWithExistingItems() throws Exception {
 
         // let's assume we have some existing usage
-        final UsageInArrearTierUnitDetail existingFooUsageTier1 = new UsageInArrearTierUnitDetail(1, "FOO", BigDecimal.ONE, 9L);
-        final UsageInArrearTierUnitDetail existingBarUsageTier2 = new UsageInArrearTierUnitDetail(2, "BAR", BigDecimal.TEN, 200L);
+        final UsageInArrearTierUnitDetail existingFooUsageTier1 = new UsageInArrearTierUnitDetail(1, "FOO", BigDecimal.ONE, BigDecimal.valueOf(9L));
+        final UsageInArrearTierUnitDetail existingBarUsageTier2 = new UsageInArrearTierUnitDetail(2, "BAR", BigDecimal.TEN, BigDecimal.valueOf(200L));
 
         List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
         rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(60L), "tracking-1")); // tier 3

--- a/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalConsumableInArrear.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalConsumableInArrear.java
@@ -89,11 +89,11 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
                                                                                                                                                        BillingPeriod.MONTHLY,
                                                                                                                                                        Collections.<Usage>emptyList(), catalogEffectiveDate));
 
-        final UsageConsumableInArrearTierUnitAggregate detail1 = new UsageConsumableInArrearTierUnitAggregate(3, "FOO", new BigDecimal("0.50"), 1L, 700L);
-        final UsageConsumableInArrearTierUnitAggregate detail2 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.ONE, 1L, 500L);
-        final UsageConsumableInArrearTierUnitAggregate detail3 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.TEN, 1L, 10L);
-        final UsageConsumableInArrearTierUnitAggregate detail4 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.ONE, 1L, 50L);
-        final UsageConsumableInArrearTierUnitAggregate detail5 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.TEN, 1L, 100L);
+        final UsageConsumableInArrearTierUnitAggregate detail1 = new UsageConsumableInArrearTierUnitAggregate(3, "FOO", new BigDecimal("0.50"), 1L, BigDecimal.valueOf(700L));
+        final UsageConsumableInArrearTierUnitAggregate detail2 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.ONE, 1L, BigDecimal.valueOf(500L));
+        final UsageConsumableInArrearTierUnitAggregate detail3 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.TEN, 1L, BigDecimal.valueOf(10L));
+        final UsageConsumableInArrearTierUnitAggregate detail4 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.ONE, 1L, BigDecimal.valueOf(50L));
+        final UsageConsumableInArrearTierUnitAggregate detail5 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.TEN, 1L, BigDecimal.valueOf(100L));
 
         final List<UsageConsumableInArrearTierUnitAggregate> existingUsage = ImmutableList.of(detail1, detail2, detail3, detail4, detail5);
 
@@ -822,12 +822,12 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         // Let's assume we were already billed on the previous period
         //
         // FOO : 10 (tier 1) + 40 (tier 2) = 50
-        long existingFooQuantity1 = 10L; // FIXME-1469 change to correct BigDecimal implementation
-        long existingFooQuantity2 = 40L; // FIXME-1469 change to correct BigDecimal implementation
+        final BigDecimal existingFooQuantity1 = BigDecimal.valueOf(10L);
+        final BigDecimal existingFooQuantity2 = BigDecimal.valueOf(40L);
         final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.ONE, 1L, existingFooQuantity1, new BigDecimal("10.00"));
         final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier2 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.TEN, 1L, existingFooQuantity2, new BigDecimal("400.00"));
         // BAR : 10 (tier 1) + 40 (tier 2)
-        long existingBarUsageQty1 = 80L; // FIXME-1469 change to correct BigDecimal implementation
+        final BigDecimal existingBarUsageQty1 = BigDecimal.valueOf(80L);
         final UsageConsumableInArrearTierUnitAggregate existingBarUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "BAR", new BigDecimal("2.00"), 1L, existingBarUsageQty1, new BigDecimal("160.00"));
 
         final List<UsageConsumableInArrearTierUnitAggregate> existingUsage = ImmutableList.of(existingFooUsageTier1, existingFooUsageTier2, existingBarUsageTier1);
@@ -919,8 +919,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", rawUsageAmount2, "tracking-1")); // tier 2
 
         // FOO : 10 (tier 1) + 40 (tier 2) = 50
-        final long existingFooUsageAmount1 = 10L; // FIXME-1469 change to correct BigDecimal implementation
-        final long existingFooUsageAmount2 = 40L; // FIXME-1469 change to correct BigDecimal implementation
+        final BigDecimal existingFooUsageAmount1 = BigDecimal.valueOf(10L);
+        final BigDecimal existingFooUsageAmount2 = BigDecimal.valueOf(40L);
         final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.ONE, 1L, existingFooUsageAmount1, new BigDecimal("10.00"));
         final String usageInArrearDetail1 = objectMapper.writeValueAsString(existingFooUsageTier1);
 
@@ -928,7 +928,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         final String usageInArrearDetail2 = objectMapper.writeValueAsString(existingFooUsageTier2);
 
         // BAR : 10 (tier 1) + 40 (tier 2)
-        final long existingBarUsageAmount1 = 80L; // FIXME-1469 change to correct BigDecimal implementation
+        final BigDecimal existingBarUsageAmount1 = BigDecimal.valueOf(80L);
         final UsageConsumableInArrearTierUnitAggregate existingBarUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "BAR", new BigDecimal("2.00"), 1L, existingBarUsageAmount1, new BigDecimal("160.00"));
         final String usageInArrearDetail3 = objectMapper.writeValueAsString(existingBarUsageTier1);
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalConsumableInArrear.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalConsumableInArrear.java
@@ -471,25 +471,25 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         Assert.assertEquals(rolledUpUsage.get(0).getEnd().compareTo(t1), 0);
         Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().size(), 2);
         Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(0).getUnitType(), "unit");
-        Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(0).getAmount(), BigDecimal.valueOf(10L)); // FIXME-1469 change to correct BigDecimal implementation
+        Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(0).getAmount(), (Long) BigDecimal.valueOf(10L).longValue()); // FIXME-1469 change to correct BigDecimal implementation
         Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(1).getUnitType(), "unit2");
-        Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(1).getAmount(), BigDecimal.valueOf(0L)); // FIXME-1469 change to correct BigDecimal implementation
+        Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(1).getAmount(), (Long) BigDecimal.valueOf(0L).longValue()); // FIXME-1469 change to correct BigDecimal implementation
 
         Assert.assertEquals(rolledUpUsage.get(1).getStart().compareTo(t1), 0);
         Assert.assertEquals(rolledUpUsage.get(1).getEnd().compareTo(t2), 0);
         Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().size(), 2);
         Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(0).getUnitType(), "unit");
-        Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(0).getAmount(), BigDecimal.valueOf(0L)); // FIXME-1469 change to correct BigDecimal implementation
+        Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(0).getAmount(), (Long) BigDecimal.valueOf(0L).longValue()); // FIXME-1469 change to correct BigDecimal implementation
         Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(1).getUnitType(), "unit2");
-        Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(1).getAmount(), BigDecimal.valueOf(0L)); // FIXME-1469 change to correct BigDecimal implementation
+        Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(1).getAmount(), (Long) BigDecimal.valueOf(0L).longValue()); // FIXME-1469 change to correct BigDecimal implementation
 
         Assert.assertEquals(rolledUpUsage.get(2).getStart().compareTo(t2), 0);
         Assert.assertEquals(rolledUpUsage.get(2).getEnd().compareTo(t3), 0);
         Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().size(), 2);
         Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(0).getUnitType(), "unit");
-        Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(0).getAmount(), BigDecimal.valueOf(20L)); // FIXME-1469 change to correct BigDecimal implementation
+        Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(0).getAmount(), (Long) BigDecimal.valueOf(20L).longValue()); // FIXME-1469 change to correct BigDecimal implementation
         Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(1).getUnitType(), "unit2");
-        Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(1).getAmount(), BigDecimal.valueOf(21L)); // FIXME-1469 change to correct BigDecimal implementation
+        Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(1).getAmount(), (Long) BigDecimal.valueOf(21L).longValue()); // FIXME-1469 change to correct BigDecimal implementation
     }
 
     @Test(groups = "fast")

--- a/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalConsumableInArrear.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalConsumableInArrear.java
@@ -902,7 +902,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
                                     startDate, endDate,
                                     amount,
                                     rateTierPrice, currency,
-                                    quantity.intValue(), // // FIXME-1469 change to correct BigDecimal implementation
+                                    quantity,
                                     usageInArrearDetail);
     }
 
@@ -936,11 +936,11 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         final List<InvoiceItem> existingItems = new ArrayList<>();
 
         final InvoiceItem i1 = new UsageInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, null,
-                                                    new LocalDate(2014, 03, 20), new LocalDate(2014, 04, 15), new BigDecimal("10.00") /* amount */, new BigDecimal("1.00") /* rate = tierPrice*/, currency, 10 /* # units*/, usageInArrearDetail1);
+                                                    new LocalDate(2014, 03, 20), new LocalDate(2014, 04, 15), new BigDecimal("10.00") /* amount */, new BigDecimal("1.00") /* rate = tierPrice*/, currency, BigDecimal.valueOf(10) /* # units*/, usageInArrearDetail1);
         final InvoiceItem i2 = new UsageInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, null,
-                                                    new LocalDate(2014, 03, 20), new LocalDate(2014, 04, 15), new BigDecimal("400.00"), new BigDecimal("10.00"), currency, 40, usageInArrearDetail2);
+                                                    new LocalDate(2014, 03, 20), new LocalDate(2014, 04, 15), new BigDecimal("400.00"), new BigDecimal("10.00"), currency, BigDecimal.valueOf(40), usageInArrearDetail2);
         final InvoiceItem i3 = new UsageInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, null,
-                                                    new LocalDate(2014, 03, 20), new LocalDate(2014, 04, 15), new BigDecimal("160.00"), new BigDecimal("2.00"), currency, 80, usageInArrearDetail3);
+                                                    new LocalDate(2014, 03, 20), new LocalDate(2014, 04, 15), new BigDecimal("160.00"), new BigDecimal("2.00"), currency, BigDecimal.valueOf(80), usageInArrearDetail3);
         existingItems.addAll(ImmutableList.<InvoiceItem>of(i1, i2, i3));
 
         List<InvoiceItem> result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.ALL_TIERS, UsageDetailMode.DETAIL, existingItems);

--- a/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalConsumableInArrear.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/usage/TestContiguousIntervalConsumableInArrear.java
@@ -178,7 +178,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
                                                                                                                                                        Collections.<Usage>emptyList(), catalogEffectiveDate)
                                                                                                                                );
 
-        List<UsageConsumableInArrearTierUnitAggregate> result = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 111L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> result = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(111L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         assertEquals(result.size(), 3);
         // 111 = 10 (tier1) + 100 (tier2) + 1 (tier3) => 10 * 1.5 + 100 * 1 + 1 * 0.5 = 115.5
         assertEquals(result.get(0).getAmount(), new BigDecimal("15.0"));
@@ -204,7 +204,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
                                                                                                                                                        Collections.<Usage>emptyList(), catalogEffectiveDate)
                                                                                                                                );
 
-        List<UsageConsumableInArrearTierUnitAggregate> result = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 5325L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> result = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(5325L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         assertEquals(result.size(), 2);
 
         // 5000 = 1000 (tier1) + 4325 (tier2) => 10 + 5 = 15
@@ -230,7 +230,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
                                                                                                                                                        Collections.<Usage>emptyList(), catalogEffectiveDate)
                                                                                                                                );
 
-        List<UsageConsumableInArrearTierUnitAggregate> result = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 5325L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> result = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(5325L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         assertEquals(result.size(), 2);
 
         // 5000 = 1000 (tier1) + 4325 (tier2) => 10 + 5 = 15
@@ -262,23 +262,23 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         //
         // In this model unit amount is first used to figure out which tier we are in, and then we price all unit at that 'target' tier
         //
-        List<UsageConsumableInArrearTierUnitAggregate> inputTier1 = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 1000L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> inputTier1 = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(1000L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         assertEquals(inputTier1.size(), 1);
         // 1000 units => (tier1) : 1000 / 100 + 1000 % 100 = 10
         assertEquals(inputTier1.get(0).getAmount(), new BigDecimal("10"));
 
-        List<UsageConsumableInArrearTierUnitAggregate> inputTier2 = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 101000L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> inputTier2 = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(101000L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         assertEquals(inputTier2.size(), 1);
         // 101000 units => (tier2) :  101000 / 1000 + 101000 % 1000 = 101 + 0 = 101
         assertEquals(inputTier2.get(0).getAmount(), new BigDecimal("101"));
 
-        List<UsageConsumableInArrearTierUnitAggregate> inputTier3 = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 101001L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> inputTier3 = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(101001L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         assertEquals(inputTier3.size(), 1);
         // 101001 units => (tier3) : 101001 / 1000 + 101001 % 1000 = 101 + 1 = 102 units => $51
         assertEquals(inputTier3.get(0).getAmount(), new BigDecimal("51.0"));
 
         // If we pass the maximum of the last tier, we price all units at the last tier
-        List<UsageConsumableInArrearTierUnitAggregate> inputLastTier = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 300000L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> inputLastTier = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(300000L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         assertEquals(inputLastTier.size(), 1);
         // 300000 units => (tier3) : 300000 / 1000 + 300000 % 1000 = 300 units => $150
         assertEquals(inputLastTier.get(0).getAmount(), new BigDecimal("150.0"));
@@ -305,7 +305,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         //
         // In this model unit amount is first used to figure out which tier we are in, and then we price all unit at that 'target' tier
         //
-        List<UsageConsumableInArrearTierUnitAggregate> inputTier1 = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 2000L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> inputTier1 = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(2000L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         // Target tier 2:
         assertEquals(inputTier1.size(), 1);
         assertEquals(inputTier1.get(0).getAmount(), new BigDecimal("20"));
@@ -332,7 +332,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
                                                                                                                                                        Collections.<Usage>emptyList(), catalogEffectiveDate)
                                                                                                                                );
 
-        List<UsageConsumableInArrearTierUnitAggregate> result = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", 111L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
+        List<UsageConsumableInArrearTierUnitAggregate> result = intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("unit", BigDecimal.valueOf(111L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of());
         assertEquals(result.size(), 1);
 
         // 111 = 111 * 0.5 =
@@ -348,10 +348,10 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // 2 items for startDate - firstBCDDate
         final List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "unit", 130L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "unit", 271L, "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "unit", BigDecimal.valueOf(130L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "unit", BigDecimal.valueOf(271L), "tracking-1"));
         // 1 items for firstBCDDate - endDate
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 04, 15), "unit", 199L, "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 04, 15), "unit", BigDecimal.valueOf(199L), "tracking-2"));
 
         final DefaultTieredBlock block = createDefaultTieredBlock("unit", 100, 10, BigDecimal.ONE);
         final DefaultTier tier = createDefaultTierWithBlocks(block);
@@ -442,21 +442,21 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         final LocalDate targetDate = t3;
 
         // Prev t0
-        final RawUsageRecord raw1 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 03, 01), "unit", 12L, "tracking-1");
+        final RawUsageRecord raw1 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 03, 01), "unit", BigDecimal.valueOf(12L), "tracking-1");
 
         // t0 - t1
-        final RawUsageRecord raw2 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 03, 15), "unit", 6L, "tracking-1");
-        final RawUsageRecord raw3 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 03, 25), "unit", 4L, "tracking-1");
+        final RawUsageRecord raw2 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 03, 15), "unit", BigDecimal.valueOf(6L), "tracking-1");
+        final RawUsageRecord raw3 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 03, 25), "unit", BigDecimal.valueOf(4L), "tracking-1");
 
         // t1 - t2 nothing
 
         // t2 - t3
-        final RawUsageRecord raw4 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 05, 15), "unit", 13L, "tracking-2");
-        final RawUsageRecord oraw1 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 05, 21), "unit2", 21L, "tracking-2");
-        final RawUsageRecord raw5 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 05, 31), "unit", 7L, "tracking-2");
+        final RawUsageRecord raw4 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 05, 15), "unit", BigDecimal.valueOf(13L), "tracking-2");
+        final RawUsageRecord oraw1 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 05, 21), "unit2", BigDecimal.valueOf(21L), "tracking-2");
+        final RawUsageRecord raw5 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 05, 31), "unit", BigDecimal.valueOf(7L), "tracking-2");
 
         // after t3
-        final RawUsageRecord raw6 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 06, 15), "unit", 100L, "tracking-3");
+        final RawUsageRecord raw6 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 06, 15), "unit", BigDecimal.valueOf(100L), "tracking-3");
 
         final List<RawUsageRecord> rawUsageRecord = ImmutableList.of(raw1, raw2, raw3, raw4, oraw1, raw5, raw6);
 
@@ -471,25 +471,25 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         Assert.assertEquals(rolledUpUsage.get(0).getEnd().compareTo(t1), 0);
         Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().size(), 2);
         Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(0).getUnitType(), "unit");
-        Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(0).getAmount(), (Long) 10L);
+        Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(0).getAmount(), BigDecimal.valueOf(10L)); // FIXME-1469 change to correct BigDecimal implementation
         Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(1).getUnitType(), "unit2");
-        Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(1).getAmount(), (Long) 0L);
+        Assert.assertEquals(rolledUpUsage.get(0).getRolledUpUnits().get(1).getAmount(), BigDecimal.valueOf(0L)); // FIXME-1469 change to correct BigDecimal implementation
 
         Assert.assertEquals(rolledUpUsage.get(1).getStart().compareTo(t1), 0);
         Assert.assertEquals(rolledUpUsage.get(1).getEnd().compareTo(t2), 0);
         Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().size(), 2);
         Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(0).getUnitType(), "unit");
-        Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(0).getAmount(), (Long) 0L);
+        Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(0).getAmount(), BigDecimal.valueOf(0L)); // FIXME-1469 change to correct BigDecimal implementation
         Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(1).getUnitType(), "unit2");
-        Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(1).getAmount(), (Long) 0L);
+        Assert.assertEquals(rolledUpUsage.get(1).getRolledUpUnits().get(1).getAmount(), BigDecimal.valueOf(0L)); // FIXME-1469 change to correct BigDecimal implementation
 
         Assert.assertEquals(rolledUpUsage.get(2).getStart().compareTo(t2), 0);
         Assert.assertEquals(rolledUpUsage.get(2).getEnd().compareTo(t3), 0);
         Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().size(), 2);
         Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(0).getUnitType(), "unit");
-        Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(0).getAmount(), (Long) 20L);
+        Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(0).getAmount(), BigDecimal.valueOf(20L)); // FIXME-1469 change to correct BigDecimal implementation
         Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(1).getUnitType(), "unit2");
-        Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(1).getAmount(), (Long) 21L);
+        Assert.assertEquals(rolledUpUsage.get(2).getRolledUpUnits().get(1).getAmount(), BigDecimal.valueOf(21L)); // FIXME-1469 change to correct BigDecimal implementation
     }
 
     @Test(groups = "fast")
@@ -507,8 +507,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
                                                                                                                                                        Collections.<Usage>emptyList(), catalogEffectiveDate)
                                                                                                                                );
         final List<UsageConsumableInArrearTierUnitAggregate> tierUnitDetails = Lists.newArrayList();
-        tierUnitDetails.addAll(intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("cell-phone-minutes", 1000L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of()));
-        tierUnitDetails.addAll(intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("Mbytes", 30720L), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of()));
+        tierUnitDetails.addAll(intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("cell-phone-minutes", BigDecimal.valueOf(1000L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of()));
+        tierUnitDetails.addAll(intervalConsumableInArrear.computeToBeBilledConsumableInArrear(null, null, new DefaultRolledUpUnit("Mbytes", BigDecimal.valueOf(30720L)), ImmutableList.<UsageConsumableInArrearTierUnitAggregate>of()));
         assertEquals(tierUnitDetails.size(), 2);
 
         final UsageConsumableInArrearAggregate details = new UsageConsumableInArrearAggregate(tierUnitDetails);
@@ -521,8 +521,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 1
         List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 99L, "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(99L), "tracking-1"));
 
         List<InvoiceItem> result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.ALL_TIERS, UsageDetailMode.AGGREGATE, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
@@ -546,8 +546,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 2
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-2"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-2"));
 
         result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.ALL_TIERS, UsageDetailMode.AGGREGATE, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
@@ -577,8 +577,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 3
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 75L, "tracking-3"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-4"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(75L), "tracking-3"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-4"));
 
         result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.ALL_TIERS, UsageDetailMode.AGGREGATE, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
@@ -623,8 +623,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 1
         List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 99L, "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(99L), "tracking-1"));
 
         List<InvoiceItem> result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.ALL_TIERS, UsageDetailMode.DETAIL, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 2);
@@ -639,8 +639,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 2
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-1"));
 
         result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.ALL_TIERS, UsageDetailMode.DETAIL, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 3);
@@ -659,8 +659,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 3
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 75L, "tracking-2"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(75L), "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-2"));
 
         result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.ALL_TIERS, UsageDetailMode.DETAIL, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 5);
@@ -691,8 +691,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 1
         List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 99L, "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(99L), "tracking-1"));
 
         List<InvoiceItem> result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.TOP_TIER, UsageDetailMode.AGGREGATE, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
@@ -715,8 +715,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 2
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-2"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-2"));
 
         result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.TOP_TIER, UsageDetailMode.AGGREGATE, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
@@ -740,8 +740,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 3
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 76L, "tracking-3"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-3"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(76L), "tracking-3"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-3"));
 
         result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.TOP_TIER, UsageDetailMode.AGGREGATE, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 1);
@@ -768,8 +768,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 1
         List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-1"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 99L, "tracking-2"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(99L), "tracking-2"));
 
         List<InvoiceItem> result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.TOP_TIER, UsageDetailMode.DETAIL, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 2);
@@ -784,8 +784,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 2
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 5L, "tracking-3"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-4"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(5L), "tracking-3"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-4"));
 
         result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.TOP_TIER, UsageDetailMode.DETAIL, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 2);
@@ -800,8 +800,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
 
         // Case 3
         rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 76L, "tracking-5"));
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 101L, "tracking-6"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(76L), "tracking-5"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(101L), "tracking-6"));
 
         result = produceInvoiceItems(rawUsageRecords, TierBlockPolicy.TOP_TIER, UsageDetailMode.DETAIL, ImmutableList.<InvoiceItem>of());
         assertEquals(result.size(), 2);
@@ -822,10 +822,13 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         // Let's assume we were already billed on the previous period
         //
         // FOO : 10 (tier 1) + 40 (tier 2) = 50
-        final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.ONE, 1L, 10L, new BigDecimal("10.00"));
-        final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier2 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.TEN, 1L, 40L, new BigDecimal("400.00"));
+        long existingFooQuantity1 = 10L; // FIXME-1469 change to correct BigDecimal implementation
+        long existingFooQuantity2 = 40L; // FIXME-1469 change to correct BigDecimal implementation
+        final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.ONE, 1L, existingFooQuantity1, new BigDecimal("10.00"));
+        final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier2 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.TEN, 1L, existingFooQuantity2, new BigDecimal("400.00"));
         // BAR : 10 (tier 1) + 40 (tier 2)
-        final UsageConsumableInArrearTierUnitAggregate existingBarUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "BAR", new BigDecimal("2.00"), 1L, 80L, new BigDecimal("160.00"));
+        long existingBarUsageQty1 = 80L; // FIXME-1469 change to correct BigDecimal implementation
+        final UsageConsumableInArrearTierUnitAggregate existingBarUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "BAR", new BigDecimal("2.00"), 1L, existingBarUsageQty1, new BigDecimal("160.00"));
 
         final List<UsageConsumableInArrearTierUnitAggregate> existingUsage = ImmutableList.of(existingFooUsageTier1, existingFooUsageTier2, existingBarUsageTier1);
 
@@ -837,8 +840,8 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         // Create usage data points (will include already billed + add new usage data)
         //
         List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 50L /* already built */ + 20L, "tracking-1")); // tier 3
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 80L /* already built */ + 120L, "tracking-1")); // tier 2
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", BigDecimal.valueOf(50L /* already built */ + 20L), "tracking-1")); // tier 3
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", BigDecimal.valueOf(80L /* already built */ + 120L), "tracking-1")); // tier 2
 
         final List<InvoiceItem> existingItems = new ArrayList<InvoiceItem>();
         final InvoiceItem ii1 = new UsageInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, null,
@@ -892,28 +895,46 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         assertEquals(itemDetails.get(4).getAmount().compareTo(new BigDecimal("1000.00")), 0);
     }
 
+    private UsageInvoiceItem newUsageInvoiceItem(final LocalDate startDate, final LocalDate endDate,
+                                                 final BigDecimal amount, final BigDecimal rateTierPrice, final BigDecimal quantity,
+                                                 final String usageInArrearDetail) {
+        return new UsageInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, null,
+                                    startDate, endDate,
+                                    amount,
+                                    rateTierPrice, currency,
+                                    quantity.intValue(), // // FIXME-1469 change to correct BigDecimal implementation
+                                    usageInArrearDetail);
+    }
+
     @Test(groups = "fast")
     public void testMultipleItemsAndTiersWithExistingItemsAllTiers_DETAIL() throws Exception {
 
         //
         // Create usage data points (will include already billed + add new usage data)
         //
-        List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", 50L /* already built */ + 20L, "tracking-1")); // tier 3
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", 80L /* already built */ + 120L, "tracking-1")); // tier 2
+        final List<RawUsageRecord> rawUsageRecords = new ArrayList<>();
+        final BigDecimal rawUsageAmount1 = BigDecimal.valueOf(50L /* already built */ + 20L);
+        final BigDecimal rawUsageAmount2 = BigDecimal.valueOf(80L /* already built */ + 120L);
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 20), "FOO", rawUsageAmount1, "tracking-1")); // tier 3
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, new LocalDate(2014, 03, 21), "BAR", rawUsageAmount2, "tracking-1")); // tier 2
 
         // FOO : 10 (tier 1) + 40 (tier 2) = 50
-        final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.ONE, 1L, 10L, new BigDecimal("10.00"));
+        final long existingFooUsageAmount1 = 10L; // FIXME-1469 change to correct BigDecimal implementation
+        final long existingFooUsageAmount2 = 40L; // FIXME-1469 change to correct BigDecimal implementation
+        final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "FOO", BigDecimal.ONE, 1L, existingFooUsageAmount1, new BigDecimal("10.00"));
         final String usageInArrearDetail1 = objectMapper.writeValueAsString(existingFooUsageTier1);
 
-        final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier2 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.TEN, 1L, 40L, new BigDecimal("400.00"));
+        final UsageConsumableInArrearTierUnitAggregate existingFooUsageTier2 = new UsageConsumableInArrearTierUnitAggregate(2, "FOO", BigDecimal.TEN, 1L, existingFooUsageAmount2, new BigDecimal("400.00"));
         final String usageInArrearDetail2 = objectMapper.writeValueAsString(existingFooUsageTier2);
+
         // BAR : 10 (tier 1) + 40 (tier 2)
-        final UsageConsumableInArrearTierUnitAggregate existingBarUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "BAR", new BigDecimal("2.00"), 1L, 80L, new BigDecimal("160.00"));
+        final long existingBarUsageAmount1 = 80L; // FIXME-1469 change to correct BigDecimal implementation
+        final UsageConsumableInArrearTierUnitAggregate existingBarUsageTier1 = new UsageConsumableInArrearTierUnitAggregate(1, "BAR", new BigDecimal("2.00"), 1L, existingBarUsageAmount1, new BigDecimal("160.00"));
         final String usageInArrearDetail3 = objectMapper.writeValueAsString(existingBarUsageTier1);
 
         // Same as previous example bu instead of creating JSON we create one item per type/tier
-        final List<InvoiceItem> existingItems = new ArrayList<InvoiceItem>();
+        final List<InvoiceItem> existingItems = new ArrayList<>();
+
         final InvoiceItem i1 = new UsageInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, null,
                                                     new LocalDate(2014, 03, 20), new LocalDate(2014, 04, 15), new BigDecimal("10.00") /* amount */, new BigDecimal("1.00") /* rate = tierPrice*/, currency, 10 /* # units*/, usageInArrearDetail1);
         final InvoiceItem i2 = new UsageInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, usageName, null,
@@ -988,7 +1009,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         final LocalDate targetDate = t1;
 
         // Prev t0
-        final RawUsageRecord raw1 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 03, 01), "unit", 12L, "tracking-1");
+        final RawUsageRecord raw1 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 03, 01), "unit", BigDecimal.valueOf(12L), "tracking-1");
 
         final List<RawUsageRecord> rawUsageRecord = ImmutableList.of(raw1);
 
@@ -1022,13 +1043,13 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         final LocalDate targetDate = t1;
 
         // At t0
-        final RawUsageRecord raw1 = new DefaultRawUsage(subscriptionId, t0, "unit", 12L, "tracking-1");
+        final RawUsageRecord raw1 = new DefaultRawUsage(subscriptionId, t0, "unit", BigDecimal.valueOf(12L), "tracking-1");
 
         // At t1
-        final RawUsageRecord raw2 = new DefaultRawUsage(subscriptionId, t1, "unit", 10L, "tracking-2");
+        final RawUsageRecord raw2 = new DefaultRawUsage(subscriptionId, t1, "unit", BigDecimal.valueOf(10L), "tracking-2");
 
         // Should be ignored
-        final RawUsageRecord raw3 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 04, 02), "unit", 100L, "tracking-3");
+        final RawUsageRecord raw3 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 04, 02), "unit", BigDecimal.valueOf(100L), "tracking-3");
 
         final List<RawUsageRecord> rawUsageRecord = ImmutableList.of(raw1, raw2, raw3);
 
@@ -1064,13 +1085,13 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         final LocalDate targetDate = t1;
 
         // At t0
-        final RawUsageRecord raw1 = new DefaultRawUsage(subscriptionId, t0, "unit", 12L, "tracking-1");
+        final RawUsageRecord raw1 = new DefaultRawUsage(subscriptionId, t0, "unit", BigDecimal.valueOf(12L), "tracking-1");
 
         // At t1
-        final RawUsageRecord raw2 = new DefaultRawUsage(subscriptionId, t1, "unit", 10L, "tracking-2");
+        final RawUsageRecord raw2 = new DefaultRawUsage(subscriptionId, t1, "unit", BigDecimal.valueOf(10L), "tracking-2");
 
         // Should be ignored
-        final RawUsageRecord raw3 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 05, BCD), "unit", 100L, "tracking-3");
+        final RawUsageRecord raw3 = new DefaultRawUsage(subscriptionId, new LocalDate(2015, 05, BCD), "unit", BigDecimal.valueOf(100L), "tracking-3");
 
         final List<RawUsageRecord> rawUsageRecord = ImmutableList.of(raw1, raw2, raw3);
 
@@ -1097,7 +1118,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         final LocalDate firstBCDDate = new LocalDate(2014, 04, 15);
 
         final List<RawUsageRecord> rawUsages = new ArrayList<RawUsageRecord>();
-        rawUsages.add(new DefaultRawUsage(subscriptionId, startDate, "unit", 55L, "tracking-1"));
+        rawUsages.add(new DefaultRawUsage(subscriptionId, startDate, "unit", BigDecimal.valueOf(55L), "tracking-1"));
 
         final DefaultTieredBlock block = createDefaultTieredBlock("unit", 1, 100, new BigDecimal("0.067"));
         final DefaultTier tier = createDefaultTierWithBlocks(block);
@@ -1179,7 +1200,7 @@ public class TestContiguousIntervalConsumableInArrear extends TestUsageInArrearB
         final LocalDate rawUsageRecordStartDate = new LocalDate(2015, 10, 16);
 
         final List<RawUsageRecord> rawUsageRecords = new ArrayList<RawUsageRecord>();
-        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, startDate, "unit", 130L, "tracking-1"));
+        rawUsageRecords.add(new DefaultRawUsage(subscriptionId, startDate, "unit", BigDecimal.valueOf(130L), "tracking-1"));
 
         final DefaultTieredBlock block = createDefaultTieredBlock("unit", 100, 10, BigDecimal.ONE);
         final DefaultTier tier = createDefaultTierWithBlocks(block);

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/InvoiceItemJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/InvoiceItemJson.java
@@ -134,7 +134,7 @@ public class InvoiceItemJson extends JsonBase {
              item.getInvoiceItemType(),
              item.getDescription(), item.getStartDate(), item.getEndDate(),
              item.getAmount(), item.getRate(), item.getCurrency(),
-             BigDecimal.valueOf(item.getQuantity()) /* FIXME-1469 : API backward compat */, item.getItemDetails(), item.getCatalogEffectiveDate(),
+             (item.getQuantity() == null ? null : BigDecimal.valueOf(item.getQuantity()) /* FIXME-1469 : API backward compat */), item.getItemDetails(), item.getCatalogEffectiveDate(),
              toInvoiceItemJson(childItems), toAuditLogJson(auditLogs));
     }
 
@@ -258,7 +258,7 @@ public class InvoiceItemJson extends JsonBase {
             }
 
             @Override
-            public Integer getQuantity() { return quantity.intValue(); /* FIXME-1469 : API backward compat */ }
+            public Integer getQuantity() { return quantity == null ? null : quantity.intValue(); /* FIXME-1469 : API backward compat */ }
 
             @Override
             public String getItemDetails() { return itemDetails; }

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/InvoiceItemJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/InvoiceItemJson.java
@@ -17,7 +17,6 @@
 package org.killbill.billing.jaxrs.json;
 
 import java.math.BigDecimal;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -65,7 +64,7 @@ public class InvoiceItemJson extends JsonBase {
     private final BigDecimal amount;
     private final BigDecimal rate;
     private final Currency currency;
-    private final Integer quantity;
+    private final BigDecimal quantity;
     private final String itemDetails;
     private final DateTime catalogEffectiveDate;
     private List<InvoiceItemJson> childItems;
@@ -93,7 +92,7 @@ public class InvoiceItemJson extends JsonBase {
                            @JsonProperty("amount") final BigDecimal amount,
                            @JsonProperty("rate") final  BigDecimal rate,
                            @JsonProperty("currency") final Currency currency,
-                           @JsonProperty("quantity") final Integer quantity,
+                           @JsonProperty("quantity") final BigDecimal quantity,
                            @JsonProperty("itemDetails") final String itemDetails,
                            @JsonProperty("catalogEffectiveDate") final DateTime catalogEffectiveDate,
                            @JsonProperty("childItems") final List<InvoiceItemJson> childItems,
@@ -259,7 +258,7 @@ public class InvoiceItemJson extends JsonBase {
             }
 
             @Override
-            public Integer getQuantity() { return quantity; }
+            public BigDecimal getQuantity() { return quantity; }
 
             @Override
             public String getItemDetails() { return itemDetails; }
@@ -389,7 +388,7 @@ public class InvoiceItemJson extends JsonBase {
         return catalogEffectiveDate;
     }
 
-    public Integer getQuantity() { return quantity; }
+    public BigDecimal getQuantity() { return quantity; }
 
     public String getItemDetails() { return itemDetails; }
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/InvoiceItemJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/InvoiceItemJson.java
@@ -134,7 +134,7 @@ public class InvoiceItemJson extends JsonBase {
              item.getInvoiceItemType(),
              item.getDescription(), item.getStartDate(), item.getEndDate(),
              item.getAmount(), item.getRate(), item.getCurrency(),
-             item.getQuantity(), item.getItemDetails(), item.getCatalogEffectiveDate(),
+             BigDecimal.valueOf(item.getQuantity()) /* FIXME-1469 : API backward compat */, item.getItemDetails(), item.getCatalogEffectiveDate(),
              toInvoiceItemJson(childItems), toAuditLogJson(auditLogs));
     }
 
@@ -258,7 +258,7 @@ public class InvoiceItemJson extends JsonBase {
             }
 
             @Override
-            public BigDecimal getQuantity() { return quantity; }
+            public Integer getQuantity() { return quantity.intValue(); /* FIXME-1469 : API backward compat */ }
 
             @Override
             public String getItemDetails() { return itemDetails; }

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/RolledUpUsageJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/RolledUpUsageJson.java
@@ -89,7 +89,7 @@ public class RolledUpUsageJson {
         }
 
         public RolledUpUnitJson(final RolledUpUnit input) {
-            this(input.getUnitType(), input.getAmount());
+            this(input.getUnitType(), BigDecimal.valueOf(input.getAmount()) /* FIXME-1469 : API backward compat */);
         }
 
         public String getUnitType() {

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/RolledUpUsageJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/RolledUpUsageJson.java
@@ -16,6 +16,7 @@
 
 package org.killbill.billing.jaxrs.json;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,7 +30,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(value="RolledUpUsage")
 public class RolledUpUsageJson {
@@ -79,11 +79,11 @@ public class RolledUpUsageJson {
     public static class RolledUpUnitJson {
 
         private final String unitType;
-        private final Long amount;
+        private final BigDecimal amount;
 
         @JsonCreator
         public RolledUpUnitJson(@JsonProperty("unitType") final String unitType,
-                                @JsonProperty("amount") final Long amount) {
+                                @JsonProperty("amount") final BigDecimal amount) {
             this.unitType = unitType;
             this.amount = amount;
         }
@@ -96,7 +96,7 @@ public class RolledUpUsageJson {
             return unitType;
         }
 
-        public Long getAmount() {
+        public BigDecimal getAmount() {
             return amount;
         }
     }

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionUsageRecordJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionUsageRecordJson.java
@@ -101,11 +101,11 @@ public class SubscriptionUsageRecordJson {
     public static class UsageRecordJson {
 
         private final LocalDate recordDate;
-        private final Long amount; // FIXME-1469 change to correct BigDecimal implementation
+        private final BigDecimal amount;
 
         @JsonCreator
         public UsageRecordJson(@JsonProperty("recordDate") final LocalDate recordDate,
-                               @JsonProperty("amount") final Long amount) {
+                               @JsonProperty("amount") final BigDecimal amount) {
             this.recordDate = recordDate;
             this.amount = amount;
         }
@@ -114,12 +114,12 @@ public class SubscriptionUsageRecordJson {
             return recordDate;
         }
 
-        public Long getAmount() {
+        public BigDecimal getAmount() {
             return amount;
         }
 
         public UsageRecord toUsageRecord() {
-            return new UsageRecord(recordDate, new BigDecimal(amount).longValue() /* FIXME-1469 : API backward compat */);
+            return new UsageRecord(recordDate, amount == null ? null : amount.longValue() /* FIXME-1469 : API backward compat */);
         }
     }
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionUsageRecordJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionUsageRecordJson.java
@@ -29,7 +29,6 @@ import org.killbill.billing.usage.api.UsageRecord;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.swagger.annotations.ApiModel;
@@ -120,8 +119,7 @@ public class SubscriptionUsageRecordJson {
         }
 
         public UsageRecord toUsageRecord() {
-            // FIXME-1469 change to correct BigDecimal implementation
-            return new UsageRecord(recordDate, new BigDecimal(amount));
+            return new UsageRecord(recordDate, new BigDecimal(amount).longValue() /* FIXME-1469 : API backward compat */);
         }
     }
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionUsageRecordJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionUsageRecordJson.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.jaxrs.json;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -101,7 +102,7 @@ public class SubscriptionUsageRecordJson {
     public static class UsageRecordJson {
 
         private final LocalDate recordDate;
-        private final Long amount;
+        private final Long amount; // FIXME-1469 change to correct BigDecimal implementation
 
         @JsonCreator
         public UsageRecordJson(@JsonProperty("recordDate") final LocalDate recordDate,
@@ -119,7 +120,8 @@ public class SubscriptionUsageRecordJson {
         }
 
         public UsageRecord toUsageRecord() {
-            return new UsageRecord(recordDate, amount);
+            // FIXME-1469 change to correct BigDecimal implementation
+            return new UsageRecord(recordDate, new BigDecimal(amount));
         }
     }
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
@@ -1674,7 +1674,7 @@ public class AccountResource extends JaxRsResourceBase {
                 return null;
             }
             @Override
-            public BigDecimal getQuantity() {
+            public Integer getQuantity() {
                 return null;
             }
             @Override

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AccountResource.java
@@ -1674,7 +1674,7 @@ public class AccountResource extends JaxRsResourceBase {
                 return null;
             }
             @Override
-            public Integer getQuantity() {
+            public BigDecimal getQuantity() {
                 return null;
             }
             @Override

--- a/jaxrs/src/test/java/org/killbill/billing/jaxrs/json/TestSubscriptionUsageRecordJson.java
+++ b/jaxrs/src/test/java/org/killbill/billing/jaxrs/json/TestSubscriptionUsageRecordJson.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.jaxrs.json;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -49,7 +50,7 @@ public class TestSubscriptionUsageRecordJson extends JaxrsTestSuiteNoDB {
         Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().size(), 1);
         Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUnitType(), "foo");
         Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUsageRecords().size(), 1);
-        Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUsageRecords().get(0).getAmount(), new Long(5L));
+        Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUsageRecords().get(0).getAmount(), Long.valueOf(5L));
         Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUsageRecords().get(0).getRecordDate(), localDate);
 
         final SubscriptionUsageRecord subscriptionUsageRecord = subscriptionUsageRecordJson.toSubscriptionUsageRecord();
@@ -58,7 +59,7 @@ public class TestSubscriptionUsageRecordJson extends JaxrsTestSuiteNoDB {
         Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().size(), 1);
         Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getUnitType(), "foo");
         Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getDailyAmount().size(), 1);
-        Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getDailyAmount().get(0).getAmount(), new Long(5L));
+        Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getDailyAmount().get(0).getAmount(), BigDecimal.valueOf(5L));
         Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getDailyAmount().get(0).getDate(), localDate);
     }
 }

--- a/jaxrs/src/test/java/org/killbill/billing/jaxrs/json/TestSubscriptionUsageRecordJson.java
+++ b/jaxrs/src/test/java/org/killbill/billing/jaxrs/json/TestSubscriptionUsageRecordJson.java
@@ -59,7 +59,7 @@ public class TestSubscriptionUsageRecordJson extends JaxrsTestSuiteNoDB {
         Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().size(), 1);
         Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getUnitType(), "foo");
         Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getDailyAmount().size(), 1);
-        Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getDailyAmount().get(0).getAmount(), BigDecimal.valueOf(5L));
+        Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getDailyAmount().get(0).getAmount(), (Long) BigDecimal.valueOf(5L).longValue() /* FIXME-1469 : API backward compat */);
         Assert.assertEquals(subscriptionUsageRecord.getUnitUsageRecord().get(0).getDailyAmount().get(0).getDate(), localDate);
     }
 }

--- a/jaxrs/src/test/java/org/killbill/billing/jaxrs/json/TestSubscriptionUsageRecordJson.java
+++ b/jaxrs/src/test/java/org/killbill/billing/jaxrs/json/TestSubscriptionUsageRecordJson.java
@@ -37,9 +37,9 @@ public class TestSubscriptionUsageRecordJson extends JaxrsTestSuiteNoDB {
         final LocalDate localDate = new LocalDate();
         final UUID subscriptionId = UUID.randomUUID();
         final String trackingId = UUID.randomUUID().toString();
-        final List<UnitUsageRecordJson> unitUsageRecords = new ArrayList<UnitUsageRecordJson>();
-        final List<UsageRecordJson> usageRecords = new ArrayList<UsageRecordJson>();
-        final UsageRecordJson usageRecordJson = new UsageRecordJson(localDate, 5L);
+        final List<UnitUsageRecordJson> unitUsageRecords = new ArrayList<>();
+        final List<UsageRecordJson> usageRecords = new ArrayList<>();
+        final UsageRecordJson usageRecordJson = new UsageRecordJson(localDate, BigDecimal.valueOf(5L));
         usageRecords.add(usageRecordJson);
         final UnitUsageRecordJson unitUsageRecordJson = new UnitUsageRecordJson("foo", usageRecords);
         unitUsageRecords.add(unitUsageRecordJson);
@@ -50,7 +50,7 @@ public class TestSubscriptionUsageRecordJson extends JaxrsTestSuiteNoDB {
         Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().size(), 1);
         Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUnitType(), "foo");
         Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUsageRecords().size(), 1);
-        Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUsageRecords().get(0).getAmount(), Long.valueOf(5L));
+        Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUsageRecords().get(0).getAmount(), BigDecimal.valueOf(5L));
         Assert.assertEquals(subscriptionUsageRecordJson.getUnitUsageRecords().get(0).getUsageRecords().get(0).getRecordDate(), localDate);
 
         final SubscriptionUsageRecord subscriptionUsageRecord = subscriptionUsageRecordJson.toSubscriptionUsageRecord();

--- a/jaxrs/src/test/java/org/killbill/billing/jaxrs/resources/TestJaxRsResourceBase.java
+++ b/jaxrs/src/test/java/org/killbill/billing/jaxrs/resources/TestJaxRsResourceBase.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.jaxrs.resources;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.joda.time.LocalDate;
@@ -34,7 +35,7 @@ public class TestJaxRsResourceBase extends JaxrsTestSuiteNoDB {
     private final JaxRsResourceBaseTest base = new JaxRsResourceBaseTest();
 
     @Test(groups = "fast")
-    public void testExtractPluginProperties() throws Exception {
+    public void testExtractPluginProperties() {
         final List<String> pluginPropertiesString = ImmutableList.<String>of("payment_cryptogram=EHuWW9PiBkWvqE5juRwDzAUFBAk=",
                                                                              "cc_number=4111111111111111",
                                                                              "cc_type=visa",
@@ -55,7 +56,7 @@ public class TestJaxRsResourceBase extends JaxrsTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    public void testExtractPluginPropertiesWithNullProperty() throws Exception {
+    public void testExtractPluginPropertiesWithNullProperty() {
         final List<String> pluginPropertiesString = ImmutableList.<String>of("foo=",
                                                                              "bar=ttt");
         final List<PluginProperty> pluginProperties = ImmutableList.<PluginProperty>copyOf(base.extractPluginProperties(pluginPropertiesString));
@@ -73,30 +74,30 @@ public class TestJaxRsResourceBase extends JaxrsTestSuiteNoDB {
 
 
     @Test(groups = "fast")
-    public void testGetHighestRecordDate() throws Exception {
+    public void testGetHighestRecordDate() {
         final UsageResourceTest usageResource = new UsageResourceTest();
 
         final List<UsageRecordJson> fooRecords = ImmutableList.<UsageRecordJson>builder()
-                .add(new UsageRecordJson(new LocalDate(2018, 03, 04), 28L))
-                .add(new UsageRecordJson(new LocalDate(2018, 03, 05), 2L))
-                .add(new UsageRecordJson(new LocalDate(2018, 03, 01), 1L))
-                .add(new UsageRecordJson(new LocalDate(2018, 04, 06), 24L))
+                .add(new UsageRecordJson(new LocalDate(2018, 03, 04), BigDecimal.valueOf(28L)))
+                .add(new UsageRecordJson(new LocalDate(2018, 03, 05), BigDecimal.valueOf(2L)))
+                .add(new UsageRecordJson(new LocalDate(2018, 03, 01), BigDecimal.valueOf(1L)))
+                .add(new UsageRecordJson(new LocalDate(2018, 04, 06), BigDecimal.valueOf(24L)))
                 .build();
         final UnitUsageRecordJson unitRecordFoo = new UnitUsageRecordJson("foo", fooRecords);
 
         final List<UsageRecordJson> barRecords = ImmutableList.<UsageRecordJson>builder()
-                .add(new UsageRecordJson(new LocalDate(2018, 02, 04), 28L))
-                .add(new UsageRecordJson(new LocalDate(2018, 03, 06), 2L))
-                .add(new UsageRecordJson(new LocalDate(2018, 04, 18), 1L)) // Highest date point
-                .add(new UsageRecordJson(new LocalDate(2018, 04, 13), 24L))
+                .add(new UsageRecordJson(new LocalDate(2018, 02, 04), BigDecimal.valueOf(28L)))
+                .add(new UsageRecordJson(new LocalDate(2018, 03, 06), BigDecimal.valueOf(2L)))
+                .add(new UsageRecordJson(new LocalDate(2018, 04, 18), BigDecimal.valueOf(1L))) // Highest date point
+                .add(new UsageRecordJson(new LocalDate(2018, 04, 13), BigDecimal.valueOf(24L)))
                 .build();
         final UnitUsageRecordJson unitRecordBar = new UnitUsageRecordJson("bar", barRecords);
 
         final List<UsageRecordJson> zooRecords = ImmutableList.<UsageRecordJson>builder()
-                .add(new UsageRecordJson(new LocalDate(2018, 02, 04), 28L))
-                .add(new UsageRecordJson(new LocalDate(2018, 03, 06), 2L))
-                .add(new UsageRecordJson(new LocalDate(2018, 04, 17), 1L))
-                .add(new UsageRecordJson(new LocalDate(2018, 04, 12), 24L))
+                .add(new UsageRecordJson(new LocalDate(2018, 02, 04), BigDecimal.valueOf(28L)))
+                .add(new UsageRecordJson(new LocalDate(2018, 03, 06), BigDecimal.valueOf(2L)))
+                .add(new UsageRecordJson(new LocalDate(2018, 04, 17), BigDecimal.valueOf(1L)))
+                .add(new UsageRecordJson(new LocalDate(2018, 04, 12), BigDecimal.valueOf(24L)))
                 .build();
         final UnitUsageRecordJson unitRecordZoo = new UnitUsageRecordJson("zoo", zooRecords);
 

--- a/payment/src/test/java/org/killbill/billing/payment/MockRecurringInvoiceItem.java
+++ b/payment/src/test/java/org/killbill/billing/payment/MockRecurringInvoiceItem.java
@@ -41,7 +41,7 @@ public class MockRecurringInvoiceItem extends EntityBase implements InvoiceItem 
     protected final BigDecimal amount;
     protected final Currency currency;
     protected final String usageName;
-    protected final Integer quantity;
+    protected final BigDecimal quantity;
     protected final String itemDetails;
     private final BigDecimal rate;
     private final UUID reversedItemId;
@@ -60,7 +60,7 @@ public class MockRecurringInvoiceItem extends EntityBase implements InvoiceItem 
 
     public MockRecurringInvoiceItem(final UUID id, final UUID invoiceId, final UUID accountId, @Nullable final UUID bundleId, @Nullable final UUID subscriptionId, final String planName, final String phaseName,
                                     final String usageName, final LocalDate startDate, final LocalDate endDate, final BigDecimal amount, final Currency currency,
-                                    final BigDecimal rate, final UUID reversedItemId, final Integer quantity, final String itemDetails) {
+                                    final BigDecimal rate, final UUID reversedItemId, final BigDecimal quantity, final String itemDetails) {
         super(id);
         this.invoiceId = invoiceId;
         this.accountId = accountId;
@@ -180,7 +180,7 @@ public class MockRecurringInvoiceItem extends EntityBase implements InvoiceItem 
     }
 
     @Override
-    public Integer getQuantity() { return quantity; }
+    public BigDecimal getQuantity() { return quantity; }
 
     @Override
     public String getItemDetails() { return itemDetails; }

--- a/payment/src/test/java/org/killbill/billing/payment/MockRecurringInvoiceItem.java
+++ b/payment/src/test/java/org/killbill/billing/payment/MockRecurringInvoiceItem.java
@@ -180,7 +180,7 @@ public class MockRecurringInvoiceItem extends EntityBase implements InvoiceItem 
     }
 
     @Override
-    public BigDecimal getQuantity() { return quantity; }
+    public Integer getQuantity() { return quantity.intValue() /* FIXME-1469 : API backward compat */; }
 
     @Override
     public String getItemDetails() { return itemDetails; }

--- a/usage/src/main/java/org/killbill/billing/usage/api/svcs/DefaultRawUsage.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/svcs/DefaultRawUsage.java
@@ -55,8 +55,8 @@ public class DefaultRawUsage implements RawUsageRecord {
     }
 
     @Override
-    public BigDecimal getAmount() {
-        return amount;
+    public Long getAmount() {
+        return amount.longValue();
     }
 
     @Override

--- a/usage/src/main/java/org/killbill/billing/usage/api/svcs/DefaultRawUsage.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/svcs/DefaultRawUsage.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.usage.api.svcs;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 import org.joda.time.LocalDate;
@@ -27,10 +28,10 @@ public class DefaultRawUsage implements RawUsageRecord {
     private final UUID subscriptionId;
     private final LocalDate recordDate;
     private final String unitType;
-    private final Long amount;
+    private final BigDecimal amount;
     private final String trackingId;
 
-    public DefaultRawUsage(final UUID subscriptionId, final LocalDate recordDate, final String unitType, final Long amount, final String trackingId) {
+    public DefaultRawUsage(final UUID subscriptionId, final LocalDate recordDate, final String unitType, final BigDecimal amount, final String trackingId) {
         this.subscriptionId = subscriptionId;
         this.recordDate = recordDate;
         this.unitType = unitType;
@@ -54,7 +55,7 @@ public class DefaultRawUsage implements RawUsageRecord {
     }
 
     @Override
-    public Long getAmount() {
+    public BigDecimal getAmount() {
         return amount;
     }
 

--- a/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultRolledUpUnit.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultRolledUpUnit.java
@@ -17,14 +17,16 @@
 
 package org.killbill.billing.usage.api.user;
 
+import java.math.BigDecimal;
+
 import org.killbill.billing.usage.api.RolledUpUnit;
 
 public class DefaultRolledUpUnit implements RolledUpUnit {
 
     private final String unitType;
-    private final Long amount;
+    private final BigDecimal amount;
 
-    public DefaultRolledUpUnit(final String unitType, final Long amount) {
+    public DefaultRolledUpUnit(final String unitType, final BigDecimal amount) {
         this.unitType = unitType;
         this.amount = amount;
     }
@@ -35,7 +37,7 @@ public class DefaultRolledUpUnit implements RolledUpUnit {
     }
 
     @Override
-    public Long getAmount() {
+    public BigDecimal getAmount() {
         return amount;
     }
 }

--- a/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultRolledUpUnit.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultRolledUpUnit.java
@@ -37,7 +37,7 @@ public class DefaultRolledUpUnit implements RolledUpUnit {
     }
 
     @Override
-    public BigDecimal getAmount() {
-        return amount;
+    public Long getAmount() {
+        return amount.longValue();
     }
 }

--- a/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultUsageUserApi.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultUsageUserApi.java
@@ -83,7 +83,8 @@ public class DefaultUsageUserApi extends BaseUserApi implements UsageUserApi {
         final List<RolledUpUsageModelDao> usages = new ArrayList<RolledUpUsageModelDao>();
         for (final UnitUsageRecord unitUsageRecord : record.getUnitUsageRecord()) {
             for (final UsageRecord usageRecord : unitUsageRecord.getDailyAmount()) {
-                usages.add(new RolledUpUsageModelDao(record.getSubscriptionId(), unitUsageRecord.getUnitType(), usageRecord.getDate(), usageRecord.getAmount(), trackingIds));
+                // FIXME-1469 : API backward compat in usageRecord.getAmount()
+                usages.add(new RolledUpUsageModelDao(record.getSubscriptionId(), unitUsageRecord.getUnitType(), usageRecord.getDate(), BigDecimal.valueOf(usageRecord.getAmount()), trackingIds));
             }
         }
         rolledUpUsageDao.record(usages, internalCallContext);
@@ -141,8 +142,9 @@ public class DefaultUsageUserApi extends BaseUserApi implements UsageUserApi {
                 continue;
             }
 
+            // FIXME-1469 : API backward compat
             BigDecimal currentAmount = tmp.get(cur.getUnitType());
-            BigDecimal updatedAmount = (currentAmount != null) ? currentAmount.add(cur.getAmount()) : cur.getAmount();
+            BigDecimal updatedAmount = (currentAmount != null) ? currentAmount.add(BigDecimal.valueOf(cur.getAmount())) : BigDecimal.valueOf(cur.getAmount());
             tmp.put(cur.getUnitType(), updatedAmount);
         }
         final List<RolledUpUnit> result = new ArrayList<RolledUpUnit>(tmp.size());

--- a/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultUsageUserApi.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/user/DefaultUsageUserApi.java
@@ -16,6 +16,7 @@
 
 package org.killbill.billing.usage.api.user;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -128,7 +129,7 @@ public class DefaultUsageUserApi extends BaseUserApi implements UsageUserApi {
     }
 
     private List<RolledUpUnit> getRolledUpUnitsForRawPluginUsage(final UUID subscriptionId, @Nullable final String unitType, final List<RawUsageRecord> rawAccountUsage) {
-        final Map<String, Long> tmp = new HashMap<String, Long>();
+        final Map<String, BigDecimal> tmp = new HashMap<>();
         for (RawUsageRecord cur : rawAccountUsage) {
             // Filter out wrong subscriptionId
             if (cur.getSubscriptionId().compareTo(subscriptionId) != 0) {
@@ -140,8 +141,8 @@ public class DefaultUsageUserApi extends BaseUserApi implements UsageUserApi {
                 continue;
             }
 
-            Long currentAmount = tmp.get(cur.getUnitType());
-            Long updatedAmount = (currentAmount != null) ? currentAmount + cur.getAmount() : cur.getAmount();
+            BigDecimal currentAmount = tmp.get(cur.getUnitType());
+            BigDecimal updatedAmount = (currentAmount != null) ? currentAmount.add(cur.getAmount()) : cur.getAmount();
             tmp.put(cur.getUnitType(), updatedAmount);
         }
         final List<RolledUpUnit> result = new ArrayList<RolledUpUnit>(tmp.size());
@@ -152,10 +153,10 @@ public class DefaultUsageUserApi extends BaseUserApi implements UsageUserApi {
     }
 
     private List<RolledUpUnit> getRolledUpUnits(final List<RolledUpUsageModelDao> usageForSubscription) {
-        final Map<String, Long> tmp = new HashMap<String, Long>();
+        final Map<String, BigDecimal> tmp = new HashMap<>();
         for (RolledUpUsageModelDao cur : usageForSubscription) {
-            Long currentAmount = tmp.get(cur.getUnitType());
-            Long updatedAmount = (currentAmount != null) ? currentAmount + cur.getAmount() : cur.getAmount();
+            BigDecimal currentAmount = tmp.get(cur.getUnitType());
+            BigDecimal updatedAmount = (currentAmount != null) ? currentAmount.add(cur.getAmount()) : cur.getAmount();
             tmp.put(cur.getUnitType(), updatedAmount);
         }
         final List<RolledUpUnit> result = new ArrayList<RolledUpUnit>(tmp.size());

--- a/usage/src/main/java/org/killbill/billing/usage/dao/RolledUpUsageModelDao.java
+++ b/usage/src/main/java/org/killbill/billing/usage/dao/RolledUpUsageModelDao.java
@@ -16,6 +16,7 @@
 
 package org.killbill.billing.usage.dao;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -26,19 +27,17 @@ import org.killbill.billing.util.entity.Entity;
 import org.killbill.billing.util.entity.dao.EntityModelDao;
 import org.killbill.billing.util.entity.dao.EntityModelDaoBase;
 
-import com.google.common.base.Strings;
-
 public class RolledUpUsageModelDao extends EntityModelDaoBase implements EntityModelDao<Entity> {
 
     private UUID subscriptionId;
     private String unitType;
     private LocalDate recordDate;
-    private Long amount;
+    private BigDecimal amount;
     private String trackingId;
 
     public RolledUpUsageModelDao() { /* For the DAO mapper */ }
 
-    public RolledUpUsageModelDao(final UUID id, final DateTime createdDate, final DateTime updatedDate, final UUID subscriptionId, final String unitType, final LocalDate recordDate, final Long amount, final String trackingId) {
+    public RolledUpUsageModelDao(final UUID id, final DateTime createdDate, final DateTime updatedDate, final UUID subscriptionId, final String unitType, final LocalDate recordDate, final BigDecimal amount, final String trackingId) {
         super(id, createdDate, updatedDate);
         this.subscriptionId = subscriptionId;
         this.unitType = unitType;
@@ -47,7 +46,7 @@ public class RolledUpUsageModelDao extends EntityModelDaoBase implements EntityM
         this.trackingId = trackingId;
     }
 
-    public RolledUpUsageModelDao(final UUID subscriptionId, final String unitType, final LocalDate recordDate, final Long amount, final String trackingId) {
+    public RolledUpUsageModelDao(final UUID subscriptionId, final String unitType, final LocalDate recordDate, final BigDecimal amount, final String trackingId) {
         this(UUIDs.randomUUID(), null, null, subscriptionId, unitType, recordDate, amount, trackingId);
     }
 
@@ -67,7 +66,7 @@ public class RolledUpUsageModelDao extends EntityModelDaoBase implements EntityM
         this.recordDate = recordDate;
     }
 
-    public Long getAmount() {
+    public BigDecimal getAmount() {
         return amount;
     }
 
@@ -79,7 +78,7 @@ public class RolledUpUsageModelDao extends EntityModelDaoBase implements EntityM
         this.unitType = unitType;
     }
 
-    public void setAmount(final Long amount) {
+    public void setAmount(final BigDecimal amount) {
         this.amount = amount;
     }
 

--- a/usage/src/main/resources/org/killbill/billing/usage/ddl.sql
+++ b/usage/src/main/resources/org/killbill/billing/usage/ddl.sql
@@ -7,7 +7,7 @@ CREATE TABLE rolled_up_usage (
     subscription_id varchar(36) NOT NULL,
     unit_type varchar(255) NOT NULL,
     record_date date NOT NULL,
-    amount bigint NOT NULL,
+    amount decimal(18, 9) NOT NULL,
     tracking_id varchar(128) NOT NULL,
     created_by varchar(50) NOT NULL,
     created_date datetime NOT NULL,

--- a/usage/src/test/java/org/killbill/billing/usage/dao/TestDefaultRolledUpUsageDao.java
+++ b/usage/src/test/java/org/killbill/billing/usage/dao/TestDefaultRolledUpUsageDao.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.usage.dao;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -38,8 +39,8 @@ public class TestDefaultRolledUpUsageDao extends UsageTestSuiteWithEmbeddedDB {
         final String unitType = "foo";
         final LocalDate startDate = new LocalDate(2013, 1, 1);
         final LocalDate endDate = new LocalDate(2013, 2, 1);
-        final Long amount1 = 10L;
-        final Long amount2 = 5L;
+        final BigDecimal amount1 = BigDecimal.valueOf(10L);
+        final BigDecimal amount2 = BigDecimal.valueOf(5L);
 
         RolledUpUsageModelDao usage1 = new RolledUpUsageModelDao(subscriptionId, unitType, startDate, amount1, UUID.randomUUID().toString());
         RolledUpUsageModelDao usage2 = new RolledUpUsageModelDao(subscriptionId, unitType, endDate.minusDays(1), amount2, UUID.randomUUID().toString());
@@ -67,9 +68,9 @@ public class TestDefaultRolledUpUsageDao extends UsageTestSuiteWithEmbeddedDB {
         final String unitType2 = "bar";
         final LocalDate startDate = new LocalDate(2013, 1, 1);
         final LocalDate endDate = new LocalDate(2013, 2, 1);
-        final Long amount1 = 10L;
-        final Long amount2 = 5L;
-        final Long amount3 = 13L;
+        final BigDecimal amount1 = BigDecimal.valueOf(10L);
+        final BigDecimal amount2 = BigDecimal.valueOf(5L);
+        final BigDecimal amount3 = BigDecimal.valueOf(13L);
 
         RolledUpUsageModelDao usage1 = new RolledUpUsageModelDao(subscriptionId, unitType1, startDate, amount1, UUID.randomUUID().toString());
         RolledUpUsageModelDao usage2 = new RolledUpUsageModelDao(subscriptionId, unitType1, startDate.plusDays(1), amount2, UUID.randomUUID().toString());
@@ -102,8 +103,9 @@ public class TestDefaultRolledUpUsageDao extends UsageTestSuiteWithEmbeddedDB {
         final String unitType = "foo";
         final LocalDate startDate = new LocalDate(2013, 1, 1);
         final LocalDate endDate = new LocalDate(2013, 2, 1);
+        final BigDecimal amount = BigDecimal.valueOf(9L);
 
-        RolledUpUsageModelDao usage1 = new RolledUpUsageModelDao(subscriptionId, unitType, endDate, 9L, UUID.randomUUID().toString());
+        RolledUpUsageModelDao usage1 = new RolledUpUsageModelDao(subscriptionId, unitType, endDate, amount, UUID.randomUUID().toString());
         List<RolledUpUsageModelDao> usages = new ArrayList<RolledUpUsageModelDao>();
         usages.add(usage1);
         rolledUpUsageDao.record(usages, internalCallContext);
@@ -119,9 +121,9 @@ public class TestDefaultRolledUpUsageDao extends UsageTestSuiteWithEmbeddedDB {
         final String unitType2 = "bar";
         final LocalDate startDate = new LocalDate(2013, 1, 1);
         final LocalDate endDate = new LocalDate(2013, 2, 1);
-        final Long amount1 = 10L;
-        final Long amount2 = 5L;
-        final Long amount3 = 13L;
+        final BigDecimal amount1 = BigDecimal.valueOf(10L);
+        final BigDecimal amount2 = BigDecimal.valueOf(5L);
+        final BigDecimal amount3 = BigDecimal.valueOf(13L);
 
         RolledUpUsageModelDao usage1 = new RolledUpUsageModelDao(subscriptionId, unitType1, startDate, amount1, UUID.randomUUID().toString());
         RolledUpUsageModelDao usage2 = new RolledUpUsageModelDao(subscriptionId, unitType1, startDate.plusDays(1), amount2, UUID.randomUUID().toString());
@@ -151,9 +153,9 @@ public class TestDefaultRolledUpUsageDao extends UsageTestSuiteWithEmbeddedDB {
         final String unitType2 = "bar";
         final LocalDate startDate = new LocalDate(2013, 1, 1);
         final LocalDate endDate = new LocalDate(2013, 2, 1);
-        final Long amount1 = 10L;
-        final Long amount2 = 5L;
-        final Long amount3 = 13L;
+        final BigDecimal amount1 = BigDecimal.valueOf(10L);
+        final BigDecimal amount2 = BigDecimal.valueOf(5L);
+        final BigDecimal amount3 = BigDecimal.valueOf(13L);
 
         String trackingId = UUIDs.randomUUID().toString();
 


### PR DESCRIPTION
All commit only fix for compile-error because of changes in `RolledUpUnit`, `UsageRecord` and `RawUsageRecord`. There are  `//FIXME-1469 ....` across source code on this PR that indicate the line will be changed when other API (like invoice API) that affected by original issue in #1469 fixed.