### PR TITLE
1615 currency and subscription

### DIFF
--- a/currency/src/main/java/org/killbill/billing/currency/DefaultCurrencyProviderPluginRegistry.java
+++ b/currency/src/main/java/org/killbill/billing/currency/DefaultCurrencyProviderPluginRegistry.java
@@ -20,14 +20,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.killbill.billing.currency.plugin.api.CurrencyPluginApi;
 import org.killbill.billing.osgi.api.OSGIServiceDescriptor;
 import org.killbill.billing.osgi.api.OSGIServiceRegistration;
-
-import com.google.inject.Inject;
 
 public class DefaultCurrencyProviderPluginRegistry implements OSGIServiceRegistration<CurrencyPluginApi> {
 

--- a/currency/src/main/java/org/killbill/billing/currency/glue/DefaultCurrencyProviderPluginRegistryProvider.java
+++ b/currency/src/main/java/org/killbill/billing/currency/glue/DefaultCurrencyProviderPluginRegistryProvider.java
@@ -17,12 +17,11 @@
 package org.killbill.billing.currency.glue;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 import org.killbill.billing.currency.DefaultCurrencyProviderPluginRegistry;
 import org.killbill.billing.currency.plugin.api.CurrencyPluginApi;
 import org.killbill.billing.osgi.api.OSGIServiceRegistration;
-
-import com.google.inject.Provider;
 
 public class DefaultCurrencyProviderPluginRegistryProvider implements Provider<OSGIServiceRegistration<CurrencyPluginApi>> {
 

--- a/subscription/src/main/java/org/killbill/billing/subscription/alignment/PlanAligner.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/alignment/PlanAligner.java
@@ -19,6 +19,7 @@ package org.killbill.billing.subscription.alignment;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -41,10 +42,6 @@ import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseTransition;
 import org.killbill.billing.subscription.catalog.SubscriptionCatalog;
 import org.killbill.billing.subscription.exceptions.SubscriptionBaseError;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 /**
  * PlanAligner offers specific APIs to return the correct {@code TimedPhase} when creating, changing Plan or to compute
@@ -345,12 +342,7 @@ public class PlanAligner extends BaseAligner {
     }
 
     private boolean isPlanContainPhaseType(final Plan plan, @Nullable final PhaseType phaseType) {
-        return Iterables.any(ImmutableList.copyOf(plan.getAllPhases()), new Predicate<PlanPhase>() {
-            @Override
-            public boolean apply(final PlanPhase input) {
-                return input.getPhaseType() == phaseType;
-            }
-        });
+        return Stream.of(plan.getAllPhases()).anyMatch(input -> input.getPhaseType() == phaseType);
     }
 
     private enum WhichPhase {

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionApiBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionApiBase.java
@@ -295,11 +295,9 @@ public class SubscriptionApiBase {
         return new DefaultSubscriptionBase((DefaultSubscriptionBase) internalSubscription, apiService, clock);
     }
 
-    // FIXME-1615 : Parameter InternalTenantContext context not used. Maybe worth to remove?
     protected DefaultSubscriptionBase createSubscriptionForApiUse(final SubscriptionBuilder builder,
                                                                   final List<SubscriptionBaseEvent> events,
-                                                                  final SubscriptionCatalog catalog,
-                                                                  final InternalTenantContext context) throws CatalogApiException {
+                                                                  final SubscriptionCatalog catalog) throws CatalogApiException {
         final DefaultSubscriptionBase subscription = new DefaultSubscriptionBase(builder, apiService, clock);
         if (!events.isEmpty()) {
             subscription.rebuildTransitions(events, catalog);

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionApiBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionApiBase.java
@@ -18,6 +18,7 @@ package org.killbill.billing.subscription.api;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -58,9 +59,6 @@ import org.killbill.billing.util.cache.CacheController;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.clock.Clock;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.sort;
-
 public class SubscriptionApiBase {
 
     protected final SubscriptionDao dao;
@@ -77,7 +75,7 @@ public class SubscriptionApiBase {
     protected SubscriptionBaseBundle getActiveBundleForKey(final String bundleKey, final SubscriptionCatalog catalog, final InternalTenantContext context) throws CatalogApiException {
         final List<SubscriptionBaseBundle> existingBundles = dao.getSubscriptionBundlesForKey(bundleKey, context);
         for (final SubscriptionBaseBundle cur : existingBundles) {
-            final List<DefaultSubscriptionBase> subscriptions = dao.getSubscriptions(cur.getId(), emptyList(), catalog, context);
+            final List<DefaultSubscriptionBase> subscriptions = dao.getSubscriptions(cur.getId(), Collections.emptyList(), catalog, context);
             for (final SubscriptionBase s : subscriptions) {
                 if (s.getCategory() == ProductCategory.ADD_ON) {
                     continue;
@@ -115,7 +113,7 @@ public class SubscriptionApiBase {
         if (result != null && !result.isEmpty()) {
             outputSubscriptions.addAll(result);
         }
-        sort(outputSubscriptions, DefaultSubscriptionInternalApi.SUBSCRIPTIONS_COMPARATOR);
+        Collections.sort(outputSubscriptions, DefaultSubscriptionInternalApi.SUBSCRIPTIONS_COMPARATOR);
 
         return createSubscriptionsForApiUse(outputSubscriptions);
     }

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/svcs/DefaultSubscriptionInternalApi.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/svcs/DefaultSubscriptionInternalApi.java
@@ -60,7 +60,6 @@ import org.killbill.billing.subscription.api.SubscriptionBaseWithAddOns;
 import org.killbill.billing.subscription.api.SubscriptionBaseWithAddOnsSpecifier;
 import org.killbill.billing.subscription.api.user.DefaultEffectiveSubscriptionEvent;
 import org.killbill.billing.subscription.api.user.DefaultSubscriptionBase;
-import org.killbill.billing.subscription.api.user.DefaultSubscriptionBaseBundle;
 import org.killbill.billing.subscription.api.user.DefaultSubscriptionStatusDryRun;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseBundle;
@@ -184,9 +183,6 @@ public class DefaultSubscriptionInternalApi extends DefaultSubscriptionBaseCreat
     @VisibleForTesting
     @Override
     public SubscriptionBaseBundle createBundleForAccount(final UUID accountId, final String bundleKey, final boolean renameCancelledBundleIfExist, final InternalCallContext context) throws SubscriptionBaseApiException {
-        final DateTime now = context.getCreatedDate();
-        // FIXME-1615 : This is not used but intellij report there's possible side effect. But I don't think so. Thought?
-        final DefaultSubscriptionBaseBundle bundle = new DefaultSubscriptionBaseBundle(bundleKey, accountId, now, now, now, now);
         if (null != bundleKey && bundleKey.length() > 255) {
             throw new SubscriptionBaseApiException(ErrorCode.EXTERNAL_KEY_LIMIT_EXCEEDED);
         }
@@ -346,7 +342,7 @@ public class DefaultSubscriptionInternalApi extends DefaultSubscriptionBaseCreat
 
 
     @Override
-    public void setChargedThroughDates(final Map<DateTime, List<UUID>> chargeThroughDates, InternalCallContext context) throws SubscriptionBaseApiException {
+    public void setChargedThroughDates(final Map<DateTime, List<UUID>> chargeThroughDates, final InternalCallContext context) throws SubscriptionBaseApiException {
             dao.updateChargedThroughDates(chargeThroughDates, context);
     }
 
@@ -555,7 +551,7 @@ public class DefaultSubscriptionInternalApi extends DefaultSubscriptionBaseCreat
         if (bcd < currentDay) {
             final LocalDate startDatePlusOneMonth = startDate.plusMonths(1);
             final int lastDayOfNextMonth = startDatePlusOneMonth.dayOfMonth().getMaximumValue();
-            final int originalBCDORLastDayOfMonth = bcd <= lastDayOfNextMonth ? bcd : lastDayOfNextMonth;
+            final int originalBCDORLastDayOfMonth = Math.min(bcd, lastDayOfNextMonth);
             requestedDate = new LocalDate(startDatePlusOneMonth.getYear(), startDatePlusOneMonth.getMonthOfYear(), originalBCDORLastDayOfMonth);
         } else if (bcd == currentDay && effectiveFromDate == null) {
             // will default to immediate event

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/timeline/DefaultSubscriptionBaseTimelineApi.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/timeline/DefaultSubscriptionBaseTimelineApi.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 
+import javax.inject.Inject;
+
 import org.joda.time.DateTime;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.callcontext.InternalTenantContext;
@@ -31,18 +33,13 @@ import org.killbill.billing.subscription.api.SubscriptionApiBase;
 import org.killbill.billing.subscription.api.SubscriptionBase;
 import org.killbill.billing.subscription.api.SubscriptionBaseApiService;
 import org.killbill.billing.subscription.api.user.DefaultSubscriptionBase;
-import org.killbill.billing.subscription.api.user.DefaultSubscriptionBaseBundle;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseBundle;
 import org.killbill.billing.subscription.catalog.SubscriptionCatalog;
 import org.killbill.billing.subscription.catalog.SubscriptionCatalogApi;
 import org.killbill.billing.subscription.engine.dao.SubscriptionDao;
-import org.killbill.billing.subscription.events.SubscriptionBaseEvent;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.clock.Clock;
-
-import com.google.common.collect.ImmutableList;
-import com.google.inject.Inject;
 
 public class DefaultSubscriptionBaseTimelineApi extends SubscriptionApiBase implements SubscriptionBaseTimelineApi {
 
@@ -64,20 +61,18 @@ public class DefaultSubscriptionBaseTimelineApi extends SubscriptionApiBase impl
     public BundleBaseTimeline getBundleTimeline(final SubscriptionBaseBundle bundle, final TenantContext context)
             throws SubscriptionBaseRepairException {
         try {
-
-
             final InternalTenantContext internalTenantContext = internalCallContextFactory.createInternalTenantContext(bundle.getAccountId(), context);
             final SubscriptionCatalog catalog = subscriptionCatalogApi.getFullCatalog(internalTenantContext);
             final List<DefaultSubscriptionBase> subscriptions = dao.getSubscriptions(bundle.getId(),
-                                                                                     ImmutableList.<SubscriptionBaseEvent>of(),
+                                                                                     Collections.emptyList(),
                                                                                      catalog,
                                                                                      internalTenantContext);
-            if (subscriptions.size() == 0) {
+            if (subscriptions.isEmpty()) {
                 throw new SubscriptionBaseRepairException(ErrorCode.SUB_NO_ACTIVE_SUBSCRIPTIONS, bundle.getId());
             }
-            final List<SubscriptionBaseTimeline> repairs = createGetSubscriptionRepairList(subscriptions, Collections.<SubscriptionBaseTimeline>emptyList(), catalog, internalTenantContext);
+            final List<SubscriptionBaseTimeline> repairs = createGetSubscriptionRepairList(subscriptions, Collections.emptyList(), catalog, internalTenantContext);
             return createGetBundleRepair(bundle.getId(), bundle.getExternalKey(), repairs);
-        } catch (CatalogApiException e) {
+        } catch (final CatalogApiException e) {
             throw new SubscriptionBaseRepairException(e);
         }
     }
@@ -115,8 +110,8 @@ public class DefaultSubscriptionBaseTimelineApi extends SubscriptionApiBase impl
 
     private List<SubscriptionBaseTimeline> createGetSubscriptionRepairList(final List<DefaultSubscriptionBase> subscriptions, final List<SubscriptionBaseTimeline> inRepair, final SubscriptionCatalog catalog, final InternalTenantContext tenantContext) throws CatalogApiException {
 
-        final List<SubscriptionBaseTimeline> result = new LinkedList<SubscriptionBaseTimeline>();
-        final Set<UUID> repairIds = new TreeSet<UUID>();
+        final List<SubscriptionBaseTimeline> result = new LinkedList<>();
+        final Set<UUID> repairIds = new TreeSet<>();
         for (final SubscriptionBaseTimeline cur : inRepair) {
             repairIds.add(cur.getId());
             result.add(cur);

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/transfer/DefaultSubscriptionBaseTransferApi.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/transfer/DefaultSubscriptionBaseTransferApi.java
@@ -18,12 +18,14 @@
 
 package org.killbill.billing.subscription.api.transfer;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.ErrorCode;
@@ -55,15 +57,11 @@ import org.killbill.billing.subscription.events.user.ApiEventBuilder;
 import org.killbill.billing.subscription.events.user.ApiEventCancel;
 import org.killbill.billing.subscription.events.user.ApiEventChange;
 import org.killbill.billing.subscription.events.user.ApiEventTransfer;
-import org.killbill.billing.subscription.exceptions.SubscriptionBaseError;
 import org.killbill.billing.util.UUIDs;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.clock.Clock;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import com.google.inject.Inject;
 
 public class DefaultSubscriptionBaseTransferApi extends SubscriptionApiBase implements SubscriptionBaseTransferApi {
 
@@ -268,7 +266,9 @@ public class DefaultSubscriptionBaseTransferApi extends SubscriptionApiBase impl
                                                                                                             .setCategory(productCategory)
                                                                                                             .setBundleStartDate(effectiveTransferDate)
                                                                                                             .setAlignStartDate(subscriptionAlignStartDate),
-                                                                                                    ImmutableList.<SubscriptionBaseEvent>of(), catalog, fromInternalCallContext);
+                                                                                                    Collections.emptyList(),
+                                                                                                    catalog,
+                                                                                                    fromInternalCallContext);
 
                 final List<SubscriptionBaseEvent> events = toEvents(existingEvents, defaultSubscriptionBase, effectiveTransferDate);
                 final SubscriptionTransferData curData = new SubscriptionTransferData(defaultSubscriptionBase, events, null);

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/transfer/DefaultSubscriptionBaseTransferApi.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/transfer/DefaultSubscriptionBaseTransferApi.java
@@ -129,11 +129,11 @@ public class DefaultSubscriptionBaseTransferApi extends SubscriptionApiBase impl
     @VisibleForTesting
     List<SubscriptionBaseEvent> toEvents(final List<ExistingEvent> existingEvents, final DefaultSubscriptionBase subscription, final DateTime transferDate) throws SubscriptionBaseTransferApiException {
         try {
-            final List<SubscriptionBaseEvent> result = new LinkedList<SubscriptionBaseEvent>();
+            final List<SubscriptionBaseEvent> result = new LinkedList<>();
             ExistingEvent prevEvent = null;
             ExistingEvent prevBCDEvent = null;
             boolean firstEvent = true;
-            for (ExistingEvent cur : existingEvents) {
+            for (final ExistingEvent cur : existingEvents) {
                 // Skip all events prior to the transferDate
                 if (cur.getEffectiveDate().isBefore(transferDate)) {
                     if (cur.getSubscriptionTransitionType() == SubscriptionBaseTransitionType.BCD_CHANGE) {
@@ -168,14 +168,14 @@ public class DefaultSubscriptionBaseTransferApi extends SubscriptionApiBase impl
 
 
             return result;
-        } catch (CatalogApiException e) {
+        } catch (final CatalogApiException e) {
             throw new SubscriptionBaseTransferApiException(e);
         }
     }
 
     private boolean insertEventToResult(final boolean firstEvent, @Nullable final ExistingEvent event, final DefaultSubscriptionBase subscription, final DateTime transferDate, final List<SubscriptionBaseEvent> result) throws CatalogApiException {
         if (event != null) {
-            SubscriptionBaseEvent newEvent = createEvent(firstEvent, event, subscription, transferDate);
+            final SubscriptionBaseEvent newEvent = createEvent(firstEvent, event, subscription, transferDate);
             if (newEvent != null) {
                 result.add(newEvent);
                 return true;
@@ -267,8 +267,7 @@ public class DefaultSubscriptionBaseTransferApi extends SubscriptionApiBase impl
                                                                                                             .setBundleStartDate(effectiveTransferDate)
                                                                                                             .setAlignStartDate(subscriptionAlignStartDate),
                                                                                                     Collections.emptyList(),
-                                                                                                    catalog,
-                                                                                                    fromInternalCallContext);
+                                                                                                    catalog);
 
                 final List<SubscriptionBaseEvent> events = toEvents(existingEvents, defaultSubscriptionBase, effectiveTransferDate);
                 final SubscriptionTransferData curData = new SubscriptionTransferData(defaultSubscriptionBase, events, null);
@@ -280,9 +279,9 @@ public class DefaultSubscriptionBaseTransferApi extends SubscriptionApiBase impl
             dao.transfer(sourceAccountId, destAccountId, bundleTransferData, transferCancelDataList, catalog, fromInternalCallContext, toInternalCallContext);
 
             return bundleTransferData.getData();
-        } catch (SubscriptionBaseRepairException e) {
+        } catch (final SubscriptionBaseRepairException e) {
             throw new SubscriptionBaseTransferApiException(e);
-        } catch (CatalogApiException e) {
+        } catch (final CatalogApiException e) {
             throw new SubscriptionBaseTransferApiException(e);
         }
     }

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBaseApiService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBaseApiService.java
@@ -21,6 +21,7 @@ package org.killbill.billing.subscription.api.user;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.joda.time.ReadableInstant;
@@ -63,7 +65,6 @@ import org.killbill.billing.subscription.catalog.SubscriptionCatalogApi;
 import org.killbill.billing.subscription.engine.addon.AddonUtils;
 import org.killbill.billing.subscription.engine.dao.SubscriptionDao;
 import org.killbill.billing.subscription.events.SubscriptionBaseEvent;
-import org.killbill.billing.subscription.events.SubscriptionBaseEvent.EventType;
 import org.killbill.billing.subscription.events.bcd.BCDEventBuilder;
 import org.killbill.billing.subscription.events.bcd.BCDEventData;
 import org.killbill.billing.subscription.events.expired.ExpiredEventBuilder;
@@ -78,21 +79,18 @@ import org.killbill.billing.subscription.events.user.ApiEventCreate;
 import org.killbill.billing.subscription.events.user.ApiEventType;
 import org.killbill.billing.subscription.events.user.ApiEventUncancel;
 import org.killbill.billing.subscription.events.user.ApiEventUndoChange;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.collect.MultiValueHashMap;
+import org.killbill.billing.util.collect.MultiValueMap;
 import org.killbill.clock.Clock;
 import org.killbill.clock.DefaultClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ListMultimap;
-import com.google.inject.Inject;
-
+// FIXME-1615 : Take care of new MultiValueMap implementation
 public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiService {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultSubscriptionBaseApiService.class);
@@ -142,9 +140,9 @@ public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiSer
             }
 
             final List<SubscriptionBaseEvent> events = dao.createSubscriptionsWithAddOns(allSubscriptions, eventsMap, kbCatalog, internalCallContext);
-            final ListMultimap<UUID, SubscriptionBaseEvent> eventsBySubscription = ArrayListMultimap.<UUID, SubscriptionBaseEvent>create();
+            final MultiValueMap<UUID, SubscriptionBaseEvent> eventsBySubscription = new MultiValueHashMap<>();
             for (final SubscriptionBaseEvent event : events) {
-                eventsBySubscription.put(event.getSubscriptionId(), event);
+                eventsBySubscription.putElement(event.getSubscriptionId(), event);
             }
 
             for (final List<SubscriptionBase> subscriptions : subscriptionBaseAndAddOnsList) {
@@ -198,7 +196,7 @@ public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiSer
 
             final DateTime effectiveDate = subscription.getEffectiveDateForPolicy(policy, null, -1, null);
 
-            return doCancelPlan(ImmutableMap.<DefaultSubscriptionBase, DateTime>of(subscription, effectiveDate), catalog, internalCallContext);
+            return doCancelPlan(Map.of(subscription, effectiveDate), catalog, internalCallContext);
         } catch (final CatalogApiException e) {
             throw new SubscriptionBaseApiException(e);
         }
@@ -215,7 +213,7 @@ public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiSer
             final SubscriptionCatalog catalog = subscriptionCatalogApi.getFullCatalog(internalCallContext);
             final DateTime effectiveDate = (requestedDateWithMs != null) ? DefaultClock.truncateMs(requestedDateWithMs) : context.getCreatedDate();
 
-            return doCancelPlan(ImmutableMap.<DefaultSubscriptionBase, DateTime>of(subscription, effectiveDate), catalog, internalCallContext);
+            return doCancelPlan(Map.of(subscription, effectiveDate), catalog, internalCallContext);
         } catch (final CatalogApiException e) {
             throw new SubscriptionBaseApiException(e);
         }
@@ -230,7 +228,7 @@ public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiSer
         final InternalCallContext internalCallContext = createCallContextFromBundleId(subscription.getBundleId(), context);
         try {
             final SubscriptionCatalog catalog = subscriptionCatalogApi.getFullCatalog(internalCallContext);
-            return cancelWithPolicyNoValidationAndCatalog(ImmutableList.<DefaultSubscriptionBase>of(subscription), policy, catalog, internalCallContext);
+            return cancelWithPolicyNoValidationAndCatalog(List.of(subscription), policy, catalog, internalCallContext);
         } catch (final CatalogApiException e) {
             throw new SubscriptionBaseApiException(e);
         }
@@ -713,11 +711,8 @@ public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiSer
     }
 
     private List<DefaultSubscriptionBase> computeAddOnsToExpire(final Collection<SubscriptionBaseEvent> expireEvents, final UUID bundleId, final DateTime effectiveDate, final SubscriptionCatalog catalog, final InternalCallContext internalCallContext) throws CatalogApiException {
-
-        final List<DefaultSubscriptionBase> subscriptionsToBeExpired = new ArrayList<DefaultSubscriptionBase>();
-
-        final List<DefaultSubscriptionBase> subscriptions = dao.getSubscriptions(bundleId, ImmutableList.<SubscriptionBaseEvent>of(), catalog, internalCallContext);
-
+        final List<DefaultSubscriptionBase> subscriptionsToBeExpired = new ArrayList<>();
+        final List<DefaultSubscriptionBase> subscriptions = dao.getSubscriptions(bundleId, Collections.emptyList(), catalog, internalCallContext);
         for (final SubscriptionBase subscription : subscriptions) {
             final DefaultSubscriptionBase cur = (DefaultSubscriptionBase) subscription;
             if (cur.getCategory() != ProductCategory.ADD_ON || cur.getState() == EntitlementState.CANCELLED || cur.getState() == EntitlementState.EXPIRED) {
@@ -739,7 +734,7 @@ public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiSer
     private List<DefaultSubscriptionBase> computeAddOnsToCancel(final Collection<SubscriptionBaseEvent> cancelEvents, final Product baseProduct, final UUID bundleId, final DateTime effectiveDate, final SubscriptionCatalog catalog, final InternalCallContext internalCallContext) throws CatalogApiException {
         // If cancellation/change occur in the future, there is nothing to do
         if (effectiveDate.compareTo(internalCallContext.getCreatedDate()) > 0) {
-            return ImmutableList.<DefaultSubscriptionBase>of();
+            return Collections.emptyList();
         } else {
             return addCancellationAddOnForEventsIfRequired(cancelEvents, baseProduct, bundleId, effectiveDate, catalog, internalCallContext);
         }
@@ -750,7 +745,7 @@ public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiSer
 
         final List<DefaultSubscriptionBase> subscriptionsToBeCancelled = new ArrayList<DefaultSubscriptionBase>();
 
-        final List<DefaultSubscriptionBase> subscriptions = dao.getSubscriptions(bundleId, ImmutableList.<SubscriptionBaseEvent>of(), catalog, internalTenantContext);
+        final List<DefaultSubscriptionBase> subscriptions = dao.getSubscriptions(bundleId, Collections.emptyList(), catalog, internalTenantContext);
 
         for (final SubscriptionBase subscription : subscriptions) {
             final DefaultSubscriptionBase cur = (DefaultSubscriptionBase) subscription;

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBaseApiService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBaseApiService.java
@@ -90,7 +90,6 @@ import org.killbill.clock.DefaultClock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// FIXME-1615 : Take care of new MultiValueMap implementation
 public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiService {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultSubscriptionBaseApiService.class);

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/core/DefaultSubscriptionBaseService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/core/DefaultSubscriptionBaseService.java
@@ -21,6 +21,8 @@ package org.killbill.billing.subscription.engine.core;
 
 import java.util.UUID;
 
+import javax.inject.Inject;
+
 import org.joda.time.DateTime;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.catalog.api.CatalogApiException;
@@ -52,7 +54,6 @@ import org.killbill.billing.util.callcontext.UserType;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.PersistentBus.EventBusException;
-import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationQueue;
 import org.killbill.notificationq.api.NotificationQueueService;
@@ -62,15 +63,12 @@ import org.killbill.notificationq.api.NotificationQueueService.NotificationQueue
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.Inject;
-
 public class DefaultSubscriptionBaseService implements EventListener, SubscriptionBaseService {
 
     public static final String NOTIFICATION_QUEUE_NAME = "subscription-events";
 
     private static final Logger log = LoggerFactory.getLogger(DefaultSubscriptionBaseService.class);
 
-    private final Clock clock;
     private final SubscriptionDao dao;
     private final PlanAligner planAligner;
     private final BusOptimizer eventBus;
@@ -82,15 +80,13 @@ public class DefaultSubscriptionBaseService implements EventListener, Subscripti
     private NotificationQueue subscriptionEventQueue;
 
     @Inject
-    public DefaultSubscriptionBaseService(final Clock clock,
-                                          final SubscriptionDao dao,
+    public DefaultSubscriptionBaseService(final SubscriptionDao dao,
                                           final PlanAligner planAligner,
                                           final BusOptimizer eventBus,
                                           final NotificationQueueService notificationQueueService,
                                           final InternalCallContextFactory internalCallContextFactory,
                                           final SubscriptionBaseApiService apiService,
                                           final SubscriptionCatalogApi subscriptionCatalogApi) {
-        this.clock = clock;
         this.dao = dao;
         this.planAligner = planAligner;
         this.eventBus = eventBus;

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -84,11 +85,14 @@ import org.killbill.billing.subscription.events.user.ApiEventCancel;
 import org.killbill.billing.subscription.events.user.ApiEventChange;
 import org.killbill.billing.subscription.events.user.ApiEventType;
 import org.killbill.billing.subscription.exceptions.SubscriptionBaseError;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.billing.util.api.AuditLevel;
 import org.killbill.billing.util.audit.AuditLogWithHistory;
 import org.killbill.billing.util.audit.dao.AuditDao;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.collect.MultiValueHashMap;
+import org.killbill.billing.util.collect.MultiValueMap;
 import org.killbill.billing.util.dao.NonEntityDao;
 import org.killbill.billing.util.dao.TableName;
 import org.killbill.billing.util.entity.Entity;
@@ -97,7 +101,6 @@ import org.killbill.billing.util.entity.dao.DefaultPaginationSqlDaoHelper.Orderi
 import org.killbill.billing.util.entity.dao.DefaultPaginationSqlDaoHelper.PaginationIteratorBuilder;
 import org.killbill.billing.util.entity.dao.EntityDaoBase;
 import org.killbill.billing.util.entity.dao.EntitySqlDao;
-import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
 import org.killbill.billing.util.optimizer.BusOptimizer;
@@ -112,17 +115,9 @@ import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Multimap;
-
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 
+// FIXME-1615 : This class complex. Ask test point to verify that changes not broke anything
 public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleModelDao, SubscriptionBaseBundle, SubscriptionApiException> implements SubscriptionDao {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultSubscriptionDao.class);
@@ -154,57 +149,37 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
 
     @Override
     public SubscriptionBaseBundle getSubscriptionBundlesForAccountAndKey(final UUID accountId, final String bundleKey, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<SubscriptionBaseBundle>() {
-            @Override
-            public SubscriptionBaseBundle inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionBundleModelDao input = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getBundlesFromAccountAndKey(accountId.toString(), bundleKey, context);
-                return SubscriptionBundleModelDao.toSubscriptionBundle(input);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionBundleModelDao input = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getBundlesFromAccountAndKey(accountId.toString(), bundleKey, context);
+            return SubscriptionBundleModelDao.toSubscriptionBundle(input);
         });
     }
 
     @Override
     public List<SubscriptionBaseBundle> getSubscriptionBundleForAccount(final UUID accountId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<SubscriptionBaseBundle>>() {
-            @Override
-            public List<SubscriptionBaseBundle> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final List<SubscriptionBundleModelDao> models = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getBundleFromAccount(accountId.toString(), context);
-
-                return new ArrayList<SubscriptionBaseBundle>(Collections2.transform(models, new Function<SubscriptionBundleModelDao, SubscriptionBaseBundle>() {
-                    @Override
-                    public SubscriptionBaseBundle apply(@Nullable final SubscriptionBundleModelDao input) {
-                        return SubscriptionBundleModelDao.toSubscriptionBundle(input);
-                    }
-                }));
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final List<SubscriptionBundleModelDao> models = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getBundleFromAccount(accountId.toString(), context);
+            return models.stream()
+                         .map(SubscriptionBundleModelDao::toSubscriptionBundle)
+                         .collect(Collectors.toList());
         });
     }
 
     @Override
     public SubscriptionBaseBundle getSubscriptionBundleFromId(final UUID bundleId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<SubscriptionBaseBundle>() {
-            @Override
-            public SubscriptionBaseBundle inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionBundleModelDao model = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getById(bundleId.toString(), context);
-                return SubscriptionBundleModelDao.toSubscriptionBundle(model);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionBundleModelDao model = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getById(bundleId.toString(), context);
+            return SubscriptionBundleModelDao.toSubscriptionBundle(model);
         });
     }
 
     @Override
     public List<SubscriptionBaseBundle> getSubscriptionBundlesForKey(final String bundleKey, final InternalTenantContext context) {
-
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<SubscriptionBaseBundle>>() {
-            @Override
-            public List<SubscriptionBaseBundle> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final List<SubscriptionBundleModelDao> models = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getBundlesForLikeKey(bundleKey, context);
-                return new ArrayList<SubscriptionBaseBundle>(Collections2.transform(models, new Function<SubscriptionBundleModelDao, SubscriptionBaseBundle>() {
-                    @Override
-                    public SubscriptionBaseBundle apply(@Nullable final SubscriptionBundleModelDao input) {
-                        return SubscriptionBundleModelDao.toSubscriptionBundle(input);
-                    }
-                }));
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final List<SubscriptionBundleModelDao> models = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getBundlesForLikeKey(bundleKey, context);
+            return models.stream()
+                         .map(SubscriptionBundleModelDao::toSubscriptionBundle)
+                         .collect(Collectors.toList());
         });
     }
 
@@ -229,126 +204,105 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
 
     @Override
     public Iterable<UUID> getNonAOSubscriptionIdsForKey(final String bundleKey, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<Iterable<UUID>>() {
-            @Override
-            public Iterable<UUID> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
 
-                final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
+            final List<SubscriptionBundleModelDao> bundles = bundleSqlDao.getBundlesForLikeKey(bundleKey, context);
 
-                final List<SubscriptionBundleModelDao> bundles = bundleSqlDao.getBundlesForLikeKey(bundleKey, context);
+            final Collection<UUID> nonAOSubscriptionIdsForKey = new LinkedList<>();
+            final SubscriptionSqlDao subscriptionSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
+            for (final SubscriptionBundleModelDao bundle : bundles) {
+                final List<SubscriptionModelDao> subscriptions = subscriptionSqlDao.getSubscriptionsFromBundleId(bundle.getId().toString(), context);
 
-                final Collection<UUID> nonAOSubscriptionIdsForKey = new LinkedList<UUID>();
-                final SubscriptionSqlDao subscriptionSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
-                for (final SubscriptionBundleModelDao bundle : bundles) {
-                    final List<SubscriptionModelDao> subscriptions = subscriptionSqlDao.getSubscriptionsFromBundleId(bundle.getId().toString(), context);
+                // Keep nonAddonSubscriptions variable for debugging purpose
+                final Collection<SubscriptionModelDao> nonAddonSubscriptions = subscriptions.stream()
+                                                                                            .filter(input -> input.getCategory() != ProductCategory.ADD_ON)
+                                                                                            .collect(Collectors.toUnmodifiableList());
 
-                    final Collection<SubscriptionModelDao> nonAddonSubscriptions = Collections2.filter(subscriptions,
-                                                                                                       new Predicate<SubscriptionModelDao>() {
-                                                                                                           @Override
-                                                                                                           public boolean apply(final SubscriptionModelDao input) {
-                                                                                                               return input.getCategory() != ProductCategory.ADD_ON;
-                                                                                                           }
-                                                                                                       });
-
-                    nonAOSubscriptionIdsForKey.addAll(Collections2.transform(nonAddonSubscriptions,
-                                                                             new Function<SubscriptionModelDao, UUID>() {
-                                                                                 @Override
-                                                                                 public UUID apply(final SubscriptionModelDao input) {
-                                                                                     return input.getId();
-                                                                                 }
-                                                                             }));
-
-                }
-
-                return nonAOSubscriptionIdsForKey;
+                nonAddonSubscriptions.stream().map(SubscriptionModelDao::getId).forEachOrdered(nonAOSubscriptionIdsForKey::add);
             }
+
+            return nonAOSubscriptionIdsForKey;
         });
+    }
+
+    //
+    // Because the creation of the SubscriptionBundle is not atomic (with creation of Subscription/SubscriptionEvent), we verify if we were left
+    // with an empty SubscriptionBaseBundle form a past failing operation (See #684). We only allow reuse if such SubscriptionBaseBundle is fully
+    // empty (and don't allow use case where all Subscription are cancelled, which is the condition for that key to be re-used)
+    // Such condition should have been checked upstream (to decide whether that key is valid or not)
+    //
+    private SubscriptionBaseBundle findExistingUnusedBundleForExternalKeyAndAccount(
+            final DefaultSubscriptionBaseBundle bundle,
+            final List<SubscriptionBundleModelDao> existingBundles,
+            final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
+            final InternalCallContext context) {
+        final SubscriptionBundleModelDao existingBundleForAccount = existingBundles.stream()
+                                                                                   // We look for strict equality ignoring tsf items with keys 'kbtsf-343453:'
+                                                                                   .filter(input -> bundle.getExternalKey().equals(input.getExternalKey()))
+                                                                                   .findFirst().orElse(null);
+
+        // If Bundle already exists, and there is 0 Subscription associated with this bundle, we reuse
+        if (existingBundleForAccount != null) {
+            final List<SubscriptionModelDao> accountSubscriptions = entitySqlDaoWrapperFactory
+                    .become(SubscriptionSqlDao.class)
+                    .getByAccountRecordId(context);
+
+            if (accountSubscriptions == null || accountSubscriptions.stream().anyMatch(input -> input.getBundleId().equals(existingBundleForAccount.getId()))) {
+                SubscriptionBundleModelDao.toSubscriptionBundle(existingBundleForAccount);
+            }
+        }
+        return null;
     }
 
     @Override
     public SubscriptionBaseBundle createSubscriptionBundle(final DefaultSubscriptionBaseBundle bundle, final SubscriptionCatalog catalog, final boolean renameCancelledBundleIfExist, final InternalCallContext context) throws SubscriptionBaseApiException {
+        return transactionalSqlDao.execute(false, SubscriptionBaseApiException.class, entitySqlDaoWrapperFactory -> {
+            final List<SubscriptionBundleModelDao> existingBundles = bundle.getExternalKey() == null ? Collections.emptyList()
+                                                                                                     : entitySqlDaoWrapperFactory.become(BundleSqlDao.class)
+                                                                                                                                 .getBundlesForLikeKey(bundle.getExternalKey(), context);
 
-        return transactionalSqlDao.execute(false, SubscriptionBaseApiException.class, new EntitySqlDaoTransactionWrapper<SubscriptionBaseBundle>() {
-
-            //
-            // Because the creation of the SubscriptionBundle is not atomic (with creation of Subscription/SubscriptionEvent), we verify if we were left
-            // with an empty SubscriptionBaseBundle form a past failing operation (See #684). We only allow reuse if such SubscriptionBaseBundle is fully
-            // empty (and don't allow use case where all Subscription are cancelled, which is the condition for that key to be re-used)
-            // Such condition should have been checked upstream (to decide whether that key is valid or not)
-            //
-
-            private SubscriptionBaseBundle findExistingUnusedBundleForExternalKeyAndAccount(final List<SubscriptionBundleModelDao> existingBundles, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) {
-                final SubscriptionBundleModelDao existingBundleForAccount = Iterables.tryFind(existingBundles, new Predicate<SubscriptionBundleModelDao>() {
-                    @Override
-                    public boolean apply(final SubscriptionBundleModelDao input) {
-                        return input.getAccountId().equals(bundle.getAccountId()) &&
-                               // We look for strict equality ignoring tsf items with keys 'kbtsf-343453:'
-                               bundle.getExternalKey().equals(input.getExternalKey());
-                    }
-
-                }).orNull();
-
-                // If Bundle already exists, and there is 0 Subscription associated with this bundle, we reuse
-                if (existingBundleForAccount != null) {
-                    final List<SubscriptionModelDao> accountSubscriptions = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getByAccountRecordId(context);
-                    if (accountSubscriptions == null ||
-                        !Iterables.any(accountSubscriptions, new Predicate<SubscriptionModelDao>() {
-                            @Override
-                            public boolean apply(final SubscriptionModelDao input) {
-                                return input.getBundleId().equals(existingBundleForAccount.getId());
-                            }
-                        })) {
-                        return SubscriptionBundleModelDao.toSubscriptionBundle(existingBundleForAccount);
-                    }
-                }
-                return null;
+            final SubscriptionBaseBundle unusedBundle = findExistingUnusedBundleForExternalKeyAndAccount(bundle, existingBundles, entitySqlDaoWrapperFactory, context);
+            if (unusedBundle != null) {
+                log.info("Found unused bundle for externalKey='{}': bundleId='{}'", bundle.getExternalKey(), unusedBundle.getId());
+                return unusedBundle;
             }
+            final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
 
-            @Override
-            public SubscriptionBaseBundle inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final List<SubscriptionBundleModelDao> existingBundles = bundle.getExternalKey() == null ? ImmutableList.<SubscriptionBundleModelDao>of()
-                                                                                                         : entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getBundlesForLikeKey(bundle.getExternalKey(), context);
+            for (SubscriptionBundleModelDao cur : existingBundles) {
+                final List<SubscriptionModelDao> subscriptions = entitySqlDaoWrapperFactory
+                        .become(SubscriptionSqlDao.class)
+                        .getSubscriptionsFromBundleId(cur.getId().toString(), context);
+                final List<SubscriptionModelDao> filtered = subscriptions == null ?
+                                                            Collections.emptyList() :
+                                                            subscriptions.stream()
+                                                                         .filter(input -> input.getCategory() != ProductCategory.ADD_ON)
+                                                                         .collect(Collectors.toUnmodifiableList());
 
-                final SubscriptionBaseBundle unusedBundle = findExistingUnusedBundleForExternalKeyAndAccount(existingBundles, entitySqlDaoWrapperFactory);
-                if (unusedBundle != null) {
-                    log.info("Found unused bundle for externalKey='{}': bundleId='{}'", bundle.getExternalKey(), unusedBundle.getId());
-                    return unusedBundle;
-                }
-                final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
-
-                for (SubscriptionBundleModelDao cur : existingBundles) {
-                    final List<SubscriptionModelDao> subscriptions = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getSubscriptionsFromBundleId(cur.getId().toString(), context);
-                    final Iterable<SubscriptionModelDao> filtered = subscriptions != null ? Iterables.filter(subscriptions, new Predicate<SubscriptionModelDao>() {
-                        @Override
-                        public boolean apply(final SubscriptionModelDao input) {
-                            return input.getCategory() != ProductCategory.ADD_ON;
-                        }
-                    }) : ImmutableList.<SubscriptionModelDao>of();
-                    for (SubscriptionModelDao f : filtered) {
-                        try {
-                            final SubscriptionBase s = buildSubscription(SubscriptionModelDao.toSubscription(f, cur.getExternalKey()), catalog, context);
-                            if (s.getState() != EntitlementState.CANCELLED) {
-                                throw new SubscriptionBaseApiException(ErrorCode.SUB_CREATE_ACTIVE_BUNDLE_KEY_EXISTS, bundle.getExternalKey());
-                            } else if (renameCancelledBundleIfExist) {
-                                log.info("Renaming bundles with externalKey='{}', prefix='cncl'", bundle.getExternalKey());
-                                renameBundleExternalKey(bundleSqlDao, bundle.getExternalKey(), "cncl", context);
-                            } /* else {
+                for (SubscriptionModelDao f : filtered) {
+                    try {
+                        final SubscriptionBase s = buildSubscription(SubscriptionModelDao.toSubscription(f, cur.getExternalKey()), catalog, context);
+                        if (s.getState() != EntitlementState.CANCELLED) {
+                            throw new SubscriptionBaseApiException(ErrorCode.SUB_CREATE_ACTIVE_BUNDLE_KEY_EXISTS, bundle.getExternalKey());
+                        } else if (renameCancelledBundleIfExist) {
+                            log.info("Renaming bundles with externalKey='{}', prefix='cncl'", bundle.getExternalKey());
+                            renameBundleExternalKey(bundleSqlDao, bundle.getExternalKey(), "cncl", context);
+                        } /* else {
                                 Code will throw SQLIntegrityConstraintViolationException because of unique constraint on externalKey; might be worth having an ErrorCode just for that
                             } */
-                        } catch (CatalogApiException e) {
-                            throw new SubscriptionBaseApiException(e);
-                        }
+                    } catch (CatalogApiException e) {
+                        throw new SubscriptionBaseApiException(e);
                     }
                 }
