### PR TITLE
Changes for cancel and changePlan processing

### DIFF
--- a/api/src/main/java/org/killbill/billing/subscription/api/SubscriptionBase.java
+++ b/api/src/main/java/org/killbill/billing/subscription/api/SubscriptionBase.java
@@ -84,6 +84,8 @@ public interface SubscriptionBase extends Entity, Blockable {
     public DateTime getEndDate();
 
     public DateTime getFutureEndDate();
+    
+    public DateTime getFutureExpiryDate();
 
     public Plan getCurrentPlan();
 

--- a/catalog/src/test/resources/org/killbill/billing/catalog/catalogTest.xml
+++ b/catalog/src/test/resources/org/killbill/billing/catalog/catalogTest.xml
@@ -164,8 +164,8 @@
                 <alignment>CHANGE_OF_PLAN</alignment>
             </changeAlignmentCase>
             <changeAlignmentCase>
-                <fromProduct>Blowdart</fromProduct>
-                <toProduct>Pistol</toProduct>
+                <fromPriceList>notrial</fromPriceList>
+                <toPriceList>fixedTerm</toPriceList>
                 <alignment>CHANGE_OF_PLAN</alignment>
             </changeAlignmentCase>
             <changeAlignmentCase>

--- a/catalog/src/test/resources/org/killbill/billing/catalog/catalogTest.xml
+++ b/catalog/src/test/resources/org/killbill/billing/catalog/catalogTest.xml
@@ -164,6 +164,11 @@
                 <alignment>CHANGE_OF_PLAN</alignment>
             </changeAlignmentCase>
             <changeAlignmentCase>
+                <fromProduct>Blowdart</fromProduct>
+                <toProduct>Pistol</toProduct>
+                <alignment>CHANGE_OF_PLAN</alignment>
+            </changeAlignmentCase>
+            <changeAlignmentCase>
                 <alignment>START_OF_SUBSCRIPTION</alignment>
             </changeAlignmentCase>
         </changeAlignment>
@@ -541,6 +546,32 @@
                 <duration>
                     <unit>MONTHS</unit>
                     <number>12</number>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>29.95</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>29.95</value>
+                        </price>
+                        <price>
+                            <currency>USD</currency>
+                            <value>29.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        <plan name="pistol-monthly-fixedterm-no-trial-8-months">
+            <product>Pistol</product>
+            <finalPhase type="FIXEDTERM">
+                <duration>
+                    <unit>MONTHS</unit>
+                    <number>8</number>
                 </duration>
                 <recurring>
                     <billingPeriod>MONTHLY</billingPeriod>
@@ -1790,6 +1821,7 @@
                 <plan>pistol-monthly-discount-and-fixedterm</plan>
                 <plan>pistol-monthly-fixedterm-and-evergreen</plan>
                 <plan>pistol-monthly-fixedterm-no-trial</plan>
+                <plan>pistol-monthly-fixedterm-no-trial-8-months</plan>
                 <plan>knife-monthly-fixedterm</plan>
             </plans>
         </childPriceList>

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -266,6 +266,24 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
         }
         return null;
     }
+    
+    @Override
+    public DateTime getFutureExpiryDate() {
+        if (transitions == null) {
+            return null;
+        }
+
+        final SubscriptionBaseTransitionDataIterator it = new SubscriptionBaseTransitionDataIterator(
+                clock, transitions, Order.ASC_FROM_PAST,
+                Visibility.ALL, TimeLimit.FUTURE_ONLY);
+        while (it.hasNext()) {
+            final SubscriptionBaseTransition cur = it.next();
+            if (cur.getTransitionType() == SubscriptionBaseTransitionType.EXPIRED) {
+                return cur.getEffectiveTransitionTime();
+            }
+        }
+        return null;
+    }    
 
     @Override
     public boolean cancel(final CallContext context) throws SubscriptionBaseApiException {

--- a/util/src/test/java/org/killbill/billing/mock/MockSubscription.java
+++ b/util/src/test/java/org/killbill/billing/mock/MockSubscription.java
@@ -208,6 +208,11 @@ public class MockSubscription implements SubscriptionBase {
     public DateTime getFutureEndDate() {
         return sub.getFutureEndDate();
     }
+    
+    @Override
+    public DateTime getFutureExpiryDate() {
+        return sub.getFutureExpiryDate();
+    }    
 
     @Override
     public EntitlementSourceType getSourceType() {


### PR DESCRIPTION
Changes for cancelPlan and changePlan processing. A few notes:

1. I've assumed that it should not be possible to cancel an expired subscription or change plan once a subscription is expired since this is in line with how cancel behaves (that is it is not possible to cancel/change a plan for a canceled subscription).
2. `cancel` require a number of tests for various scenarios (`cancel`, `cancelWithDate`, `cancelWithPolicy`, `cancelBeforeFixedTermExpiry`, `cancelAfterFixedTermExpiry`, `cancelSubscriptionWithAddOn` to name just a few). The same goes for change plan. For now, I've written only a subset of these tests in `TestUserApiExpire`. Let me know if you think we need more tests to cover some of the above scenarios and/or other scenarios that I may have missed.
1. For plan change, I've only written tests for `START_OF_SUBSCRIPTION` and` START_OF_PLAN` alignments since these seem like the most common change alignment cases. Let me know if more tests are needed for the other types of alignments. 