### PR TITLE
subscription: Rework event ordering to ensure we have always a 'start…

### DIFF
--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -818,27 +818,7 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
 
         this.events = inputEvents;
 
-
-        Collections.sort(inputEvents, new Comparator<SubscriptionBaseEvent>() {
-            @Override
-            public int compare(final SubscriptionBaseEvent o1, final SubscriptionBaseEvent o2) {
-                final int res = o1.getEffectiveDate().compareTo(o2.getEffectiveDate());
-                if (res != 0) {
-                    return res;
-                }
-
-                // In-memory events have a total order of 0, make sure they are after on disk event
-                if (o1.getTotalOrdering() == 0 && o2.getTotalOrdering() > 0) {
-                    return 1;
-                } else if (o1.getTotalOrdering() > 0 && o2.getTotalOrdering() == 0) {
-                    return -1;
-                } else if (o1.getTotalOrdering() == o2.getTotalOrdering()) {
-                    return 0;
-                } else {
-                    return o1.getTotalOrdering() < (o2.getTotalOrdering()) ? -1 : 1;
-                }
-            }
-        });
+        Collections.sort(inputEvents);
 
         removeEverythingPastCancelEvent(events);
 

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
@@ -532,10 +532,10 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
             @Override
             public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
                 final UUID subscriptionId = subscription.getId();
                 cancelNextPhaseEventFromTransaction(subscriptionId, entitySqlDaoWrapperFactory, context);
-                createAndRefresh(transactional, new SubscriptionEventModelDao(nextPhaseEvent), context);
+                createAndRefresh(eventSqlDao, new SubscriptionEventModelDao(nextPhaseEvent), context);
                 recordFutureNotificationFromTransaction(entitySqlDaoWrapperFactory,
                                                         nextPhaseEvent.getEffectiveDate(),
                                                         new SubscriptionNotificationKey(nextPhaseEvent.getId()), context);
@@ -554,7 +554,8 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<SubscriptionBaseEvent>() {
             @Override
             public SubscriptionBaseEvent inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventModelDao model = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getById(eventId.toString(), context);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                final SubscriptionEventModelDao model = eventSqlDao.getById(eventId.toString(), context);
                 return SubscriptionEventModelDao.toSubscriptionEvent(model);
             }
         });
@@ -577,7 +578,9 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<SubscriptionBaseEvent>>() {
             @Override
             public List<SubscriptionBaseEvent> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final List<SubscriptionEventModelDao> eventModels = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getFutureActiveEventForSubscription(subscriptionId.toString(), now, context);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                final List<SubscriptionEventModelDao> eventModels = eventSqlDao.getFutureActiveEventForSubscription(subscriptionId.toString(), now, context);
+                Collections.sort(eventModels);
                 return toSubscriptionBaseEvents(eventModels);
             }
         });
@@ -591,7 +594,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
             @Override
             public List<SubscriptionBaseEvent> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
                 final SubscriptionSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionSqlDao.class);
-                final SubscriptionEventSqlDao eventsDaoFromSameTransaction = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                final SubscriptionEventSqlDao eventsSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
 
 
                 int busEffSeqId = 0;
