### PR TITLE
invoice: Fix issue with invoice optimization (bill run scenario) in ca…

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -91,7 +91,8 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
                                                 final InternalCallContext internalCallContext) throws InvoiceApiException {
         final Multimap<UUID, LocalDate> createdItemsPerDayPerSubscription = LinkedListMultimap.<UUID, LocalDate>create();
 
-        final InvoicePruner invoicePruner = new InvoicePruner(existingInvoices.getInvoices());
+
+        final InvoicePruner invoicePruner = new InvoicePruner(existingInvoices);
         final Set<UUID> toBeIgnored = invoicePruner.getFullyRepairedItemsClosure();
         final AccountItemTree accountItemTree = new AccountItemTree(account.getId(), invoiceId);
         for (final Invoice invoice : existingInvoices.getInvoices()) {


### PR DESCRIPTION
…se of repair in new invoice.

The InvoicePruner is now aware of the optmization being ON and instead of throwing an illegal state when discovering
a dangling `REPAIR` item, it simply discards it.