-
-                final SubscriptionBundleModelDao model = new SubscriptionBundleModelDao(bundle);
-                // Preserve Original created date
-                if (!existingBundles.isEmpty()) {
-                    model.setOriginalCreatedDate(existingBundles.get(0).getCreatedDate());
-                }
-                final SubscriptionBundleModelDao result = createAndRefresh(bundleSqlDao, model, context);
-                return SubscriptionBundleModelDao.toSubscriptionBundle(result);
             }
+
+            final SubscriptionBundleModelDao model = new SubscriptionBundleModelDao(bundle);
+            // Preserve Original created date
+            if (!existingBundles.isEmpty()) {
+                model.setOriginalCreatedDate(existingBundles.get(0).getCreatedDate());
+            }
+            final SubscriptionBundleModelDao result = createAndRefresh(bundleSqlDao, model, context);
+            return SubscriptionBundleModelDao.toSubscriptionBundle(result);
         });
     }
 
@@ -357,13 +311,9 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     private void renameBundleExternalKey(final BundleSqlDao bundleSqlDao, final String externalKey, final String prefix, final InternalCallContext context) {
         final List<SubscriptionBundleModelDao> bundleModelDaos = bundleSqlDao.getBundlesForKey(externalKey, context);
         if (!bundleModelDaos.isEmpty()) {
-            final Collection<String> bundleIdsToRename = Collections2.<SubscriptionBundleModelDao, String>transform(bundleModelDaos,
-                                                                                                                    new Function<SubscriptionBundleModelDao, String>() {
-                                                                                                                        @Override
-                                                                                                                        public String apply(final SubscriptionBundleModelDao input) {
-                                                                                                                            return input.getId().toString();
-                                                                                                                        }
-                                                                                                                    });
+            final Collection<String> bundleIdsToRename = bundleModelDaos.stream()
+                                                                        .map(input -> input.getId().toString())
+                                                                        .collect(Collectors.toUnmodifiableList());
             bundleSqlDao.renameBundleExternalKey(bundleIdsToRename, prefix, context);
         }
     }