@@ -606,7 +609,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
                         final List<SubscriptionBaseEvent> initialEvents = initialEventsMap.get(defaultSubscriptionBase.getId());
 
                         for (final SubscriptionBaseEvent cur : initialEvents) {
-                            createdEvents.add(createAndRefresh(eventsDaoFromSameTransaction, new SubscriptionEventModelDao(cur), context));
+                            createdEvents.add(createAndRefresh(eventsSqlDao, new SubscriptionEventModelDao(cur), context));
 
                             final boolean isBusEvent = cur.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0 && (cur.getType() == EventType.API_USER || cur.getType() == EventType.BCD_UPDATE);
                             final int seqId = isBusEvent ? busEffSeqId++ : 0;
@@ -688,13 +691,13 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
             @Override
             public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
 
                 final UUID subscriptionId = subscription.getId();
 
                 Set<SubscriptionEventModelDao> targetEvents = new HashSet<SubscriptionEventModelDao>();
                 final Date now = context.getCreatedDate().toDate();
-                final List<SubscriptionEventModelDao> eventModels = transactional.getFutureActiveEventForSubscription(subscriptionId.toString(), now, contextWithUpdatedDate);
+                final List<SubscriptionEventModelDao> eventModels = eventSqlDao.getFutureActiveEventForSubscription(subscriptionId.toString(), now, contextWithUpdatedDate);
 
                 for (final SubscriptionEventModelDao cur : eventModels) {
                     if (cur.getEventType() == EventType.API_USER && cur.getUserType() == targetOperation) {
@@ -706,10 +709,10 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
 
                 if (!targetEvents.isEmpty()) {
                     for (SubscriptionEventModelDao target : targetEvents) {
-                        transactional.unactiveEvent(target.getId().toString(), contextWithUpdatedDate);
+                        eventSqlDao.unactiveEvent(target.getId().toString(), contextWithUpdatedDate);
                     }
                     for (final SubscriptionBaseEvent cur : inputEvents) {
-                        transactional.create(new SubscriptionEventModelDao(cur), contextWithUpdatedDate);
+                        eventSqlDao.create(new SubscriptionEventModelDao(cur), contextWithUpdatedDate);
                         recordFutureNotificationFromTransaction(entitySqlDaoWrapperFactory,
                                                                 cur.getEffectiveDate(),
                                                                 new SubscriptionNotificationKey(cur.getId()),
@@ -738,8 +741,9 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
             @Override
             public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
 
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                final List<SubscriptionEventModelDao> activeSubscriptionEvents = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getActiveEventsForSubscription(subscription.getId().toString(), context);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                final List<SubscriptionEventModelDao> activeSubscriptionEvents = eventSqlDao.getActiveEventsForSubscription(subscription.getId().toString(), context);
+                Collections.sort(activeSubscriptionEvents);
 
                 // First event is CREATE/TRANSFER event
                 final SubscriptionEventModelDao firstSubscriptionEvent = activeSubscriptionEvents.get(0);
@@ -777,7 +781,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
                 cancelFutureEventsFromTransaction(activePresentOrFutureSubscriptionEvents, entitySqlDaoWrapperFactory, false, context);
 
                 for (final SubscriptionBaseEvent cur : inputChangeEvents) {
-                    createAndRefresh(transactional, new SubscriptionEventModelDao(cur), context);
+                    createAndRefresh(eventSqlDao, new SubscriptionEventModelDao(cur), context);
 
                     final boolean isBusEvent = cur.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0 && (cur.getType() == EventType.API_USER || cur.getType() == EventType.BCD_UPDATE);
                     recordBusOrFutureNotificationFromTransaction(subscription, cur, entitySqlDaoWrapperFactory, isBusEvent, 0, catalog, context);
@@ -796,6 +800,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     }
 
     private List<SubscriptionBaseEvent> filterSubscriptionBaseEvents(final Collection<SubscriptionEventModelDao> models) {
+        // TODO
         final Collection<SubscriptionEventModelDao> filteredModels = Collections2.filter(models, new Predicate<SubscriptionEventModelDao>() {
             @Override
             public boolean apply(@Nullable final SubscriptionEventModelDao input) {
@@ -818,10 +823,10 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<SubscriptionBaseEvent>>() {
             @Override
             public List<SubscriptionBaseEvent> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventSqlDao subscriptionEventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
                 final List<SubscriptionEventModelDao> models = cutoffDt == null ?
-                                                               subscriptionEventSqlDao.getByAccountRecordId(context) :
-                                                               subscriptionEventSqlDao.getActiveByAccountRecordId(cutoffDt.toDate(), context);
+                                                               eventSqlDao.getByAccountRecordId(context) :
+                                                               eventSqlDao.getActiveByAccountRecordId(cutoffDt.toDate(), context);
                 return filterSubscriptionBaseEvents(models);
             }
         });
@@ -831,8 +836,8 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
             throws EntityPersistenceException {
         final UUID subscriptionId = subscription.getId();
         cancelFutureEventsFromTransaction(subscriptionId, cancelEvent.getEffectiveDate(), entitySqlDaoWrapperFactory, true, context);
-        final SubscriptionEventSqlDao subscriptionEventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-        final SubscriptionEventModelDao cancelEventWithUpdatedTotalOrdering = createAndRefresh(subscriptionEventSqlDao, new SubscriptionEventModelDao(cancelEvent), context);
+        final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+        final SubscriptionEventModelDao cancelEventWithUpdatedTotalOrdering = createAndRefresh(eventSqlDao, new SubscriptionEventModelDao(cancelEvent), context);
 
         final SubscriptionBaseEvent refreshedSubscriptionEvent = SubscriptionEventModelDao.toSubscriptionEvent(cancelEventWithUpdatedTotalOrdering);
         final boolean isBusEvent = refreshedSubscriptionEvent.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0;
@@ -847,7 +852,9 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     }
 
     private void cancelFutureEventsFromTransaction(final UUID subscriptionId, final DateTime effectiveDate, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final boolean includingBCDChange, final InternalCallContext context) {
-        final List<SubscriptionEventModelDao> eventModels = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getFutureOrPresentActiveEventForSubscription(subscriptionId.toString(), effectiveDate.toDate(), context);
+        final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+        final List<SubscriptionEventModelDao> eventModels = eventSqlDao.getFutureOrPresentActiveEventForSubscription(subscriptionId.toString(), effectiveDate.toDate(), context);
+        Collections.sort(eventModels);
         cancelFutureEventsFromTransaction(eventModels, entitySqlDaoWrapperFactory, includingBCDChange, context);
     }
 
@@ -876,7 +883,10 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         SubscriptionEventModelDao futureEvent = null;
         final Date now = context.getCreatedDate().toDate();
 
-        final List<SubscriptionEventModelDao> eventModels = dao.become(SubscriptionEventSqlDao.class).getFutureActiveEventForSubscription(subscriptionId.toString(), now, context);
+        final SubscriptionEventSqlDao eventSqlDao = dao.become(SubscriptionEventSqlDao.class);
+        final List<SubscriptionEventModelDao> eventModels = eventSqlDao.getFutureActiveEventForSubscription(subscriptionId.toString(), now, context);
+        Collections.sort(eventModels);
+
         for (final SubscriptionEventModelDao cur : eventModels) {
             if (cur.getEventType() == type &&
                 (apiType == null || apiType == cur.getUserType())) {
@@ -895,7 +905,8 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     private void unactivateEventFromTransaction(final Entity event, final EntitySqlDaoWrapperFactory dao, final InternalCallContext context) {
         if (event != null) {
             final String eventId = event.getId().toString();
-            dao.become(SubscriptionEventSqlDao.class).unactiveEvent(eventId, context);
+            final SubscriptionEventSqlDao eventSqlDao = dao.become(SubscriptionEventSqlDao.class);
+            eventSqlDao.unactiveEvent(eventId, context);
         }
     }
 
@@ -1076,8 +1087,8 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
                 final BundleSqlDao bundleSqlDao = entitySqlDaoWrapperFactory.become(BundleSqlDao.class);
                 renameBundleExternalKey(bundleSqlDao, bundleTransferData.getData().getExternalKey(), "tsf", fromContext);
 
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                transferBundleDataFromTransaction(bundleTransferData, transactional, entitySqlDaoWrapperFactory, toContext);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                transferBundleDataFromTransaction(bundleTransferData, eventSqlDao, entitySqlDaoWrapperFactory, toContext);
                 return null;
             }
         });
@@ -1101,8 +1112,8 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
             @Override
             public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                createAndRefresh(transactional, new SubscriptionEventModelDao(bcdEvent), context);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                createAndRefresh(eventSqlDao, new SubscriptionEventModelDao(bcdEvent), context);
 
                 // Notify the Bus
                 notifyBusOfRequestedChange(entitySqlDaoWrapperFactory, subscription, bcdEvent, SubscriptionBaseTransitionType.BCD_CHANGE, 0, context);
@@ -1142,8 +1153,8 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
         return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLogWithHistory>>() {
             @Override
             public List<AuditLogWithHistory> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) {
-                final SubscriptionEventSqlDao transactional = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
-                return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.SUBSCRIPTION_EVENTS, eventId, auditLevel, context);
+                final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+                return auditDao.getAuditLogsWithHistoryForId(eventSqlDao, TableName.SUBSCRIPTION_EVENTS, eventId, auditLevel, context);
             }
         });
     }
@@ -1183,7 +1194,9 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     }
 
     private List<SubscriptionBaseEvent> getEventsForSubscriptionInTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final UUID subscriptionId, final InternalTenantContext context) {
-        final List<SubscriptionEventModelDao> models = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class).getActiveEventsForSubscription(subscriptionId.toString(), context);
+        final SubscriptionEventSqlDao eventSqlDao = entitySqlDaoWrapperFactory.become(SubscriptionEventSqlDao.class);
+        final List<SubscriptionEventModelDao> models = eventSqlDao.getActiveEventsForSubscription(subscriptionId.toString(), context);
+        Collections.sort(models);
         return filterSubscriptionBaseEvents(models);
     }
 

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/SubscriptionEventSqlDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/SubscriptionEventSqlDao.java
@@ -19,12 +19,11 @@
 package org.killbill.billing.subscription.engine.dao;
 
 import java.util.Date;
