### PR TITLE
Prototype code for #1661

### DIFF
--- a/api/src/main/java/org/killbill/billing/subscription/api/SubscriptionBase.java
+++ b/api/src/main/java/org/killbill/billing/subscription/api/SubscriptionBase.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
+import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.BillingAlignment;
 import org.killbill.billing.catalog.api.BillingPeriod;
@@ -121,7 +122,7 @@ public interface SubscriptionBase extends Entity, Blockable {
 
     public DateTime getDateOfFirstRecurringNonZeroCharge();
 
-    public List<SubscriptionBillingEvent> getSubscriptionBillingEvents(VersionedCatalog catalog) throws SubscriptionBaseApiException;
+    public List<SubscriptionBillingEvent> getSubscriptionBillingEvents(VersionedCatalog catalog, InternalTenantContext context) throws SubscriptionBaseApiException;
 
     public BillingAlignment getBillingAlignment(PlanPhaseSpecifier spec, DateTime transitionTime, VersionedCatalog catalog) throws SubscriptionBaseApiException;
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions.java
@@ -145,46 +145,6 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
 
 
 
-    @Test(groups = "slow")
-    public void testSubscriptionNotAlignedWithVersionChange() throws Exception {
-
-        final LocalDate today = new LocalDate(2018, 3, 15);
-        clock.setDay(today);
-
-        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
-
-        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
-
-        final DefaultEntitlement bpEntitlement =
-                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey1", "PlumberInsurance",
-                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
-                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
-
-        assertNotNull(bpEntitlement);
-        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
-                                                         new ExpectedInvoiceItemCheck(new LocalDate(2018, 3, 15), new LocalDate(2018, 4, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
-        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
-
-
-        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addMonths(1); // 2018-04-15
-        assertListenerStatus();
-
-        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 4, 15), new LocalDate(2018, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
-        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
-
-        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addMonths(1); // 2018-05-15
-        assertListenerStatus();
-
-        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 15), new LocalDate(2018, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
-        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
-
-
-    }
-
         @Test(groups = "slow")
     public void testUsagePlan() throws Exception {
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions.java
@@ -138,14 +138,62 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
         clock.addMonths(1);
         assertListenerStatus();
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 8, callContext,
-                                    new ExpectedInvoiceItemCheck(new LocalDate(2018, 8, 1), new LocalDate(2018, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("69.95")));
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 8, 1), new LocalDate(2018, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("69.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(2).getEffectiveDate()), 0);
 
+    }
+
+
+
+    @Test(groups = "slow")
+    public void testSubscriptionNotAlignedWithVersionChange() throws Exception {
+
+        final LocalDate today = new LocalDate(2018, 3, 15);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+
+        final DefaultEntitlement bpEntitlement =
+                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey1", "PlumberInsurance",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+
+        assertNotNull(bpEntitlement);
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2018, 3, 15), new LocalDate(2018, 4, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2018-04-15
+        assertListenerStatus();
+
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 4, 15), new LocalDate(2018, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("26.64")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addDays(16); // 2018-05-01
+        assertListenerStatus();
+
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 1), new LocalDate(2018, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("27.98")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addDays(14); // 2018-05-15
+        assertListenerStatus();
+
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 15), new LocalDate(2018, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
 
 
     }
 
-    @Test(groups = "slow")
+        @Test(groups = "slow")
     public void testUsagePlan() throws Exception {
 
         final LocalDate today = new LocalDate(2018, 1, 1);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptions.java
@@ -171,22 +171,14 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptions extends TestIn
         assertListenerStatus();
 
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 4, 15), new LocalDate(2018, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("26.64")));
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 4, 15), new LocalDate(2018, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addDays(16); // 2018-05-01
+        clock.addMonths(1); // 2018-05-15
         assertListenerStatus();
 
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 1), new LocalDate(2018, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("27.98")));
-        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
-
-        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addDays(14); // 2018-05-15
-        assertListenerStatus();
-
-        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
                                                  new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 15), new LocalDate(2018, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig extends TestIntegrationBase {
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogWithEffectiveDateForExistingSubscriptions");
+        // Custom subscription config to test the alignment for the catalog effectiveDateForExistingSubscriptions
+        allExtraProperties.put("org.killbill.subscription.align.effectiveDateForExistingSubscriptions", "true");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+
+
+    @Test(groups = "slow")
+    public void testSubscriptionNotAlignedWithVersionChange() throws Exception {
+
+        final LocalDate today = new LocalDate(2018, 3, 15);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+
+        final DefaultEntitlement bpEntitlement =
+                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey1", "PlumberInsurance",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+
+        assertNotNull(bpEntitlement);
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2018, 3, 15), new LocalDate(2018, 4, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2018-04-15
+        assertListenerStatus();
+
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 4, 15), new LocalDate(2018, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2018-05-15
+        assertListenerStatus();
+
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 15), new LocalDate(2018, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+
+    }
+
+
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig.java
@@ -47,7 +47,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
     @Override
     protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
         final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
-        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogWithEffectiveDateForExistingSubscriptions");
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig");
         // Custom subscription config to test the alignment for the catalog effectiveDateForExistingSubscriptions
         allExtraProperties.put("org.killbill.subscription.align.effectiveDateForExistingSubscriptions", "true");
         return super.getConfigSource(null, allExtraProperties);
@@ -56,7 +56,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
     @Test(groups = "slow")
     public void testSubscriptionNotAlignedWithVersionChange1() throws Exception {
 
-        final LocalDate today = new LocalDate(2018, 3, 15);
+        final LocalDate today = new LocalDate(2022, 3, 15);
         clock.setDay(today);
 
         final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
@@ -64,31 +64,31 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
         final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
 
         final DefaultEntitlement bpEntitlement =
-                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey1", "PlumberInsurance",
+                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey1", "Liability",
                                                            ProductCategory.BASE, BillingPeriod.MONTHLY,
                                                            NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
 
         assertNotNull(bpEntitlement);
         Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
-                                                         new ExpectedInvoiceItemCheck(new LocalDate(2018, 3, 15), new LocalDate(2018, 4, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2022, 3, 15), new LocalDate(2022, 4, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addMonths(1); // 2018-04-15
+        clock.addMonths(1); // 2022-04-15
         assertListenerStatus();
 
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 4, 15), new LocalDate(2018, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 4, 15), new LocalDate(2022, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
 
-        // Catalog v2 is 2018-04-01, but PlumberInsurance effDt is 2018-05-01
+        // Catalog v2 is 2022-04-01, but Liability effDt is 2022-05-01
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addMonths(1); // 2018-05-15
+        clock.addMonths(1); // 2022-05-15
         assertListenerStatus();
 
         // We expect to see no pro-ration because of property 'align.effectiveDateForExistingSubscriptions' and new price
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 15), new LocalDate(2018, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 5, 15), new LocalDate(2022, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
 
     }
@@ -97,7 +97,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
     @Test(groups = "slow")
     public void testSubscriptionNotAlignedWithVersionChange2() throws Exception {
 
-        final LocalDate today = new LocalDate(2018, 3, 15);
+        final LocalDate today = new LocalDate(2022, 3, 15);
         clock.setDay(today);
 
         final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
@@ -106,31 +106,31 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
         final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(20));
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
 
-        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("plumber-insurance-monthly-no-trial");
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("liability-monthly-no-trial");
 
         entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, 15, null, null), null, null, null, false, false, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
         Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
-                                                         new ExpectedInvoiceItemCheck(new LocalDate(2018, 3, 15), new LocalDate(2018, 4, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2022, 3, 15), new LocalDate(2022, 4, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addMonths(1); // 2018-04-15
+        clock.addMonths(1); // 2022-04-15
         assertListenerStatus();
 
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 4, 15), new LocalDate(2018, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 4, 15), new LocalDate(2022, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
 
-        // Catalog v2 is 2018-04-01, but PlumberInsurance effDt is 2018-05-01
+        // Catalog v2 is 2022-04-01, but Liability effDt is 2022-05-01
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addMonths(1); // 2018-05-15
+        clock.addMonths(1); // 2022-05-15
         assertListenerStatus();
 
         // We expect to see no pro-ration because of property 'align.effectiveDateForExistingSubscriptions' and new price
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 15), new LocalDate(2018, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 5, 15), new LocalDate(2022, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
 
     }
@@ -138,8 +138,8 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
     @Test(groups = "slow")
     public void testSubscriptionNotAlignedWithVersionChange3() throws Exception {
 
-        // Catalog v2 is 2018-04-01, but PlumberInsurance effDt is 2018-05-01
-        final LocalDate today = new LocalDate(2018, 4, 15);
+        // Catalog v2 is 2022-04-01 so new price applies right away
+        final LocalDate today = new LocalDate(2022, 4, 15);
         clock.setDay(today);
 
         final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
@@ -148,23 +148,64 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
         final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(20));
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
 
-        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("plumber-insurance-monthly-no-trial");
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("liability-monthly-no-trial");
 
         entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, 15, null, null), null, null, null, false, false, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 
         // We expect the C2 price right away as we started after C2 effDt
         Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
-                                                         new ExpectedInvoiceItemCheck(new LocalDate(2018, 4, 15), new LocalDate(2018, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2022, 4, 15), new LocalDate(2022, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        clock.addMonths(1); // 2018-05-15
+        clock.addMonths(1); // 2022-05-15
         assertListenerStatus();
 
         // We expect to see no pro-ration because of property 'align.effectiveDateForExistingSubscriptions' and new price
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2018, 5, 15), new LocalDate(2018, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 5, 15), new LocalDate(2022, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+    }
+
+
+    @Test(groups = "slow")
+    public void testSubscriptionNotAlignedWithVersionChange4() throws Exception {
+
+        // Catalog v2 is 2022-04-01, but Collision effDt is 2022-05-15
+        final LocalDate today = new LocalDate(2022, 3, 5);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        // We chose 20 (> local BCD = 15) to ensure test fails if local bcd is not correct taken into account
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(20));
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("collision-monthly-no-trial");
+
+        entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, 5, null, null), null, null, null, false, false, ImmutableList.<PluginProperty>of(), callContext);
+        assertListenerStatus();
+
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2022, 3, 5), new LocalDate(2022, 4, 5), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2022-04-05
+        assertListenerStatus();
+
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 4, 5), new LocalDate(2022, 5, 5), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2022-05-05
+        assertListenerStatus();
+
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 5, 5), new LocalDate(2022, 6, 5), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
     }
 }

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig/Insurance-v1.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig/Insurance-v1.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2014 The Billing Project, Inc.
+  ~
+  ~ Ning licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2022-01-01T00:00:00+00:00</effectiveDate>
+    <catalogName>Insurance</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+        <currency>GBP</currency>
+        <currency>EUR</currency>
+    </currencies>
+
+    <units>
+    </units>
+
+    <products>
+        <product name="Liability">
+            <category>BASE</category>
+        </product>
+        <product name="Collision">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+    </rules>
+
+    <plans>
+        <plan name="liability-monthly-no-trial">
+            <product>Liability</product>
+            <initialPhases>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>49.95</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>49.95</value>
+                        </price>
+                        <price>
+                            <currency>USD</currency>
+                            <value>49.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        <plan name="collision-monthly-no-trial">
+            <product>Collision</product>
+            <initialPhases>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>49.95</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>49.95</value>
+                        </price>
+                        <price>
+                            <currency>USD</currency>
+                            <value>49.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>liability-monthly-no-trial</plan>
+                <plan>collision-monthly-no-trial</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig/Insurance-v2.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig/Insurance-v2.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2014 The Billing Project, Inc.
+  ~
+  ~ Ning licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2022-04-01T00:00:00+00:00</effectiveDate>
+    <catalogName>Insurance</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+        <currency>GBP</currency>
+        <currency>EUR</currency>
+    </currencies>
+
+    <units>
+    </units>
+
+    <products>
+        <product name="Liability">
+            <category>BASE</category>
+        </product>
+        <product name="Collision">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+    </rules>
+
+    <plans>
+        <plan name="liability-monthly-no-trial">
+            <effectiveDateForExistingSubscriptions>2022-05-01T00:00:00+00:00</effectiveDateForExistingSubscriptions>
+            <product>Liability</product>
+            <initialPhases>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>59.95</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>59.95</value>
+                        </price>
+                        <price>
+                            <currency>USD</currency>
+                            <value>59.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        <plan name="collision-monthly-no-trial">
+            <effectiveDateForExistingSubscriptions>2022-05-15T00:00:00+00:00</effectiveDateForExistingSubscriptions>
+            <product>Collision</product>
+            <initialPhases>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>59.95</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>59.95</value>
+                        </price>
+                        <price>
+                            <currency>USD</currency>
+                            <value>59.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+
+
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>liability-monthly-no-trial</plan>
+                <plan>collision-monthly-no-trial</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionApiBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionApiBase.java
@@ -186,7 +186,7 @@ public class SubscriptionApiBase {
                         policy = planChangeResult.getPolicy();
                     }
                     // We pass null for billingAlignment, accountTimezone, account BCD because this is not available which means that dryRun with START_OF_TERM BillingPolicy will fail
