### PR TITLE
invoice: Add new config InvoiceConfig#isUsageMissingLenient

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1259,6 +1259,16 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         }
 
         @Override
+        public boolean isUsageMissingLenient() {
+            return defaultInvoiceConfig.isUsageMissingLenient();
+        }
+
+        @Override
+        public boolean isUsageMissingLenient(final InternalTenantContext tenantContext) {
+            return defaultInvoiceConfig.isUsageMissingLenient();
+        }
+
+        @Override
         public int getMaxDailyNumberOfItemsSafetyBound() {
             return defaultInvoiceConfig.getMaxDailyNumberOfItemsSafetyBound();
         }

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -85,6 +85,20 @@ public class MultiTenantInvoiceConfig extends MultiTenantConfigBase implements I
     }
 
     @Override
+    public boolean isUsageMissingLenient() {
+        return staticConfig.isUsageMissingLenient();
+    }
+
+    @Override
+    public boolean isUsageMissingLenient(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("isUsageMissingLenient", tenantContext);
+        if (result != null) {
+            return Boolean.parseBoolean(result);
+        }
+        return isUsageMissingLenient();
+    }
+
+    @Override
     public int getMaxDailyNumberOfItemsSafetyBound() {
         return staticConfig.getMaxDailyNumberOfItemsSafetyBound();
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalConsumableUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalConsumableUsageInArrear.java
@@ -224,8 +224,9 @@ public class ContiguousIntervalConsumableUsageInArrear extends ContiguousInterva
             // We generate an entry if we consumed anything on this tier or if this is the first tier to also support $0 Usage item
             if (hasPreviousUsage) {
                 final Long previousUsageQuantity = tierNum <= lastPreviousUsageTier ? previousUsage.get(tierNum - 1).getQuantity() : 0;
-                // Be lenient for dryRun use cases as we could have plugin optimizations not returning full usage data
-                if (!isDryRun) {
+                // Be lenient for dryRun use cases (as we could have plugin optimizations not returning full usage data) or unless configured.
+                if (!isDryRun &&
+                    !invoiceConfig.isUsageMissingLenient(internalTenantContext)) {
                     if (tierNum < lastPreviousUsageTier) {
                         Preconditions.checkState(nbUsedTierBlocks == previousUsageQuantity, String.format("Expected usage for subscription='%s', targetDate='%s', startDt='%s', endDt='%s', tier='%d', unit='%s' to be full, instead found units='[%d/%d]'",
                                                                                                           getSubscriptionId(), targetDate, startDate, endDate, tierNum, tieredBlock.getUnit().getName(), nbUsedTierBlocks, previousUsageQuantity));

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -72,6 +72,16 @@ public interface InvoiceConfig extends KillbillConfig {
     @Description("Whether we disable writing $0 usage amounts")
     boolean isUsageZeroAmountDisabled(@Param("dummy") final InternalTenantContext tenantContext);
 
+    @Config("org.killbill.invoice.usage.missing.lenient")
+    @Default("false")
+    @Description("Whether we fail invoice when we discover missing past usage records")
+    boolean isUsageMissingLenient();
+
+    @Config("org.killbill.invoice.usage.missing.lenient")
+    @Default("false")
+    @Description("Whether we fail invoice when we discover missing past usage records")
+    boolean isUsageMissingLenient(@Param("dummy") final InternalTenantContext tenantContext);
+
     @Config("org.killbill.invoice.maxDailyNumberOfItemsSafetyBound")
     @Default("15")
     @Description("Maximum daily number of invoice items to generate for a subscription id")


### PR DESCRIPTION
With this new config, we prevent failing invoice generation when past usage records seem missing