### PR TITLE
entitlement, junction: Optimize junction code to pull less blocking s…

### DIFF
--- a/api/src/main/java/org/killbill/billing/junction/BlockingInternalApi.java
+++ b/api/src/main/java/org/killbill/billing/junction/BlockingInternalApi.java
@@ -29,7 +29,7 @@ public interface BlockingInternalApi {
 
     public BlockingState getBlockingStateForService(UUID blockableId, BlockingStateType blockingStateType, String serviceName, InternalTenantContext context);
 
-    public List<BlockingState> getBlockingAllForAccount(final VersionedCatalog catalog, InternalTenantContext context);
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, InternalTenantContext context);
 
     public void setBlockingState(BlockingState state, InternalCallContext context);
 }

--- a/api/src/main/java/org/killbill/billing/junction/BlockingInternalApi.java
+++ b/api/src/main/java/org/killbill/billing/junction/BlockingInternalApi.java
@@ -19,6 +19,9 @@ package org.killbill.billing.junction;
 import java.util.List;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.VersionedCatalog;
@@ -29,7 +32,7 @@ public interface BlockingInternalApi {
 
     public BlockingState getBlockingStateForService(UUID blockableId, BlockingStateType blockingStateType, String serviceName, InternalTenantContext context);
 
-    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, InternalTenantContext context);
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, @Nullable final LocalDate cutoffDt, InternalTenantContext context);
 
     public void setBlockingState(BlockingState state, InternalCallContext context);
 }

--- a/api/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseInternalApi.java
+++ b/api/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseInternalApi.java
@@ -73,7 +73,6 @@ public interface SubscriptionBaseInternalApi {
     public List<SubscriptionBase> getSubscriptionsForBundle(UUID bundleId, DryRunArguments dryRunArguments, InternalTenantContext context)
             throws SubscriptionBaseApiException;
 
-    // TODO_CATALOG revisit which apis should take a Catalog
     public Map<UUID, List<SubscriptionBase>> getSubscriptionsForAccount(VersionedCatalog catalog, final LocalDate cutoffDt,  InternalTenantContext context) throws SubscriptionBaseApiException;
 
     public SubscriptionBase getBaseSubscription(UUID bundleId, InternalTenantContext context) throws SubscriptionBaseApiException;

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultInternalBlockingApi.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultInternalBlockingApi.java
@@ -21,6 +21,9 @@ package org.killbill.billing.entitlement.api.svcs;
 import java.util.List;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.StaticCatalog;
@@ -50,8 +53,8 @@ public class DefaultInternalBlockingApi implements BlockingInternalApi {
     }
 
     @Override
-    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
-        return dao.getBlockingAllForAccountRecordId(catalog, context);
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, @Nullable final LocalDate cutoffDt, final InternalTenantContext context) {
+        return dao.getBlockingActiveForAccount(catalog, cutoffDt, context);
     }
 
     @Override

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultInternalBlockingApi.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultInternalBlockingApi.java
@@ -50,7 +50,7 @@ public class DefaultInternalBlockingApi implements BlockingInternalApi {
     }
 
     @Override
-    public List<BlockingState> getBlockingAllForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
         return dao.getBlockingAllForAccountRecordId(catalog, context);
     }
 

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateDao.java
@@ -68,6 +68,16 @@ public interface BlockingStateDao extends EntityDao<BlockingStateModelDao, Block
     public List<BlockingState> getBlockingAllForAccountRecordId(VersionedCatalog catalog, InternalTenantContext context);
 
     /**
+     * Return all events for tuple {service, blockable_id} having at least one block_billing
+     *
+     * @param catalog full catalog
+     * @param context call context
+     * @return list of active blocking states for that account
+     */
+    public List<BlockingState> getBlockingActiveForAccount(VersionedCatalog catalog, InternalTenantContext context);
+
+
+    /**
      * Return all events (past and future) across all services for a given set of blockableIds
      *
      * @param blockableIds ids of the blockable object

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateDao.java
@@ -22,7 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.VersionedCatalog;
@@ -74,7 +77,7 @@ public interface BlockingStateDao extends EntityDao<BlockingStateModelDao, Block
      * @param context call context
      * @return list of active blocking states for that account
      */