@@ -375,55 +325,43 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
 
     @Override
     public SubscriptionBase getSubscriptionFromId(final UUID subscriptionId, final SubscriptionCatalog kbCatalog, final InternalTenantContext context) throws CatalogApiException {
-        final DefaultSubscriptionBase shellSubscription = transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<DefaultSubscriptionBase>() {
-            @Override
-            public DefaultSubscriptionBase inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getById(subscriptionId.toString(), context);
-                final SubscriptionBundleModelDao bundleModel = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getById(subscriptionModel.getBundleId().toString(), context);
-                return SubscriptionModelDao.toSubscription(subscriptionModel, bundleModel.getExternalKey());
-            }
+        final DefaultSubscriptionBase shellSubscription = transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getById(subscriptionId.toString(), context);
+            final SubscriptionBundleModelDao bundleModel = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getById(subscriptionModel.getBundleId().toString(), context);
+            return SubscriptionModelDao.toSubscription(subscriptionModel, bundleModel.getExternalKey());
         });
         return buildSubscription(shellSubscription, kbCatalog, context);
     }
 
     @Override
     public SubscriptionBase getSubscriptionFromExternalKey(final String externalKey, final SubscriptionCatalog catalog, final InternalTenantContext context) throws CatalogApiException {
-        final DefaultSubscriptionBase shellSubscription = transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<DefaultSubscriptionBase>() {
-            @Override
-            public DefaultSubscriptionBase inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getSubscriptionByExternalKey(externalKey, context);
-                if (subscriptionModel == null) {
-                    return null;
-                }
-                final SubscriptionBundleModelDao bundleModel = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getById(subscriptionModel.getBundleId().toString(), context);
-                return SubscriptionModelDao.toSubscription(subscriptionModel, bundleModel.getExternalKey());
+        final DefaultSubscriptionBase shellSubscription = transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getSubscriptionByExternalKey(externalKey, context);
+            if (subscriptionModel == null) {
+                return null;
             }
+            final SubscriptionBundleModelDao bundleModel = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getById(subscriptionModel.getBundleId().toString(), context);
+            return SubscriptionModelDao.toSubscription(subscriptionModel, bundleModel.getExternalKey());
         });
         return buildSubscription(shellSubscription, catalog, context);
     }
 
     @Override
     public UUID getBundleIdFromSubscriptionId(final UUID subscriptionId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<UUID>() {
-            @Override
-            public UUID inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getById(subscriptionId.toString(), context);
-                return subscriptionModel.getBundleId();
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getById(subscriptionId.toString(), context);
+            return subscriptionModel.getBundleId();
         });
     }
 
     @Override
     public UUID getSubscriptionIdFromSubscriptionExternalKey(final String externalKey, final InternalTenantContext context) throws SubscriptionBaseApiException {
-        return transactionalSqlDao.execute(true, SubscriptionBaseApiException.class, new EntitySqlDaoTransactionWrapper<UUID>() {
-            @Override
-            public UUID inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getSubscriptionByExternalKey(externalKey, context);
-                if (subscriptionModel == null) {
-                    throw new SubscriptionBaseApiException(ErrorCode.SUB_INVALID_SUBSCRIPTION_EXTERNAL_KEY, externalKey);
-                }
-                return subscriptionModel.getId();
+        return transactionalSqlDao.execute(true, SubscriptionBaseApiException.class, entitySqlDaoWrapperFactory -> {
+            final SubscriptionModelDao subscriptionModel = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getSubscriptionByExternalKey(externalKey, context);
+            if (subscriptionModel == null) {
+                throw new SubscriptionBaseApiException(ErrorCode.SUB_INVALID_SUBSCRIPTION_EXTERNAL_KEY, externalKey);
             }
+            return subscriptionModel.getId();
         });
     }
 
@@ -433,20 +371,16 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     }
 
     private List<DefaultSubscriptionBase> getSubscriptionFromBundleId(final UUID bundleId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<DefaultSubscriptionBase>>() {
-            @Override
-            public List<DefaultSubscriptionBase> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-
-                final SubscriptionBundleModelDao bundleModel = entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getById(bundleId.toString(), context);
-
-                final List<SubscriptionModelDao> models = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class).getSubscriptionsFromBundleId(bundleId.toString(), context);
-                return new ArrayList<DefaultSubscriptionBase>(Collections2.transform(models, new Function<SubscriptionModelDao, DefaultSubscriptionBase>() {
-                    @Override
-                    public DefaultSubscriptionBase apply(@Nullable final SubscriptionModelDao input) {
-                        return SubscriptionModelDao.toSubscription(input, bundleModel.getExternalKey());
-                    }
-                }));
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionBundleModelDao bundleModel = entitySqlDaoWrapperFactory
+                    .become(BundleSqlDao.class)
+                    .getById(bundleId.toString(), context);
+            final List<SubscriptionModelDao> models = entitySqlDaoWrapperFactory
+                    .become(SubscriptionSqlDao.class)
+                    .getSubscriptionsFromBundleId(bundleId.toString(), context);
+            return models.stream()
+                         .map(input -> SubscriptionModelDao.toSubscription(input, bundleModel.getExternalKey()))
+                         .collect(Collectors.toList());
         });
     }
 