-                    changeEffectiveDate = subscriptionForChange.getEffectiveDateForPolicy(policy, null, -1, context);
+                    changeEffectiveDate = subscriptionForChange.getEffectiveDateForPolicy(policy, null, context);
                 }
                 dryRunEvents = apiService.getEventsOnChangePlan(subscriptionForChange, plan, plan.getPriceList().getName(), changeEffectiveDate, true, entitlementSpecifier.getBillCycleDay(), catalog, context);
                 break;
@@ -204,7 +204,7 @@ public class SubscriptionApiBase {
                         policy = catalog.planCancelPolicy(spec, clock.getUTCNow(), subscriptionForCancellation.getStartDate());
                     }
                     // We pass null for billingAlignment, accountTimezone, account BCD because this is not available which means that dryRun with START_OF_TERM BillingPolicy will fail
-                    cancelEffectiveDate = subscriptionForCancellation.getEffectiveDateForPolicy(policy, null, -1, context);
+                    cancelEffectiveDate = subscriptionForCancellation.getEffectiveDateForPolicy(policy, null, context);
                 }
                 dryRunEvents = apiService.getEventsOnCancelPlan(subscriptionForCancellation, cancelEffectiveDate, true, catalog, context);
                 break;

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseApiService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseApiService.java
@@ -38,7 +38,6 @@ import org.killbill.billing.subscription.catalog.SubscriptionCatalog;
 import org.killbill.billing.subscription.events.SubscriptionBaseEvent;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
