### PR TITLE
1615 killbill catalog

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -39,12 +39,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <!-- Required scope for the maven shade plugin (tools) -->
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>provided</scope>

--- a/catalog/src/main/java/org/killbill/billing/catalog/CatalogEntityCollection.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/CatalogEntityCollection.java
@@ -22,31 +22,30 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
 
 import org.killbill.billing.catalog.api.CatalogEntity;
 
-import com.google.common.collect.Ordering;
-
 public class CatalogEntityCollection<T extends CatalogEntity> implements Collection<T>, Externalizable {
 
     private final Map<String, T> data;
 
     public CatalogEntityCollection() {
-        this.data = new TreeMap<String, T>(Ordering.<String>natural());
+        this.data = new TreeMap<String, T>(Comparator.naturalOrder());
     }
 
     public CatalogEntityCollection(final T[] entities) {
-        this.data = new TreeMap<String, T>(Ordering.<String>natural());
+        this.data = new TreeMap<String, T>(Comparator.naturalOrder());
         for (final T cur : entities) {
             addEntry(cur);
         }
     }
 
     public CatalogEntityCollection(final Iterable<T> entities) {
-        this.data = new TreeMap<String, T>(Ordering.<String>natural());
+        this.data = new TreeMap<String, T>(Comparator.naturalOrder());
         for (final T cur : entities) {
             addEntry(cur);
         }

--- a/catalog/src/main/java/org/killbill/billing/catalog/CatalogUpdater.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/CatalogUpdater.java
@@ -19,6 +19,7 @@ package org.killbill.billing.catalog;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
+import java.util.Collections;
 
 import javax.xml.bind.JAXBException;
 
@@ -51,8 +52,6 @@ import org.killbill.xmlloader.ValidationException;
 import org.killbill.xmlloader.XMLLoader;
 import org.killbill.xmlloader.XMLWriter;
 
-import com.google.common.collect.ImmutableList;
-
 public class CatalogUpdater {
 
     public static String DEFAULT_CATALOG_NAME = "DEFAULT";
@@ -83,8 +82,8 @@ public class CatalogUpdater {
                 .setCatalogName(DEFAULT_CATALOG_NAME)
                 .setEffectiveDate(effectiveDate.toDate())
                 .setRecurringBillingMode(BillingMode.IN_ADVANCE)
-                .setProducts(ImmutableList.<Product>of())
-                .setPlans(ImmutableList.<Plan>of())
+                .setProducts(Collections.emptyList())
+                .setPlans(Collections.emptyList())
                 .setPriceLists(new DefaultPriceListSet(defaultPriceList, new DefaultPriceList[0]))
                 .setPlanRules(getSaneDefaultPlanRules(defaultPriceList));
         if (currencies != null && currencies.length > 0) {

--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultCatalogService.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultCatalogService.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.catalog;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.killbill.billing.callcontext.InternalTenantContext;
@@ -36,8 +37,6 @@ import org.killbill.billing.tenant.api.TenantKV.TenantKey;
 import org.killbill.billing.util.config.definition.CatalogConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.inject.Inject;
 
 public class DefaultCatalogService implements KillbillService, CatalogService {
 

--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultTier.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultTier.java
@@ -41,9 +41,6 @@ import org.killbill.xmlloader.ValidatingConfig;
 import org.killbill.xmlloader.ValidationError;
 import org.killbill.xmlloader.ValidationErrors;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-
 @XmlAccessorType(XmlAccessType.NONE)
 public class DefaultTier extends ValidatingConfig<StandaloneCatalog> implements Tier, Externalizable {
 
@@ -79,15 +76,13 @@ public class DefaultTier extends ValidatingConfig<StandaloneCatalog> implements 
         for (int i = 0; i < in.getTieredBlocks().length; i++) {
             if (override != null && override.getTieredBlockPriceOverrides() != null) {
                 final TieredBlock curTieredBlock = in.getTieredBlocks()[i];
-                final TieredBlockPriceOverride overriddenTierBlock = Iterables.tryFind(override.getTieredBlockPriceOverrides(), new Predicate<TieredBlockPriceOverride>() {
-                    @Override
-                    public boolean apply(final TieredBlockPriceOverride input) {
-                        return (input != null && input.getUnitName().equals(curTieredBlock.getUnit().getName()) &&
-                                (input.getSize().compareTo(curTieredBlock.getSize()) == 0) &&
-                                (input.getMax().compareTo(curTieredBlock.getMax()) == 0));
-                    }
-
-                }).orNull();
+                final TieredBlockPriceOverride overriddenTierBlock = override
+                        .getTieredBlockPriceOverrides()
+                        .stream()
+                        .filter(input -> (input != null && input.getUnitName().equals(curTieredBlock.getUnit().getName()) &&
+                                          (input.getSize().compareTo(curTieredBlock.getSize()) == 0) &&
+                                          (input.getMax().compareTo(curTieredBlock.getMax()) == 0)))
+                        .findFirst().orElse(null);
                 blocks[i] = (overriddenTierBlock != null) ? new DefaultTieredBlock(in.getTieredBlocks()[i], overriddenTierBlock, currency) :
                             (DefaultTieredBlock) in.getTieredBlocks()[i];
             } else {

--- a/catalog/src/main/java/org/killbill/billing/catalog/caching/DefaultCatalogCache.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/caching/DefaultCatalogCache.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.catalog.caching;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -38,7 +39,8 @@ import org.killbill.billing.catalog.plugin.VersionedCatalogMapper;
 import org.killbill.billing.catalog.plugin.api.CatalogPluginApi;
 import org.killbill.billing.catalog.plugin.api.VersionedPluginCatalog;
 import org.killbill.billing.osgi.api.OSGIServiceRegistration;
-import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.Preconditions;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 import org.killbill.billing.util.cache.Cachable.CacheType;
 import org.killbill.billing.util.cache.CacheController;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
@@ -48,10 +50,6 @@ import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 public class DefaultCatalogCache implements CatalogCache {
 
@@ -157,7 +155,7 @@ public class DefaultCatalogCache implements CatalogCache {
             // As a guideline, if plugin keeps seeing new Plans/Products, this can all fit into the same version; however if there is a true versioning
             // (e.g deleted Plans...), then multiple versions must be returned.
             //
-            final DateTime latestCatalogUpdatedDate = plugin.getLatestCatalogVersion(ImmutableList.<PluginProperty>of(), tenantContext);
+            final DateTime latestCatalogUpdatedDate = plugin.getLatestCatalogVersion(Collections.emptyList(), tenantContext);
             // A null latestCatalogUpdatedDate bypasses caching, by fetching full catalog from plugin below (compatibility mode with 0.18.x or non optimized plugin api mode)
             final boolean cacheable = latestCatalogUpdatedDate != null;
             if (cacheable) {
@@ -170,7 +168,7 @@ public class DefaultCatalogCache implements CatalogCache {
                 }
             }
 
-            final VersionedPluginCatalog pluginCatalog = plugin.getVersionedPluginCatalog(ImmutableList.<PluginProperty>of(), tenantContext);
+            final VersionedPluginCatalog pluginCatalog = plugin.getVersionedPluginCatalog(Collections.emptyList(), tenantContext);
             // First plugin that gets something (for that tenant) returns it
             if (pluginCatalog != null) {
                 // The log entry is only interesting if there are multiple plugins

--- a/catalog/src/main/java/org/killbill/billing/catalog/caching/DefaultOverriddenPlanCache.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/caching/DefaultOverriddenPlanCache.java
@@ -17,7 +17,6 @@
 
 package org.killbill.billing.catalog.caching;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,9 +52,6 @@ import org.killbill.billing.util.cache.CacheController;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.cache.CacheLoaderArgument;
 import org.killbill.billing.util.cache.OverriddenPlanCacheLoader.LoaderCallback;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 
 public class DefaultOverriddenPlanCache implements OverriddenPlanCache {
 
@@ -119,17 +115,13 @@ public class DefaultOverriddenPlanCache implements OverriddenPlanCache {
     }
 
     private PlanPhasePriceOverride[] createOverrides(final Plan defaultPlan, final List<CatalogOverridePhaseDefinitionModelDao> phaseDefs, final InternalTenantContext context) {
-
         final PlanPhasePriceOverride[] result = new PlanPhasePriceOverride[defaultPlan.getAllPhases().length];
 
         for (int i = 0; i < defaultPlan.getAllPhases().length; i++) {
             final PlanPhase curPhase = defaultPlan.getAllPhases()[i];
-            final CatalogOverridePhaseDefinitionModelDao overriddenPhase = Iterables.tryFind(phaseDefs, new Predicate<CatalogOverridePhaseDefinitionModelDao>() {
-                @Override
-                public boolean apply(final CatalogOverridePhaseDefinitionModelDao input) {
-                    return input.getParentPhaseName().equals(curPhase.getName());
-                }
-            }).orNull();
+            final CatalogOverridePhaseDefinitionModelDao overriddenPhase = phaseDefs.stream()
+                    .filter(input -> input.getParentPhaseName().equals(curPhase.getName()))
+                    .findFirst().orElse(null);
 
             if (overriddenPhase != null) {
                 List<UsagePriceOverride> usagePriceOverrides = getUsagePriceOverrides(curPhase, overriddenPhase, context);
@@ -143,17 +135,14 @@ public class DefaultOverriddenPlanCache implements OverriddenPlanCache {
 
     List<UsagePriceOverride> getUsagePriceOverrides(PlanPhase curPhase, CatalogOverridePhaseDefinitionModelDao overriddenPhase, final InternalTenantContext context) {
 
-        final List<UsagePriceOverride> usagePriceOverrides = new ArrayList<UsagePriceOverride>();
+        final List<UsagePriceOverride> usagePriceOverrides = new ArrayList<>();
         final List<CatalogOverrideUsageDefinitionModelDao> usageDefs = overrideDao.getOverriddenPhaseUsages(overriddenPhase.getRecordId(), context);
 
         for (int i = 0; i < curPhase.getUsages().length; i++) {
             final Usage curUsage = curPhase.getUsages()[i];
-            final CatalogOverrideUsageDefinitionModelDao overriddenUsage = Iterables.tryFind(usageDefs, new Predicate<CatalogOverrideUsageDefinitionModelDao>() {
-                @Override
-                public boolean apply(final CatalogOverrideUsageDefinitionModelDao input) {
-                    return input.getParentUsageName().equals(curUsage.getName());
-                }
-            }).orNull();
+            final CatalogOverrideUsageDefinitionModelDao overriddenUsage = usageDefs.stream()
+                    .filter(input -> input.getParentUsageName().equals(curUsage.getName()))
+                    .findFirst().orElse(null);
 
             if (overriddenUsage != null) {
                 List<TierPriceOverride> tierPriceOverrides = getTierPriceOverrides(curUsage, overriddenUsage, context);
@@ -165,32 +154,30 @@ public class DefaultOverriddenPlanCache implements OverriddenPlanCache {
 
     List<TierPriceOverride> getTierPriceOverrides(Usage curUsage, CatalogOverrideUsageDefinitionModelDao overriddenUsage, final InternalTenantContext context) {
 
-        final List<TierPriceOverride> tierPriceOverrides = new ArrayList<TierPriceOverride>();
+        final List<TierPriceOverride> tierPriceOverrides = new ArrayList<>();
 
         final List<CatalogOverrideTierDefinitionModelDao> tierDefs = overrideDao.getOverriddenUsageTiers(overriddenUsage.getRecordId(), context);
         for (int i = 0; i < curUsage.getTiers().length; i++) {
             final Tier curTier = curUsage.getTiers()[i];
             final TieredBlock[] curTieredBlocks = curTier.getTieredBlocks();
+            final CatalogOverrideTierDefinitionModelDao overriddenTier = tierDefs.stream()
+                    .filter(input -> {
+                        final List<CatalogOverrideBlockDefinitionModelDao> blockDefs = overrideDao.getOverriddenTierBlocks(input.getRecordId(), context);
+                        for (final CatalogOverrideBlockDefinitionModelDao blockDef : blockDefs) {
+                            final String unitName = blockDef.getParentUnitName();
 
-            final CatalogOverrideTierDefinitionModelDao overriddenTier = Iterables.tryFind(tierDefs, new Predicate<CatalogOverrideTierDefinitionModelDao>() {
-                @Override
-                public boolean apply(final CatalogOverrideTierDefinitionModelDao input) {
-                    final List<CatalogOverrideBlockDefinitionModelDao> blockDefs = overrideDao.getOverriddenTierBlocks(input.getRecordId(), context);
-                    for (CatalogOverrideBlockDefinitionModelDao blockDef : blockDefs) {
-                        String unitName = blockDef.getParentUnitName();
-
-                        for (final TieredBlock curTieredBlock : curTieredBlocks) {
-                            if (unitName.equals(curTieredBlock.getUnit().getName()) &&
-                                blockDef.getSize().compareTo(curTieredBlock.getSize()) == 0 &&
-                                blockDef.getMax().compareTo(curTieredBlock.getMax()) == 0) {
-                                return true;
+                            for (final TieredBlock curTieredBlock : curTieredBlocks) {
+                                if (unitName.equals(curTieredBlock.getUnit().getName()) &&
+                                    blockDef.getSize().compareTo(curTieredBlock.getSize()) == 0 &&
+                                    blockDef.getMax().compareTo(curTieredBlock.getMax()) == 0) {
+                                    return true;
+                                }
                             }
                         }
-                    }
-                    return false;
-                }
+                        return false;
+                    })
+                    .findFirst().orElse(null);
 
-            }).orNull();
 
             if (overriddenTier != null) {
                 List<TieredBlockPriceOverride> tieredBlockPriceOverrides = getTieredBlockPriceOverrides(curTier, overriddenTier, context);
@@ -202,24 +189,21 @@ public class DefaultOverriddenPlanCache implements OverriddenPlanCache {
 
     List<TieredBlockPriceOverride> getTieredBlockPriceOverrides(Tier curTier, CatalogOverrideTierDefinitionModelDao overriddenTier, final InternalTenantContext context) {
 
-        final List<TieredBlockPriceOverride> blockPriceOverrides = new ArrayList<TieredBlockPriceOverride>();
+        final List<TieredBlockPriceOverride> blockPriceOverrides = new ArrayList<>();
         final List<CatalogOverrideBlockDefinitionModelDao> blockDefs = overrideDao.getOverriddenTierBlocks(overriddenTier.getRecordId(), context);
 
         for (int i = 0; i < curTier.getTieredBlocks().length; i++) {
             final TieredBlock curTieredBlock = curTier.getTieredBlocks()[i];
-            final CatalogOverrideBlockDefinitionModelDao overriddenTierBlock = Iterables.tryFind(blockDefs, new Predicate<CatalogOverrideBlockDefinitionModelDao>() {
-                @Override
-                public boolean apply(final CatalogOverrideBlockDefinitionModelDao input) {
-                    return (input.getParentUnitName().equals(curTieredBlock.getUnit().getName()) &&
-                            input.getSize().compareTo(curTieredBlock.getSize()) == 0 &&
-                            input.getMax().compareTo(curTieredBlock.getMax()) == 0);
-
-                }
-            }).orNull();
-
-            if (overriddenTierBlock != null) {
-                blockPriceOverrides.add(new DefaultTieredBlockPriceOverride(overriddenTierBlock.getParentUnitName(), overriddenTierBlock.getSize(), overriddenTierBlock.getPrice(), Currency.valueOf(overriddenTierBlock.getCurrency()), overriddenTierBlock.getMax()));
-            }
+            blockDefs.stream()
+                     .filter(input -> (input.getParentUnitName().equals(curTieredBlock.getUnit().getName()) &&
+                                       input.getSize().compareTo(curTieredBlock.getSize()) == 0 &&
+                                       input.getMax().compareTo(curTieredBlock.getMax()) == 0))
+                     .findFirst()
+                     .ifPresent(input -> blockPriceOverrides.add(new DefaultTieredBlockPriceOverride(input.getParentUnitName(),
+                                                                                                 input.getSize(),
+                                                                                                 input.getPrice(),
+                                                                                                 Currency.valueOf(input.getCurrency()),
+                                                                                                 input.getMax())));
         }
         return blockPriceOverrides;
     }

--- a/catalog/src/main/java/org/killbill/billing/catalog/dao/DefaultCatalogOverrideDao.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/dao/DefaultCatalogOverrideDao.java
@@ -20,6 +20,8 @@ package org.killbill.billing.catalog.dao;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.joda.time.DateTime;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
@@ -40,17 +42,13 @@ import org.skife.jdbi.v2.IDBI;
 import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.TransactionStatus;
 
-import com.google.inject.Inject;
-
 public class DefaultCatalogOverrideDao implements CatalogOverrideDao {
 
     private final IDBI dbi;
-    private final Clock clock;
 
     @Inject
-    public DefaultCatalogOverrideDao(final IDBI dbi, final Clock clock) {
+    public DefaultCatalogOverrideDao(final IDBI dbi) {
         this.dbi = dbi;
-        this.clock = clock;
         // There is no real good place to do that but here (since the sqlDao are NOT EntitySqlDao and DBPProvider belongs in common)... oh well..
         ((DBI) dbi).registerMapper(new LowerToCamelBeanMapperFactory(CatalogOverridePlanDefinitionModelDao.class));
         ((DBI) dbi).registerMapper(new LowerToCamelBeanMapperFactory(CatalogOverridePhaseDefinitionModelDao.class));

--- a/catalog/src/main/java/org/killbill/billing/catalog/glue/CatalogModule.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/glue/CatalogModule.java
@@ -18,6 +18,8 @@
 
 package org.killbill.billing.catalog.glue;
 
+import java.util.Objects;
+
 import org.killbill.billing.catalog.DefaultCatalogService;
 import org.killbill.billing.catalog.api.CatalogInternalApi;
 import org.killbill.billing.catalog.api.CatalogService;
@@ -45,8 +47,7 @@ import org.killbill.billing.util.config.definition.CatalogConfig;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.ConfigurationObjectFactory;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
+// FIXME-1615 : Part of internal DI system
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 
@@ -59,7 +60,7 @@ public class CatalogModule extends KillBillModule {
     public CatalogModule(final KillbillConfigSource configSource) {
         super(configSource);
         // Unless explicitly specified we keep current "-" delimiter for backward compatibility
-        final boolean useRECXMLNamesCompliant = Boolean.valueOf(MoreObjects.<String>firstNonNull(configSource.getString("org.killbill.catalog.price.override.delimiter.REC-xml-names-19990114.compliant"), "false"));
+        final boolean useRECXMLNamesCompliant = Boolean.valueOf(Objects.requireNonNullElse(configSource.getString("org.killbill.catalog.price.override.delimiter.REC-xml-names-19990114.compliant"), "false"));
         this.priceOverridePattern = new PriceOverridePattern(useRECXMLNamesCompliant);
     }
 

--- a/catalog/src/main/java/org/killbill/billing/catalog/glue/DefaultCatalogProviderPluginRegistryProvider.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/glue/DefaultCatalogProviderPluginRegistryProvider.java
@@ -17,12 +17,12 @@
 
 package org.killbill.billing.catalog.glue;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
+
 import org.killbill.billing.catalog.plugin.api.CatalogPluginApi;
 import org.killbill.billing.catalog.provider.DefaultCatalogProviderPluginRegistry;
 import org.killbill.billing.osgi.api.OSGIServiceRegistration;
-
-import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 public class DefaultCatalogProviderPluginRegistryProvider implements Provider<OSGIServiceRegistration<CatalogPluginApi>> {
 

--- a/catalog/src/main/java/org/killbill/billing/catalog/io/VersionedCatalogLoader.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/io/VersionedCatalogLoader.java
@@ -28,11 +28,13 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import javax.inject.Inject;
 import javax.xml.bind.JAXBException;
 
 import org.killbill.billing.ErrorCode;
@@ -44,6 +46,7 @@ import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.catalog.override.PriceOverride;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.config.definition.CatalogConfig;
+import org.killbill.billing.util.io.IOUtils;
 import org.killbill.commons.concurrent.Executors;
 import org.killbill.xmlloader.UriAccessor;
 import org.killbill.xmlloader.ValidationError;
@@ -51,10 +54,6 @@ import org.killbill.xmlloader.ValidationException;
 import org.killbill.xmlloader.XMLLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.io.Resources;
-import com.google.inject.Inject;
 
 public class VersionedCatalogLoader implements CatalogLoader, Closeable {
 
@@ -71,7 +70,7 @@ public class VersionedCatalogLoader implements CatalogLoader, Closeable {
     public VersionedCatalogLoader(final CatalogConfig config,
                                   final PriceOverride priceOverride,
                                   final InternalCallContextFactory internalCallContextFactory) {
-        this.executorService = Executors.newFixedThreadPool(MoreObjects.firstNonNull(config.getCatalogThreadNb(), 1), VersionedCatalogLoader.class.getName());
+        this.executorService = Executors.newFixedThreadPool(Objects.requireNonNullElse(config.getCatalogThreadNb(), 1), VersionedCatalogLoader.class.getName());
         this.priceOverride = priceOverride;
         this.internalCallContextFactory = internalCallContextFactory;
     }
@@ -119,7 +118,7 @@ public class VersionedCatalogLoader implements CatalogLoader, Closeable {
         } catch (final MalformedURLException ignore) {
         }
         // If not, this must be something on the classpath
-        return Resources.getResource(urlString);
+        return IOUtils.getResourceAsURL(urlString);
     }
 
     public VersionedCatalog load(final Collection<String> catalogXMLs, final boolean filterTemplateCatalog, final Long tenantRecordId) throws CatalogApiException {

--- a/catalog/src/main/java/org/killbill/billing/catalog/override/DefaultPriceOverride.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/override/DefaultPriceOverride.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.ErrorCode;
@@ -50,10 +51,6 @@ import org.killbill.billing.catalog.caching.PriceOverridePattern;
 import org.killbill.billing.catalog.dao.CatalogOverrideDao;
 import org.killbill.billing.catalog.dao.CatalogOverridePlanDefinitionModelDao;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.inject.Inject;
-
 public class DefaultPriceOverride implements PriceOverride {
 
     private static final AtomicLong DRY_RUN_PLAN_IDX = new AtomicLong(0);
@@ -80,26 +77,25 @@ public class DefaultPriceOverride implements PriceOverride {
         final PlanPhasePriceOverride[] resolvedOverride = new PlanPhasePriceOverride[parentPlan.getAllPhases().length];
         int index = 0;
         for (final PlanPhase curPhase : parentPlan.getAllPhases()) {
-            final PlanPhasePriceOverride curOverride = Iterables.tryFind(overrides, new Predicate<PlanPhasePriceOverride>() {
-                @Override
-                public boolean apply(final PlanPhasePriceOverride input) {
-                    if (input.getPhaseName() != null) {
-                        return input.getPhaseName().equals(curPhase.getName());
-                    }
-                    // If the phaseName was not passed, we infer by matching the phaseType. This obviously would not work in a case where
-                    // a plan is defined with multiple phases of the same type.
-                    final PlanPhaseSpecifier curPlanPhaseSpecifier = input.getPlanPhaseSpecifier();
-                    if (curPlanPhaseSpecifier.getPhaseType().equals(curPhase.getPhaseType())) {
-                        return true;
-                    }
-                    return false;
-                }
-            }).orNull();
+            final PlanPhasePriceOverride curOverride = overrides.stream()
+                    .filter(input -> {
+                        if (input.getPhaseName() != null) {
+                            return input.getPhaseName().equals(curPhase.getName());
+                        }
+                        // If the phaseName was not passed, we infer by matching the phaseType. This obviously would not work in a case where
+                        // a plan is defined with multiple phases of the same type.
+                        final PlanPhaseSpecifier curPlanPhaseSpecifier = input.getPlanPhaseSpecifier();
+                        return curPlanPhaseSpecifier.getPhaseType().equals(curPhase.getPhaseType());
+                    })
+                    .findFirst().orElse(null);
 
             if (curOverride != null) {
-                List<UsagePriceOverride> resolvedUsageOverrides = getResolvedUsageOverrides(curPhase.getUsages(), curOverride.getUsagePriceOverrides());
-                resolvedOverride[index++] = new DefaultPlanPhasePriceOverride(curPhase.getName(), curOverride.getCurrency(), curOverride.getFixedPrice(),
-                                                                              curOverride.getRecurringPrice(), resolvedUsageOverrides);
+                final List<UsagePriceOverride> resolvedUsageOverrides = getResolvedUsageOverrides(curPhase.getUsages(), curOverride.getUsagePriceOverrides());
+                resolvedOverride[index++] = new DefaultPlanPhasePriceOverride(curPhase.getName(),
+                                                                              curOverride.getCurrency(),
+                                                                              curOverride.getFixedPrice(),
+                                                                              curOverride.getRecurringPrice(),
+                                                                              resolvedUsageOverrides);
             } else {
                 resolvedOverride[index++] = null;
             }
@@ -138,16 +134,13 @@ public class DefaultPriceOverride implements PriceOverride {
         return result;
     }
 
-    public List<UsagePriceOverride> getResolvedUsageOverrides(Usage[] usages, List<UsagePriceOverride> usagePriceOverrides) throws CatalogApiException {
-        List<UsagePriceOverride> resolvedUsageOverrides = new ArrayList<UsagePriceOverride>();
+    public List<UsagePriceOverride> getResolvedUsageOverrides(final Usage[] usages, final List<UsagePriceOverride> usagePriceOverrides) throws CatalogApiException {
+        List<UsagePriceOverride> resolvedUsageOverrides = new ArrayList<>();
 
         for (final Usage curUsage : usages) {
-            final UsagePriceOverride curOverride = Iterables.tryFind(usagePriceOverrides, new Predicate<UsagePriceOverride>() {
-                @Override
-                public boolean apply(final UsagePriceOverride input) {
-                    return input.getName() != null && input.getName().equals(curUsage.getName());
-                }
-            }).orNull();
+            final UsagePriceOverride curOverride = usagePriceOverrides.stream()
+                    .filter(input -> input.getName() != null && input.getName().equals(curUsage.getName()))
+                    .findFirst().orElse(null);
             if (curOverride != null) {
                 List<TierPriceOverride> tierPriceOverrides = getResolvedTierOverrides(curUsage.getTiers(), curOverride.getTierPriceOverrides());
                 resolvedUsageOverrides.add(new DefaultUsagePriceOverride(curUsage.getName(), curUsage.getUsageType(), tierPriceOverrides));
@@ -160,34 +153,30 @@ public class DefaultPriceOverride implements PriceOverride {
     }
 
     public List<TierPriceOverride> getResolvedTierOverrides(Tier[] tiers, List<TierPriceOverride> tierPriceOverrides) throws CatalogApiException {
-        List<TierPriceOverride> resolvedTierOverrides = new ArrayList<TierPriceOverride>();
+        List<TierPriceOverride> resolvedTierOverrides = new ArrayList<>();
 
         for (final Tier curTier : tiers) {
-            final TierPriceOverride curOverride = Iterables.tryFind(tierPriceOverrides, new Predicate<TierPriceOverride>() {
-                @Override
-                public boolean apply(final TierPriceOverride input) {
+            final TierPriceOverride curOverride = tierPriceOverrides.stream()
+                    .filter(input -> {
+                        if (input.getTieredBlockPriceOverrides() != null) {
+                            for (TieredBlockPriceOverride blockPriceOverride : input.getTieredBlockPriceOverrides()) {
+                                String unitName = blockPriceOverride.getUnitName();
 
-                    if (input.getTieredBlockPriceOverrides() != null) {
-                        for (TieredBlockPriceOverride blockPriceOverride : input.getTieredBlockPriceOverrides()) {
-                            String unitName = blockPriceOverride.getUnitName();
-
-                            for (int i = 0; i < curTier.getTieredBlocks().length; i++) {
-                                TieredBlock curTieredBlock = curTier.getTieredBlocks()[i];
-                                if (unitName.equals(curTieredBlock.getUnit().getName()) &&
-                                    blockPriceOverride.getSize().compareTo(curTieredBlock.getSize()) == 0 &&
-                                    blockPriceOverride.getMax().compareTo(curTieredBlock.getMax()) == 0) {
-                                    return true;
+                                for (int i = 0; i < curTier.getTieredBlocks().length; i++) {
+                                    final TieredBlock curTieredBlock = curTier.getTieredBlocks()[i];
+                                    if (unitName.equals(curTieredBlock.getUnit().getName()) &&
+                                        blockPriceOverride.getSize().compareTo(curTieredBlock.getSize()) == 0 &&
+                                        blockPriceOverride.getMax().compareTo(curTieredBlock.getMax()) == 0) {
+                                        return true;
+                                    }
                                 }
                             }
                         }
-                    }
-                    return false;
-                }
-            }).orNull();
+                        return false;
+                    }).findFirst().orElse(null);
 
             if (curOverride != null) {
-                List<TieredBlockPriceOverride> tieredBlockPriceOverrides = getResolvedTieredBlockPriceOverrides(curTier.getTieredBlocks(),
-                                                                                                                curOverride.getTieredBlockPriceOverrides());
+                final List<TieredBlockPriceOverride> tieredBlockPriceOverrides = getResolvedTieredBlockPriceOverrides(curTier.getTieredBlocks(), curOverride.getTieredBlockPriceOverrides());
                 resolvedTierOverrides.add(new DefaultTierPriceOverride(tieredBlockPriceOverrides));
             } else {
                 resolvedTierOverrides.add(null);
@@ -198,19 +187,15 @@ public class DefaultPriceOverride implements PriceOverride {
     }
 
     public List<TieredBlockPriceOverride> getResolvedTieredBlockPriceOverrides(TieredBlock[] tieredBlocks, List<TieredBlockPriceOverride> tieredBlockPriceOverrides) throws CatalogApiException {
-        List<TieredBlockPriceOverride> resolvedTieredBlockPriceOverrides = new ArrayList<TieredBlockPriceOverride>();
+        List<TieredBlockPriceOverride> resolvedTieredBlockPriceOverrides = new ArrayList<>();
 
         for (final TieredBlock curTieredBlock : tieredBlocks) {
-
-            final TieredBlockPriceOverride curOverride = Iterables.tryFind(tieredBlockPriceOverrides, new Predicate<TieredBlockPriceOverride>() {
-                @Override
-                public boolean apply(final TieredBlockPriceOverride input) {
-                    return input.getUnitName() != null && input.getSize() != null && input.getMax() != null &&
-                           (input.getUnitName().equals(curTieredBlock.getUnit().getName()) &&
-                            input.getSize().compareTo(curTieredBlock.getSize()) == 0 &&
-                            input.getMax().compareTo(curTieredBlock.getMax()) == 0);
-                }
-            }).orNull();
+            final TieredBlockPriceOverride curOverride = tieredBlockPriceOverrides.stream()
+                    .filter(input -> input.getUnitName() != null && input.getSize() != null && input.getMax() != null &&
+                                     (input.getUnitName().equals(curTieredBlock.getUnit().getName()) &&
+                                      input.getSize().compareTo(curTieredBlock.getSize()) == 0 &&
+                                      input.getMax().compareTo(curTieredBlock.getMax()) == 0))
+                    .findFirst().orElse(null);
 
             if (curOverride != null) {
                 resolvedTieredBlockPriceOverrides.add(new DefaultTieredBlockPriceOverride(curTieredBlock.getUnit().getName(), curOverride.getSize(), curOverride.getPrice(), curOverride.getCurrency(), curOverride.getMax()));

--- a/catalog/src/main/java/org/killbill/billing/catalog/plugin/StandaloneCatalogMapper.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/plugin/StandaloneCatalogMapper.java
@@ -22,7 +22,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
@@ -82,10 +86,7 @@ import org.killbill.billing.catalog.rules.DefaultCasePriceList;
 import org.killbill.billing.catalog.rules.DefaultCaseStandardNaming;
 import org.killbill.billing.catalog.rules.DefaultPlanRules;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import static org.killbill.billing.util.collect.CollectionTransformer.iterableToList;
 
 public class StandaloneCatalogMapper {
 
@@ -136,57 +137,27 @@ public class StandaloneCatalogMapper {
     }
 
     final DefaultCaseChangePlanPolicy[] toDefaultCaseChangePlanPolicies(final Iterable<CaseChangePlanPolicy> input) {
-        return toArrayWithTransform(input, new Function<CaseChangePlanPolicy, DefaultCaseChangePlanPolicy>() {
-            @Override
-            public DefaultCaseChangePlanPolicy apply(final CaseChangePlanPolicy input) {
-                return toDefaultCaseChangePlanPolicy(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultCaseChangePlanPolicy);
     }
 
     final DefaultCaseChangePlanAlignment[] toDefaultCaseChangePlanAlignments(final Iterable<CaseChangePlanAlignment> input) {
-        return toArrayWithTransform(input, new Function<CaseChangePlanAlignment, DefaultCaseChangePlanAlignment>() {
-            @Override
-            public DefaultCaseChangePlanAlignment apply(final CaseChangePlanAlignment input) {
-                return toDefaultCaseChangePlanAlignment(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultCaseChangePlanAlignment);
     }
 
     final DefaultCaseBillingAlignment[] toDefaultCaseBillingAlignments(final Iterable<CaseBillingAlignment> input) {
-        return toArrayWithTransform(input, new Function<CaseBillingAlignment, DefaultCaseBillingAlignment>() {
-            @Override
-            public DefaultCaseBillingAlignment apply(final CaseBillingAlignment input) {
-                return toDefaultCaseBillingAlignment(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultCaseBillingAlignment);
     }
 
     final DefaultCaseCancelPolicy[] toDefaultCaseCancelPolicys(final Iterable<CaseCancelPolicy> input) {
-        return toArrayWithTransform(input, new Function<CaseCancelPolicy, DefaultCaseCancelPolicy>() {
-            @Override
-            public DefaultCaseCancelPolicy apply(final CaseCancelPolicy input) {
-                return toDefaultCaseCancelPolicy(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultCaseCancelPolicy);
     }
 
     final DefaultCaseCreateAlignment[] toDefaultCaseCreateAlignments(final Iterable<CaseCreateAlignment> input) {
-        return toArrayWithTransform(input, new Function<CaseCreateAlignment, DefaultCaseCreateAlignment>() {
-            @Override
-            public DefaultCaseCreateAlignment apply(final CaseCreateAlignment input) {
-                return toCaseCreateAlignment(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toCaseCreateAlignment);
     }
 
     final DefaultCasePriceList[] toDefaultCasePriceLists(final Iterable<CasePriceList> input) {
-        return toArrayWithTransform(input, new Function<CasePriceList, DefaultCasePriceList>() {
-            @Override
-            public DefaultCasePriceList apply(final CasePriceList input) {
-                return toDefaultCasePriceList(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultCasePriceList);
     }
 
     final DefaultCasePriceList toDefaultCasePriceList(final CasePriceList input) {
@@ -257,8 +228,10 @@ public class StandaloneCatalogMapper {
 
     private Iterable<Product> toDefaultProducts(final Iterable<Product> input) {
         if (tmpDefaultProducts == null) {
-            final Map<String, Product> map = new HashMap<String, Product>();
-            for (final Product product : input) map.put(product.getName(), toDefaultProduct(product));
+            final Map<String, Product> map = new HashMap<>();
+            for (final Product product : input) {
+                map.put(product.getName(), toDefaultProduct(product));
+            }
             tmpDefaultProducts = map;
         }
         return tmpDefaultProducts.values();
@@ -268,16 +241,15 @@ public class StandaloneCatalogMapper {
         if (!input.iterator().hasNext()) {
             return Collections.emptyList();
         }
-        final Iterable<String> inputProductNames = Iterables.transform(input, new Function<Product, String>() {
-            @Override
-            public String apply(final Product input) {
-                return input.getName();
-            }
-        });
+        final Iterable<String> inputProductNames = input.stream()
+                .map(Product::getName)
+                .collect(Collectors.toUnmodifiableList());
         final Collection<Product> filteredAndOrdered = new ArrayList<Product>(input.size());
         for (final String cur : inputProductNames) {
             final Product found = tmpDefaultProducts.get(cur);
-            if (found == null) throw new IllegalStateException("Failed to find product " + cur);
+            if (found == null) {
+                throw new IllegalStateException("Failed to find product " + cur);
+            }
             filteredAndOrdered.add(found);
         }
         return filteredAndOrdered;
@@ -285,8 +257,10 @@ public class StandaloneCatalogMapper {
 
     private Iterable<Plan> toDefaultPlans(final StaticCatalog staticCatalog, final Iterable<Plan> input) {
         if (tmpDefaultPlans == null) {
-            final Map<String, Plan> map = new HashMap<String, Plan>();
-            for (final Plan plan : input) map.put(plan.getName(), toDefaultPlan(staticCatalog, plan));
+            final Map<String, Plan> map = new HashMap<>();
+            for (final Plan plan : input) {
+                map.put(plan.getName(), toDefaultPlan(staticCatalog, plan));
+            }
             tmpDefaultPlans = map;
         }
         return tmpDefaultPlans.values();
@@ -297,12 +271,9 @@ public class StandaloneCatalogMapper {
         if (tmpDefaultPlans == null) {
             throw new IllegalStateException("Cannot filter on uninitialized plans");
         }
-        return Iterables.filter(tmpDefaultPlans.values(), new Predicate<Plan>() {
-            @Override
-            public boolean apply(final Plan input) {
-                return ((DefaultPlan)input).getPriceListName().equals(priceListName);
-            }
-        });
+        return tmpDefaultPlans.values().stream()
+                .filter(input -> ((DefaultPlan)input).getPriceListName().equals(priceListName))
+                .collect(Collectors.toUnmodifiableList());
     }
 
     private DefaultPriceListSet toDefaultPriceListSet(final PriceList defaultPriceList, final Iterable<PriceList> childrenPriceLists) {
@@ -316,39 +287,19 @@ public class StandaloneCatalogMapper {
         if (!input.iterator().hasNext()) {
             return new DefaultPlanPhase[0];
         }
-        return toArrayWithTransform(input, new Function<PlanPhase, DefaultPlanPhase>() {
-            @Override
-            public DefaultPlanPhase apply(final PlanPhase input) {
-                return toDefaultPlanPhase(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultPlanPhase);
     }
 
     private DefaultPriceList[] toDefaultPriceLists(final Iterable<PriceList> input) {
-        return toArrayWithTransform(input, new Function<PriceList, DefaultPriceList>() {
-            @Override
-            public DefaultPriceList apply(final PriceList input) {
-                return toDefaultPriceList(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultPriceList);
     }
 
     private DefaultPrice[] toDefaultPrices(final Iterable<Price> input) {
-        return toArrayWithTransform(input, new Function<Price, DefaultPrice>() {
-            @Override
-            public DefaultPrice apply(final Price input) {
-                return toDefaultPrice(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultPrice);
     }
 
     private DefaultUnit[] toDefaultUnits(final Iterable<Unit> input) {
-        return toArrayWithTransform(input, new Function<Unit, DefaultUnit>() {
-            @Override
-            public DefaultUnit apply(final Unit inputTransform) {
-                return toDefaultUnit(inputTransform);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultUnit);
     }
 
     private DefaultUnit toDefaultUnit(final Unit input) {
@@ -402,7 +353,7 @@ public class StandaloneCatalogMapper {
         result.setRecurringBillingMode(input.getRecurringBillingMode());
         result.setEffectiveDateForExistingSubscriptions(input.getEffectiveDateForExistingSubscriptions());
         result.setFinalPhase(toDefaultPlanPhase(input.getFinalPhase()));
-        result.setInitialPhases(toDefaultPlanPhases(ImmutableList.copyOf(input.getInitialPhases())));
+        result.setInitialPhases(toDefaultPlanPhases(List.of(input.getInitialPhases())));
         result.setPlansAllowedInBundle(input.getPlansAllowedInBundle());
         result.setProduct(toDefaultProduct(input.getProduct()));
         result.setPriceListName(input.getPriceList().getName());
@@ -453,7 +404,7 @@ public class StandaloneCatalogMapper {
         DefaultInternationalPrice result = null;
         if (input != null) {
             result = new DefaultInternationalPrice();
-            result.setPrices(toDefaultPrices(ImmutableList.copyOf(input.getPrices())));
+            result.setPrices(toDefaultPrices(List.of(input.getPrices())));
         }
         return result;
     }
@@ -470,13 +421,7 @@ public class StandaloneCatalogMapper {
     }
 
     private DefaultUsage[] toDefaultUsages(final Iterable<Usage> input) {
-        return toArrayWithTransform(input, new Function<Usage, DefaultUsage>() {
-            @Nullable
-            @Override
-            public DefaultUsage apply(@Nullable final Usage input) {
-                return toDefaultUsage(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultUsage);
     }
 
     private DefaultUsage toDefaultUsage(final Usage input) {
@@ -501,12 +446,7 @@ public class StandaloneCatalogMapper {
     }
 
     private DefaultLimit[] toDefaultLimits(final Iterable<Limit> input) {
-        return toArrayWithTransform(input, new Function<Limit, DefaultLimit>() {
-            @Override
-            public DefaultLimit apply(final Limit input) {
-                return toDefaultLimit(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultLimit);
     }
 
     private DefaultLimit toDefaultLimit(final Limit input) {
@@ -521,13 +461,7 @@ public class StandaloneCatalogMapper {
     }
 
     private DefaultBlock[] toDefaultBlocks(final Iterable<Block> input) {
-        return toArrayWithTransform(input, new Function<Block, DefaultBlock>() {
-            @Nullable
-            @Override
-            public DefaultBlock apply(@Nullable final Block input) {
-                return toDefaultBlock(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultBlock);
     }
 
     private DefaultBlock toDefaultBlock(final Block input) {
@@ -543,13 +477,7 @@ public class StandaloneCatalogMapper {
     }
 
     private DefaultTier[] toDefaultTiers(final Iterable<Tier> input) {
-        return toArrayWithTransform(input, new Function<Tier, DefaultTier>() {
-            @Nullable
-            @Override
-            public DefaultTier apply(@Nullable final Tier input) {
-                return toDefaultTier(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultTier);
     }
 
     private DefaultTier toDefaultTier(final Tier input) {
@@ -569,13 +497,7 @@ public class StandaloneCatalogMapper {
     }
 
     private DefaultTieredBlock[] toDefaultTieredBlocks(Iterable<TieredBlock> input) {
-        return toArrayWithTransform(input, new Function<TieredBlock, DefaultTieredBlock>() {
-            @Nullable
-            @Override
-            public DefaultTieredBlock apply(@Nullable final TieredBlock input) {
-                return toDefaultTieredBlock(input);
-            }
-        });
+        return toArrayWithTransform(input, this::toDefaultTieredBlock);
     }
 
     private DefaultTieredBlock toDefaultTieredBlock(TieredBlock input) {
@@ -595,7 +517,9 @@ public class StandaloneCatalogMapper {
         if (input == null || !input.iterator().hasNext()) {
             return null;
         }
-        final Iterable<C> tmp = Iterables.transform(input, transformer);
+        final Iterable<C> tmp = StreamSupport.stream(input.spliterator(), false)
+                                             .map(transformer)
+                                             .collect(Collectors.toUnmodifiableList());
         return toArray(tmp);
     }
 
@@ -605,7 +529,7 @@ public class StandaloneCatalogMapper {
         }
         final C[] foo = (C[]) java.lang.reflect.Array
                 .newInstance(input.iterator().next().getClass(), 1);
-        return ImmutableList.<C>copyOf(input).toArray(foo);
+        return iterableToList(input).toArray(foo);
     }
 
 }

--- a/catalog/src/main/java/org/killbill/billing/catalog/rules/DefaultPlanRules.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/rules/DefaultPlanRules.java
@@ -24,6 +24,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -53,8 +54,6 @@ import org.killbill.billing.catalog.api.rules.PlanRules;
 import org.killbill.xmlloader.ValidatingConfig;
 import org.killbill.xmlloader.ValidationError;
 import org.killbill.xmlloader.ValidationErrors;
-
-import com.google.common.collect.ImmutableList;
 
 @XmlAccessorType(XmlAccessType.NONE)
 public class DefaultPlanRules extends ValidatingConfig<StandaloneCatalog> implements PlanRules, Externalizable {
@@ -95,32 +94,32 @@ public class DefaultPlanRules extends ValidatingConfig<StandaloneCatalog> implem
 
     @Override
     public Iterable<CaseChangePlanPolicy> getCaseChangePlanPolicy() {
-        return ImmutableList.<CaseChangePlanPolicy>copyOf(changeCase);
+        return List.of(changeCase);
     }
 
     @Override
     public Iterable<CaseChangePlanAlignment> getCaseChangePlanAlignment() {
-        return ImmutableList.<CaseChangePlanAlignment>copyOf(changeAlignmentCase);
+        return List.of(changeAlignmentCase);
     }
 
     @Override
     public Iterable<CaseCancelPolicy> getCaseCancelPolicy() {
-        return ImmutableList.<CaseCancelPolicy>copyOf(cancelCase);
+        return List.of(cancelCase);
     }
 
     @Override
     public Iterable<CaseCreateAlignment> getCaseCreateAlignment() {
-        return ImmutableList.<CaseCreateAlignment>copyOf(createAlignmentCase);
+        return List.of(createAlignmentCase);
     }
 
     @Override
     public Iterable<CaseBillingAlignment> getCaseBillingAlignment() {
-        return ImmutableList.<CaseBillingAlignment>copyOf(billingAlignmentCase);
+        return List.of(billingAlignmentCase);
     }
 
     @Override
     public Iterable<CasePriceList> getCasePriceList() {
-        return ImmutableList.<CasePriceList>copyOf(priceListCase);
+        return List.of(priceListCase);
     }
 
     @Override

--- a/catalog/src/test/java/org/killbill/billing/catalog/CatalogTestSuiteNoDB.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/CatalogTestSuiteNoDB.java
@@ -16,6 +16,8 @@
 
 package org.killbill.billing.catalog;
 
+import javax.inject.Inject;
+
 import org.killbill.billing.GuicyKillbillTestSuiteNoDB;
 import org.killbill.billing.catalog.caching.CatalogCache;
 import org.killbill.billing.catalog.caching.CatalogCacheInvalidationCallback;
@@ -24,12 +26,11 @@ import org.killbill.billing.catalog.io.VersionedCatalogLoader;
 import org.killbill.billing.catalog.override.PriceOverride;
 import org.killbill.billing.tenant.api.TenantInternalApi;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
+import org.killbill.billing.util.io.IOUtils;
 import org.killbill.xmlloader.XMLLoader;
 import org.testng.annotations.BeforeClass;
 
-import com.google.common.io.Resources;
 import com.google.inject.Guice;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 
 public abstract class CatalogTestSuiteNoDB extends GuicyKillbillTestSuiteNoDB {
@@ -63,6 +64,6 @@ public abstract class CatalogTestSuiteNoDB extends GuicyKillbillTestSuiteNoDB {
     }
 
     protected StandaloneCatalog getCatalog(final String name) throws Exception {
-        return XMLLoader.getObjectFromString(Resources.getResource("org/killbill/billing/catalog/" + name).toExternalForm(), StandaloneCatalog.class);
+        return XMLLoader.getObjectFromString(IOUtils.getResourceAsURL("org/killbill/billing/catalog/" + name).toExternalForm(), StandaloneCatalog.class);
     }
 }

--- a/catalog/src/test/java/org/killbill/billing/catalog/CatalogTestSuiteWithEmbeddedDB.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/CatalogTestSuiteWithEmbeddedDB.java
@@ -17,18 +17,19 @@
 
 package org.killbill.billing.catalog;
 
+import javax.inject.Inject;
+
 import org.killbill.billing.GuicyKillbillTestSuiteWithEmbeddedDB;
 import org.killbill.billing.catalog.caching.PriceOverridePattern;
 import org.killbill.billing.catalog.dao.CatalogOverrideDao;
 import org.killbill.billing.catalog.glue.TestCatalogModuleWithEmbeddedDB;
 import org.killbill.billing.catalog.override.PriceOverride;
+import org.killbill.billing.util.io.IOUtils;
 import org.killbill.xmlloader.XMLLoader;
 import org.skife.jdbi.v2.IDBI;
 import org.testng.annotations.BeforeClass;
 
-import com.google.common.io.Resources;
 import com.google.inject.Guice;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 
 public class CatalogTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuiteWithEmbeddedDB {
@@ -55,6 +56,6 @@ public class CatalogTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuiteWithEm
     }
 
     protected StandaloneCatalog getCatalog(final String name) throws Exception {
-        return XMLLoader.getObjectFromString(Resources.getResource("org/killbill/billing/catalog/" + name).toExternalForm(), StandaloneCatalog.class);
+        return XMLLoader.getObjectFromString(IOUtils.getResourceAsURL("org/killbill/billing/catalog/" + name).toExternalForm(), StandaloneCatalog.class);
     }
 }

--- a/catalog/src/test/java/org/killbill/billing/catalog/MockPlan.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/MockPlan.java
@@ -18,12 +18,10 @@ package org.killbill.billing.catalog;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
-import org.joda.time.DateTime;
 import org.killbill.billing.catalog.api.BillingMode;
 import org.killbill.billing.catalog.api.Plan;
-
-import com.google.common.collect.ImmutableList;
 
 public class MockPlan extends DefaultPlan {
 
@@ -135,13 +133,13 @@ public class MockPlan extends DefaultPlan {
     }
 
     public static Collection<Plan> createAll() {
-        return ImmutableList.<Plan>of(createBicycleTrialEvergreen1USD(),
-                               createBicycleNoTrialEvergreen1USD(),
-                               createPickupTrialEvergreen10USD(),
-                               createSportsCarTrialEvergreen100USD(),
-                               createJetTrialEvergreen1000USD(),
-                               createJetTrialFixedTermEvergreen1000USD(),
-                               createHornMonthlyNoTrial1USD());
+        return List.of(createBicycleTrialEvergreen1USD(),
+                       createBicycleNoTrialEvergreen1USD(),
+                       createPickupTrialEvergreen10USD(),
+                       createSportsCarTrialEvergreen100USD(),
+                       createJetTrialEvergreen1000USD(),
+                       createJetTrialFixedTermEvergreen1000USD(),
+                       createHornMonthlyNoTrial1USD());
     }
 
 

--- a/catalog/src/test/java/org/killbill/billing/catalog/MockProduct.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/MockProduct.java
@@ -17,11 +17,10 @@
 package org.killbill.billing.catalog;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.killbill.billing.catalog.api.Product;
 import org.killbill.billing.catalog.api.ProductCategory;
-
-import com.google.common.collect.ImmutableList;
 
 public class MockProduct extends DefaultProduct {
 
@@ -66,13 +65,12 @@ public class MockProduct extends DefaultProduct {
     }
 
     public static Collection<Product> createAll() {
-        return ImmutableList.<Product>of(
-                createBicycle(),
-                createPickup(),
-                createSportsCar(),
-                createJet(),
-                createHorn(),
-                createRedPaintJob());
+        return List.of(createBicycle(),
+                       createPickup(),
+                       createSportsCar(),
+                       createJet(),
+                       createHorn(),
+                       createRedPaintJob());
     }
 
 

--- a/catalog/src/test/java/org/killbill/billing/catalog/TestCatalogUpdater.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/TestCatalogUpdater.java
@@ -20,6 +20,7 @@ package org.killbill.billing.catalog;
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
+import java.util.Collections;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.ErrorCode;
@@ -37,13 +38,11 @@ import org.killbill.billing.catalog.api.SimplePlanDescriptor;
 import org.killbill.billing.catalog.api.StaticCatalog;
 import org.killbill.billing.catalog.api.TimeUnit;
 import org.killbill.billing.catalog.api.user.DefaultSimplePlanDescriptor;
+import org.killbill.billing.util.io.IOUtils;
 import org.killbill.xmlloader.XMLLoader;
 import org.killbill.xmlloader.XMLWriter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.io.Resources;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -65,7 +64,7 @@ public class TestCatalogUpdater extends CatalogTestSuiteNoDB {
     @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/842")
     public void testCreateAmbiguousPlan() throws CatalogApiException {
         final DateTime now = clock.getUTCNow();
-        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("foo-monthly-12345", "Foo", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 0, TimeUnit.UNLIMITED, ImmutableList.<String>of());
+        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("foo-monthly-12345", "Foo", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 0, TimeUnit.UNLIMITED, Collections.emptyList());
 
         final CatalogUpdater catalogUpdater = new CatalogUpdater(now, desc.getCurrency());
         catalogUpdater.addSimplePlanDescriptor(desc);
@@ -97,7 +96,7 @@ public class TestCatalogUpdater extends CatalogTestSuiteNoDB {
     public void testAddNoTrialPlanOnFirstCatalog() throws CatalogApiException {
 
         final DateTime now = clock.getUTCNow();
-        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("foo-monthly", "Foo", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 0, TimeUnit.UNLIMITED, ImmutableList.<String>of());
+        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("foo-monthly", "Foo", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 0, TimeUnit.UNLIMITED, Collections.emptyList());
 
         final CatalogUpdater catalogUpdater = new CatalogUpdater(now, desc.getCurrency());
 
@@ -137,7 +136,7 @@ public class TestCatalogUpdater extends CatalogTestSuiteNoDB {
     public void testAddTrialPlanOnFirstCatalog() throws CatalogApiException {
 
         final DateTime now = clock.getUTCNow();
-        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("foo-monthly", "Foo", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 14, TimeUnit.DAYS, ImmutableList.<String>of());
+        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("foo-monthly", "Foo", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 14, TimeUnit.DAYS, Collections.emptyList());
 
         final CatalogUpdater catalogUpdater = new CatalogUpdater(now, desc.getCurrency());
 
@@ -189,7 +188,7 @@ public class TestCatalogUpdater extends CatalogTestSuiteNoDB {
 
         final CatalogUpdater catalogUpdater = new CatalogUpdater(originalCatalog);
 
-        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("standard-annual", "Standard", ProductCategory.BASE, Currency.USD, BigDecimal.TEN, BillingPeriod.MONTHLY, 0, TimeUnit.UNLIMITED, ImmutableList.<String>of());
+        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("standard-annual", "Standard", ProductCategory.BASE, Currency.USD, BigDecimal.TEN, BillingPeriod.MONTHLY, 0, TimeUnit.UNLIMITED, Collections.emptyList());
         catalogUpdater.addSimplePlanDescriptor(desc);
 
         final StandaloneCatalog catalog = catalogUpdater.getCatalog();
@@ -222,7 +221,7 @@ public class TestCatalogUpdater extends CatalogTestSuiteNoDB {
 
         final CatalogUpdater catalogUpdater = new CatalogUpdater(originalCatalog);
 
-        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.DAYS, ImmutableList.<String>of());
+        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.DAYS, Collections.emptyList());
         catalogUpdater.addSimplePlanDescriptor(desc);
 
         final StandaloneCatalog catalog = catalogUpdater.getCatalog();
@@ -254,31 +253,31 @@ public class TestCatalogUpdater extends CatalogTestSuiteNoDB {
         CatalogUpdater catalogUpdater = new CatalogUpdater(originalCatalog);
 
         // Existing Plan has a 30 days trial => try with no TRIAL
-        SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 0, TimeUnit.DAYS, ImmutableList.<String>of());
+        SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 0, TimeUnit.DAYS, Collections.emptyList());
         addBadSimplePlanDescriptor(catalogUpdater, desc);
 
         // Existing Plan has a 30 days trial => try different trial length
-        desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 14, TimeUnit.DAYS, ImmutableList.<String>of());
+        desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 14, TimeUnit.DAYS, Collections.emptyList());
         addBadSimplePlanDescriptor(catalogUpdater, desc);
 
         // Existing Plan has a 30 days trial => try different trial unit
-        desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.MONTHS, ImmutableList.<String>of());
+        desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.MONTHS, Collections.emptyList());
         addBadSimplePlanDescriptor(catalogUpdater, desc);
 
         // Existing Plan has a MONTHLY recurring => try with ANNUAL BillingPeriod
-        desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.ANNUAL, 30, TimeUnit.DAYS, ImmutableList.<String>of());
+        desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.ANNUAL, 30, TimeUnit.DAYS, Collections.emptyList());
         addBadSimplePlanDescriptor(catalogUpdater, desc);
 
         // Existing Plan has a discount phase
-        desc = new DefaultSimplePlanDescriptor("dynamic-monthly", "Dynamic", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.MONTHS, ImmutableList.<String>of());
+        desc = new DefaultSimplePlanDescriptor("dynamic-monthly", "Dynamic", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.MONTHS, Collections.emptyList());
         addBadSimplePlanDescriptor(catalogUpdater, desc);
 
         // Existing Plan has final fixedterm phase
-        desc = new DefaultSimplePlanDescriptor("superdynamic-fixedterm", "SuperDynamic", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.DAYS, ImmutableList.<String>of());
+        desc = new DefaultSimplePlanDescriptor("superdynamic-fixedterm", "SuperDynamic", ProductCategory.BASE, Currency.EUR, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.DAYS, Collections.emptyList());
         addBadSimplePlanDescriptor(catalogUpdater, desc);
 
         // Existing Plan a different recurring price ($100)
-        desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.USD, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.DAYS, ImmutableList.<String>of());
+        desc = new DefaultSimplePlanDescriptor("standard-monthly", "Standard", ProductCategory.BASE, Currency.USD, BigDecimal.TEN, BillingPeriod.MONTHLY, 30, TimeUnit.DAYS, Collections.emptyList());
         addBadSimplePlanDescriptor(catalogUpdater, desc);
     }
 
@@ -339,7 +338,7 @@ public class TestCatalogUpdater extends CatalogTestSuiteNoDB {
 
         final CatalogUpdater catalogUpdater = new CatalogUpdater(originalCatalog);
 
-        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("dynamic-annual", "Dynamic", ProductCategory.BASE, Currency.USD, BigDecimal.TEN, BillingPeriod.MONTHLY, 14, TimeUnit.DAYS, ImmutableList.<String>of());
+        final SimplePlanDescriptor desc = new DefaultSimplePlanDescriptor("dynamic-annual", "Dynamic", ProductCategory.BASE, Currency.USD, BigDecimal.TEN, BillingPeriod.MONTHLY, 14, TimeUnit.DAYS, Collections.emptyList());
         catalogUpdater.addSimplePlanDescriptor(desc);
 
         final String expectedXML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
@@ -579,7 +578,7 @@ public class TestCatalogUpdater extends CatalogTestSuiteNoDB {
 
     private StandaloneCatalog enhanceOriginalCatalogForInvalidTestCases(final String catalogName) throws Exception {
 
-        final StandaloneCatalog catalog = XMLLoader.getObjectFromString(Resources.getResource(catalogName).toExternalForm(), StandaloneCatalog.class);
+        final StandaloneCatalog catalog = XMLLoader.getObjectFromString(IOUtils.getResourceAsURL(catalogName).toExternalForm(), StandaloneCatalog.class);
 
         final MutableStaticCatalog mutableCatalog = new DefaultMutableStaticCatalog(catalog);
 

--- a/catalog/src/test/java/org/killbill/billing/catalog/TestDefaultPriceOverride.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/TestDefaultPriceOverride.java
@@ -20,7 +20,6 @@ package org.killbill.billing.catalog;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.catalog.api.CatalogApiException;
@@ -32,19 +31,36 @@ import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
 import org.killbill.billing.catalog.api.Price;
 import org.killbill.billing.catalog.api.TierPriceOverride;
 import org.killbill.billing.catalog.api.TieredBlockPriceOverride;
+import org.killbill.billing.catalog.api.Unit;
 import org.killbill.billing.catalog.api.UsagePriceOverride;
 import org.killbill.billing.catalog.api.UsageType;
-import org.killbill.billing.catalog.override.DefaultPriceOverride;
 import org.testng.annotations.Test;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestDefaultPriceOverride extends CatalogTestSuiteWithEmbeddedDB {
+
+    private PlanPhasePriceOverride findPlanPhasePriceOverrideByName(final List<PlanPhasePriceOverride> overrides,
+                                                                    final String name) {
+        return overrides.stream().filter(input -> input.getPhaseName().equals(name)).findFirst().orElse(null);
+    }
+
+    /**
+     * name comparison will be param's {@link DefaultTieredBlock#getUnit} {@link Unit#getName()}
+     * size comparison will be param's {@link DefaultTieredBlock#getSize()}
+     * max comparison will be param's {@link DefaultTieredBlock#getMax()}
+     *
+     * In this class, {@link DefaultTieredBlock} instance variable name usually named "initialTieredBlock".
+     */
+    private TieredBlockPriceOverride findTieredBlockPriceOverrideByNameSizeAndMax(final List<TieredBlockPriceOverride> overrides,
+                                                                                  final DefaultTieredBlock initialTieredBlock) {
+        return overrides.stream()
+                        .filter(input -> input.getUnitName().equals(initialTieredBlock.getUnit().getName()) &&
+                                         input.getSize().compareTo(initialTieredBlock.getSize()) == 0 &&
+                                         input.getMax().compareTo(initialTieredBlock.getMax()) == 0)
+                        .findFirst().orElse(null);
+    }
 
     @Test(groups = "slow")
     public void testBasicWithLegacyNamePattern() throws Exception {
@@ -78,12 +94,7 @@ public class TestDefaultPriceOverride extends CatalogTestSuiteWithEmbeddedDB {
             final DefaultPlanPhase initialPhase = (DefaultPlanPhase) plan.getAllPhases()[i];
             final DefaultPlanPhase newPhase = (DefaultPlanPhase) overriddenPlan.getAllPhases()[i];
 
-            final PlanPhasePriceOverride override = Iterables.tryFind(overrides, new Predicate<PlanPhasePriceOverride>() {
-                @Override
-                public boolean apply(final PlanPhasePriceOverride input) {
-                    return input.getPhaseName().equals(initialPhase.getName());
-                }
-            }).orNull();
+            final PlanPhasePriceOverride override = findPlanPhasePriceOverrideByName(overrides, initialPhase.getName());
 
             assertNotEquals(newPhase.getName(), initialPhase.getName());
             assertEquals(newPhase.getDuration(), initialPhase.getDuration());
@@ -149,12 +160,7 @@ public class TestDefaultPriceOverride extends CatalogTestSuiteWithEmbeddedDB {
             final DefaultPlanPhase initialPhase = (DefaultPlanPhase) plan.getAllPhases()[i];
             final DefaultPlanPhase newPhase = (DefaultPlanPhase) overriddenPlan.getAllPhases()[i];
 
-            final PlanPhasePriceOverride override = Iterables.tryFind(overrides, new Predicate<PlanPhasePriceOverride>() {
-                @Override
-                public boolean apply(final PlanPhasePriceOverride input) {
-                    return input.getPhaseName().equals(initialPhase.getName());
-                }
-            }).orNull();
+            final PlanPhasePriceOverride override = findPlanPhasePriceOverrideByName(overrides, initialPhase.getName());
 
             assertNotEquals(newPhase.getName(), initialPhase.getName());
             assertEquals(newPhase.getName(), overriddenPlan.getName() + "-" + initialPhase.getName().split("-")[initialPhase.getName().split("-").length - 1]);
@@ -243,17 +249,9 @@ public class TestDefaultPriceOverride extends CatalogTestSuiteWithEmbeddedDB {
                 assertEquals(newTier.getTieredBlocks().length, initialTier.getTieredBlocks().length);
 
                 for (int k = 0; k < newTier.getTieredBlocks().length; k++) {
-                    final DefaultTieredBlock initialTieredBlock = (DefaultTieredBlock) initialTier.getTieredBlocks()[k];
-                    final DefaultTieredBlock newTieredBlock = (DefaultTieredBlock) newTier.getTieredBlocks()[k];
-                    final TieredBlockPriceOverride override = Iterables.tryFind(tieredBlockPriceOverrides, new Predicate<TieredBlockPriceOverride>() {
-                        @Override
-                        public boolean apply(final TieredBlockPriceOverride input) {
-
-                            return input.getUnitName().equals(initialTieredBlock.getUnit().getName()) &&
-                                   input.getSize().compareTo(initialTieredBlock.getSize()) == 0 &&
-                                   input.getMax().compareTo(initialTieredBlock.getMax()) == 0;
-                        }
-                    }).orNull();
+                    final DefaultTieredBlock initialTieredBlock = initialTier.getTieredBlocks()[k];
+                    final DefaultTieredBlock newTieredBlock = newTier.getTieredBlocks()[k];
+                    final TieredBlockPriceOverride override = findTieredBlockPriceOverrideByNameSizeAndMax(tieredBlockPriceOverrides, initialTieredBlock);
 
                     assertEquals(newTieredBlock.getUnit().getName(), initialTieredBlock.getUnit().getName());
                     assertEquals(newTieredBlock.getMax(), initialTieredBlock.getMax());
@@ -302,14 +300,9 @@ public class TestDefaultPriceOverride extends CatalogTestSuiteWithEmbeddedDB {
         assertNotEquals(overriddenPlan.getFinalPhase().getName(), plan.getFinalPhase().getName());
 
         final DefaultPlanPhase initialPhase = (DefaultPlanPhase) plan.getFinalPhase();
-        final DefaultPlanPhase newPhase = (DefaultPlanPhase) overriddenPlan.getFinalPhase();
+        final DefaultPlanPhase newPhase = overriddenPlan.getFinalPhase();
 
-        final PlanPhasePriceOverride override = Iterables.tryFind(overrides, new Predicate<PlanPhasePriceOverride>() {
-            @Override
-            public boolean apply(final PlanPhasePriceOverride input) {
-                return input.getPhaseName().equals(initialPhase.getName());
-            }
-        }).orNull();
+        final PlanPhasePriceOverride override = findPlanPhasePriceOverrideByName(overrides, initialPhase.getName());
 
         assertNotEquals(newPhase.getName(), initialPhase.getName());
         assertEquals(newPhase.getName(), overriddenPlan.getName() + "-" + initialPhase.getName().split("-")[initialPhase.getName().split("-").length - 1]);
@@ -340,20 +333,12 @@ public class TestDefaultPriceOverride extends CatalogTestSuiteWithEmbeddedDB {
                 assertEquals(newTier.getTieredBlocks().length, initialTier.getTieredBlocks().length);
 
                 for (int k = 0; k < newTier.getTieredBlocks().length; k++) {
-                    final DefaultTieredBlock initialTieredBlock = (DefaultTieredBlock) initialTier.getTieredBlocks()[k];
-                    final DefaultTieredBlock newTieredBlock = (DefaultTieredBlock) newTier.getTieredBlocks()[k];
+                    final DefaultTieredBlock initialTieredBlock = initialTier.getTieredBlocks()[k];
+                    final DefaultTieredBlock newTieredBlock = newTier.getTieredBlocks()[k];
                     List<TieredBlockPriceOverride> tieredBlockPriceOverrides = new ArrayList<TieredBlockPriceOverride>();
                     tieredBlockPriceOverrides.addAll(tieredBlockPriceOverrides1);
                     tieredBlockPriceOverrides.addAll(tieredBlockPriceOverrides2);
-                    final TieredBlockPriceOverride tieredBlockPriceOverride = Iterables.tryFind(tieredBlockPriceOverrides, new Predicate<TieredBlockPriceOverride>() {
-                        @Override
-                        public boolean apply(final TieredBlockPriceOverride input) {
-
-                            return input.getUnitName().equals(initialTieredBlock.getUnit().getName()) &&
-                                   input.getSize().compareTo(initialTieredBlock.getSize()) == 0 &&
-                                   input.getMax().compareTo(initialTieredBlock.getMax()) == 0;
-                        }
-                    }).orNull();
+                    final TieredBlockPriceOverride tieredBlockPriceOverride = findTieredBlockPriceOverrideByNameSizeAndMax(tieredBlockPriceOverrides, initialTieredBlock);
 
                     assertEquals(newTieredBlock.getUnit().getName(), initialTieredBlock.getUnit().getName());
                     assertEquals(newTieredBlock.getMax(), initialTieredBlock.getMax());

--- a/catalog/src/test/java/org/killbill/billing/catalog/TestStandaloneCatalog.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/TestStandaloneCatalog.java
@@ -16,14 +16,13 @@
 
 package org.killbill.billing.catalog;
 
+import java.util.List;
+
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.catalog.api.PhaseType;
-import org.killbill.billing.catalog.api.Plan;
 import org.killbill.xmlloader.ValidationException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestStandaloneCatalog extends CatalogTestSuiteNoDB {
 
@@ -66,7 +65,7 @@ public class TestStandaloneCatalog extends CatalogTestSuiteNoDB {
         phaseDiscount1.setPlan(plan1);
         phaseDiscount2.setPlan(plan2);
 
-        final StandaloneCatalog cat = new MockCatalog().setPlans(ImmutableList.<Plan>of(plan1, plan2));
+        final StandaloneCatalog cat = new MockCatalog().setPlans(List.of(plan1, plan2));
 
         Assert.assertEquals(cat.findPhase("TestPlan1-discount"), phaseDiscount1);
         Assert.assertEquals(cat.findPhase("TestPlan2-discount"), phaseDiscount2);

--- a/catalog/src/test/java/org/killbill/billing/catalog/TestStandaloneCatalogWithPriceOverride.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/TestStandaloneCatalogWithPriceOverride.java
@@ -18,7 +18,8 @@
 package org.killbill.billing.catalog;
 
 import java.math.BigDecimal;
-import java.util.regex.Matcher;
+import java.util.Collections;
+import java.util.List;
 
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.catalog.api.BillingPeriod;
@@ -29,13 +30,9 @@ import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
 import org.killbill.billing.catalog.api.PlanPhasePriceOverridesWithCallContext;
 import org.killbill.billing.catalog.api.PlanSpecifier;
 import org.killbill.billing.catalog.api.StaticCatalog;
-import org.killbill.billing.catalog.api.UsagePriceOverride;
-import org.killbill.billing.catalog.override.DefaultPriceOverride;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestStandaloneCatalogWithPriceOverride extends CatalogTestSuiteWithEmbeddedDB {
 
@@ -51,8 +48,8 @@ public class TestStandaloneCatalogWithPriceOverride extends CatalogTestSuiteWith
         final PlanSpecifier spec = new PlanSpecifier("standard-monthly-67890");
         final PlanPhasePriceOverridesWithCallContext overrides = Mockito.mock(PlanPhasePriceOverridesWithCallContext.class);
         Mockito.when(overrides.getCallContext()).thenReturn(callContext);
-        final PlanPhasePriceOverride override = new DefaultPlanPhasePriceOverride("standard-monthly-evergreen", Currency.USD, null, BigDecimal.ONE, ImmutableList.<UsagePriceOverride>of());
-        Mockito.when(overrides.getOverrides()).thenReturn(ImmutableList.of(override));
+        final PlanPhasePriceOverride override = new DefaultPlanPhasePriceOverride("standard-monthly-evergreen", Currency.USD, null, BigDecimal.ONE, Collections.emptyList());
+        Mockito.when(overrides.getOverrides()).thenReturn(List.of(override));
         final Plan plan = standaloneCatalogWithPriceOverride.createOrFindPlan(spec, overrides);
         Assert.assertTrue(plan.getName().startsWith("standard-monthly-67890-"));
         Assert.assertTrue(priceOverridePattern.isOverriddenPlan(plan.getName()));

--- a/catalog/src/test/java/org/killbill/billing/catalog/io/TestVersionedCatalogLoader.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/io/TestVersionedCatalogLoader.java
@@ -24,19 +24,17 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.catalog.CatalogTestSuiteNoDB;
-import org.killbill.billing.catalog.DefaultVersionedCatalog;
 import org.killbill.billing.catalog.api.CatalogApiException;
-import org.killbill.billing.catalog.api.StaticCatalog;
 import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.util.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.io.Files;
-import com.google.common.io.Resources;
 
 public class TestVersionedCatalogLoader extends CatalogTestSuiteNoDB {
 
@@ -113,7 +111,7 @@ public class TestVersionedCatalogLoader extends CatalogTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testLoad() throws CatalogApiException {
-        final VersionedCatalog c = loader.loadDefaultCatalog(Resources.getResource("org/killbill/billing/catalog/versionedCatalog").toString());
+        final VersionedCatalog c = loader.loadDefaultCatalog(IOUtils.getResourceAsURL("org/killbill/billing/catalog/versionedCatalog").toString());
         Assert.assertEquals(c.getVersions().size(), 4);
         DateTime dt = new DateTime("2011-01-01T00:00:00+00:00");
         Assert.assertEquals(c.getVersions().get(0).getEffectiveDate(), dt.toDate());
@@ -155,10 +153,10 @@ public class TestVersionedCatalogLoader extends CatalogTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testLoadCatalogFromExternalFile() throws CatalogApiException, IOException, URISyntaxException {
-        final File originFile = new File(Resources.getResource("org/killbill/billing/catalog/SpyCarBasic.xml").toURI());
-        final File destinationFile = new File(Files.createTempDir().toString() + "/SpyCarBasicRelocated.xml");
+        final File originFile = new File(IOUtils.getResourceAsURL("org/killbill/billing/catalog/SpyCarBasic.xml").toURI());
+        final File destinationFile = Files.createTempFile(null, "SpyCarBasicRelocated.xml").toFile();
         destinationFile.deleteOnExit();
-        Files.copy(originFile, destinationFile);
+        Files.copy(originFile.toPath(), destinationFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         final VersionedCatalog c = loader.loadDefaultCatalog(destinationFile.toURI().toString());
         Assert.assertEquals(c.getCatalogName(), "SpyCarBasic");
     }

--- a/catalog/src/test/java/org/killbill/billing/catalog/plugin/TestCatalogPluginMapping.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/plugin/TestCatalogPluginMapping.java
@@ -17,14 +17,11 @@
 
 package org.killbill.billing.catalog.plugin;
 
+import java.util.List;
+
 import org.joda.time.DateTime;
 import org.killbill.billing.catalog.CatalogTestSuiteNoDB;
 import org.killbill.billing.catalog.StandaloneCatalog;
-import org.killbill.billing.catalog.api.Currency;
-import org.killbill.billing.catalog.api.Plan;
-import org.killbill.billing.catalog.api.PriceList;
-import org.killbill.billing.catalog.api.Product;
-import org.killbill.billing.catalog.api.Unit;
 import org.killbill.billing.catalog.api.rules.CaseBillingAlignment;
 import org.killbill.billing.catalog.api.rules.CaseCancelPolicy;
 import org.killbill.billing.catalog.api.rules.CaseChangePlanAlignment;
@@ -34,8 +31,6 @@ import org.killbill.billing.catalog.api.rules.CasePriceList;
 import org.killbill.billing.catalog.plugin.api.StandalonePluginCatalog;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestCatalogPluginMapping extends CatalogTestSuiteNoDB {
 
@@ -52,11 +47,11 @@ public class TestCatalogPluginMapping extends CatalogTestSuiteNoDB {
 
     }
 
-    private StandalonePluginCatalog buildStandalonePluginCatalog(final StandaloneCatalog inputCatalog) throws Exception {
+    private StandalonePluginCatalog buildStandalonePluginCatalog(final StandaloneCatalog inputCatalog) {
 
-        final TestModelPlanRules rules = new TestModelPlanRules(ImmutableList.<Product>copyOf(inputCatalog.getProducts()),
-                                                      ImmutableList.<Plan>copyOf(inputCatalog.getPlans()),
-                                                      inputCatalog.getPriceLists().getAllPriceLists());
+        final TestModelPlanRules rules = new TestModelPlanRules(List.copyOf(inputCatalog.getProducts()),
+                                                                List.copyOf(inputCatalog.getPlans()),
+                                                                inputCatalog.getPriceLists().getAllPriceLists());
 
         if (inputCatalog.getPlanRules().getCaseChangePlanPolicy() != null) {
             for (final CaseChangePlanPolicy cur : inputCatalog.getPlanRules().getCaseChangePlanPolicy()) {
@@ -89,13 +84,13 @@ public class TestCatalogPluginMapping extends CatalogTestSuiteNoDB {
             }
         }
         final TestModelStandalonePluginCatalog result = new TestModelStandalonePluginCatalog(new DateTime(inputCatalog.getEffectiveDate()),
-                                                                                   ImmutableList.<Currency>copyOf(inputCatalog.getSupportedCurrencies()),
-                                                                                   ImmutableList.<Product>copyOf(inputCatalog.getProducts()),
-                                                                                   ImmutableList.<Plan>copyOf(inputCatalog.getPlans()),
+                                                                                   List.of(inputCatalog.getSupportedCurrencies()),
+                                                                                   List.copyOf(inputCatalog.getProducts()),
+                                                                                   List.copyOf(inputCatalog.getPlans()),
                                                                                    inputCatalog.getPriceLists().getDefaultPricelist(),
-                                                                                   ImmutableList.<PriceList>copyOf(inputCatalog.getPriceLists().getChildPriceLists()),
+                                                                                   List.of(inputCatalog.getPriceLists().getChildPriceLists()),
                                                                                    rules,
-                                                                                   ImmutableList.<Unit>copyOf(inputCatalog.getUnits()));
+                                                                                   List.of(inputCatalog.getUnits()));
         return result;
     }
 

--- a/catalog/src/test/java/org/killbill/billing/catalog/plugin/TestModelPlanRules.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/plugin/TestModelPlanRules.java
@@ -19,6 +19,7 @@ package org.killbill.billing.catalog.plugin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
@@ -45,8 +46,7 @@ import org.killbill.billing.catalog.api.rules.CaseCreateAlignment;
 import org.killbill.billing.catalog.api.rules.CasePriceList;
 import org.killbill.billing.catalog.api.rules.PlanRules;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
+import static org.killbill.billing.util.collect.CollectionTransformer.iterableToList;
 
 public class TestModelPlanRules implements PlanRules {
 
@@ -214,37 +214,22 @@ public class TestModelPlanRules implements PlanRules {
     }
 
     private Product findProduct(@Nullable final String productName) {
-        return find(products, productName, "products", new Predicate<Product>() {
-            @Override
-            public boolean apply(final Product input) {
-                return input.getName().equals(productName);
-            }
-        });
+        return find(products, productName, "products", input -> input.getName().equals(productName));
     }
 
     private Plan findPlan(@Nullable final String planName) {
-        return find(plans, planName, "plans", new Predicate<Plan>() {
-            @Override
-            public boolean apply(final Plan input) {
-                return input.getName().equals(planName);
-            }
-        });
+        return find(plans, planName, "plans", input -> input.getName().equals(planName));
     }
 
     private PriceList findPriceList(@Nullable final String priceListName) {
-        return find(priceLists, priceListName, "pricelists", new Predicate<PriceList>() {
-            @Override
-            public boolean apply(final PriceList input) {
-                return input.getName().equals(priceListName);
-            }
-        });
+        return find(priceLists, priceListName, "pricelists", input -> input.getName().equals(priceListName));
     }
 
     private <T> T find(final Iterable<T> all, @Nullable final String name, final String what, final Predicate<T> predicate) {
         if (name == null) {
             return null;
         }
-        final T result = Iterables.tryFind(all, predicate).orNull();
+        final T result = iterableToList(all).stream().filter(predicate).findFirst().orElse(null);
         if (result == null) {
             throw new IllegalStateException(String.format("%s : cannot find entry %s", what, name));
         }


### PR DESCRIPTION
Work for #1615 in `catalog` module. 20+ classes, but one thing that probably worth to mention is about:

`<!-- Required scope for the maven shade plugin (tools) -->`

comment in Guava dependency [pom.xml](https://github.com/killbill/killbill/compare/work-for-release-0.23.x...xsalefter:1615-killbill_catalog?expand=1#diff-19265f7f2096d2f336503b67d72a52073836d053b0e4d995875919c0f0271364L41). We able to remove guava dependency and `fast`, `slow` build is success, but I'm not sure with shade plugin. Perhaps it is just old comment?