@@ -455,10 +389,10 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         final Map<UUID, List<DefaultSubscriptionBase>> subscriptionsFromAccountId = getSubscriptionsFromAccountId(cutoffDt, context);
         final List<SubscriptionBaseEvent> eventsForAccount = getEventsForAccountId(cutoffDt, context);
 
-        final Map<UUID, List<DefaultSubscriptionBase>> result = new HashMap<UUID, List<DefaultSubscriptionBase>>();
-        final Multimap<UUID, SubscriptionBaseEvent> eventsForSubscriptions = ArrayListMultimap.create();
+        final Map<UUID, List<DefaultSubscriptionBase>> result = new HashMap<>();
+        final MultiValueMap<UUID, SubscriptionBaseEvent> eventsForSubscriptions = new MultiValueHashMap<>();
         for (final SubscriptionBaseEvent evt : eventsForAccount) {
-            eventsForSubscriptions.put(evt.getSubscriptionId(), evt);
+            eventsForSubscriptions.putElement(evt.getSubscriptionId(), evt);
         }
         for (final UUID bundleId : subscriptionsFromAccountId.keySet()) {
             final List<DefaultSubscriptionBase> subscriptionsForBundle = subscriptionsFromAccountId.get(bundleId);
@@ -468,41 +402,31 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     }
 
     public Map<UUID, List<DefaultSubscriptionBase>> getSubscriptionsFromAccountId(@Nullable final LocalDate cutoffDt, final InternalTenantContext context) {
-        final List<DefaultSubscriptionBase> allSubscriptions = transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<DefaultSubscriptionBase>>() {
-            @Override
-            public List<DefaultSubscriptionBase> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
+        final List<DefaultSubscriptionBase> allSubscriptions = transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionSqlDao subscriptionSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
+            final List<SubscriptionModelDao> subscriptionModels = cutoffDt == null ?
+                                                                  subscriptionSqlDao.getByAccountRecordId(context) :
+                                                                  subscriptionSqlDao.getActiveByAccountRecordId(cutoffDt.toDate(), context);
 
+            // We avoid pulling the bundles when a cutoffDt is specified, as those are not really used
+            final List<SubscriptionBundleModelDao> bundleModels = cutoffDt == null ?
+                                                                  entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getByAccountRecordId(context) :
+                                                                  Collections.emptyList();
+            return subscriptionModels.stream()
+                                     .map(input -> {
+                                         final SubscriptionBundleModelDao bundleModel = bundleModels.stream()
+                                                                                                    .filter(bundleInput -> bundleInput.getId().equals(input.getBundleId()))
+                                                                                                    .findFirst().orElse(null);
+                                         final String bundleExternalKey = bundleModel != null ? bundleModel.getExternalKey() : null;
 
-                final SubscriptionSqlDao subscriptionSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
-                final List<SubscriptionModelDao> subscriptionModels = cutoffDt == null ?
-                                                                      subscriptionSqlDao.getByAccountRecordId(context) :
-                                                                      subscriptionSqlDao.getActiveByAccountRecordId(cutoffDt.toDate(), context);
-
-                // We avoid pulling the bundles when a cutoffDt is specified, as those are not really used
-                final List<SubscriptionBundleModelDao> bundleModels = cutoffDt == null ?
-                                                                      entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getByAccountRecordId(context) :
-                                                                      ImmutableList.of();
-
-                return new ArrayList<DefaultSubscriptionBase>(Collections2.transform(subscriptionModels, new Function<SubscriptionModelDao, DefaultSubscriptionBase>() {
-                    @Override
-                    public DefaultSubscriptionBase apply(final SubscriptionModelDao input) {
-                        final SubscriptionBundleModelDao bundleModel = Iterables.tryFind(bundleModels, new Predicate<SubscriptionBundleModelDao>() {
-                            @Override
-                            public boolean apply(final SubscriptionBundleModelDao bundleInput) {
-                                return bundleInput.getId().equals(input.getBundleId());
-                            }
-                        }).orNull();
-                        final String bundleExternalKey = bundleModel != null ? bundleModel.getExternalKey() : null;
-                        return SubscriptionModelDao.toSubscription(input, bundleExternalKey);
-                    }
-                }));
-            }
+                                         return SubscriptionModelDao.toSubscription(input, bundleExternalKey);
+                                     }).collect(Collectors.toUnmodifiableList());
         });
 
-        final Map<UUID, List<DefaultSubscriptionBase>> result = new HashMap<UUID, List<DefaultSubscriptionBase>>();
+        final Map<UUID, List<DefaultSubscriptionBase>> result = new HashMap<>();
         for (final DefaultSubscriptionBase subscriptionBase : allSubscriptions) {
             if (result.get(subscriptionBase.getBundleId()) == null) {
-                result.put(subscriptionBase.getBundleId(), new LinkedList<DefaultSubscriptionBase>());
+                result.put(subscriptionBase.getBundleId(), new LinkedList<>());
             }
             result.get(subscriptionBase.getBundleId()).add(subscriptionBase);
         }
@@ -512,159 +436,129 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
 
     @Override
     public void updateChargedThroughDates(final Map<DateTime, List<UUID>> chargeThroughDates, final InternalCallContext context) {
-
         final InternalCallContext contextWithUpdatedDate = contextWithUpdatedDate(context);
-
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionSqlDao transactionalDao = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
-                for (final Map.Entry<DateTime, List<UUID>>  kv : chargeThroughDates.entrySet()) {
-                    transactionalDao.updateChargedThroughDates(kv.getValue(), kv.getKey().toDate(), contextWithUpdatedDate);
-                }
-                return null;
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final SubscriptionSqlDao transactionalDao = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
+            for (final Map.Entry<DateTime, List<UUID>>  kv : chargeThroughDates.entrySet()) {
+                transactionalDao.updateChargedThroughDates(kv.getValue(), kv.getKey().toDate(), contextWithUpdatedDate);
             }
+            return null;
         });
     }
 