-import org.skife.config.Param;
 
 public interface SubscriptionBaseApiService {
 
@@ -111,6 +110,6 @@ public interface SubscriptionBaseApiService {
 
     int getAccountBCD(InternalTenantContext context) throws SubscriptionBaseApiException;
 
-    // If we expose more than one config, we should not instead return the SubscriptionConfig object
-    boolean isEffectiveDateForExistingSubscriptionsAlignedToBCD(@Param("dummy") final InternalTenantContext tenantContext);
+    // If we expose more than one config, we should instead return the SubscriptionConfig object
+    boolean isEffectiveDateForExistingSubscriptionsAlignedToBCD(final InternalTenantContext tenantContext);
 }

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseApiService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseApiService.java
@@ -108,6 +108,6 @@ public interface SubscriptionBaseApiService {
 
     boolean undoChangePlan(DefaultSubscriptionBase defaultSubscriptionBase, CallContext context) throws SubscriptionBaseApiException;
 
-    int getBCD(InternalTenantContext context) throws SubscriptionBaseApiException;
+    int getAccountBCD(InternalTenantContext context) throws SubscriptionBaseApiException;
 
 }

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseApiService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseApiService.java
@@ -38,6 +38,7 @@ import org.killbill.billing.subscription.catalog.SubscriptionCatalog;
 import org.killbill.billing.subscription.events.SubscriptionBaseEvent;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.skife.config.Param;
 
 public interface SubscriptionBaseApiService {
 
@@ -110,4 +111,6 @@ public interface SubscriptionBaseApiService {
 
     int getAccountBCD(InternalTenantContext context) throws SubscriptionBaseApiException;
 
+    // If we expose more than one config, we should not instead return the SubscriptionConfig object
+    boolean isEffectiveDateForExistingSubscriptionsAlignedToBCD(@Param("dummy") final InternalTenantContext tenantContext);
 }

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseApiService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/SubscriptionBaseApiService.java
@@ -68,12 +68,12 @@ public interface SubscriptionBaseApiService {
 
     // Return the effective date of the change
     public DateTime changePlanWithRequestedDate(DefaultSubscriptionBase subscription, EntitlementSpecifier spec,
-                                                 DateTime requestedDate, CallContext context)
+                                                DateTime requestedDate, CallContext context)
             throws SubscriptionBaseApiException;
 
     // Return the effective date of the change
     public DateTime changePlanWithPolicy(DefaultSubscriptionBase subscription, EntitlementSpecifier spec,
-                                          BillingActionPolicy policy, CallContext context)
+                                         BillingActionPolicy policy, CallContext context)
             throws SubscriptionBaseApiException;
 
     public int handleBasePlanEvent(final DefaultSubscriptionBase subscription, final SubscriptionBaseEvent event, SubscriptionCatalog catalog, final CallContext context) throws CatalogApiException;
@@ -107,4 +107,7 @@ public interface SubscriptionBaseApiService {
                                                              final InternalTenantContext internalTenantContext) throws CatalogApiException;
 
     boolean undoChangePlan(DefaultSubscriptionBase defaultSubscriptionBase, CallContext context) throws SubscriptionBaseApiException;
+
+    int getBCD(InternalTenantContext context) throws SubscriptionBaseApiException;
+
 }

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/svcs/DefaultSubscriptionInternalApi.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/svcs/DefaultSubscriptionInternalApi.java
@@ -63,7 +63,6 @@ import org.killbill.billing.subscription.api.user.SubscriptionBaseBundle;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseTransition;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseTransitionData;
 import org.killbill.billing.subscription.api.user.SubscriptionBillingEvent;
