### PR TITLE
subscription, jaxrs: Provide a (hacky) way to specify Subscription keys during transfer. See #1627

### DIFF
--- a/api/src/main/java/org/killbill/billing/subscription/api/transfer/SubscriptionBaseTransferApi.java
+++ b/api/src/main/java/org/killbill/billing/subscription/api/transfer/SubscriptionBaseTransferApi.java
@@ -16,6 +16,7 @@
 
 package org.killbill.billing.subscription.api.transfer;
 
+import java.util.Map;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -32,6 +33,7 @@ public interface SubscriptionBaseTransferApi {
      * @param sourceAccountId   the unique id for the account on which the bundle will be transferred from
      * @param destAccountId     the unique id for the account on which the bundle will be transferred to
      * @param bundleKey         the externalKey for the bundle
+     * @param subExtKeysMap     a map for all new subscription external Keys
      * @param requestedDate     the date at which this transfer should occur
      * @param transferAddOn     whether or not we should also transfer ADD_ON subscriptions existing on that {@code SubscriptionBaseBundle}
      * @param cancelImmediately whether cancellation on the sourceAccount occurs immediately
@@ -40,7 +42,7 @@ public interface SubscriptionBaseTransferApi {
      * @throws SubscriptionBaseTransferApiException
      *          if the system could not transfer the {@code SubscriptionBaseBundle}
      */
-    public SubscriptionBaseBundle transferBundle(final UUID sourceAccountId, final UUID destAccountId, final String bundleKey, final DateTime requestedDate,
-                                             final boolean transferAddOn, final boolean cancelImmediately, final CallContext context)
+    public SubscriptionBaseBundle transferBundle(final UUID sourceAccountId, final UUID destAccountId, final String bundleKey, final Map<UUID, String> subExtKeysMap, final DateTime requestedDate,
+                                                 final boolean transferAddOn, final boolean cancelImmediately, final CallContext context)
             throws SubscriptionBaseTransferApiException;
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestBundleTransfer.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestBundleTransfer.java
@@ -19,6 +19,8 @@
 package org.killbill.billing.beatrix.integration;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -82,7 +84,7 @@ public class TestBundleTransfer extends TestIntegrationBase {
         final Account newAccount = createAccountWithNonOsgiPaymentMethod(getAccountData(17));
 
         busHandler.pushExpectedEvents(NextEvent.TRANSFER, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        transferApi.transferBundle(account.getId(), newAccount.getId(), "externalKey", clock.getUTCNow(), false, false, callContext);
+        transferApi.transferBundle(account.getId(), newAccount.getId(), "externalKey", Collections.emptyMap(), clock.getUTCNow(), false, false, callContext);
         assertListenerStatus();
 
         final List<Invoice> invoices = invoiceUserApi.getInvoicesByAccount(newAccount.getId(), false, false, callContext);
@@ -128,7 +130,7 @@ public class TestBundleTransfer extends TestIntegrationBase {
         final Account newAccount = createAccountWithNonOsgiPaymentMethod(getAccountData(0));
 
         busHandler.pushExpectedEvents(NextEvent.TRANSFER, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        transferApi.transferBundle(account.getId(), newAccount.getId(), "externalKey", clock.getUTCNow(), false, false, callContext);
+        transferApi.transferBundle(account.getId(), newAccount.getId(), "externalKey", Collections.emptyMap(), clock.getUTCNow(), false, false, callContext);
         assertListenerStatus();
 
         // Verify the BCD of the new account
@@ -184,7 +186,7 @@ public class TestBundleTransfer extends TestIntegrationBase {
         final Account newAccount = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
 
         busHandler.pushExpectedEvents(NextEvent.CANCEL, NextEvent.TRANSFER, NextEvent.INVOICE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        transferApi.transferBundle(account.getId(), newAccount.getId(), "externalKey", clock.getUTCNow(), false, true, callContext);
+        transferApi.transferBundle(account.getId(), newAccount.getId(), "externalKey", Collections.emptyMap(), clock.getUTCNow(), false, true, callContext);
         assertListenerStatus();
 
         List<Invoice> invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, callContext);

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlementApiFast.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlementApiFast.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.killbill.billing.entitlement.EntitlementTestSuiteNoDB;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.jackson.ObjectMapper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestDefaultEntitlementApiFast extends EntitlementTestSuiteNoDB {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test(groups = "fast", description = "Test bundle transfer property deserialization")
+    public void testBundleTransferRegex() throws Exception {
+        final List<PluginProperty> props = new ArrayList<PluginProperty>();
+        props.add(new PluginProperty("foo", "bar", false));
+        props.add(new PluginProperty("177be083-e56f-4505-87ba-e5d306c5e8bf", "bar", false));
+        props.add(new PluginProperty("KB_SUB_ID_fca6f8b9-eee3-433e-a5ef-5653afce4594", "value1", false));
+        props.add(new PluginProperty("KB_SUB_ID_6b00a69b-27e7-4675-bca2-8ad1cf5e533e", "value2", false));
+
+        final Map<UUID, String> res = DefaultEntitlementApi.toSubExtKeysMap(props);
+        Assert.assertEquals(res.size(), 2);
+        Assert.assertEquals(res.get(UUID.fromString("fca6f8b9-eee3-433e-a5ef-5653afce4594")), "value1");
+        Assert.assertEquals(res.get(UUID.fromString("6b00a69b-27e7-4675-bca2-8ad1cf5e533e")), "value2");
+    }
+
+}

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestBundle.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestBundle.java
@@ -18,7 +18,9 @@
 
 package org.killbill.billing.jaxrs;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -127,10 +129,13 @@ public class TestBundle extends TestJaxrsBase {
 
         final Account newAccount = createAccountWithDefaultPaymentMethod();
 
+        final Map<String, String> props = new HashMap<>();
+        final String subKey = String.format("KB_SUB_ID_%s", entitlementJsonNoEvents.getSubscriptionId());
+        props.put(subKey, "new-sub-key");
         final Bundle bundle = new Bundle();
         bundle.setAccountId(newAccount.getAccountId());
         bundle.setBundleId(entitlementJsonNoEvents.getBundleId());
-        bundleApi.transferBundle(entitlementJsonNoEvents.getBundleId(), bundle, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        bundleApi.transferBundle(entitlementJsonNoEvents.getBundleId(), bundle, null, props, requestOptions);
 
         existingBundles = bundleApi.getBundleByKey(bundleExternalKey, requestOptions);
         assertEquals(existingBundles.size(), 1);
@@ -138,6 +143,8 @@ public class TestBundle extends TestJaxrsBase {
         assertNotEquals(newBundle.getBundleId(), originalBundle.getBundleId());
         assertEquals(newBundle.getExternalKey(), originalBundle.getExternalKey());
         assertEquals(newBundle.getAccountId(), newAccount.getAccountId());
+        assertEquals(newBundle.getSubscriptions().size(), 1);
+        assertEquals(newBundle.getSubscriptions().get(0).getExternalKey(), "new-sub-key");
 
         final Bundles bundles = bundleApi.getBundleByKey(bundleExternalKey, true, AuditLevel.NONE, requestOptions);
         assertEquals(bundles.size(), 2);

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/transfer/DefaultSubscriptionBaseTransferApi.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/transfer/DefaultSubscriptionBaseTransferApi.java
@@ -20,6 +20,7 @@ package org.killbill.billing.subscription.api.transfer;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -175,7 +176,8 @@ public class DefaultSubscriptionBaseTransferApi extends SubscriptionApiBase impl
 
     @Override
     public SubscriptionBaseBundle transferBundle(final UUID sourceAccountId, final UUID destAccountId,
-                                                 final String bundleKey, final DateTime transferDate, final boolean transferAddOn,
+                                                 final String bundleKey, final Map<UUID, String> subExtKeysMap,
+                                                 final DateTime transferDate, final boolean transferAddOn,
                                                  final boolean cancelImmediately, final CallContext context) throws SubscriptionBaseTransferApiException {
         final InternalCallContext fromInternalCallContext = internalCallContextFactory.createInternalCallContext(sourceAccountId, context);
         final InternalCallContext toInternalCallContext = internalCallContextFactory.createInternalCallContext(destAccountId, context);
@@ -242,11 +244,15 @@ public class DefaultSubscriptionBaseTransferApi extends SubscriptionApiBase impl
                     bundleStartdate = oldSubscription.getStartDate();
                 }
 
+
+                // Use any key provided from the map subExtKeysMap
+                final String subExtKey = subExtKeysMap.get(oldSubscription.getId());
                 // Create the new subscription for the new bundle on the new account
                 final DefaultSubscriptionBase defaultSubscriptionBase = createSubscriptionForApiUse(new SubscriptionBuilder()
                                                                                                             .setId(UUIDs.randomUUID())
                                                                                                             .setBundleId(subscriptionBundleData.getId())
                                                                                                             .setBundleExternalKey(subscriptionBundleData.getExternalKey())
+                                                                                                            .setExternalKey(subExtKey)
                                                                                                             .setCategory(productCategory)
                                                                                                             .setBundleStartDate(effectiveTransferDate)
                                                                                                             .setAlignStartDate(subscriptionAlignStartDate),

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
@@ -392,6 +392,9 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
             @Override
             public DefaultSubscriptionBase inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
                 final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getSubscriptionByExternalKey(externalKey, context);
+                if (subscriptionModel == null) {
+                    return null;
+                }
                 final SubscriptionBundleModelDao bundleModel = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getById(subscriptionModel.getBundleId().toString(), context);
                 return SubscriptionModelDao.toSubscription(subscriptionModel, bundleModel.getExternalKey());
             }

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/transfer/TestTransfer.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/transfer/TestTransfer.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.subscription.api.transfer;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -94,7 +95,7 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
 
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
         testListener.pushExpectedEvent(NextEvent.CANCEL);
-        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), transferRequestedDate, false, false, callContext);
+        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), new HashMap<>(), transferRequestedDate, false, false, callContext);
         assertListenerStatus();
         final DateTime afterTransferDate = clock.getUTCNow();
 
@@ -143,7 +144,7 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
 
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
         final DateTime transferRequestedDate = clock.getUTCNow();
-        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), transferRequestedDate, false, false, callContext);
+        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), new HashMap<>(), transferRequestedDate, false, false, callContext);
         assertListenerStatus();
 
         // CHECK OLD BASE IS CANCEL AT THE TRANSFER DATE
@@ -190,7 +191,7 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
         final DateTime transferRequestedDate = clock.getUTCNow();
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
         testListener.pushExpectedEvent(NextEvent.CANCEL);
-        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), transferRequestedDate, false, false, callContext);
+        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), new HashMap<>(), transferRequestedDate, false, false, callContext);
         assertListenerStatus();
         final DateTime afterTransferDate = clock.getUTCNow();
 