-    @Override 
+    @Override
     public void createNextPhaseOrExpiredEvent(final DefaultSubscriptionBase subscription, final SubscriptionBaseEvent readyPhaseEvent, final SubscriptionBaseEvent nextPhaseOrExpiredEvent, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                final UUID subscriptionId = subscription.getId();
-                cancelNextPhaseEventFromTransaction(subscriptionId, entitySqlDaoWrapperFactory, context);
-                createAndRefresh(transactional, new SubscriptionEventModelDao(nextPhaseOrExpiredEvent), context);
-                recordFutureNotificationFromTransaction(entitySqlDaoWrapperFactory,
-                                                        nextPhaseOrExpiredEvent.getEffectiveDate(),
-                                                        new SubscriptionNotificationKey(nextPhaseOrExpiredEvent.getId()), context);
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+            final UUID subscriptionId = subscription.getId();
+            cancelNextPhaseEventFromTransaction(subscriptionId, entitySqlDaoWrapperFactory, context);
+            createAndRefresh(transactional, new SubscriptionEventModelDao(nextPhaseOrExpiredEvent), context);
+            recordFutureNotificationFromTransaction(entitySqlDaoWrapperFactory,
+                                                    nextPhaseOrExpiredEvent.getEffectiveDate(),
+                                                    new SubscriptionNotificationKey(nextPhaseOrExpiredEvent.getId()), context);
 
-                // Notify the Bus
-                if (nextPhaseOrExpiredEvent.getType() == EventType.PHASE) {
-                    notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, nextPhaseOrExpiredEvent, SubscriptionBaseTransitionType.PHASE, 0, context);
-                } else {
-                    notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, nextPhaseOrExpiredEvent, SubscriptionBaseTransitionType.EXPIRED, 0, context);
-                }
-                notifyBusOfEffectiveImmediateChange(entitySqlDaoWrapperFactory, subscription, readyPhaseEvent, 0, context);
-
-                return null;
+            // Notify the Bus
+            if (nextPhaseOrExpiredEvent.getType() == EventType.PHASE) {
+                notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, nextPhaseOrExpiredEvent, SubscriptionBaseTransitionType.PHASE, 0, context);
+            } else {
+                notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, nextPhaseOrExpiredEvent, SubscriptionBaseTransitionType.EXPIRED, 0, context);
             }
+            notifyBusOfEffectiveImmediateChange(entitySqlDaoWrapperFactory, subscription, readyPhaseEvent, 0, context);
+
+            return null;
         });
-    }    
+    }
 
     @Override
     public SubscriptionBaseEvent getEventById(final UUID eventId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<SubscriptionBaseEvent>() {
-            @Override
-            public SubscriptionBaseEvent inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventModelDao model = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getById(eventId.toString(), context);
-                return SubscriptionEventModelDao.toSubscriptionEvent(model);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionEventModelDao model = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getById(eventId.toString(), context);
+            return SubscriptionEventModelDao.toSubscriptionEvent(model);
         });
     }
 
     @Override
     public List<SubscriptionBaseEvent> getEventsForSubscription(final UUID subscriptionId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<SubscriptionBaseEvent>>() {
-            @Override
-            public List<SubscriptionBaseEvent> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return getEventsForSubscriptionInTransaction(entitySqlDaoWrapperFactory, subscriptionId, context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> getEventsForSubscriptionInTransaction(entitySqlDaoWrapperFactory, subscriptionId, context));
     }
 
     @Override
     public List<SubscriptionBaseEvent> getPendingEventsForSubscription(final UUID subscriptionId, final InternalTenantContext context) {
         final Date now = clock.getUTCNow().toDate();
-
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<SubscriptionBaseEvent>>() {
-            @Override
-            public List<SubscriptionBaseEvent> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final List<SubscriptionEventModelDao> eventModels = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getFutureActiveEventForSubscription(subscriptionId.toString(), now, context);
-                return toSubscriptionBaseEvents(eventModels);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final List<SubscriptionEventModelDao> eventModels = entitySqlDaoWrapperFactory
+                    .become(SubscriptionEventSqlDao.class)
+                    .getFutureActiveEventForSubscription(subscriptionId.toString(), now, context);
+            return toSubscriptionBaseEvents(eventModels);
         });
     }
 
     @Override
-    public List<SubscriptionBaseEvent> createSubscriptionsWithAddOns(final List<SubscriptionBaseWithAddOns> subscriptions, final Map<UUID, List<SubscriptionBaseEvent>> initialEventsMap, final SubscriptionCatalog catalog, final InternalCallContext context) {
-
+    public List<SubscriptionBaseEvent> createSubscriptionsWithAddOns(final List<SubscriptionBaseWithAddOns> subscriptions,
+                                                                     final Map<UUID, List<SubscriptionBaseEvent>> initialEventsMap,
+                                                                     final SubscriptionCatalog catalog,
+                                                                     final InternalCallContext context) {
         final boolean groupBusEvents = eventBus.shouldAggregateSubscriptionEvents(context);
-        return transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<List<SubscriptionBaseEvent>>() {
-            @Override
-            public List<SubscriptionBaseEvent> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
-                final SubscriptionEventSqlDao eventsDaoFromSameTransaction = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+        return transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final SubscriptionSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
+            final SubscriptionEventSqlDao eventsDaoFromSameTransaction = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+            int busEffSeqId = 0;
+            int busReqSeqId = 0;
+            final List<SubscriptionEventModelDao> createdEvents = new LinkedList<SubscriptionEventModelDao>();
+            for (final SubscriptionBaseWithAddOns subscription : subscriptions) {
+                for (final SubscriptionBase subscriptionBase : subscription.getSubscriptionBaseList()) {
+                    // Safe cast
+                    final DefaultSubscriptionBase defaultSubscriptionBase = (DefaultSubscriptionBase) subscriptionBase;
+                    createAndRefresh(transactional, new SubscriptionModelDao(defaultSubscriptionBase), context);
 
+                    final List<SubscriptionBaseEvent> initialEvents = initialEventsMap.get(defaultSubscriptionBase.getId());
 
-                int busEffSeqId = 0;
-                int busReqSeqId = 0;
-                final List<SubscriptionEventModelDao> createdEvents = new LinkedList<SubscriptionEventModelDao>();
-                for (final SubscriptionBaseWithAddOns subscription : subscriptions) {
-                    for (final SubscriptionBase subscriptionBase : subscription.getSubscriptionBaseList()) {
-                        // Safe cast
-                        final DefaultSubscriptionBase defaultSubscriptionBase = (DefaultSubscriptionBase) subscriptionBase;
-                        createAndRefresh(transactional, new SubscriptionModelDao(defaultSubscriptionBase), context);
+                    for (final SubscriptionBaseEvent cur : initialEvents) {
+                        createdEvents.add(createAndRefresh(eventsDaoFromSameTransaction, new SubscriptionEventModelDao(cur), context));
 
-                        final List<SubscriptionBaseEvent> initialEvents = initialEventsMap.get(defaultSubscriptionBase.getId());
-
-                        for (final SubscriptionBaseEvent cur : initialEvents) {
-                            createdEvents.add(createAndRefresh(eventsDaoFromSameTransaction, new SubscriptionEventModelDao(cur), context));
-
-                            final boolean isBusEvent = cur.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0 && (cur.getType() == EventType.API_USER || cur.getType() == EventType.BCD_UPDATE);
-                            final int seqId = isBusEvent ? busEffSeqId++ : 0;
-                            if (!isBusEvent || !groupBusEvents || seqId == 0) {
-                                recordBusOrFutureNotificationFromTransaction(defaultSubscriptionBase, cur, entitySqlDaoWrapperFactory, isBusEvent, seqId, catalog, context);
-                            }
+                        final boolean isBusEvent = cur.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0 && (cur.getType() == EventType.API_USER || cur.getType() == EventType.BCD_UPDATE);
+                        final int seqId = isBusEvent ? busEffSeqId++ : 0;
+                        if (!isBusEvent || !groupBusEvents || seqId == 0) {
+                            recordBusOrFutureNotificationFromTransaction(defaultSubscriptionBase, cur, entitySqlDaoWrapperFactory, isBusEvent, seqId, catalog, context);
                         }
+                    }
 
-                        // Notify the Bus of the latest requested change, if needed
-                        if (!initialEvents.isEmpty()) {
-                            if (!groupBusEvents || busReqSeqId == 0) {
-                                notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, defaultSubscriptionBase, initialEvents.get(initialEvents.size() - 1), SubscriptionBaseTransitionType.CREATE, busReqSeqId++, context);
-                            }
+                    // Notify the Bus of the latest requested change, if needed
+                    if (!initialEvents.isEmpty()) {
+                        if (!groupBusEvents || busReqSeqId == 0) {
+                            notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, defaultSubscriptionBase, initialEvents.get(initialEvents.size() - 1), SubscriptionBaseTransitionType.CREATE, busReqSeqId++, context);
                         }
                     }
                 }
-                return toSubscriptionBaseEvents(createdEvents);
             }
+            return toSubscriptionBaseEvents(createdEvents);
         });
     }
 
     @Override
     public void cancelOrExpireSubscriptionOnNotification(final DefaultSubscriptionBase subscription, final SubscriptionBaseEvent event, final List<DefaultSubscriptionBase> subscriptions, final List<SubscriptionBaseEvent> cancelOrExpireEvents, final SubscriptionCatalog catalog, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                cancelOrExpireSubscriptionsFromTransaction(entitySqlDaoWrapperFactory, subscriptions, cancelOrExpireEvents, catalog, context);
-                // Make sure to always send the event, even if there were no subscriptions to cancel
-                notifyBusOfEffectiveImmediateChange(entitySqlDaoWrapperFactory, subscription, event, subscriptions.size(), context);
-                return null;
-            }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            cancelOrExpireSubscriptionsFromTransaction(entitySqlDaoWrapperFactory, subscriptions, cancelOrExpireEvents, catalog, context);
+            // Make sure to always send the event, even if there were no subscriptions to cancel
+            notifyBusOfEffectiveImmediateChange(entitySqlDaoWrapperFactory, subscription, event, subscriptions.size(), context);
+            return null;
         });
     }
 
     @Override
     public void notifyOnBasePlanEvent(final DefaultSubscriptionBase subscription, final SubscriptionBaseEvent event, final SubscriptionCatalog catalog, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                notifyBusOfEffectiveImmediateChange(entitySqlDaoWrapperFactory, subscription, event, 0, context);
-                return null;
-            }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            notifyBusOfEffectiveImmediateChange(entitySqlDaoWrapperFactory, subscription, event, 0, context);
+            return null;
         });
 
     }
 
     @Override
     public void cancelSubscriptions(final List<DefaultSubscriptionBase> subscriptions, final List<SubscriptionBaseEvent> cancelEvents, final SubscriptionCatalog catalog, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                cancelOrExpireSubscriptionsFromTransaction(entitySqlDaoWrapperFactory, subscriptions, cancelEvents, catalog, context);
-                return null;
-            }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            cancelOrExpireSubscriptionsFromTransaction(entitySqlDaoWrapperFactory, subscriptions, cancelEvents, catalog, context);
+            return null;
         });
     }
 
@@ -689,150 +583,132 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     private void undoOperation(final DefaultSubscriptionBase subscription, final List<SubscriptionBaseEvent> inputEvents, final ApiEventType targetOperation, final SubscriptionBaseTransitionType transitionType, final InternalCallContext context) {
 
         final InternalCallContext contextWithUpdatedDate = contextWithUpdatedDate(context);
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-
-                final UUID subscriptionId = subscription.getId();
-
-                Set<SubscriptionEventModelDao> targetEvents = new HashSet<SubscriptionEventModelDao>();
-                final Date now = context.getCreatedDate().toDate();
-                final List<SubscriptionEventModelDao> eventModels = transactional.getFutureActiveEventForSubscription(subscriptionId.toString(), now, contextWithUpdatedDate);
-
-                for (final SubscriptionEventModelDao cur : eventModels) {
-                    if (cur.getEventType() == EventType.API_USER && cur.getUserType() == targetOperation) {
-                        targetEvents.add(cur);
-                    } else if (cur.getEventType() == EventType.PHASE) {
-                        targetEvents.add(cur);
-                    }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+            final UUID subscriptionId = subscription.getId();
+            final Set<SubscriptionEventModelDao> targetEvents = new HashSet<SubscriptionEventModelDao>();
+            final Date now = context.getCreatedDate().toDate();
+            final List<SubscriptionEventModelDao> eventModels = transactional.getFutureActiveEventForSubscription(subscriptionId.toString(), now, contextWithUpdatedDate);
+            for (final SubscriptionEventModelDao cur : eventModels) {
+                if (cur.getEventType() == EventType.API_USER && cur.getUserType() == targetOperation) {
+                    targetEvents.add(cur);
+                } else if (cur.getEventType() == EventType.PHASE) {
+                    targetEvents.add(cur);
                 }
-
-                if (!targetEvents.isEmpty()) {
-                    for (SubscriptionEventModelDao target : targetEvents) {
-                        transactional.unactiveEvent(target.getId().toString(), contextWithUpdatedDate);
-                    }
-                    for (final SubscriptionBaseEvent cur : inputEvents) {
-                        transactional.create(new SubscriptionEventModelDao(cur), contextWithUpdatedDate);
-                        recordFutureNotificationFromTransaction(entitySqlDaoWrapperFactory,
-                                                                cur.getEffectiveDate(),
-                                                                new SubscriptionNotificationKey(cur.getId()),
-                                                                contextWithUpdatedDate);
-                    }
-
-                    // Notify the Bus of the latest requested change
-                    notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, inputEvents.get(inputEvents.size() - 1), transitionType, 0, contextWithUpdatedDate);
-                }
-
-                return null;
             }
+
+            if (!targetEvents.isEmpty()) {
+                for (SubscriptionEventModelDao target : targetEvents) {
+                    transactional.unactiveEvent(target.getId().toString(), contextWithUpdatedDate);
+                }
+                for (final SubscriptionBaseEvent cur : inputEvents) {
+                    transactional.create(new SubscriptionEventModelDao(cur), contextWithUpdatedDate);
+                    recordFutureNotificationFromTransaction(entitySqlDaoWrapperFactory,
+                                                            cur.getEffectiveDate(),
+                                                            new SubscriptionNotificationKey(cur.getId()),
+                                                            contextWithUpdatedDate);
+                }
+
+                // Notify the Bus of the latest requested change
+                notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, inputEvents.get(inputEvents.size() - 1), transitionType, 0, contextWithUpdatedDate);
+            }
+
+            return null;
         });
     }
 
     @Override