-import java.util.List;
+import java.util.SortedSet;
 
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.subscription.engine.dao.model.SubscriptionEventModelDao;
-import org.killbill.billing.subscription.engine.dao.model.SubscriptionModelDao;
 import org.killbill.billing.subscription.events.SubscriptionBaseEvent;
 import org.killbill.billing.util.audit.ChangeType;
 import org.killbill.billing.util.entity.dao.Audited;
@@ -44,20 +43,20 @@ public interface SubscriptionEventSqlDao extends EntitySqlDao<SubscriptionEventM
                               @SmartBindBean final InternalCallContext context);
 
     @SqlQuery
-    public List<SubscriptionEventModelDao> getActiveByAccountRecordId(@Bind("cutoffDt") Date cutoffDt,
-                                                                 @SmartBindBean final InternalTenantContext context);
+    public SortedSet<SubscriptionEventModelDao> getActiveByAccountRecordId(@Bind("cutoffDt") Date cutoffDt,
+                                                                           @SmartBindBean final InternalTenantContext context);
 
     @SqlQuery
-    public List<SubscriptionEventModelDao> getFutureActiveEventForSubscription(@Bind("subscriptionId") String subscriptionId,
-                                                                               @Bind("now") Date now,
+    public SortedSet<SubscriptionEventModelDao> getFutureActiveEventForSubscription(@Bind("subscriptionId") String subscriptionId,
+                                                                                    @Bind("now") Date now,
+                                                                                    @SmartBindBean final InternalTenantContext context);
+
+    @SqlQuery
+    public SortedSet<SubscriptionEventModelDao> getFutureOrPresentActiveEventForSubscription(@Bind("subscriptionId") String subscriptionId,
+                                                                                             @Bind("now") Date now,
+                                                                                             @SmartBindBean final InternalTenantContext context);
+
+    @SqlQuery
+    public SortedSet<SubscriptionEventModelDao> getActiveEventsForSubscription(@Bind("subscriptionId") String subscriptionId,
                                                                                @SmartBindBean final InternalTenantContext context);
-
-    @SqlQuery
-    public List<SubscriptionEventModelDao> getFutureOrPresentActiveEventForSubscription(@Bind("subscriptionId") String subscriptionId,
-                                                                                        @Bind("now") Date now,
-                                                                                        @SmartBindBean final InternalTenantContext context);
-
-    @SqlQuery
-    public List<SubscriptionEventModelDao> getActiveEventsForSubscription(@Bind("subscriptionId") String subscriptionId,
-                                                                          @SmartBindBean final InternalTenantContext context);
 }

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/model/SubscriptionEventModelDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/model/SubscriptionEventModelDao.java
@@ -35,7 +35,7 @@ import org.killbill.billing.util.dao.TableName;
 import org.killbill.billing.util.entity.dao.EntityModelDao;
 import org.killbill.billing.util.entity.dao.EntityModelDaoBase;
 
