### PR TITLE
catalog: prevent StackOverflowError with invalid catalogs

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/CatalogEntityCollection.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/CatalogEntityCollection.java
@@ -206,4 +206,12 @@ public class CatalogEntityCollection<T extends CatalogEntity> implements Collect
     public void writeExternal(final ObjectOutput oo) throws IOException {
         oo.writeObject(data);
     }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("CatalogEntityCollection{");
+        sb.append("data=").append(data.keySet());
+        sb.append('}');
+        return sb.toString();
+    }
 }

--- a/catalog/src/test/java/org/killbill/billing/catalog/TestStandaloneCatalog.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/TestStandaloneCatalog.java
@@ -16,6 +16,8 @@
 
 package org.killbill.billing.catalog;
 
+import java.util.Collections;
+
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.catalog.api.PhaseType;
 import org.killbill.billing.catalog.api.Plan;
@@ -33,22 +35,24 @@ public class TestStandaloneCatalog extends CatalogTestSuiteNoDB {
             getCatalog("CatalogWithValidationErrors.xml");
             Assert.fail();
         } catch (final ValidationException e) {
-            Assert.assertEquals(e.getErrors().size(), 15);
-            Assert.assertEquals(e.getErrors().get(0).getDescription(), "Invalid product for plan 'standard'");
-            Assert.assertEquals(e.getErrors().get(1).getDescription(), "Duration can only have 'UNLIMITED' unit if the number is omitted");
-            Assert.assertEquals(e.getErrors().get(2).getDescription(), "Finite Duration must have a well defined length");
-            Assert.assertEquals(e.getErrors().get(3).getDescription(), "Initial Phase standard-trial-evergreen of plan standard-trial cannot be of type EVERGREEN");
-            Assert.assertEquals(e.getErrors().get(4).getDescription(), "Final Phase standard-trial-trial of plan standard-trial cannot be of type TRIAL");
-            Assert.assertEquals(e.getErrors().get(5).getDescription(), "Duplicate rule for change plan DefaultCaseChangePlanPolicy {policy=IMMEDIATE, phaseType=null, fromProduct=DefaultProduct{name='Standard', category=BASE, included=org.killbill.billing.catalog.CatalogEntityCollection@0, available=org.killbill.billing.catalog.CatalogEntityCollection@0, limits=[], catalogName='CatalogWithValidationErrors'}, fromProductCategory=null, fromBillingPeriod=null, fromPriceList=null, toProduct=null, toProductCategory=null, toBillingPeriod=null, toPriceList=null}");
-            Assert.assertEquals(e.getErrors().get(6).getDescription(), "Missing default rule case for plan change");
-            Assert.assertEquals(e.getErrors().get(7).getDescription(), "Duplicate rule for plan cancellation DefaultCaseCancelPolicy{policy =IMMEDIATE, phaseType =null, product=DefaultProduct{name='Standard', category=BASE, included=org.killbill.billing.catalog.CatalogEntityCollection@0, available=org.killbill.billing.catalog.CatalogEntityCollection@0, limits=[], catalogName='CatalogWithValidationErrors'}, productCategory=null, billingPeriod=null, priceList=null}");
-            Assert.assertEquals(e.getErrors().get(8).getDescription(), "Missing default rule case for plan cancellation");
-            Assert.assertEquals(e.getErrors().get(9).getDescription(), "Duplicate rule for plan change alignment DefaultCaseChangePlanAlignment {alignment=START_OF_BUNDLE, phaseType=null, fromProduct=null, fromProductCategory=null, fromBillingPeriod=null, fromPriceList=null, toProduct=null, toProductCategory=null, toBillingPeriod=null, toPriceList=null}");
-            Assert.assertEquals(e.getErrors().get(10).getDescription(), "Duplicate rule for create plan alignment DefaultCaseCreateAlignment {alignment =START_OF_BUNDLE, product=null, productCategory=null, billingPeriod=null, priceList=null}");
-            Assert.assertEquals(e.getErrors().get(11).getDescription(), "Duplicate rule for billing alignment DefaultCaseBillingAlignment {alignment=ACCOUNT, phaseType=null, product=null, productCategory=null, billingPeriod=null, priceList=null}");
-            Assert.assertEquals(e.getErrors().get(12).getDescription(), "Duplicate rule for price list transition DefaultCasePriceList {fromProduct=null, fromProductCategory=null, fromBillingPeriod=null, fromPriceList=null, toPriceList=DefaultPriceList{name='DEFAULT}}");
-            Assert.assertEquals(e.getErrors().get(13).getDescription(), "EVERGREEN Phase 'standard-trial-evergreen' for plan 'standard-trial' in version 'Fri Feb 08 00:00:00 GMT 2013' must have duration as UNLIMITED'");
-            Assert.assertEquals(e.getErrors().get(14).getDescription(), "'TRIAL' Phase 'standard-trial-trial' for plan 'standard-trial' in version 'Fri Feb 08 00:00:00 GMT 2013' must not have duration as UNLIMITED'");
+            Assert.assertEquals(e.getErrors().size(), 17);
+            Assert.assertEquals(e.getErrors().get(0).getDescription(), "Product refers to itself in included section");
+            Assert.assertEquals(e.getErrors().get(1).getDescription(), "Product refers to itself in available section");
+            Assert.assertEquals(e.getErrors().get(2).getDescription(), "Invalid product for plan 'standard'");
+            Assert.assertEquals(e.getErrors().get(3).getDescription(), "Duration can only have 'UNLIMITED' unit if the number is omitted");
+            Assert.assertEquals(e.getErrors().get(4).getDescription(), "Finite Duration must have a well defined length");
+            Assert.assertEquals(e.getErrors().get(5).getDescription(), "Initial Phase standard-trial-evergreen of plan standard-trial cannot be of type EVERGREEN");
+            Assert.assertEquals(e.getErrors().get(6).getDescription(), "Final Phase standard-trial-trial of plan standard-trial cannot be of type TRIAL");
+            Assert.assertEquals(e.getErrors().get(7).getDescription(), "Duplicate rule for change plan DefaultCaseChangePlanPolicy {policy=IMMEDIATE, phaseType=null, fromProduct=DefaultProduct{name='Standard', category=BASE, included=CatalogEntityCollection{data=[Standard]}, available=CatalogEntityCollection{data=[Standard]}, limits=[], catalogName='CatalogWithValidationErrors'}, fromProductCategory=null, fromBillingPeriod=null, fromPriceList=null, toProduct=null, toProductCategory=null, toBillingPeriod=null, toPriceList=null}");
+            Assert.assertEquals(e.getErrors().get(8).getDescription(), "Missing default rule case for plan change");
+            Assert.assertEquals(e.getErrors().get(9).getDescription(), "Duplicate rule for plan cancellation DefaultCaseCancelPolicy{policy =IMMEDIATE, phaseType =null, product=DefaultProduct{name='Standard', category=BASE, included=CatalogEntityCollection{data=[Standard]}, available=CatalogEntityCollection{data=[Standard]}, limits=[], catalogName='CatalogWithValidationErrors'}, productCategory=null, billingPeriod=null, priceList=null}");
+            Assert.assertEquals(e.getErrors().get(10).getDescription(), "Missing default rule case for plan cancellation");
+            Assert.assertEquals(e.getErrors().get(11).getDescription(), "Duplicate rule for plan change alignment DefaultCaseChangePlanAlignment {alignment=START_OF_BUNDLE, phaseType=null, fromProduct=null, fromProductCategory=null, fromBillingPeriod=null, fromPriceList=null, toProduct=null, toProductCategory=null, toBillingPeriod=null, toPriceList=null}");
+            Assert.assertEquals(e.getErrors().get(12).getDescription(), "Duplicate rule for create plan alignment DefaultCaseCreateAlignment {alignment =START_OF_BUNDLE, product=null, productCategory=null, billingPeriod=null, priceList=null}");
+            Assert.assertEquals(e.getErrors().get(13).getDescription(), "Duplicate rule for billing alignment DefaultCaseBillingAlignment {alignment=ACCOUNT, phaseType=null, product=null, productCategory=null, billingPeriod=null, priceList=null}");
+            Assert.assertEquals(e.getErrors().get(14).getDescription(), "Duplicate rule for price list transition DefaultCasePriceList {fromProduct=null, fromProductCategory=null, fromBillingPeriod=null, fromPriceList=null, toPriceList=DefaultPriceList{name='DEFAULT}}");
+            Assert.assertEquals(e.getErrors().get(15).getDescription(), "EVERGREEN Phase 'standard-trial-evergreen' for plan 'standard-trial' in version 'Fri Feb 08 00:00:00 GMT 2013' must have duration as UNLIMITED'");
+            Assert.assertEquals(e.getErrors().get(16).getDescription(), "'TRIAL' Phase 'standard-trial-trial' for plan 'standard-trial' in version 'Fri Feb 08 00:00:00 GMT 2013' must not have duration as UNLIMITED'");
         }
     }
 