@@ -239,7 +240,7 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
 
         final DateTime transferRequestedDate = clock.getUTCNow();
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
-        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), transferRequestedDate, false, false, callContext);
+        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), new HashMap<>(), transferRequestedDate, false, false, callContext);
         assertListenerStatus();
 
         // CHECK OLD BASE IS CANCEL AT THE TRANSFER DATE
@@ -333,11 +334,16 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
         final DateTime ctd = baseSubscription.getStartDate().plusDays(30).plusMonths(1);
         setChargedThroughDate(baseSubscription.getId(), ctd, internalCallContext);
 
+        final HashMap<UUID, String> subExtKeysMap = new HashMap<>();
+        subExtKeysMap.put(baseSubscription.getId(), "new-base-key");
+        subExtKeysMap.put(aoSubscription1.getId(), "new-ao1-key");
+        subExtKeysMap.put(aoSubscription2.getId(), "new-ao2-key");
+
         final DateTime transferRequestedDate = clock.getUTCNow();
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
-        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), transferRequestedDate, true, false, callContext);
+        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), subExtKeysMap, transferRequestedDate, true, false, callContext);
         assertListenerStatus();
 
         // RETRIEVE NEW BUNDLE AND CHECK SUBSCRIPTIONS
@@ -347,31 +353,35 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
         final SubscriptionBaseBundle newBundle = bundlesForAccountAndKey.get(0);
         final List<SubscriptionBase> subscriptions = subscriptionInternalApi.getSubscriptionsForBundle(newBundle.getId(), null, internalCallContext);
         assertEquals(subscriptions.size(), 3);