-import org.killbill.billing.subscription.api.user.SubscriptionBuilder;
 import org.killbill.billing.subscription.catalog.DefaultSubscriptionCatalogApi;
 import org.killbill.billing.subscription.catalog.SubscriptionCatalog;
 import org.killbill.billing.subscription.catalog.SubscriptionCatalogApi;
@@ -362,7 +361,7 @@ public class DefaultSubscriptionInternalApi extends DefaultSubscriptionBaseCreat
     @Override
     public List<SubscriptionBillingEvent> getSubscriptionBillingEvents(final VersionedCatalog publicCatalog, final SubscriptionBase subscription, final InternalTenantContext context) throws SubscriptionBaseApiException {
         final SubscriptionCatalog catalog = DefaultSubscriptionCatalogApi.wrapCatalog(publicCatalog, clock);
-        return subscription.getSubscriptionBillingEvents(catalog.getCatalog());
+        return subscription.getSubscriptionBillingEvents(catalog.getCatalog(), context);
     }
 
     @Override

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -20,7 +20,6 @@ package org.killbill.billing.subscription.api.user;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -642,7 +641,7 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
                                 DateTime nextEffectiveDate = new DateTime(nextPlan.getEffectiveDateForExistingSubscriptions()).toDateTime(DateTimeZone.UTC);
                                 final PlanPhase nextPlanPhase = nextPlan.findPhase(planPhase.getName());
 