-    public void changePlan(final DefaultSubscriptionBase subscription, final List<SubscriptionBaseEvent> originalInputChangeEvents, final List<DefaultSubscriptionBase> subscriptionsToBeCancelled, final List<SubscriptionBaseEvent> cancelEvents, final SubscriptionCatalog catalog, final InternalCallContext context) {
-
+    public void changePlan(final DefaultSubscriptionBase subscription, final List<SubscriptionBaseEvent> originalInputChangeEvents,
+                           final List<DefaultSubscriptionBase> subscriptionsToBeCancelled, final List<SubscriptionBaseEvent> cancelEvents,
+                           final SubscriptionCatalog catalog, final InternalCallContext context) {
         // First event is expected to be the subscription CHANGE event
         final SubscriptionBaseEvent inputChangeEvent = originalInputChangeEvents.get(0);
         Preconditions.checkState(inputChangeEvent.getType() == EventType.API_USER &&
                                  ((ApiEvent) inputChangeEvent).getApiEventType() == ApiEventType.CHANGE);
         Preconditions.checkState(inputChangeEvent.getSubscriptionId().equals(subscription.getId()));
 
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+            final List<SubscriptionEventModelDao> activeSubscriptionEvents = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getActiveEventsForSubscription(subscription.getId().toString(), context);
 
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                final List<SubscriptionEventModelDao> activeSubscriptionEvents = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getActiveEventsForSubscription(subscription.getId().toString(), context);
+            // First event is CREATE/TRANSFER event
+            final SubscriptionEventModelDao firstSubscriptionEvent = activeSubscriptionEvents.get(0);
+            final Iterable<SubscriptionEventModelDao> activePresentOrFutureSubscriptionEvents = activeSubscriptionEvents.stream()
+                                                                                                                        .filter(input -> input.getEffectiveDate().compareTo(inputChangeEvent.getEffectiveDate()) >= 0)
+                                                                                                                        .collect(Collectors.toUnmodifiableList());
 
-                // First event is CREATE/TRANSFER event
-                final SubscriptionEventModelDao firstSubscriptionEvent = activeSubscriptionEvents.get(0);
-                final Iterable<SubscriptionEventModelDao> activePresentOrFutureSubscriptionEvents = Iterables.filter(activeSubscriptionEvents, new Predicate<SubscriptionEventModelDao>() {
-                    @Override
-                    public boolean apply(SubscriptionEventModelDao input) {
-                        return input.getEffectiveDate().compareTo(inputChangeEvent.getEffectiveDate()) >= 0;
-                    }
-                });
+            // We do a little magic here in case the CHANGE coincides exactly with the CREATE event to invalidate original CREATE event and
+            // change the input CHANGE event into a CREATE event.
+            final boolean isChangePlanOnStartDate = firstSubscriptionEvent.getEffectiveDate().compareTo(inputChangeEvent.getEffectiveDate()) == 0;
 
-                // We do a little magic here in case the CHANGE coincides exactly with the CREATE event to invalidate original CREATE event and
-                // change the input CHANGE event into a CREATE event.
-                final boolean isChangePlanOnStartDate = firstSubscriptionEvent.getEffectiveDate().compareTo(inputChangeEvent.getEffectiveDate()) == 0;
+            final List<SubscriptionBaseEvent> inputChangeEvents;
+            if (isChangePlanOnStartDate) {
 
-                final List<SubscriptionBaseEvent> inputChangeEvents;
-                if (isChangePlanOnStartDate) {
+                // Rebuild input event list with first the CREATE event and all original input events except for inputChangeEvent
+                inputChangeEvents = new ArrayList<SubscriptionBaseEvent>();
+                final SubscriptionBaseEvent newCreateEvent = new ApiEventBuilder((ApiEventChange) inputChangeEvent)
+                        .setApiEventType(firstSubscriptionEvent.getUserType())
+                        .build();
 
-                    // Rebuild input event list with first the CREATE event and all original input events except for inputChangeEvent
-                    inputChangeEvents = new ArrayList<SubscriptionBaseEvent>();
-                    final SubscriptionBaseEvent newCreateEvent = new ApiEventBuilder((ApiEventChange) inputChangeEvent)
-                            .setApiEventType(firstSubscriptionEvent.getUserType())
-                            .build();
+                originalInputChangeEvents.remove(0);
+                inputChangeEvents.add(newCreateEvent);
+                inputChangeEvents.addAll(originalInputChangeEvents);
 
-                    originalInputChangeEvents.remove(0);
-                    inputChangeEvents.add(newCreateEvent);
-                    inputChangeEvents.addAll(originalInputChangeEvents);
+                // Deactivate original CREATE event
+                unactivateEventFromTransaction(firstSubscriptionEvent, entitySqlDaoWrapperFactory, context);
 
-                    // Deactivate original CREATE event
-                    unactivateEventFromTransaction(firstSubscriptionEvent, entitySqlDaoWrapperFactory, context);
-
-                } else {
-                    inputChangeEvents = originalInputChangeEvents;
-                }
-
-                unactivateFutureEventsFromTransaction(activePresentOrFutureSubscriptionEvents, entitySqlDaoWrapperFactory, false, context);
-
-                for (final SubscriptionBaseEvent cur : inputChangeEvents) {
-                    createAndRefresh(transactional, new SubscriptionEventModelDao(cur), context);
-
-                    final boolean isBusEvent = cur.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0 && (cur.getType() == EventType.API_USER || cur.getType() == EventType.BCD_UPDATE);
-                    recordBusOrFutureNotificationFromTransaction(subscription, cur, entitySqlDaoWrapperFactory, isBusEvent, 0, catalog, context);
-                }
-
-                // Notify the Bus of the latest requested change
-                final SubscriptionBaseEvent finalEvent = inputChangeEvents.get(inputChangeEvents.size() - 1);
-                notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, finalEvent, SubscriptionBaseTransitionType.CHANGE, 0, context);
-
-                // Cancel associated add-ons
-                cancelOrExpireSubscriptionsFromTransaction(entitySqlDaoWrapperFactory, subscriptionsToBeCancelled, cancelEvents, catalog, context);
-
-                return null;
+            } else {
+                inputChangeEvents = originalInputChangeEvents;
             }
+
+            unactivateFutureEventsFromTransaction(activePresentOrFutureSubscriptionEvents, entitySqlDaoWrapperFactory, false, context);
+
+            for (final SubscriptionBaseEvent cur : inputChangeEvents) {
+                createAndRefresh(transactional, new SubscriptionEventModelDao(cur), context);
+
+                final boolean isBusEvent = cur.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0 && (cur.getType() == EventType.API_USER || cur.getType() == EventType.BCD_UPDATE);
+                recordBusOrFutureNotificationFromTransaction(subscription, cur, entitySqlDaoWrapperFactory, isBusEvent, 0, catalog, context);
+            }
+
+            // Notify the Bus of the latest requested change
+            final SubscriptionBaseEvent finalEvent = inputChangeEvents.get(inputChangeEvents.size() - 1);
+            notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, finalEvent, SubscriptionBaseTransitionType.CHANGE, 0, context);
+
+            // Cancel associated add-ons
+            cancelOrExpireSubscriptionsFromTransaction(entitySqlDaoWrapperFactory, subscriptionsToBeCancelled, cancelEvents, catalog, context);
+
+            return null;
         });
     }
 
     private List<SubscriptionBaseEvent> filterSubscriptionBaseEvents(final Collection<SubscriptionEventModelDao> models) {
-        final Collection<SubscriptionEventModelDao> filteredModels = Collections2.filter(models, new Predicate<SubscriptionEventModelDao>() {
-            @Override
-            public boolean apply(@Nullable final SubscriptionEventModelDao input) {
-                return input.getUserType() != ApiEventType.UNCANCEL && input.getUserType() != ApiEventType.UNDO_CHANGE;
-            }
-        });
+        final Collection<SubscriptionEventModelDao> filteredModels = models.stream()
+                                                                           .filter(input -> input.getUserType() != ApiEventType.UNCANCEL && input.getUserType() != ApiEventType.UNDO_CHANGE)
+                                                                           .collect(Collectors.toList());
         return toSubscriptionBaseEvents(filteredModels);
     }
 
     private List<SubscriptionBaseEvent> toSubscriptionBaseEvents(final Collection<SubscriptionEventModelDao> eventModels) {
-        return new ArrayList<SubscriptionBaseEvent>(Collections2.transform(eventModels, new Function<SubscriptionEventModelDao, SubscriptionBaseEvent>() {
-            @Override
-            public SubscriptionBaseEvent apply(final SubscriptionEventModelDao input) {
-                return SubscriptionEventModelDao.toSubscriptionEvent(input);
-            }
-        }));
+        return eventModels.stream()
+                          .map(SubscriptionEventModelDao::toSubscriptionEvent)
+                          .collect(Collectors.toList());
     }
 
     public List<SubscriptionBaseEvent> getEventsForAccountId(@Nullable final LocalDate cutoffDt, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<SubscriptionBaseEvent>>() {
-            @Override
-            public List<SubscriptionBaseEvent> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventSqlDao subscriptionEventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                final List<SubscriptionEventModelDao> models = cutoffDt == null ?
-                                                               subscriptionEventSqlDao.getByAccountRecordId(context) :
-                                                               subscriptionEventSqlDao.getActiveByAccountRecordId(cutoffDt.toDate(), context);
-                return filterSubscriptionBaseEvents(models);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionEventSqlDao subscriptionEventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+            final List<SubscriptionEventModelDao> models = cutoffDt == null ?
+                                                           subscriptionEventSqlDao.getByAccountRecordId(context) :
+                                                           subscriptionEventSqlDao.getActiveByAccountRecordId(cutoffDt.toDate(), context);
+            return filterSubscriptionBaseEvents(models);
         });
     }
 
-    private void cancelOrExpireSubscriptionFromTransaction(final DefaultSubscriptionBase subscription, final SubscriptionBaseEvent cancelOrExpireEvent, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final SubscriptionCatalog catalog, final InternalCallContext context, final int seqId)
-            throws EntityPersistenceException {
+    private void cancelOrExpireSubscriptionFromTransaction(final DefaultSubscriptionBase subscription,
+                                                           final SubscriptionBaseEvent cancelOrExpireEvent,
+                                                           final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
+                                                           final SubscriptionCatalog catalog,
+                                                           final InternalCallContext context, final int seqId) throws EntityPersistenceException {
         final UUID subscriptionId = subscription.getId();
         unactivateFutureEventsFromTransaction(subscriptionId, cancelOrExpireEvent.getEffectiveDate(), entitySqlDaoWrapperFactory, true, context);
         final SubscriptionEventSqlDao subscriptionEventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
@@ -931,8 +807,11 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         throw new SubscriptionBaseError("Unexpected code path in buildSubscription");
     }
 
-    private List<DefaultSubscriptionBase> buildBundleSubscriptions(final List<DefaultSubscriptionBase> input, @Nullable final Multimap<UUID, SubscriptionBaseEvent> eventsForSubscription,
-                                                            @Nullable final Collection<SubscriptionBaseEvent> dryRunEvents, final SubscriptionCatalog catalog, final InternalTenantContext context) throws CatalogApiException {
+    private List<DefaultSubscriptionBase> buildBundleSubscriptions(final List<DefaultSubscriptionBase> input,
+                                                                   @Nullable final MultiValueMap<UUID, SubscriptionBaseEvent> eventsForSubscription,
+                                                                   @Nullable final Collection<SubscriptionBaseEvent> dryRunEvents,
+                                                                   final SubscriptionCatalog catalog,
+                                                                   final InternalTenantContext context) throws CatalogApiException {
         if (input == null || input.isEmpty()) {
             return Collections.emptyList();
         }
@@ -1067,88 +946,68 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     public void transfer(final UUID srcAccountId, final UUID destAccountId, final BundleTransferData bundleTransferData,
                          final List<TransferCancelData> transferCancelData, final SubscriptionCatalog catalog, final InternalCallContext fromContext, final InternalCallContext toContext) {
 
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-
-                // Cancel the subscriptions for the old bundle
-                for (final TransferCancelData cancel : transferCancelData) {
-                    cancelOrExpireSubscriptionFromTransaction(cancel.getSubscription(), cancel.getCancelEvent(), entitySqlDaoWrapperFactory, catalog, fromContext, 0);
-                }
-
-                // Rename externalKey from source bundle
-                final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
-                renameBundleExternalKey(bundleSqlDao, bundleTransferData.getData().getExternalKey(), "tsf", fromContext);
-
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                transferBundleDataFromTransaction(bundleTransferData, transactional, entitySqlDaoWrapperFactory, toContext);
-                return null;
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            // Cancel the subscriptions for the old bundle
+            for (final TransferCancelData cancel : transferCancelData) {
+                cancelOrExpireSubscriptionFromTransaction(cancel.getSubscription(), cancel.getCancelEvent(), entitySqlDaoWrapperFactory, catalog, fromContext, 0);
             }
+
+            // Rename externalKey from source bundle
+            final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
+            renameBundleExternalKey(bundleSqlDao, bundleTransferData.getData().getExternalKey(), "tsf", fromContext);
+
+            final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+            transferBundleDataFromTransaction(bundleTransferData, transactional, entitySqlDaoWrapperFactory, toContext);
+            return null;
         });
     }
 
     @Override
     public void updateBundleExternalKey(final UUID bundleId, final String externalKey, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-
-                final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
-                bundleSqlDao.updateBundleExternalKey(bundleId.toString(), externalKey, contextWithUpdatedDate(context));
-                return null;
-            }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
+            bundleSqlDao.updateBundleExternalKey(bundleId.toString(), externalKey, contextWithUpdatedDate(context));
+            return null;
         });
     }
 
     @Override
     public void createBCDChangeEvent(final DefaultSubscriptionBase subscription, final SubscriptionBaseEvent bcdEvent, final SubscriptionCatalog catalog, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                createAndRefresh(transactional, new SubscriptionEventModelDao(bcdEvent), context);
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+            createAndRefresh(transactional, new SubscriptionEventModelDao(bcdEvent), context);
 
-                // Notify the Bus
-                notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, bcdEvent, SubscriptionBaseTransitionType.BCD_CHANGE, 0, context);
-                final boolean isBusEvent = bcdEvent.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0;
-                recordBusOrFutureNotificationFromTransaction(subscription, bcdEvent, entitySqlDaoWrapperFactory, isBusEvent, 0, catalog, context);
+            // Notify the Bus
+            notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, bcdEvent, SubscriptionBaseTransitionType.BCD_CHANGE, 0, context);
+            final boolean isBusEvent = bcdEvent.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0;
+            recordBusOrFutureNotificationFromTransaction(subscription, bcdEvent, entitySqlDaoWrapperFactory, isBusEvent, 0, catalog, context);
 