@@ -72,5 +76,16 @@ public class TestStandaloneCatalog extends CatalogTestSuiteNoDB {
         Assert.assertEquals(cat.findPhase("TestPlan2-discount"), phaseDiscount2);
         Assert.assertEquals(cat.findPhase("TestPlan1-trial"), phaseTrial1);
         Assert.assertEquals(cat.findPhase("TestPlan2-trial"), phaseTrial2);
+    }
+
+    @Test(groups = "fast")
+    public void testStackOverflow() {
+        final MockProduct mockProduct = new MockProduct();
+        mockProduct.setAvailable(Collections.singleton(mockProduct));
+
+        final StandaloneCatalog cat = new MockCatalog().setProducts(Collections.singleton(mockProduct));
+        final StandaloneCatalog cat2 = new MockCatalog().setEffectiveDate(cat.getEffectiveDate()).setProducts(Collections.singleton(mockProduct));
+
+        Assert.assertEquals(cat, cat2);
     }
 }

--- a/catalog/src/test/resources/org/killbill/billing/catalog/CatalogWithValidationErrors.xml
+++ b/catalog/src/test/resources/org/killbill/billing/catalog/CatalogWithValidationErrors.xml
@@ -31,6 +31,12 @@
     <products>
         <product name="Standard">
             <category>BASE</category>
+            <included>
+                <addonProduct>Standard</addonProduct>
+            </included>
+            <available>
+                <addonProduct>Standard</addonProduct>
+            </available>
         </product>
     </products>
 


### PR DESCRIPTION
`<included>` and `<available>` product sub-sections should not reference to itself. This patch adds a validation rule to
prevent this.

For existing users, set the following System Property: `org.killbill.catalog.validation.ignoreSelfReferencingProducts=true` if modifying existing catalogs is not immediately practical.

Note: this property might be removed in a future version.