-                                nextEffectiveDate = alignToNextBCD(plan, planPhase, nextEffectiveDate, catalog, null, context);
+                                nextEffectiveDate = alignToNextBCDIfRequired(plan, planPhase, nextEffectiveDate, catalog, null, context);
 
                                 // Computed from the nextPlan
                                 final DateTime catalogEffectiveDateForNextPlan = CatalogDateHelper.toUTCDateTime(nextPlan.getCatalog().getEffectiveDate());
@@ -691,7 +690,11 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
     }
 
 
-    private DateTime alignToNextBCD(final Plan curPlan, final PlanPhase curPlanPhase, final DateTime originalDate, final SubscriptionCatalog catalog, final Integer bcdLocal, final InternalTenantContext context) throws SubscriptionBaseApiException, CatalogApiException {
+    private DateTime alignToNextBCDIfRequired(final Plan curPlan, final PlanPhase curPlanPhase, final DateTime originalDate, final SubscriptionCatalog catalog, final Integer bcdLocal, final InternalTenantContext context) throws SubscriptionBaseApiException, CatalogApiException {
+
+        if (!apiService.isEffectiveDateForExistingSubscriptionsAlignedToBCD(context)) {
+            return originalDate;
+        }
 
         final BillingAlignment billingAlignment = catalog.billingAlignment(new PlanPhaseSpecifier(curPlan.getName(), curPlanPhase.getPhaseType()),
                                                                            originalDate, originalDate);

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -696,7 +696,7 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
         final BillingAlignment billingAlignment = catalog.billingAlignment(new PlanPhaseSpecifier(curPlan.getName(), curPlanPhase.getPhaseType()),
                                                                            originalDate, originalDate);
 
-        final int accountBillCycleDayLocal = apiService.getBCD(context);
+        final int accountBillCycleDayLocal = apiService.getAccountBCD(context);
         Integer bcd = bcdLocal;
         if (bcd == null) {
             bcd = BillCycleDayCalculator.calculateBcdForAlignment(null, this, this, billingAlignment, context, accountBillCycleDayLocal);
@@ -758,7 +758,7 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
 
     public DateTime getEffectiveDateForPolicy(final BillingActionPolicy policy, @Nullable final BillingAlignment alignment, final InternalTenantContext context) throws SubscriptionBaseApiException {
 
-        final Integer accountBillCycleDayLocal = apiService != null ? apiService.getBCD(context) : null;
+        final Integer accountBillCycleDayLocal = apiService != null ? apiService.getAccountBCD(context) : null;
         final DateTime candidateResult;
         switch (policy) {
             case IMMEDIATE:

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBaseApiService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBaseApiService.java
@@ -658,7 +658,7 @@ public class DefaultSubscriptionBaseApiService implements SubscriptionBaseApiSer
     }
 
     @Override
-    public int getBCD(InternalTenantContext context) throws SubscriptionBaseApiException {
+    public int getAccountBCD(InternalTenantContext context) throws SubscriptionBaseApiException {
         try {
             return accountInternalApi.getBCD(context);
         } catch (final AccountApiException e) {

--- a/subscription/src/main/java/org/killbill/billing/subscription/config/MultiTenantSubscriptionConfig.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/config/MultiTenantSubscriptionConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.subscription.config;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.util.config.definition.KillbillConfig;
+import org.killbill.billing.util.config.definition.SubscriptionConfig;
+import org.killbill.billing.util.config.tenant.CacheConfig;
+import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.glue.KillBillModule;
+
+public class MultiTenantSubscriptionConfig extends MultiTenantConfigBase implements SubscriptionConfig {
+
+    private final SubscriptionConfig staticConfig;
+
+    @Inject
+    public MultiTenantSubscriptionConfig(@Named(KillBillModule.STATIC_CONFIG) final SubscriptionConfig staticConfig, final CacheConfig cacheConfig) {
+        super(cacheConfig);
+        this.staticConfig = staticConfig;
+    }
+
+    @Override
+    public boolean isEffectiveDateForExistingSubscriptionsAlignedToBCD() {
+        return staticConfig.isEffectiveDateForExistingSubscriptionsAlignedToBCD();
+    }
+
+    @Override
+    public boolean isEffectiveDateForExistingSubscriptionsAlignedToBCD(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("isEffectiveDateForExistingSubscriptionsAlignedToBCD", tenantContext);
+        if (result != null) {
+            return Boolean.parseBoolean(result);
+        }
+        return isEffectiveDateForExistingSubscriptionsAlignedToBCD();
+    }
+
+    @Override
+    protected Class<? extends KillbillConfig> getConfigClass() {
+        return SubscriptionConfig.class;
+    }
+}

--- a/subscription/src/main/java/org/killbill/billing/subscription/glue/DefaultSubscriptionModule.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/glue/DefaultSubscriptionModule.java
@@ -32,6 +32,7 @@ import org.killbill.billing.subscription.api.transfer.SubscriptionBaseTransferAp
 import org.killbill.billing.subscription.api.user.DefaultSubscriptionBaseApiService;
 import org.killbill.billing.subscription.catalog.DefaultSubscriptionCatalogApi;
 import org.killbill.billing.subscription.catalog.SubscriptionCatalogApi;
+import org.killbill.billing.subscription.config.MultiTenantSubscriptionConfig;
 import org.killbill.billing.subscription.engine.addon.AddonUtils;
 import org.killbill.billing.subscription.engine.core.DefaultSubscriptionBaseService;
 import org.killbill.billing.subscription.engine.dao.DefaultSubscriptionDao;
@@ -40,6 +41,8 @@ import org.killbill.billing.util.config.definition.SubscriptionConfig;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.ConfigurationObjectFactory;
 
+import com.google.inject.name.Names;
+
 public class DefaultSubscriptionModule extends KillBillModule implements SubscriptionModule {
 
     public DefaultSubscriptionModule(final KillbillConfigSource configSource) {
@@ -47,9 +50,14 @@ public class DefaultSubscriptionModule extends KillBillModule implements Subscri
     }
 
     protected void installConfig() {
-        final SubscriptionConfig config = new ConfigurationObjectFactory(skifeConfigSource).build(SubscriptionConfig.class);
-        bind(SubscriptionConfig.class).toInstance(config);
+        installConfig(new ConfigurationObjectFactory(skifeConfigSource).build(SubscriptionConfig.class));
     }
+
+    protected void installConfig(final SubscriptionConfig staticInvoiceConfig) {
+        bind(SubscriptionConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(staticInvoiceConfig);
+        bind(SubscriptionConfig.class).to(MultiTenantSubscriptionConfig.class).asEagerSingleton();
+    }
+
 
     protected void installSubscriptionDao() {
         bind(SubscriptionDao.class).to(DefaultSubscriptionDao.class).asEagerSingleton();

--- a/subscription/src/test/java/org/killbill/billing/subscription/SubscriptionTestSuiteNoDB.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/SubscriptionTestSuiteNoDB.java
@@ -37,6 +37,7 @@ import org.killbill.billing.catalog.api.CatalogService;
 import org.killbill.billing.dao.MockNonEntityDao;
 import org.killbill.billing.lifecycle.api.BusService;
 import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.billing.subscription.api.SubscriptionBaseApiService;
 import org.killbill.billing.subscription.api.SubscriptionBaseInternalApi;
 import org.killbill.billing.subscription.api.SubscriptionBaseService;
 import org.killbill.billing.subscription.api.timeline.SubscriptionBaseTimelineApi;
@@ -77,6 +78,8 @@ public class SubscriptionTestSuiteNoDB extends GuicyKillbillTestSuiteNoDB {
     protected ImmutableAccountInternalApi immutableAccountInternalApi;
     @Inject
     protected SubscriptionBaseService subscriptionBaseService;
+    @Inject
+    protected SubscriptionBaseApiService subscriptionBaseApiService;
     @Inject
     protected SubscriptionBaseInternalApi subscriptionInternalApi;
     @Inject
@@ -155,6 +158,7 @@ public class SubscriptionTestSuiteNoDB extends GuicyKillbillTestSuiteNoDB {
         this.catalog = DefaultSubscriptionCatalogApi.wrapCatalog(subscriptionTestInitializer.initCatalog(catalogService, internalCallContext), clock);
         this.accountData = subscriptionTestInitializer.initAccountData(clock);
 
+        Mockito.when(accountInternalApi.getBCD(Mockito.any())). thenReturn(1);
         final Account account = GuicyKillbillTestSuiteNoDB.createMockAccount(accountData,
                                                                              accountUserApi,
                                                                              accountInternalApi,

--- a/util/src/main/java/org/killbill/billing/util/bcd/BillCycleDayCalculator.java
+++ b/util/src/main/java/org/killbill/billing/util/bcd/BillCycleDayCalculator.java
@@ -62,12 +62,10 @@ public abstract class BillCycleDayCalculator {
         }
         final int lastDayOfMonth = proposedDate.dayOfMonth().getMaximumValue();
         int proposedBillCycleDate = proposedDate.getDayOfMonth();
-        if (proposedBillCycleDate < billingCycleDay) {
-            if (billingCycleDay <= lastDayOfMonth) {
-                proposedBillCycleDate = billingCycleDay;
-            } else {
-                proposedBillCycleDate = lastDayOfMonth;
-            }
+        if (billingCycleDay <= lastDayOfMonth) {
+            proposedBillCycleDate = billingCycleDay;
+        } else {
+            proposedBillCycleDate = lastDayOfMonth;
         }
         return new LocalDate(proposedDate.getYear(), proposedDate.getMonthOfYear(), proposedBillCycleDate, proposedDate.getChronology());
     }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/SubscriptionConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/SubscriptionConfig.java
@@ -17,5 +17,22 @@
 
 package org.killbill.billing.util.config.definition;
 
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.skife.config.Config;
+import org.skife.config.Default;
+import org.skife.config.Description;
+import org.skife.config.Param;
+
 public interface SubscriptionConfig extends KillbillConfig {
+
+    @Config("org.killbill.subscription.align.effectiveDateForExistingSubscriptions")
+    @Default("false")
+    @Description("Whether to align the per-plan effectiveDateForExistingSubscriptions with the next per-subscription BCD")
+    boolean isEffectiveDateForExistingSubscriptionsAlignedToBCD();
+
+    @Config("org.killbill.subscription.align.effectiveDateForExistingSubscriptions")
+    @Default("false")
+    @Description("Whether to align the per-plan effectiveDateForExistingSubscriptions with the next per-subscription BCD")
+    boolean isEffectiveDateForExistingSubscriptionsAlignedToBCD(@Param("dummy") final InternalTenantContext tenantContext);
+
 }

--- a/util/src/test/java/org/killbill/billing/mock/MockSubscription.java
+++ b/util/src/test/java/org/killbill/billing/mock/MockSubscription.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
+import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.BillingAlignment;
 import org.killbill.billing.catalog.api.BillingPeriod;
@@ -31,7 +32,6 @@ import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.catalog.api.PriceList;
 import org.killbill.billing.catalog.api.Product;
 import org.killbill.billing.catalog.api.ProductCategory;
-import org.killbill.billing.catalog.api.StaticCatalog;
 import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.entitlement.api.Entitlement.EntitlementSourceType;
 import org.killbill.billing.entitlement.api.Entitlement.EntitlementState;
@@ -176,7 +176,7 @@ public class MockSubscription implements SubscriptionBase {
     }
 
     @Override
-    public List<SubscriptionBillingEvent> getSubscriptionBillingEvents(final VersionedCatalog publicCatalog) throws SubscriptionBaseApiException {
+    public List<SubscriptionBillingEvent> getSubscriptionBillingEvents(final VersionedCatalog publicCatalog, final InternalTenantContext context) throws SubscriptionBaseApiException {
         return null;
     }
 

--- a/util/src/test/java/org/killbill/billing/util/bcd/TestBillCycleDayCalculator.java
+++ b/util/src/test/java/org/killbill/billing/util/bcd/TestBillCycleDayCalculator.java
@@ -148,7 +148,7 @@ public class TestBillCycleDayCalculator extends UtilTestSuiteNoDB {
         final int bcd = 17;
 
         final LocalDate result = BillCycleDayCalculator.alignProposedBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
-        Assert.assertEquals(result, new LocalDate(2022, 7, 19));
+        Assert.assertEquals(result, new LocalDate(2022, 7, 17));
     }
 
     private void verifyBCDCalculation(final DateTimeZone accountTimeZone, final DateTime startDateUTC, final int bcdLocal) throws AccountApiException, CatalogApiException {

--- a/util/src/test/java/org/killbill/billing/util/bcd/TestBillCycleDayCalculator.java
+++ b/util/src/test/java/org/killbill/billing/util/bcd/TestBillCycleDayCalculator.java
@@ -22,11 +22,13 @@ import java.util.UUID;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
 import org.killbill.billing.GuicyKillbillTestSuiteNoDB;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.account.api.AccountApiException;
 import org.killbill.billing.account.api.ImmutableAccountData;
 import org.killbill.billing.catalog.api.BillingAlignment;
+import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.catalog.api.Plan;
 import org.killbill.billing.mock.MockAccountBuilder;
@@ -127,6 +129,26 @@ public class TestBillCycleDayCalculator extends UtilTestSuiteNoDB {
         createAccountAndRefreshTimeAwareContext(accountTimeZone, startDate);
 
         verifyBCDCalculation(accountTimeZone, startDate, bcdLocal);
+    }
+
+    @Test(groups = "fast")
+    public void testAlignProposedBillCycleDate1() {
+        final DateTime proposedDate = new DateTime(2022, 7, 19, 17, 28, 0, DateTimeZone.UTC);
+        final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
+        final int bcd = 23;
+
+        final LocalDate result = BillCycleDayCalculator.alignProposedBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
+        Assert.assertEquals(result, new LocalDate(2022, 7, 23));
+    }
+
+    @Test(groups = "fast")
+    public void testAlignProposedBillCycleDate2() {
+        final DateTime proposedDate = new DateTime(2022, 7, 19, 17, 28, 0, DateTimeZone.UTC);
+        final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
+        final int bcd = 17;
+
+        final LocalDate result = BillCycleDayCalculator.alignProposedBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
+        Assert.assertEquals(result, new LocalDate(2022, 7, 19));
     }
 
     private void verifyBCDCalculation(final DateTimeZone accountTimeZone, final DateTime startDateUTC, final int bcdLocal) throws AccountApiException, CatalogApiException {


### PR DESCRIPTION
* In https://github.com/killbill/killbill/commit/85a045f5a14b7112dc8a615414bd5cb8f52ecef8, there is a new test case that shows the current behavior.
* In https://github.com/killbill/killbill/commit/415c0c0a050ccf372989563688fe2c04d8fd8593, there is a prototype fix that removes the pro-ration when transition to a new Plan version.

`ci` tests fail, because the new behavior is hardcoded and in particular make the existing test `TestCatalogWithEffectiveDateForExistingSubscriptions.testRecurringPlan` fail (See TestCatalogWithEffectiveDateForExistingSubscriptions.java:120)

Notes:

- This new [method](https://github.com/killbill/killbill/pull/1663/files#diff-6c9485b2174859a0d155b69e387e4b868e364c2608ba08fd0a2db9c49101fc46R694) is very similar to [this one](https://github.com/killbill/killbill/blob/killbill-0.22.28/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java#L732), which we know need some attention (e.g billing alignment policies).
- The wiring is difficult and leads to that terrible piece [here](https://github.com/killbill/killbill/pull/1663/files#diff-6c9485b2174859a0d155b69e387e4b868e364c2608ba08fd0a2db9c49101fc46R761) // Would need tio be fixed
- The config inside `Subscription` does not exist, so if we go this direction this is more work. On `0.24.x`, we could make the behavior configurable inside the catalog.