-                return null;
-            }
+            return null;
         });
 
     }
 
     @Override
     public List<AuditLogWithHistory> getSubscriptionBundleAuditLogsWithHistoryForId(final UUID bundleId, final AuditLevel auditLevel, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLogWithHistory>>() {
-            @Override
-            public List<AuditLogWithHistory> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) {
-                final BundleSqlDao transactional = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
-                return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.BUNDLES, bundleId, auditLevel, context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final BundleSqlDao transactional = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
+            return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.BUNDLES, bundleId, auditLevel, context);
         });
     }
 
     @Override
     public List<AuditLogWithHistory> getSubscriptionAuditLogsWithHistoryForId(final UUID subscriptionId, final AuditLevel auditLevel, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLogWithHistory>>() {
-            @Override
-            public List<AuditLogWithHistory> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) {
-                final SubscriptionSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
-                return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.SUBSCRIPTIONS, subscriptionId, auditLevel, context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
+            return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.SUBSCRIPTIONS, subscriptionId, auditLevel, context);
         });
     }
 
     @Override
     public List<AuditLogWithHistory> getSubscriptionEventAuditLogsWithHistoryForId(final UUID eventId, final AuditLevel auditLevel, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLogWithHistory>>() {
-            @Override
-            public List<AuditLogWithHistory> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) {
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.SUBSCRIPTION_EVENTS, eventId, auditLevel, context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+            return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.SUBSCRIPTION_EVENTS, eventId, auditLevel, context);
         });
     }
 

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
@@ -118,7 +118,6 @@ import org.slf4j.LoggerFactory;
 import static java.util.Collections.emptyList;
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 
-// FIXME-1615 : This class complex. Ask test point to verify that changes not broke anything
 public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleModelDao, SubscriptionBaseBundle, SubscriptionApiException> implements SubscriptionDao {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultSubscriptionDao.class);

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
@@ -115,7 +115,6 @@ import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.util.Collections.emptyList;
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 
 public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleModelDao, SubscriptionBaseBundle, SubscriptionApiException> implements SubscriptionDao {
@@ -259,7 +258,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
 
         return transactionalSqlDao.execute(false, SubscriptionBaseApiException.class, entitySqlDaoWrapperFactory -> {
             final List<SubscriptionBundleModelDao> existingBundles = bundle.getExternalKey() == null ?
-                                                                     emptyList() :
+                                                                     Collections.emptyList() :
                                                                      entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getBundlesForLikeKey(bundle.getExternalKey(), context);
 
             final SubscriptionBaseBundle unusedBundle = findExistingUnusedBundleForExternalKeyAndAccount(bundle, existingBundles, entitySqlDaoWrapperFactory, context);
@@ -276,7 +275,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
                         .getSubscriptionsFromBundleId(cur.getId().toString(), context);
 
                 final Iterable<SubscriptionModelDao> filtered = subscriptions == null ?
-                                                                emptyList() :
+                                                                Collections.emptyList() :
                                                                 subscriptions.stream()
                                                                              .filter(input -> input.getCategory() != ProductCategory.ADD_ON)
                                                                              .collect(Collectors.toUnmodifiableList());
@@ -412,7 +411,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
             // We avoid pulling the bundles when a cutoffDt is specified, as those are not really used
             final List<SubscriptionBundleModelDao> bundleModels = cutoffDt == null ?
                                                                   entitySqlDaoWrapperFactory.become(BundleSqlDao.class).getByAccountRecordId(context) :
-                                                                  emptyList();
+                                                                  Collections.emptyList();
             return subscriptionModels.stream()
                                      .map(input -> {
                                          final SubscriptionBundleModelDao bundleModel = bundleModels.stream()
@@ -814,7 +813,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
                                                                    final SubscriptionCatalog catalog,
                                                                    final InternalTenantContext context) throws CatalogApiException {
         if (input == null || input.isEmpty()) {
-            return emptyList();
+            return Collections.emptyList();
         }
 
         // Make sure BasePlan -- if exists-- is first

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/model/SubscriptionBundleModelDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/model/SubscriptionBundleModelDao.java
@@ -16,6 +16,7 @@
 
 package org.killbill.billing.subscription.engine.dao.model;
 
+import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -26,8 +27,6 @@ import org.killbill.billing.subscription.api.user.SubscriptionBaseBundle;
 import org.killbill.billing.util.dao.TableName;
 import org.killbill.billing.util.entity.dao.EntityModelDao;
 import org.killbill.billing.util.entity.dao.EntityModelDaoBase;
-
-import com.google.common.base.MoreObjects;
 
 public class SubscriptionBundleModelDao extends EntityModelDaoBase implements EntityModelDao<SubscriptionBaseBundle> {
 
@@ -47,7 +46,7 @@ public class SubscriptionBundleModelDao extends EntityModelDaoBase implements En
     public SubscriptionBundleModelDao(final UUID id, final String key, final UUID accountId, final DateTime lastSysUpdateDate,
                                       final DateTime createdDate, DateTime originalCreatedDate, final DateTime updateDate) {
         super(id, createdDate, updateDate);
-        this.externalKey = MoreObjects.firstNonNull(key, id.toString());
+        this.externalKey = Objects.requireNonNullElse(key, id.toString());
         this.accountId = accountId;
         this.lastSysUpdateDate = lastSysUpdateDate;
         this.originalCreatedDate = originalCreatedDate;

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/model/SubscriptionModelDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/model/SubscriptionModelDao.java
@@ -16,6 +16,7 @@
 
 package org.killbill.billing.subscription.engine.dao.model;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -27,8 +28,6 @@ import org.killbill.billing.subscription.api.SubscriptionBase;
 import org.killbill.billing.util.dao.TableName;
 import org.killbill.billing.util.entity.dao.EntityModelDao;
 import org.killbill.billing.util.entity.dao.EntityModelDaoBase;
-
-import com.google.common.base.MoreObjects;
 
 public class SubscriptionModelDao extends EntityModelDaoBase implements EntityModelDao<SubscriptionBase> {
 
@@ -46,7 +45,7 @@ public class SubscriptionModelDao extends EntityModelDaoBase implements EntityMo
                                 final DateTime chargedThroughDate, final boolean migrated, final DateTime createdDate, final DateTime updateDate) {
         super(id, createdDate, updateDate);
         this.bundleId = bundleId;
-        this.externalKey = MoreObjects.firstNonNull(externalKey, id.toString());;
+        this.externalKey = Objects.requireNonNullElse(externalKey, id.toString());;
         this.category = category;
         this.startDate = startDate;
         this.bundleStartDate = bundleStartDate;

--- a/subscription/src/test/java/org/killbill/billing/subscription/SubscriptionTestSuiteWithEmbeddedDB.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/SubscriptionTestSuiteWithEmbeddedDB.java
@@ -60,8 +60,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
@@ -166,7 +164,7 @@ public class SubscriptionTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuiteW
     }
 
     protected void setChargedThroughDate(final UUID entitlementId, final DateTime ctd, final InternalCallContext internalCallContext) throws SubscriptionBaseApiException {
-        final Map<DateTime, List<UUID>> chargeThroughDates = ImmutableMap.of(ctd, ImmutableList.of(entitlementId));
+        final Map<DateTime, List<UUID>> chargeThroughDates = Map.of(ctd, List.of(entitlementId));
         subscriptionInternalApi.setChargedThroughDates(chargeThroughDates, internalCallContext);
     }
 

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/transfer/TestDefaultSubscriptionTransferApi.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/transfer/TestDefaultSubscriptionTransferApi.java
@@ -52,8 +52,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 // Simple unit tests for DefaultSubscriptionBaseTransferApi, see TestTransfer for more advanced tests with dao
 public class TestDefaultSubscriptionTransferApi extends SubscriptionTestSuiteNoDB {
 
@@ -81,8 +79,8 @@ public class TestDefaultSubscriptionTransferApi extends SubscriptionTestSuiteNoD
     public void testEventsForCancelledSubscriptionBeforeTransfer() throws Exception {
         final DateTime subscriptionStartTime = clock.getUTCNow();
         final DateTime subscriptionCancelTime = subscriptionStartTime.plusDays(1);
-        final ImmutableList<ExistingEvent> existingEvents = ImmutableList.<ExistingEvent>of(createEvent(subscriptionStartTime, SubscriptionBaseTransitionType.CREATE),
-                                                                                            createEvent(subscriptionCancelTime, SubscriptionBaseTransitionType.CANCEL));
+        final List<ExistingEvent> existingEvents = List.of(createEvent(subscriptionStartTime, SubscriptionBaseTransitionType.CREATE),
+                                                           createEvent(subscriptionCancelTime, SubscriptionBaseTransitionType.CANCEL));
         final SubscriptionBuilder subscriptionBuilder = new SubscriptionBuilder();
         final DefaultSubscriptionBase subscription = new DefaultSubscriptionBase(subscriptionBuilder);
 
@@ -97,8 +95,8 @@ public class TestDefaultSubscriptionTransferApi extends SubscriptionTestSuiteNoD
 
         final DateTime subscriptionStartTime = clock.getUTCNow();
         final DateTime subscriptionCancelTime = subscriptionStartTime.plusDays(1);
-        final ImmutableList<ExistingEvent> existingEvents = ImmutableList.<ExistingEvent>of(createEvent(subscriptionStartTime, SubscriptionBaseTransitionType.CREATE),
-                                                                                            createEvent(subscriptionCancelTime, SubscriptionBaseTransitionType.CANCEL));
+        final List<ExistingEvent> existingEvents = List.of(createEvent(subscriptionStartTime, SubscriptionBaseTransitionType.CREATE),
+                                                           createEvent(subscriptionCancelTime, SubscriptionBaseTransitionType.CANCEL));
         final SubscriptionBuilder subscriptionBuilder = new SubscriptionBuilder();
         final DefaultSubscriptionBase subscription = new DefaultSubscriptionBase(subscriptionBuilder);
 

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestSubscriptionHelper.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestSubscriptionHelper.java
@@ -60,8 +60,6 @@ import org.killbill.clock.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -227,7 +225,7 @@ public class TestSubscriptionHelper {
             testListener.pushExpectedEvent(NextEvent.CREATE);
         }
 
-        final ImmutableList<EntitlementSpecifier> entitlementSpecifiers = ImmutableList.<EntitlementSpecifier>of(new EntitlementSpecifier() {
+        final List<EntitlementSpecifier> entitlementSpecifiers = List.of(new EntitlementSpecifier() {
             @Override
             public PlanPhaseSpecifier getPlanPhaseSpecifier() {
                 if (planName == null) {
@@ -259,7 +257,7 @@ public class TestSubscriptionHelper {
                                                                                                                                 false);
 
         final SubscriptionBaseWithAddOns subscriptionBaseWithAddOns = subscriptionApi.createBaseSubscriptionsWithAddOns(catalog,
-                                                                                                                        ImmutableList.<SubscriptionBaseWithAddOnsSpecifier>of(subscriptionBaseWithAddOnsSpecifier),
+                                                                                                                        List.of(subscriptionBaseWithAddOnsSpecifier),
                                                                                                                         false,
                                                                                                                         internalCallContext).get(0);
         final DefaultSubscriptionBase subscription = (DefaultSubscriptionBase) subscriptionBaseWithAddOns.getSubscriptionBaseList().get(0);

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiCreate.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiCreate.java
@@ -44,12 +44,9 @@ import org.killbill.billing.subscription.SubscriptionTestSuiteWithEmbeddedDB;
 import org.killbill.billing.subscription.api.SubscriptionBaseWithAddOns;
 import org.killbill.billing.subscription.api.SubscriptionBaseWithAddOnsSpecifier;
 import org.killbill.billing.subscription.events.SubscriptionBaseEvent;
-import org.killbill.billing.subscription.events.expired.ExpiredEvent;
 import org.killbill.billing.subscription.events.phase.PhaseEvent;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
@@ -303,7 +300,7 @@ public class TestUserApiCreate extends SubscriptionTestSuiteWithEmbeddedDB {
                                                                                                              this.internalCallContext.getUserToken(),
                                                                                                              this.internalCallContext.getTenantRecordId());
 
-        final Iterable<EntitlementSpecifier> specifiers = ImmutableList.<EntitlementSpecifier>of(new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("shotgun-monthly"), 18, null, null));
+        final Iterable<EntitlementSpecifier> specifiers = List.of(new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("shotgun-monthly"), 18, null, null));
         final SubscriptionBaseWithAddOnsSpecifier subscriptionBaseWithAddOnsSpecifier = new SubscriptionBaseWithAddOnsSpecifier(bundle.getId(),
                                                                                                                                 bundle.getExternalKey(),
                                                                                                                                 specifiers,
@@ -312,7 +309,7 @@ public class TestUserApiCreate extends SubscriptionTestSuiteWithEmbeddedDB {
 
         testListener.pushExpectedEvents(NextEvent.CREATE, NextEvent.BCD_CHANGE);
         final List<SubscriptionBaseWithAddOns> subscriptionBaseWithAddOns = subscriptionInternalApi.createBaseSubscriptionsWithAddOns(catalog.getCatalog(),
-                                                                                                                                      ImmutableList.<SubscriptionBaseWithAddOnsSpecifier>of(subscriptionBaseWithAddOnsSpecifier),
+                                                                                                                                      List.of(subscriptionBaseWithAddOnsSpecifier),
                                                                                                                                       false,
                                                                                                                                       internalCallContext);
         testListener.assertListenerStatus();

--- a/subscription/src/test/java/org/killbill/billing/subscription/engine/dao/MockSubscriptionDaoMemory.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/engine/dao/MockSubscriptionDaoMemory.java
@@ -25,10 +25,12 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeSet;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -75,9 +77,6 @@ import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.MoreObjects;
-import com.google.inject.Inject;
 
 public class MockSubscriptionDaoMemory extends MockEntityDaoBase<SubscriptionBundleModelDao, SubscriptionBaseBundle, SubscriptionApiException> implements SubscriptionDao {
 
@@ -183,7 +182,7 @@ public class MockSubscriptionDaoMemory extends MockEntityDaoBase<SubscriptionBun
     @Override
     public SubscriptionBaseBundle createSubscriptionBundle(final DefaultSubscriptionBaseBundle bundle, final SubscriptionCatalog catalog, final boolean renameCancelledBundleIfExist, final InternalCallContext context) {
         bundles.add(new DefaultSubscriptionBaseBundle(bundle.getId(),
-                                                      MoreObjects.firstNonNull(bundle.getExternalKey(), UUID.randomUUID().toString()),
+                                                      Objects.requireNonNullElse(bundle.getExternalKey(), UUID.randomUUID().toString()),
                                                       bundle.getAccountId(),
                                                       bundle.getOriginalCreatedDate(),
                                                       bundle.getCreatedDate(),

--- a/subscription/src/test/java/org/killbill/billing/subscription/engine/dao/MockSubscriptionDaoSql.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/engine/dao/MockSubscriptionDaoSql.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.subscription.engine.dao;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.killbill.billing.subscription.engine.addon.AddonUtils;
@@ -30,16 +31,21 @@ import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.skife.jdbi.v2.IDBI;
 
-import com.google.inject.Inject;
-
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 
 public class MockSubscriptionDaoSql extends DefaultSubscriptionDao {
 
     @Inject
-    public MockSubscriptionDaoSql(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final AddonUtils addonUtils, final NotificationQueueService notificationQueueService,
-                                  final BusOptimizer eventBus, final CacheControllerDispatcher cacheControllerDispatcher,
-                                  final NonEntityDao nonEntityDao, final AuditDao auditDao, final InternalCallContextFactory internalCallContextFactory) {
-        super(dbi, roDbi, clock, addonUtils, notificationQueueService, eventBus, cacheControllerDispatcher, nonEntityDao, auditDao, internalCallContextFactory);
+    public MockSubscriptionDaoSql(final IDBI dbi,
+                                  @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi,
+                                  final Clock clock, final AddonUtils addonUtils,
+                                  final NotificationQueueService notificationQueueService, final BusOptimizer eventBus,
+                                  final CacheControllerDispatcher cacheControllerDispatcher, final NonEntityDao nonEntityDao,
+                                  final AuditDao auditDao, final InternalCallContextFactory internalCallContextFactory) {
+        super(dbi, roDbi,
+              clock, addonUtils,
+              notificationQueueService, eventBus,
+              cacheControllerDispatcher, nonEntityDao,
+              auditDao, internalCallContextFactory);
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/collect/MultiValueHashMap.java
+++ b/util/src/main/java/org/killbill/billing/util/collect/MultiValueHashMap.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.collect;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class MultiValueHashMap<K, E> extends HashMap<K, List<E>> implements MultiValueMap<K, E> {
+
+    @Override
+    public void putElement(final K key, final E... elements) {
+        if (elements == null || elements.length == 0) {
+            throw new IllegalArgumentException("MultiValueHashMap#putElement() contains null or empty element");
+        }
+        if (super.containsKey(key)) {
+            super.get(key).addAll(List.of(elements));
+        } else {
+            super.put(key, new ArrayList<>(List.of(elements)));
+        }
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/collect/MultiValueMap.java
+++ b/util/src/main/java/org/killbill/billing/util/collect/MultiValueMap.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.collect;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple {@link Map} extension where the value is a {@link List}. The value will contain duplicate value.
+ */
+public interface MultiValueMap<K, E> extends Map<K, List<E>> {
+
+    /**
+     * Add value to {@link List} associated with the key.
+     * @param key map key
+     * @param elements value to add to the {@link List}
+     */
+    void putElement(K key, E... elements);
+}

--- a/util/src/test/java/org/killbill/billing/util/collect/TestMultiValueHashMap.java
+++ b/util/src/test/java/org/killbill/billing/util/collect/TestMultiValueHashMap.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.collect;
+
+import java.util.Objects;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestMultiValueHashMap {
+
+    @Test(groups = "fast")
+    public void putElement() {
+        final MultiValueMap<String, KeyValue> multiValueMap = new MultiValueHashMap<>();
+        multiValueMap.putElement("one", new KeyValue("a", "A"));
+        multiValueMap.putElement("two", new KeyValue("b", "B"), new KeyValue("c", "C"));
+
+        assertEquals(multiValueMap.size(), 2);
+        assertEquals(multiValueMap.get("one").size(), 1);
+        assertEquals(multiValueMap.get("two").size(), 2);
+
+        multiValueMap.putElement("two", new KeyValue("c", "C")); // same element, to prove that values size will keep increase.
+
+        assertEquals(multiValueMap.get("two").size(), 3);
+    }
+
+    @Test(groups = "fast")
+    public void putElementThenThrowIllegalArgs() {
+        final MultiValueMap<String, KeyValue> multiValueMap = new MultiValueHashMap<>();
+
+        try {
+            multiValueMap.putElement("one", null);
+            fail("IllegalArgumentException should be thrown because null element");
+        } catch (final IllegalArgumentException ignored) {}
+
+        try {
+            multiValueMap.putElement("one");
+            fail("IllegalArgumentException should be thrown because empty element");
+        } catch (final IllegalArgumentException ignored) {}
+    }
+
+    static class KeyValue {
+        private final String key;
+        private final String value;
+
+        public KeyValue(final String key, final String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final KeyValue keyValue = (KeyValue) o;
+            return key.equals(keyValue.key) && value.equals(keyValue.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
+    }
+}

--- a/util/src/test/java/org/killbill/billing/util/entity/TestDefaultPagination.java
+++ b/util/src/test/java/org/killbill/billing/util/entity/TestDefaultPagination.java
@@ -16,6 +16,7 @@
 
 package org.killbill.billing.util.entity;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.testng.Assert;
@@ -23,18 +24,16 @@ import org.testng.annotations.Test;
 
 import org.killbill.billing.util.UtilTestSuiteNoDB;
 
-import static java.util.Collections.emptyList;
-
 public class TestDefaultPagination extends UtilTestSuiteNoDB {
 
     @Test(groups = "fast", description = "Test Util: Pagination builder tests")
     public void testDefaultPaginationBuilder() throws Exception {
-        Assert.assertEquals(DefaultPagination.<Integer>build(0L, 0L, emptyList()), expectedOf(0L, 0L, 0L, emptyList()));
-        Assert.assertEquals(DefaultPagination.<Integer>build(0L, 10L, emptyList()), expectedOf(0L, 0L, 0L, emptyList()));
-        Assert.assertEquals(DefaultPagination.<Integer>build(10L, 0L, emptyList()), expectedOf(10L, 0L, 0L, emptyList()));
-        Assert.assertEquals(DefaultPagination.<Integer>build(10L, 10L, emptyList()), expectedOf(10L, 0L, 0L, emptyList()));
+        Assert.assertEquals(DefaultPagination.<Integer>build(0L, 0L, Collections.emptyList()), expectedOf(0L, 0L, 0L, Collections.emptyList()));
+        Assert.assertEquals(DefaultPagination.<Integer>build(0L, 10L, Collections.emptyList()), expectedOf(0L, 0L, 0L, Collections.emptyList()));
+        Assert.assertEquals(DefaultPagination.<Integer>build(10L, 0L, Collections.emptyList()), expectedOf(10L, 0L, 0L, Collections.emptyList()));
+        Assert.assertEquals(DefaultPagination.<Integer>build(10L, 10L, Collections.emptyList()), expectedOf(10L, 0L, 0L, Collections.emptyList()));
 
-        Assert.assertEquals(DefaultPagination.<Integer>build(0L, 0L, List.of(1, 2, 3, 4, 5)), expectedOf(0L, 0L, 5L, emptyList()));
+        Assert.assertEquals(DefaultPagination.<Integer>build(0L, 0L, List.of(1, 2, 3, 4, 5)), expectedOf(0L, 0L, 5L, Collections.emptyList()));
         Assert.assertEquals(DefaultPagination.<Integer>build(0L, 10L, List.of(1, 2, 3, 4, 5)), expectedOf(0L, 5L, 5L, List.of(1, 2, 3, 4, 5)));
         Assert.assertEquals(DefaultPagination.<Integer>build(4L, 10L, List.of(1, 2, 3, 4, 5)), expectedOf(4L, 1L, 5L, List.of(5)));
 
@@ -43,7 +42,7 @@ public class TestDefaultPagination extends UtilTestSuiteNoDB {
         Assert.assertEquals(DefaultPagination.<Integer>build(2L, 3L, List.of(1, 2, 3, 4, 5)), expectedOf(2L, 3L, 5L, List.of(3, 4, 5)));
         Assert.assertEquals(DefaultPagination.<Integer>build(3L, 3L, List.of(1, 2, 3, 4, 5)), expectedOf(3L, 2L, 5L, List.of(4, 5)));
         Assert.assertEquals(DefaultPagination.<Integer>build(4L, 3L, List.of(1, 2, 3, 4, 5)), expectedOf(4L, 1L, 5L, List.of(5)));
-        Assert.assertEquals(DefaultPagination.<Integer>build(5L, 3L, List.of(1, 2, 3, 4, 5)), expectedOf(5L, 0L, 5L, emptyList()));
+        Assert.assertEquals(DefaultPagination.<Integer>build(5L, 3L, List.of(1, 2, 3, 4, 5)), expectedOf(5L, 0L, 5L, Collections.emptyList()));
     }
 
     private Pagination<Integer> expectedOf(final Long currentOffset, final Long totalNbRecords,

--- a/util/src/test/java/org/killbill/billing/util/security/shiro/realm/TestKillBillJdbcRealm.java
+++ b/util/src/test/java/org/killbill/billing/util/security/shiro/realm/TestKillBillJdbcRealm.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.util.security.shiro.realm;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -39,8 +40,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import static java.util.Collections.emptyList;
 
 public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
 
@@ -122,10 +121,10 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
     @Test(groups = "slow")
     public void testEmptyPermissions() throws SecurityApiException {
         securityApi.addRoleDefinition("sanity1", null, callContext);
-        validateUserRoles(securityApi.getRoleDefinition("sanity1", callContext), emptyList());
+        validateUserRoles(securityApi.getRoleDefinition("sanity1", callContext), Collections.emptyList());
 
-        securityApi.addRoleDefinition("sanity2", emptyList(), callContext);
-        validateUserRoles(securityApi.getRoleDefinition("sanity2", callContext), emptyList());
+        securityApi.addRoleDefinition("sanity2", Collections.emptyList(), callContext);
+        validateUserRoles(securityApi.getRoleDefinition("sanity2", callContext), Collections.emptyList());
     }
 
     @Test(groups = "slow")


### PR DESCRIPTION
PR for #1615 for `currency` and `subscription` modules. Things that may need attention:

- [MultiValueMap](https://github.com/killbill/killbill/compare/work-for-release-0.23.x...xsalefter:1615-currency-and-subscription?expand=1#diff-98acdefe979d09a280923cfd61679af13f1593cec1f760c638055397a4145a94) and its [implementation](https://github.com/killbill/killbill/compare/work-for-release-0.23.x...xsalefter:1615-currency-and-subscription?expand=1#diff-6ad59a0d6aaf83d6e67fbec252f6a91b982e5d7cfbac23af147999cd81c4266d), especially the collection data type that will hold the values. Is `List` enough (at least for now)? Should we use `Set` instead of `List`? Do you think naming is Ok?

- [TenantCacheInvalidation](https://github.com/killbill/killbill/compare/work-for-release-0.23.x...xsalefter:1615-currency-and-subscription?expand=1#diff-50733d56a1fc0bcc660547aff8440dd1c1d969146a5ed7cf51e02924fc3f9a6c) use `MultiValueMap` instead of `Map<K, Collection<V>>`

- Some FIXME: [SubscriptionApiBase](https://github.com/killbill/killbill/compare/work-for-release-0.23.x...xsalefter:1615-currency-and-subscription?expand=1#diff-699f89a95013c79d65f3a2489c333b27c2dc0d176b9ef086afad26a71dbaf997R298), [DefaultSubscriptionInternalApi](https://github.com/killbill/killbill/compare/work-for-release-0.23.x...xsalefter:1615-currency-and-subscription?expand=1#diff-24d91c9d52326d020033a24837e591030b00dcd2dbf344e014445597a8e90b6aR186).