-        boolean foundBP = false;
-        boolean foundAO1 = false;
-        boolean foundAO2 = false;
+
+        SubscriptionBase newBaseSubscription = null;
+        SubscriptionBase newAoSubscription1 = null;
+        SubscriptionBase newAoSubscription2 = null;
         for (final SubscriptionBase cur : subscriptions) {
             final Plan curPlan = cur.getCurrentPlan();
             final Product curProduct = curPlan.getProduct();
             if (curProduct.getName().equals(baseProduct)) {
-                foundBP = true;
+                newBaseSubscription = cur;
                 assertTrue(((DefaultSubscriptionBase) cur).getAlignStartDate().compareTo(((DefaultSubscriptionBase) baseSubscription).getAlignStartDate()) == 0);
                 assertNull(cur.getPendingTransition());
+                assertEquals(cur.getExternalKey(), "new-base-key");
             } else if (curProduct.getName().equals(aoProduct1)) {
-                foundAO1 = true;
+                newAoSubscription1 = cur;
                 assertTrue(((DefaultSubscriptionBase) cur).getAlignStartDate().compareTo((aoSubscription1).getAlignStartDate()) == 0);
                 assertNull(cur.getPendingTransition());
+                assertEquals(cur.getExternalKey(), "new-ao1-key");
             } else if (curProduct.getName().equals(aoProduct2)) {
-                foundAO2 = true;
+                newAoSubscription2 = cur;
                 assertTrue(((DefaultSubscriptionBase) cur).getAlignStartDate().compareTo((aoSubscription2).getAlignStartDate()) == 0);
                 assertNotNull(cur.getPendingTransition());
+                assertEquals(cur.getExternalKey(), "new-ao2-key");
             } else {
                 Assert.fail("Unexpected product " + curProduct.getName());
             }
         }