-    public List<BlockingState> getBlockingActiveForAccount(VersionedCatalog catalog, InternalTenantContext context);
+    public List<BlockingState> getBlockingActiveForAccount(VersionedCatalog catalog, @Nullable final LocalDate cutoffDt, InternalTenantContext context);
 
 
     /**

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.java
@@ -57,6 +57,10 @@ public interface BlockingStateSqlDao extends EntitySqlDao<BlockingStateModelDao,
                                                                              @SmartBindBean final InternalTenantContext context);
 
     @SqlQuery
+    public abstract List<BlockingStateModelDao> getBlockingActiveForAccount(@SmartBindBean final InternalTenantContext context);
+
+
+    @SqlQuery
     public abstract List<BlockingStateModelDao> getBlockingHistoryForService(@Bind("blockableId") UUID blockableId,
                                                                              @Bind("service") String serviceName,
                                                                              @SmartBindBean final InternalTenantContext context);

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
@@ -204,6 +204,23 @@ public class DefaultBlockingStateDao extends EntityDaoBase<BlockingStateModelDao
     }
 
     @Override
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
+        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<BlockingState>>() {
+            @Override
+            public List<BlockingState> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
+                final BlockingStateSqlDao sqlDao = entitySqlDaoWrapperFactory.become(BlockingStateSqlDao.class);
+                return new ArrayList<BlockingState>(Collections2.transform(sqlDao.getBlockingActiveForAccount(context),
+                                                                           new Function<BlockingStateModelDao, BlockingState>() {
+                                                                               @Override
+                                                                               public BlockingState apply(@Nullable final BlockingStateModelDao src) {
+                                                                                   return BlockingStateModelDao.toBlockingState(src);
+                                                                               }
+                                                                           }));
+            }
+        });
+    }
+
+    @Override
     public List<BlockingState> getByBlockingIds(Iterable<UUID> blockableIds, final InternalTenantContext context) {
         return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<BlockingState>>() {
             @Override

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import javax.inject.Named;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.callcontext.InternalCallContext;
@@ -204,7 +205,7 @@ public class DefaultBlockingStateDao extends EntityDaoBase<BlockingStateModelDao
     }
 
     @Override
-    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, @Nullable final LocalDate cutoffDt, final InternalTenantContext context) {
         return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<BlockingState>>() {
             @Override
             public List<BlockingState> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
@@ -33,6 +33,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.ProductCategory;
@@ -236,13 +237,13 @@ public class ProxyBlockingStateDao implements BlockingStateDao {
     @Override
     public List<BlockingState> getBlockingAllForAccountRecordId(final VersionedCatalog catalog, final InternalTenantContext context) {
         final List<BlockingState> statesOnDisk = delegate.getBlockingAllForAccountRecordId(catalog, context);
-        return addBlockingStatesNotOnDisk(statesOnDisk, catalog, context);
+        return addBlockingStatesNotOnDisk(statesOnDisk, catalog, null, context);
     }
 
     @Override
-    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
-        final List<BlockingState> statesOnDisk = delegate.getBlockingActiveForAccount(catalog, context);
-        return addBlockingStatesNotOnDisk(statesOnDisk, catalog, context);
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, @Nullable final LocalDate cutoffDt, final InternalTenantContext context) {
+        final List<BlockingState> statesOnDisk = delegate.getBlockingActiveForAccount(catalog, cutoffDt, context);
+        return addBlockingStatesNotOnDisk(statesOnDisk, catalog, cutoffDt, context);
     }
 
     @Override
@@ -269,6 +270,7 @@ public class ProxyBlockingStateDao implements BlockingStateDao {
     // See DefaultEntitlement#computeAddOnBlockingStates
     private List<BlockingState> addBlockingStatesNotOnDisk(final List<BlockingState> blockingStatesOnDisk,
                                                            final VersionedCatalog catalog,
+                                                           @Nullable final LocalDate cutoffDt,
                                                            final InternalTenantContext context) {
         final Collection<BlockingState> blockingStatesOnDiskCopy = new LinkedList<BlockingState>(blockingStatesOnDisk);
 
@@ -276,8 +278,7 @@ public class ProxyBlockingStateDao implements BlockingStateDao {
         final Iterable<SubscriptionBase> baseSubscriptionsToConsider;
         final Iterable<EventsStream> eventsStreams;
         try {
-            // TODO cutoffDt
-            final Map<UUID, List<SubscriptionBase>> subscriptions = subscriptionInternalApi.getSubscriptionsForAccount(catalog, null, context);
+            final Map<UUID, List<SubscriptionBase>> subscriptions = subscriptionInternalApi.getSubscriptionsForAccount(catalog, cutoffDt, context);
             baseSubscriptionsToConsider = Iterables.<SubscriptionBase>filter(Iterables.<SubscriptionBase>concat(subscriptions.values()),
                                                                              new Predicate<SubscriptionBase>() {
                                                                                  @Override

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
@@ -240,6 +240,12 @@ public class ProxyBlockingStateDao implements BlockingStateDao {
     }
 
     @Override
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
+        final List<BlockingState> statesOnDisk = delegate.getBlockingActiveForAccount(catalog, context);
+        return addBlockingStatesNotOnDisk(statesOnDisk, catalog, context);
+    }
+
+    @Override
     public List<BlockingState> getByBlockingIds(final Iterable<UUID> blockableIds, final InternalTenantContext context) {
         return delegate.getByBlockingIds(blockableIds, context);
     }
@@ -270,6 +276,7 @@ public class ProxyBlockingStateDao implements BlockingStateDao {
         final Iterable<SubscriptionBase> baseSubscriptionsToConsider;
         final Iterable<EventsStream> eventsStreams;
         try {
+            // TODO cutoffDt
             final Map<UUID, List<SubscriptionBase>> subscriptions = subscriptionInternalApi.getSubscriptionsForAccount(catalog, null, context);
             baseSubscriptionsToConsider = Iterables.<SubscriptionBase>filter(Iterables.<SubscriptionBase>concat(subscriptions.values()),
                                                                              new Predicate<SubscriptionBase>() {

--- a/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
+++ b/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
@@ -123,7 +123,7 @@ join (
   and <accountRecordIdField("")> = :accountRecordId
   <AND_CHECK_TENANT("")>
   and block_billing
-  group by 1, 2
+  group by service, blockable_id
   having count(*) > 0) tmp
 on bs1.service = tmp.service
    and bs1.blockable_id = tmp.blockable_id

--- a/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
+++ b/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
@@ -104,7 +104,35 @@ where <accountRecordIdField("t.")> = :accountRecordId
 <AND_CHECK_TENANT("t.")>
 <defaultOrderBy("t.")>
 ;
- >>
+>>
+
+
+getBlockingActiveForAccount() ::= <<
+select
+<allTableFields("bs1.")>
+from
+blocking_states bs1
+join (
+  select
+   service
+  , blockable_id
+  , count(*)
+  from
+  blocking_states
+  where 1=1
+  and <accountRecordIdField("")> = :accountRecordId
+  <AND_CHECK_TENANT("")>
+  and block_billing
+  group by 1, 2
+  having count(*) > 0) tmp
+on bs1.service = tmp.service
+   and bs1.blockable_id = tmp.blockable_id
+where 1=1
+and <accountRecordIdField("bs1.")> = :accountRecordId
+<AND_CHECK_TENANT("bs1.")>
+order by bs1.service, bs1.blockable_id, bs1.block_billing
+;
+>>
 
 getBlockingHistoryForService() ::= <<
 select

--- a/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
+++ b/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
@@ -122,7 +122,7 @@ join (
   where 1=1
   and <accountRecordIdField("")> = :accountRecordId
   <AND_CHECK_TENANT("")>
-  and block_billing
+  and block_billing = 1
   group by service, blockable_id
   having count(*) > 0) tmp
 on bs1.service = tmp.service

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/block/TestBlockingApi.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/block/TestBlockingApi.java
@@ -40,7 +40,6 @@ import org.killbill.billing.entitlement.api.SubscriptionApiException;
 import org.killbill.billing.junction.DefaultBlockingState;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
@@ -102,7 +101,7 @@ public class TestBlockingApi extends EntitlementTestSuiteWithEmbeddedDB {
         blockingInternalApi.setBlockingState(state2, internalCallContext);
         assertListenerStatus();
 
-        final List<BlockingState> blockingAll = blockingInternalApi.getBlockingAllForAccount(catalog, internalCallContext);
+        final List<BlockingState> blockingAll = blockingInternalApi.getBlockingActiveForAccount(catalog, internalCallContext);
         final List<BlockingState> history = ImmutableList.<BlockingState>copyOf(Collections2.<BlockingState>filter(blockingAll,
                                                                                                                    new Predicate<BlockingState>() {
                                                                                                                        @Override
@@ -173,7 +172,7 @@ public class TestBlockingApi extends EntitlementTestSuiteWithEmbeddedDB {
         baseEntitlement = entitlementApi.getEntitlementForId(baseEntitlement.getId(), callContext);
         assertEquals(baseEntitlement.getState(), EntitlementState.ACTIVE);
 
-        final List<BlockingState> blockingAll = blockingInternalApi.getBlockingAllForAccount(catalog, internalCallContext);
+        final List<BlockingState> blockingAll = blockingInternalApi.getBlockingActiveForAccount(catalog, internalCallContext);
         final List<BlockingState> history = ImmutableList.<BlockingState>copyOf(Collections2.<BlockingState>filter(blockingAll,
                                                                                                                    new Predicate<BlockingState>() {
                                                                                                                        @Override

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/block/TestBlockingApi.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/block/TestBlockingApi.java
@@ -84,7 +84,7 @@ public class TestBlockingApi extends EntitlementTestSuiteWithEmbeddedDB {
 
         final boolean blockChange = true;
         final boolean blockEntitlement = false;
-        final boolean blockBilling = false;
+        final boolean blockBilling = true;
 
         final Account account = createAccount(getAccountData(7));
 
@@ -101,7 +101,7 @@ public class TestBlockingApi extends EntitlementTestSuiteWithEmbeddedDB {
         blockingInternalApi.setBlockingState(state2, internalCallContext);
         assertListenerStatus();
 
-        final List<BlockingState> blockingAll = blockingInternalApi.getBlockingActiveForAccount(catalog, internalCallContext);
+        final List<BlockingState> blockingAll = blockingInternalApi.getBlockingActiveForAccount(catalog, null, internalCallContext);
         final List<BlockingState> history = ImmutableList.<BlockingState>copyOf(Collections2.<BlockingState>filter(blockingAll,
                                                                                                                    new Predicate<BlockingState>() {
                                                                                                                        @Override
@@ -124,7 +124,7 @@ public class TestBlockingApi extends EntitlementTestSuiteWithEmbeddedDB {
 
         final boolean blockChange = false;
         final boolean blockEntitlement = true;
-        final boolean blockBilling = false;
+        final boolean blockBilling = true;
 
         final Account account = createAccount(getAccountData(7));
 
@@ -172,7 +172,7 @@ public class TestBlockingApi extends EntitlementTestSuiteWithEmbeddedDB {
         baseEntitlement = entitlementApi.getEntitlementForId(baseEntitlement.getId(), callContext);
         assertEquals(baseEntitlement.getState(), EntitlementState.ACTIVE);
 
-        final List<BlockingState> blockingAll = blockingInternalApi.getBlockingActiveForAccount(catalog, internalCallContext);
+        final List<BlockingState> blockingAll = blockingInternalApi.getBlockingActiveForAccount(catalog, null, internalCallContext);
         final List<BlockingState> history = ImmutableList.<BlockingState>copyOf(Collections2.<BlockingState>filter(blockingAll,
                                                                                                                    new Predicate<BlockingState>() {
                                                                                                                        @Override

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/dao/MockBlockingStateDao.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/dao/MockBlockingStateDao.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.VersionedCatalog;
@@ -88,7 +89,7 @@ public class MockBlockingStateDao extends MockEntityDaoBase<BlockingStateModelDa
     }
 
     @Override
-    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, @Nullable final LocalDate cutoffDt, final InternalTenantContext context) {
         return MoreObjects.firstNonNull(blockingStatesPerAccountRecordId.get(context.getAccountRecordId()), ImmutableList.<BlockingState>of());
     }
 

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/dao/MockBlockingStateDao.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/dao/MockBlockingStateDao.java
@@ -88,6 +88,11 @@ public class MockBlockingStateDao extends MockEntityDaoBase<BlockingStateModelDa
     }
 
     @Override
+    public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
+        return MoreObjects.firstNonNull(blockingStatesPerAccountRecordId.get(context.getAccountRecordId()), ImmutableList.<BlockingState>of());
+    }
+
+    @Override
     public List<BlockingState> getByBlockingIds(final Iterable<UUID> blockableIds, final InternalTenantContext context) {
         final List<BlockingState> result = new ArrayList<>();
         for (UUID cur : blockableIds) {

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/dao/TestBlockingDao.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/dao/TestBlockingDao.java
@@ -182,7 +182,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
         Assert.assertEquals(states.size(), 5);
 
 
-        states = blockingStateDao.getBlockingActiveForAccount(catalog, internalCallContext);
+        states = blockingStateDao.getBlockingActiveForAccount(catalog, null, internalCallContext);
         Assert.assertEquals(states.size(), 2);
 
     }

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/dao/TestBlockingDao.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/dao/TestBlockingDao.java
@@ -138,6 +138,56 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
     }
 
 
+
+    @Test(groups = "slow", description = "Verify active blocking states are being returned")
+    public void testActiveBlockingStates() throws AccountApiException {
+
+        final UUID accountId = createAccount(getAccountData(1)).getId();
+        final String service = "Coco";
+
+        clock.setDay(new LocalDate(2022, 1, 18));
+
+        testListener.pushExpectedEvent(NextEvent.BLOCK);
+        final BlockingState stateA1 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, "warning", service, false, false, false, clock.getUTCNow());
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(ImmutableMap.<BlockingState, Optional<UUID>>of(stateA1, Optional.<UUID>absent()), internalCallContext);
+        assertListenerStatus();
+
+        clock.addDays(1);
+
+        testListener.pushExpectedEvent(NextEvent.BLOCK);
+        final BlockingState stateA2 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, "warning+", service, false, false, false, clock.getUTCNow());
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(ImmutableMap.<BlockingState, Optional<UUID>>of(stateA2, Optional.<UUID>absent()), internalCallContext);
+        assertListenerStatus();
+
+        final UUID bundleId = UUID.randomUUID();
+        testListener.pushExpectedEvent(NextEvent.BLOCK);
+        final BlockingState stateB1 = new DefaultBlockingState(bundleId, BlockingStateType.SUBSCRIPTION_BUNDLE, "block", service, true, true, true, clock.getUTCNow());
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(ImmutableMap.<BlockingState, Optional<UUID>>of(stateB1, Optional.<UUID>absent()), internalCallContext);
+        assertListenerStatus();
+
+        clock.addDays(1);
+
+        testListener.pushExpectedEvent(NextEvent.BLOCK);
+        final BlockingState stateA3 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, "warning++", service, false, false, false, clock.getUTCNow());
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(ImmutableMap.<BlockingState, Optional<UUID>>of(stateA3, Optional.<UUID>absent()), internalCallContext);
+        assertListenerStatus();
+
+        testListener.pushExpectedEvent(NextEvent.BLOCK);
+        final BlockingState stateB2 = new DefaultBlockingState(bundleId, BlockingStateType.SUBSCRIPTION_BUNDLE, "unblock", service, false, false, false, clock.getUTCNow());
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(ImmutableMap.<BlockingState, Optional<UUID>>of(stateB2, Optional.<UUID>absent()), internalCallContext);
+        assertListenerStatus();
+
+
+        List<BlockingState> states = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
+        Assert.assertEquals(states.size(), 5);
+
+
+        states = blockingStateDao.getBlockingActiveForAccount(catalog, internalCallContext);
+        Assert.assertEquals(states.size(), 2);
+
+    }
+
+
     @Test(groups = "slow", description = "Check BlockingStateDao with multiple services")
     public void testDaoWithMultipleServices() throws Exception {
         final UUID uuid = createAccount(getAccountData(1)).getId();

--- a/junction/src/main/java/org/killbill/billing/junction/plumbing/billing/BlockingCalculator.java
+++ b/junction/src/main/java/org/killbill/billing/junction/plumbing/billing/BlockingCalculator.java
@@ -92,7 +92,7 @@ public class BlockingCalculator {
         final Collection<BillingEvent> billingEventsToAdd = new TreeSet<BillingEvent>();
         final Collection<BillingEvent> billingEventsToRemove = new TreeSet<BillingEvent>();
 
-        final List<BlockingState> blockingEvents = blockingApi.getBlockingAllForAccount(catalog, context);
+        final List<BlockingState> blockingEvents = blockingApi.getBlockingActiveForAccount(catalog, context);
 
         // Group blocking states per type
         final Collection<BlockingState> accountBlockingEvents = new LinkedList<BlockingState>();

--- a/junction/src/main/java/org/killbill/billing/junction/plumbing/billing/BlockingCalculator.java
+++ b/junction/src/main/java/org/killbill/billing/junction/plumbing/billing/BlockingCalculator.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.CatalogApiException;
@@ -79,11 +80,13 @@ public class BlockingCalculator {
      * Given a set of billing events, add corresponding blocking (overdue) billing events.
      *
      * @param billingEvents the original list of billing events to update (without overdue events)
+     * @param cutoffDt an optional cutoffDt to filter out billing events
      */
     public boolean insertBlockingEvents(final SortedSet<BillingEvent> billingEvents,
                                         final Set<UUID> skippedSubscriptions,
                                         final Map<UUID, List<SubscriptionBase>> subscriptionsForAccount,
                                         final VersionedCatalog catalog,
+                                        @Nullable final LocalDate cutoffDt,
                                         final InternalTenantContext context) throws CatalogApiException {
         if (billingEvents.size() <= 0) {
             return false;
@@ -92,7 +95,7 @@ public class BlockingCalculator {
         final Collection<BillingEvent> billingEventsToAdd = new TreeSet<BillingEvent>();
         final Collection<BillingEvent> billingEventsToRemove = new TreeSet<BillingEvent>();
 
-        final List<BlockingState> blockingEvents = blockingApi.getBlockingActiveForAccount(catalog, context);
+        final List<BlockingState> blockingEvents = blockingApi.getBlockingActiveForAccount(catalog, cutoffDt, context);
 
         // Group blocking states per type
         final Collection<BlockingState> accountBlockingEvents = new LinkedList<BlockingState>();

--- a/junction/src/main/java/org/killbill/billing/junction/plumbing/billing/DefaultInternalBillingApi.java
+++ b/junction/src/main/java/org/killbill/billing/junction/plumbing/billing/DefaultInternalBillingApi.java
@@ -50,7 +50,6 @@ import org.killbill.billing.subscription.api.SubscriptionBase;
 import org.killbill.billing.subscription.api.SubscriptionBaseInternalApi;
 import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
-import org.killbill.billing.subscription.api.user.SubscriptionBaseBundle;
 import org.killbill.billing.subscription.api.user.SubscriptionBillingEvent;
 import org.killbill.billing.tag.TagInternalApi;
 import org.killbill.billing.util.UUIDs;
@@ -119,7 +118,7 @@ public class DefaultInternalBillingApi implements BillingInternalApi {
         // Pretty-print the events, before and after the blocking calculator does its magic
         final StringBuilder logStringBuilder = new StringBuilder("Computed billing events for accountId='").append(accountId).append("'");
         eventsToString(logStringBuilder, result);
-        if (blockCalculator.insertBlockingEvents(result, skippedSubscriptions, subscriptionsForAccount, fullCatalog, context)) {
+        if (blockCalculator.insertBlockingEvents(result, skippedSubscriptions, subscriptionsForAccount, fullCatalog, cutoffDt, context)) {
             logStringBuilder.append("\nBilling Events After Blocking");
             eventsToString(logStringBuilder, result);
         }
@@ -190,7 +189,6 @@ public class DefaultInternalBillingApi implements BillingInternalApi {
             if (dryRunArgumentsForBundle == null || dryRunArgumentsForBundle.getAction() == null) {
                 subscriptions = getSubscriptionsForAccountByBundleId(subscriptionsForAccount, bundleId);
             } else {
-                // TODO cutoffdt for dryRun ?
                 subscriptions = subscriptionApi.getSubscriptionsForBundle(bundleId, dryRunArgumentsForBundle, context);
             }
 
@@ -277,7 +275,7 @@ public class DefaultInternalBillingApi implements BillingInternalApi {
         final Map<UUID, Integer> bcdCache = new HashMap<UUID, Integer>();
 
         for (final SubscriptionBase subscription : subscriptions) {
-
+            // TODO Can we batch those ?
             final List<SubscriptionBillingEvent> billingTransitions = subscriptionApi.getSubscriptionBillingEvents(catalog, subscription, context);
             if (billingTransitions.isEmpty() ||
                 (billingTransitions.get(0).getType() != SubscriptionBaseTransitionType.CREATE &&

--- a/junction/src/test/java/org/killbill/billing/junction/plumbing/billing/TestBlockingCalculator.java
+++ b/junction/src/test/java/org/killbill/billing/junction/plumbing/billing/TestBlockingCalculator.java
@@ -155,7 +155,7 @@ public class TestBlockingCalculator extends JunctionTestSuiteNoDB {
                                                                                                                         blockingState2, Optional.<UUID>absent()),
                                                                          internalCallContext);
 
-        blockingCalculator.insertBlockingEvents(billingEvents, new HashSet<UUID>(), subscriptionsForAccount, catalog, internalCallContext);
+        blockingCalculator.insertBlockingEvents(billingEvents, new HashSet<UUID>(), subscriptionsForAccount, catalog, null, internalCallContext);
 
         assertEquals(billingEvents.size(), 7);
 
@@ -799,7 +799,7 @@ public class TestBlockingCalculator extends JunctionTestSuiteNoDB {
                                                                                                                         blockingState4, Optional.<UUID>absent()),
                                                                          internalCallContext);
 
-        blockingCalculator.insertBlockingEvents(billingEvents, new HashSet<UUID>(), subscriptionsForAccount, catalog, internalCallContext);
+        blockingCalculator.insertBlockingEvents(billingEvents, new HashSet<UUID>(), subscriptionsForAccount, catalog, null, internalCallContext);
 
         assertEquals(billingEvents.size(), 5);
         final List<BillingEvent> events = new ArrayList<BillingEvent>(billingEvents);

--- a/overdue/src/test/java/org/killbill/billing/overdue/glue/TestOverdueModule.java
+++ b/overdue/src/test/java/org/killbill/billing/overdue/glue/TestOverdueModule.java
@@ -101,7 +101,7 @@ public class TestOverdueModule extends DefaultOverdueModule {
         }
 
         @Override
-        public List<BlockingState> getBlockingAllForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
+        public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
             throw new UnsupportedOperationException();
         }
 

--- a/overdue/src/test/java/org/killbill/billing/overdue/glue/TestOverdueModule.java
+++ b/overdue/src/test/java/org/killbill/billing/overdue/glue/TestOverdueModule.java
@@ -21,6 +21,9 @@ package org.killbill.billing.overdue.glue;
 import java.util.List;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.VersionedCatalog;
@@ -101,7 +104,7 @@ public class TestOverdueModule extends DefaultOverdueModule {
         }
 
         @Override
-        public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, final InternalTenantContext context) {
+        public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, @Nullable final LocalDate cutoffDt, final InternalTenantContext context) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
Series of code optimization to avoid pulling too much state:
* In https://github.com/killbill/killbill/pull/1566/commits/46a5125ed6388f464603a0ba88c574033cf24004, we optimize junction code to pull less blocking states, i.e  the minimum required to compute the 'disable durations' per `{service, blocked_id}`
* In https://github.com/killbill/killbill/pull/1566/commits/d20365f38601885d9aeac84a489922642889f390, we avoid pulling all account bundles (independent of any optimization flags)
* In https://github.com/killbill/killbill/pull/1566/commits/e35ed5cd1a5def9ca1c56465f2f3f9639ea44d05, we propagate the `cutoffDt` to entitlement so that it can be used from this module as well (when the code again pulls all subscriptions).
* 
