### PR TITLE
payment: fix race condition in on-the-fly Janitor

### DIFF
--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/control/DefaultControlInitiated.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/control/DefaultControlInitiated.java
@@ -126,7 +126,8 @@ public class DefaultControlInitiated implements LeavingStateCallback {
                     // the properties will be serialized in the enteringState callback (any plugin that sets a
                     // retried date is responsible to correctly remove sensitive information such as CVV, ...)
                     //
-                    final byte[] serializedProperties = PluginPropertySerializer.serialize(ImmutableList.<PluginProperty>of());
+                    // TODO Make this configurable (e.g. rejectList?)
+                    final byte[] serializedProperties = PluginPropertySerializer.serialize(stateContext.getProperties());
 
                     attempt = new PaymentAttemptModelDao(stateContext.getAccount().getId(), stateContext.getPaymentMethodId(),
                                                          utcNow, utcNow, stateContext.getPaymentExternalKey(), stateContext.getTransactionId(),


### PR DESCRIPTION
When running the on-the-fly Janitor while the onSuccessCalls of the initial payment control state machine haven't finished running yet, the plugin properties could have been wiped.

Draft PR as this is very much a conversation starter (we cannot just store the initial plugin properties, as it would introduce a regression for payment deployments).