-        assertTrue(foundBP);
-        assertTrue(foundAO1);
-        assertTrue(foundAO2);
+        assertNotNull(newBaseSubscription);
+        assertNotNull(newAoSubscription1);
+        assertNotNull(newAoSubscription2);
 
         // MOVE AFTER CANCEL DATE TO TRIGGER OLD SUBSCRIPTIONS CANCELLATION + LASER_SCOPE PHASE EVENT
         testListener.pushExpectedEvents(NextEvent.PHASE, NextEvent.PHASE);
@@ -382,13 +392,38 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
         assertListenerStatus();
 
         // ISSUE ANOTHER TRANSFER TO CHECK THAT WE CAN TRANSFER AGAIN-- NOTE WILL NOT WORK ON PREVIOUS ACCOUNT (LIMITATION)
+
+        subExtKeysMap.clear();
+        subExtKeysMap.put(newBaseSubscription.getId(), "latest-base-key");
+        subExtKeysMap.put(newAoSubscription1.getId(), "latest-ao1-key");
+        subExtKeysMap.put(newAoSubscription2.getId(), "latest-ao2-key");
+
         final DateTime newTransferRequestedDate = clock.getUTCNow();
         testListener.pushExpectedEvent(NextEvent.CANCEL);
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
-        transferApi.transferBundle(newBundle.getAccountId(), finalNewAccountId, newBundle.getExternalKey(), newTransferRequestedDate, true, false, callContext);
+        transferApi.transferBundle(newBundle.getAccountId(), finalNewAccountId, newBundle.getExternalKey(), subExtKeysMap, newTransferRequestedDate, true, false, callContext);
         assertListenerStatus();
+
+        final List<SubscriptionBaseBundle> latestBundlesForAccountAndKey = subscriptionInternalApi.getBundlesForAccountAndKey(finalNewAccountId, newBundle.getExternalKey(), internalCallContext);
+        assertEquals(latestBundlesForAccountAndKey.size(), 1);
+
+        final SubscriptionBaseBundle latestSubscriptionBundle = latestBundlesForAccountAndKey.get(0);
+        final List<SubscriptionBase> latestSubscriptions = subscriptionInternalApi.getSubscriptionsForBundle(latestSubscriptionBundle.getId(), null, internalCallContext);
+        assertEquals(latestSubscriptions.size(), 3);
+
+        final SubscriptionBase latestBaseSubscription = subscriptionInternalApi.getSubscriptionFromExternalKey("latest-base-key", internalCallContext);
+        assertNotNull(latestBaseSubscription);
+        assertEquals(latestBaseSubscription.getBundleId(), latestSubscriptionBundle.getId());
+
+        final SubscriptionBase latestAoSubscription1 = subscriptionInternalApi.getSubscriptionFromExternalKey("latest-ao1-key", internalCallContext);
+        assertNotNull(latestAoSubscription1);
+        assertEquals(latestAoSubscription1.getBundleId(), latestSubscriptionBundle.getId());
+
+        final SubscriptionBase latestAoSubscription2 = subscriptionInternalApi.getSubscriptionFromExternalKey("latest-ao2-key", internalCallContext);
+        assertNotNull(latestAoSubscription2);
+        assertEquals(latestAoSubscription2.getBundleId(), latestSubscriptionBundle.getId());
     }
 
     @Test(groups = "slow")
@@ -428,7 +463,7 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
 
         final DateTime transferRequestedDate = clock.getUTCNow();
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
-        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), transferRequestedDate, true, false, callContext);
+        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), new HashMap<>(), transferRequestedDate,  true, false, callContext);
         assertListenerStatus();
 
         final List<SubscriptionBaseBundle> bundlesForAccountAndKey = subscriptionInternalApi.getBundlesForAccountAndKey(newAccountId, bundle.getExternalKey(), internalCallContext);
@@ -470,7 +505,7 @@ public class TestTransfer extends SubscriptionTestSuiteWithEmbeddedDB {
         clock.addDays(1);
         final DateTime transferRequestedDate = clock.getUTCNow();
         testListener.pushExpectedEvent(NextEvent.TRANSFER);
-        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), transferRequestedDate, true, false, callContext);
+        transferApi.transferBundle(bundle.getAccountId(), newAccountId, bundle.getExternalKey(), new HashMap<>(), transferRequestedDate, true, false, callContext);
         assertListenerStatus();
 
         final List<SubscriptionBaseBundle> bundlesForAccountAndKey = subscriptionInternalApi.getBundlesForAccountAndKey(newAccountId, bundle.getExternalKey(), internalCallContext);


### PR DESCRIPTION

Because of apis restrictions, we rely on plugin properties to pass this information.

The format of the (plugin properties) keys is undocumented and is subject to change in future releases; it is namespaced with `KB_` to minimize collisions with possible use cases of entitlement plugin using their own keys.

Proper fix will be introduced in `0.24` release.