-public class SubscriptionEventModelDao extends EntityModelDaoBase implements EntityModelDao<SubscriptionBaseEvent> {
+public class SubscriptionEventModelDao extends EntityModelDaoBase implements EntityModelDao<SubscriptionBaseEvent>, Comparable<SubscriptionEventModelDao> {
     private long totalOrdering;
     private EventType eventType;
     private ApiEventType userType;
@@ -216,6 +216,8 @@ public class SubscriptionEventModelDao extends EntityModelDaoBase implements Ent
         return result;
     }
 
+
+
     public boolean isOfSubscriptionBaseTransitionType(final SubscriptionBaseTransitionType type) {
         switch(type) {
             case CREATE:
@@ -327,5 +329,13 @@ public class SubscriptionEventModelDao extends EntityModelDaoBase implements Ent
     @Override
     public TableName getHistoryTableName() {
         return TableName.SUBSCRIPTION_EVENT_HISTORY;
+    }
+
+    @Override
+    public int compareTo(final SubscriptionEventModelDao o) {
+
+        final SubscriptionBaseEvent thisEvent = toSubscriptionEvent(this);
+        final SubscriptionBaseEvent otherEvent = o.toSubscriptionEvent(o);
+        return thisEvent.compareTo(otherEvent);
     }
 }

--- a/subscription/src/test/java/org/killbill/billing/subscription/alignment/TestPlanAligner.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/alignment/TestPlanAligner.java
@@ -20,6 +20,7 @@ package org.killbill.billing.subscription.alignment;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.catalog.api.CatalogApiException;
@@ -379,13 +380,15 @@ public class TestPlanAligner extends SubscriptionTestSuiteNoDB {
 
     private DefaultSubscriptionBase createSubscription(final DateTime bundleStartDate, final DateTime alignStartDate, final String productName, final PhaseType phaseType) throws CatalogApiException {
         final SubscriptionBuilder builder = new SubscriptionBuilder();
+        builder.setId(UUID.randomUUID());
         builder.setBundleStartDate(bundleStartDate);
         // Make sure to set the dates apart
         builder.setAlignStartDate(new DateTime(alignStartDate));
 
         // Create the transitions
         final DefaultSubscriptionBase defaultSubscriptionBase = new DefaultSubscriptionBase(builder, null, clock);
-        final SubscriptionBaseEvent event = createSubscriptionEvent(builder.getAlignStartDate(),
+        final SubscriptionBaseEvent event = createSubscriptionEvent(defaultSubscriptionBase.getId(),
+                                                                    builder.getAlignStartDate(),
                                                                     productName,
                                                                     phaseType,
                                                                     ApiEventType.CREATE
@@ -406,12 +409,14 @@ public class TestPlanAligner extends SubscriptionTestSuiteNoDB {
                                     final String previousProductName,
                                     final String newProductName,
                                     final PhaseType commonPhaseType) throws CatalogApiException {
-        final SubscriptionBaseEvent previousEvent = createSubscriptionEvent(defaultSubscriptionBase.getStartDate(),
+        final SubscriptionBaseEvent previousEvent = createSubscriptionEvent(defaultSubscriptionBase.getId(),
+                                                                            defaultSubscriptionBase.getStartDate(),
                                                                             previousProductName,
                                                                             commonPhaseType,
                                                                             ApiEventType.CREATE
                                                                            );
-        final SubscriptionBaseEvent event = createSubscriptionEvent(effectiveChangeDate,
+        final SubscriptionBaseEvent event = createSubscriptionEvent(defaultSubscriptionBase.getId(),
+                                                                    effectiveChangeDate,
                                                                     newProductName,
                                                                     commonPhaseType,
                                                                     ApiEventType.CHANGE
@@ -430,11 +435,13 @@ public class TestPlanAligner extends SubscriptionTestSuiteNoDB {
         Assert.assertNotNull(newTransitions.get(1).getNextPhase());
     }
 
-    private SubscriptionBaseEvent createSubscriptionEvent(final DateTime effectiveDate,
+    private SubscriptionBaseEvent createSubscriptionEvent(final UUID subscriptionId,
+                                                          final DateTime effectiveDate,
                                                           final String productName,
                                                           final PhaseType phaseType,
                                                           final ApiEventType apiEventType) {
         final ApiEventBuilder eventBuilder = new ApiEventBuilder();
+        eventBuilder.setSubscriptionId(subscriptionId);
         eventBuilder.setEffectiveDate(effectiveDate);
         eventBuilder.setEventPlan(productName);
         eventBuilder.setEventPlanPhase(productName + "-" + phaseType.toString().toLowerCase());


### PR DESCRIPTION
…' event first

The previous ordering logic to broke ties between events having the exact same effective date
based on the underlying `record_id`. The issue with this approach is that our [current changePlan logic](https://github.com/killbill/killbill/blob/killbill-0.22.28/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java#L752) rewrites events and a result a new 'start' event may end up being inserted with a greater `record_id`.

Example of what happened with events all having exact same effective date:

Before change operation
* `CREATE`/`TRANSFER`, `BCD_UPDATE`

After change operation
* `CREATE`/`TRANSFER` (inactive), `BCD_UPDATE`, `CREATE`/`TRANSFER` = `BCD_UPDATE`, `CREATE`/`TRANSFER`

So the first event is now a  `BCD_UPDATE`

This would lead to the following trace:

```
Caused by: java.lang.NullPointerException: null
	at org.killbill.billing.subscription.api.user.DefaultSubscriptionBase.getSourceType(DefaultSubscriptionBase.java:197)
	at org.killbill.billing.entitlement.api.DefaultEntitlement.getSourceType(DefaultEntitlement.java:253)
	at org.killbill.billing.jaxrs.json.SubscriptionJson.<init>(SubscriptionJson.java:389)
	at org.killbill.billing.jaxrs.resources.SubscriptionResource.getSubscription(SubscriptionResource.java:173)
	at org.killbill.billing.jaxrs.resources.SubscriptionResource_$$_jvst5f5_2._d46getSubscription(SubscriptionResource_$$_jvst5f5_2.java)
	at jdk.internal.reflect.GeneratedMethodAccessor539.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.glassfish.hk2.utilities.reflection.ReflectionHelper.invoke(ReflectionHelper.java:1268)
	at org.jvnet.hk2.internal.MethodInterceptorHandler$MethodInvocationImpl.proceed(MethodInterceptorHandler.java:164)
	at org.killbill.commons.skeleton.metrics.TimedResourceInterceptor.invoke(TimedResourceInterceptor.java:70)
	at org.jvnet.hk2.internal.MethodInterceptorHandler.invoke(MethodInterceptorHandler.java:97)
	at org.killbill.billing.jaxrs.resources.SubscriptionResource_$$_jvst5f5_2.getSubscription(SubscriptionResource_$$_jvst5f5_2.java)
	at jdk.internal.reflect.GeneratedMethodAccessor538.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)
	... 89 common frames omitted
```

The code now takes into account the type of events to ensure we also have a 'start' event first.

Also, the ordering logic is now embedded in the `SubscriptionBaseEvent` so we can imply call `Collections.sort()` from various places.

Additionally, we also sort events inside the SubscriptionDao to ensure that looking at events in this layer provides the right view (that was another bug).

TODO:
* Should the sorting logic be stricter at ordering ties for variuous types such as `BCD_UPDATE`, `PHASE`, `CHANGE_PLAN`, i.e is any combination of those leading to the same result?
* Should we have a  proxy `SubscriptionEventSqlDao` layer that ensures the ordering instead of forcing caller to always call sort?
* Am i missing sort operations?
* Could we extract the sort for the entitlement module as well?