### PR TITLE
server: support for encoded audit headers

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/filters/RequestDataFilter.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/filters/RequestDataFilter.java
@@ -18,8 +18,10 @@
 package org.killbill.billing.server.filters;
 
 import java.io.OutputStream;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 
 import javax.inject.Singleton;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -31,9 +33,13 @@ import org.glassfish.jersey.server.ContainerException;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.spi.ContainerResponseWriter;
+import org.killbill.billing.jaxrs.resources.JaxrsResource;
 import org.killbill.billing.util.UUIDs;
 import org.killbill.commons.request.Request;
 import org.killbill.commons.request.RequestData;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
 
 @Singleton
 public class RequestDataFilter implements ContainerRequestFilter, ContainerResponseFilter {
@@ -42,11 +48,46 @@ public class RequestDataFilter implements ContainerRequestFilter, ContainerRespo
 
     private static final String LEGACY_REQUEST_ID_HEADER = "X-Killbill-Request-Id-Req";
 
+    private static final String KILL_BILL_ENCODING_HEADER = "X-Killbill-Encoding";
+
     @Override
     public void filter(final ContainerRequestContext requestContext) {
         final List<String> requestIdHeaderRequests = getRequestId(requestContext);
         final String requestId = (requestIdHeaderRequests == null || requestIdHeaderRequests.isEmpty()) ? UUIDs.randomUUID().toString() : requestIdHeaderRequests.get(0);
         Request.setPerThreadRequestData(new RequestData(requestId));
+
+        final List<String> kbEncodingHeaders = requestContext.getHeaders().get(KILL_BILL_ENCODING_HEADER);
+        final String kbEncodingHeader = (kbEncodingHeaders == null || kbEncodingHeaders.isEmpty()) ? null : kbEncodingHeaders.get(0);
+        if (kbEncodingHeader != null) {
+            requestContext.getHeaders()
+                          .replaceAll(new BiFunction<String, List<String>, List<String>>() {
+                              @Override
+                              public List<String> apply(final String k, final List<String> v) {
+                                  if (k.equalsIgnoreCase(JaxrsResource.HDR_COMMENT) ||
+                                      k.equalsIgnoreCase(JaxrsResource.HDR_REASON) ||
+                                      k.equalsIgnoreCase(JaxrsResource.HDR_CREATED_BY)) {
+                                      return Lists.transform(v,
+                                                             new Function<String, String>() {
+                                                                 @Override
+                                                                 public String apply(final String input) {
+                                                                     if ("base64".equalsIgnoreCase(kbEncodingHeader)) {
+                                                                         try {
+                                                                             return new String(Base64.getDecoder().decode(input));
+                                                                         } catch (final IllegalArgumentException e) {
+                                                                             // Not Base64 after all? Be lenient...
+                                                                             return input;
+                                                                         }
+                                                                     } else {
+                                                                         return input;
+                                                                     }
+                                                                 }
+                                                             });
+                                  } else {
+                                      return v;
+                                  }
+                              }
+                          });
+        }
     }
 
     @Override

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccount.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccount.java
@@ -19,6 +19,8 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +31,7 @@ import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.client.KillBillClientException;
+import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.model.Accounts;
 import org.killbill.billing.client.model.AuditLogs;
 import org.killbill.billing.client.model.CustomFields;
@@ -40,6 +43,7 @@ import org.killbill.billing.client.model.gen.CustomField;
 import org.killbill.billing.client.model.gen.PaymentMethod;
 import org.killbill.billing.client.model.gen.PaymentMethodPluginDetail;
 import org.killbill.billing.client.model.gen.Tag;
+import org.killbill.billing.jaxrs.resources.JaxrsResource;
 import org.killbill.billing.osgi.api.OSGIServiceRegistration;
 import org.killbill.billing.payment.plugin.api.PaymentPluginApi;
 import org.killbill.billing.payment.provider.MockPaymentProviderPlugin;
@@ -51,6 +55,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.inject.Inject;
 
 import static org.testng.Assert.assertEquals;
@@ -84,6 +89,25 @@ public class TestAccount extends TestJaxrsBase {
         }
 
         mockPaymentProviderPlugin.clear();
+    }
+
+    @Test(groups = "slow", description = "Verify encoded headers")
+    public void testEncodedHeaders() throws Exception {
+        final String comment = "マリオありがとう！ しかし、私たちの王女は別の城にいます！";
+        final RequestOptions requestOptions = RequestOptions.builder()
+                                                            // All 3 headers will be decoded, so non encoded values might become corrupted (e.g. Toto -> Nh)
+                                                            .withCreatedBy(createdBy)
+                                                            .withReason(reason)
+                                                            .withComment(Base64.getEncoder().encodeToString(comment.getBytes(StandardCharsets.UTF_8)))
+                                                            .withHeader("X-Killbill-Encoding", "base64")
+                                                            .withFollowLocation(true)
+                                                            .withQueryParamsForFollow(ImmutableMultimap.of(JaxrsResource.QUERY_AUDIT, AuditLevel.MINIMAL.name()))
+                                                            .build();
+        final Account emptyAccount = new Account();
+
+        final Account account = accountApi.createAccount(emptyAccount, requestOptions);
+        Assert.assertNotNull(account.getExternalKey());
+        Assert.assertEquals(account.getAuditLogs().get(0).getComments(), comment);
     }
 
     @Test(groups = "slow", description = "Verify no PII data is required")


### PR DESCRIPTION
Support utf-8 characters in audit headers by allowing them to be sent encoded.

The header `X-Killbill-Encoding` must be specified (only base64 is supported at the moment).
