### PR TITLE
1615 invoice part 1

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -30,12 +30,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -51,6 +54,7 @@ import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.entitlement.api.EntitlementSpecifier;
 import org.killbill.billing.entitlement.api.SubscriptionEventType;
+import org.killbill.billing.entity.EntityBase;
 import org.killbill.billing.events.BusInternalEvent;
 import org.killbill.billing.events.EffectiveSubscriptionInternalEvent;
 import org.killbill.billing.events.InvoiceNotificationInternalEvent;
@@ -94,11 +98,14 @@ import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.platform.api.KillbillService.KILLBILL_SERVICES;
 import org.killbill.billing.subscription.api.SubscriptionBaseInternalApi;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
+import org.killbill.billing.util.Joiner;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.billing.util.UUIDs;
 import org.killbill.billing.util.api.TagApiException;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.globallocker.LockerType;
 import org.killbill.billing.util.optimizer.BusOptimizer;
@@ -114,21 +121,6 @@ import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificatio
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
-import com.google.inject.Inject;
-
 public class InvoiceDispatcher {
 
     private static final Logger log = LoggerFactory.getLogger(InvoiceDispatcher.class);
@@ -136,7 +128,6 @@ public class InvoiceDispatcher {
     private static final long NANO_TO_MILLI_SEC = (1000L * 1000L);
     public static final int MAX_NB_ITEMS_TO_PRINT = 20;
 
-    private static final Ordering<DateTime> UPCOMING_NOTIFICATION_DATE_ORDERING = Ordering.natural();
     private static final Joiner JOINER_COMMA = Joiner.on(",");
     private static final TargetDateDryRunArguments TARGET_DATE_DRY_RUN_ARGUMENTS = new TargetDateDryRunArguments();
 
@@ -265,8 +256,13 @@ public class InvoiceDispatcher {
     public void processSubscriptionForInvoiceNotification(final LocalDate targetDate, final InternalCallContext context) throws InvoiceApiException {
         final Invoice dryRunInvoice = processSubscriptionInternal(targetDate, true, false, context);
         if (dryRunInvoice != null && dryRunInvoice.getBalance().compareTo(BigDecimal.ZERO) > 0) {
-            final InvoiceNotificationInternalEvent event = new DefaultInvoiceNotificationInternalEvent(dryRunInvoice.getAccountId(), dryRunInvoice.getBalance(), dryRunInvoice.getCurrency(),
-                                                                                                       context.toUTCDateTime(targetDate), context.getAccountRecordId(), context.getTenantRecordId(), context.getUserToken());
+            final InvoiceNotificationInternalEvent event = new DefaultInvoiceNotificationInternalEvent(dryRunInvoice.getAccountId(),
+                                                                                                       dryRunInvoice.getBalance(),
+                                                                                                       dryRunInvoice.getCurrency(),
+                                                                                                       context.toUTCDateTime(targetDate),
+                                                                                                       context.getAccountRecordId(),
+                                                                                                       context.getTenantRecordId(),
+                                                                                                       context.getUserToken());
             try {
                 eventBus.post(event);
             } catch (final EventBusException e) {
@@ -392,7 +388,7 @@ public class InvoiceDispatcher {
 
             final Invoice invoice;
             if (!isDryRun) {
-                final InvoiceWithFutureNotifications invoiceWithFutureNotifications = processAccountWithLockAndInputTargetDate(accountId, inputTargetDate, billingEvents, accountInvoices, dryRunInfo, isRescheduled, Lists.newLinkedList(), invoiceTimings, context);
+                final InvoiceWithFutureNotifications invoiceWithFutureNotifications = processAccountWithLockAndInputTargetDate(accountId, inputTargetDate, billingEvents, accountInvoices, dryRunInfo, isRescheduled, new LinkedList<>(), invoiceTimings, context);
                 invoice = invoiceWithFutureNotifications != null ? invoiceWithFutureNotifications.getInvoice() : null;
                 if (parkedAccount) {
                     try {
@@ -406,13 +402,14 @@ public class InvoiceDispatcher {
                 final NotificationQueue notificationQueue = notificationQueueService.getNotificationQueue(KILLBILL_SERVICES.INVOICE_SERVICE.getServiceName(),
                                                                                                           DefaultNextBillingDateNotifier.NEXT_BILLING_DATE_NOTIFIER_QUEUE);
                 final Iterable<NotificationEventWithMetadata<NextBillingDateNotificationKey>> futureNotificationsIterable = notificationQueue.getFutureNotificationForSearchKeys(context.getAccountRecordId(), context.getTenantRecordId());
+
                 // Copy the results as retrieving the iterator will issue a query each time. This also makes sure the underlying JDBC connection is closed.
-                final List<NotificationEventWithMetadata<NextBillingDateNotificationKey>> futureNotifications = ImmutableList.<NotificationEventWithMetadata<NextBillingDateNotificationKey>>copyOf(futureNotificationsIterable);
+                final List<NotificationEventWithMetadata<NextBillingDateNotificationKey>> futureNotifications = Iterables.toUnmodifiableList(futureNotificationsIterable);
 
                 final Map<UUID, DateTime> nextScheduledSubscriptionsEventMap = getNextTransitionsForSubscriptions(billingEvents);
 
                 // List of all existing invoice notifications
-                final Set<LocalDate> allCandidateTargetDates = getUpcomingInvoiceCandidateDates(futureNotifications, nextScheduledSubscriptionsEventMap, ImmutableList.<UUID>of(), context);
+                final Set<LocalDate> allCandidateTargetDates = getUpcomingInvoiceCandidateDates(futureNotifications, nextScheduledSubscriptionsEventMap, Collections.emptyList(), context);
 
                 if (dryRunArguments.getDryRunType() == DryRunType.UPCOMING_INVOICE) {
 
@@ -497,7 +494,7 @@ public class InvoiceDispatcher {
 
     private Invoice processDryRun_UPCOMING_INVOICE_Invoice(final UUID accountId, final Set<LocalDate> allCandidateTargetDates, final BillingEventSet billingEvents, final AccountInvoices accountInvoices, final DryRunInfo dryRunInfo, final Map<InvoiceTiming, Long> invoiceTimings, final InternalCallContext context) throws InvoiceApiException {
         for (final LocalDate curTargetDate : allCandidateTargetDates) {
-            final InvoiceWithFutureNotifications invoiceWithFutureNotifications = processAccountWithLockAndInputTargetDate(accountId, curTargetDate, billingEvents, accountInvoices, dryRunInfo, false, Lists.newLinkedList(), invoiceTimings, context);
+            final InvoiceWithFutureNotifications invoiceWithFutureNotifications = processAccountWithLockAndInputTargetDate(accountId, curTargetDate, billingEvents, accountInvoices, dryRunInfo, false, new LinkedList<>(), invoiceTimings, context);
             final Invoice invoice = invoiceWithFutureNotifications != null ? invoiceWithFutureNotifications.getInvoice() : null;
             if (invoice != null) {
                 return invoice;
@@ -556,12 +553,7 @@ public class InvoiceDispatcher {
                 // we need to only keep the latest invoice with all the items currently being generated
                 // See https://github.com/killbill/killbill/issues/1313
                 final UUID additionalInvoiceId = additionalInvoice.getId();
-                Iterables.removeIf(augmentedExistingInvoices, new Predicate<Invoice>() {
-                    @Override
-                    public boolean apply(final Invoice input) {
-                        return input.getId().equals(additionalInvoiceId);
-                    }
-                });
+                augmentedExistingInvoices.removeIf(input -> input.getId().equals(additionalInvoiceId));
                 augmentedExistingInvoices.add(additionalInvoice);
             }
             prev = cur;
@@ -592,24 +584,17 @@ public class InvoiceDispatcher {
         if (dryRunArguments == null ||
             !dryRunArguments.getDryRunType().equals(DryRunType.UPCOMING_INVOICE) ||
             (dryRunArguments.getSubscriptionId() == null && dryRunArguments.getBundleId() == null)) {
-            return ImmutableList.<UUID>of();
+            return Collections.emptyList();
         }
 
         if (dryRunArguments.getSubscriptionId() != null) {
-            return ImmutableList.of(dryRunArguments.getSubscriptionId());
+            return List.of(dryRunArguments.getSubscriptionId());
         }
 
-        return Iterables.transform(Iterables.filter(billingEvents, new Predicate<BillingEvent>() {
-            @Override
-            public boolean apply(final BillingEvent input) {
-                return input.getBundleId().equals(dryRunArguments.getBundleId());
-            }
-        }), new Function<BillingEvent, UUID>() {
-            @Override
-            public UUID apply(final BillingEvent input) {
-                return input.getSubscriptionId();
-            }
-        });
+        return billingEvents.stream()
+                .filter(input -> input.getBundleId().equals(dryRunArguments.getBundleId()))
+                .map(BillingEvent::getSubscriptionId)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     private InvoiceWithFutureNotifications processAccountWithLockAndInputTargetDate(final UUID accountId,
@@ -768,12 +753,10 @@ public class InvoiceDispatcher {
         final UUID targetInvoiceId;
         // Filter out DRAFT invoices for computation  of existing items unless Account is in AUTO_INVOICING_REUSE_DRAFT
         if (billingEvents.isAccountAutoInvoiceReuseDraft()) {
-            final Invoice existingDraft = Iterables.tryFind(accountInvoices.getInvoices(), new Predicate<Invoice>() {
-                @Override
-                public boolean apply(final Invoice input) {
-                    return input.getStatus() == InvoiceStatus.DRAFT;
-                }
-            }).orNull();
+            final Invoice existingDraft = accountInvoices.getInvoices().stream()
+                    .filter(input -> input.getStatus() == InvoiceStatus.DRAFT)
+                    .findFirst()
+                    .orElse(null);
             targetInvoiceId = existingDraft != null ? existingDraft.getId() : null;
         } else {
             targetInvoiceId = null;
@@ -786,13 +769,10 @@ public class InvoiceDispatcher {
         final FutureAccountNotificationsBuilder notificationsBuilder = new FutureAccountNotificationsBuilder();
         notificationsBuilder.setRescheduled(true);
 
-        final Set<UUID> subscriptionIds = ImmutableSet.<UUID>copyOf(Iterables.<BillingEvent, UUID>transform(billingEvents,
-                                                                                                            new Function<BillingEvent, UUID>() {
-                                                                                                                @Override
-                                                                                                                public UUID apply(final BillingEvent billingEvent) {
-                                                                                                                    return billingEvent.getSubscriptionId();
-                                                                                                                }
-                                                                                                            }));
+        final Set<UUID> subscriptionIds = billingEvents.stream()
+                .map(BillingEvent::getSubscriptionId)
+                .collect(Collectors.toUnmodifiableSet());
+
         populateNextFutureNotificationDate(rescheduleDate, subscriptionIds, notificationsBuilder, context);
 
         // Even though a plugin forced us to reschedule the invoice generation, honor the dry run notifications settings
@@ -803,7 +783,7 @@ public class InvoiceDispatcher {
 
     private void populateNextFutureNotificationDate(final DateTime notificationDateTime, final Set<UUID> subscriptionIds, final FutureAccountNotificationsBuilder notificationsBuilder, final InternalCallContext context) {
         final LocalDate notificationDate = context.toLocalDate(notificationDateTime);
-        notificationsBuilder.setNotificationListForTrigger(ImmutableMap.<LocalDate, Set<UUID>>of(notificationDate, subscriptionIds));
+        notificationsBuilder.setNotificationListForTrigger(Map.<LocalDate, Set<UUID>>of(notificationDate, subscriptionIds));
     }
 
     private FutureAccountNotifications createNextFutureNotificationDate(final InvoiceWithMetadata invoiceWithMetadata, final BillingEventSet billingEvents, final InternalCallContext context) {
@@ -852,7 +832,7 @@ public class InvoiceDispatcher {
         final long dryRunNotificationTime = invoiceConfig.getDryRunNotificationSchedule(context).getMillis();
         final boolean isInvoiceNotificationEnabled = dryRunNotificationTime > 0;
 
-        final Map<LocalDate, Set<UUID>> notificationListForDryRun = isInvoiceNotificationEnabled ? new HashMap<LocalDate, Set<UUID>>() : ImmutableMap.<LocalDate, Set<UUID>>of();
+        final Map<LocalDate, Set<UUID>> notificationListForDryRun = isInvoiceNotificationEnabled ? new HashMap<LocalDate, Set<UUID>>() : Collections.emptyMap();
         if (isInvoiceNotificationEnabled) {
             for (final Entry<LocalDate, Set<UUID>> entry : notificationListForTrigger.entrySet()) {
                 final LocalDate curDate = entry.getKey();
@@ -881,17 +861,13 @@ public class InvoiceDispatcher {
     }
 
     private List<InvoiceItemModelDao> transformToInvoiceModelDao(final List<InvoiceItem> invoiceItems) {
-        return Lists.transform(invoiceItems,
-                               new Function<InvoiceItem, InvoiceItemModelDao>() {
-                                   @Override
-                                   public InvoiceItemModelDao apply(final InvoiceItem input) {
-                                       return new InvoiceItemModelDao(input);
-                                   }
-                               });
+        return invoiceItems.stream()
+                .map(InvoiceItemModelDao::new)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     private Set<UUID> getUniqueInvoiceIds(final Invoice invoice) {
-        final Set<UUID> uniqueInvoiceIds = new TreeSet<UUID>();
+        final Set<UUID> uniqueInvoiceIds = new TreeSet<>();
         for (final InvoiceItem invoiceItem : invoice.getInvoiceItems()) {
             uniqueInvoiceIds.add(invoiceItem.getInvoiceId());
         }
@@ -903,7 +879,7 @@ public class InvoiceDispatcher {
         if (isRealInvoiceWithItems) {
             tmp.append(String.format("Generated invoiceId='%s', numberOfItems='%d', accountId='%s', targetDate='%s':", invoice.getId(), invoice.getNumberOfItems(), account.getId(), targetDate));
         } else {
-            final String adjustedInvoices = JOINER_COMMA.join(adjustedUniqueOtherInvoiceId.toArray(new UUID[adjustedUniqueOtherInvoiceId.size()]));
+            final String adjustedInvoices = JOINER_COMMA.join(adjustedUniqueOtherInvoiceId);
             tmp.append(String.format("Adjusting existing invoiceId='%s', numberOfItems='%d', accountId='%s', targetDate='%s':%n",
                                      adjustedInvoices, invoice.getNumberOfItems(), account.getId(), targetDate));
         }
@@ -923,7 +899,7 @@ public class InvoiceDispatcher {
     private void setFutureNotifications(final ImmutableAccountData account,
                                         final FutureAccountNotifications futureAccountNotifications,
                                         final InternalCallContext context) {
-        commitInvoiceAndSetFutureNotifications(account, null, null, ImmutableSet.of(), futureAccountNotifications, null, context);
+        commitInvoiceAndSetFutureNotifications(account, null, null, Collections.emptySet(), futureAccountNotifications, null, context);
     }
 
     private void commitInvoiceAndSetFutureNotifications(final ImmutableAccountData account,
@@ -944,13 +920,7 @@ public class InvoiceDispatcher {
     private InvoiceItem computeCBAOnExistingInvoice(final Invoice invoice, final InternalCallContext context) throws InvoiceApiException {
         // Transformation to Invoice -> InvoiceModelDao
         final InvoiceModelDao invoiceModelDao = new InvoiceModelDao(invoice);
-        final List<InvoiceItemModelDao> invoiceItemModelDaos = ImmutableList.copyOf(Collections2.transform(invoice.getInvoiceItems(),
-                                                                                                           new Function<InvoiceItem, InvoiceItemModelDao>() {
-                                                                                                               @Override
-                                                                                                               public InvoiceItemModelDao apply(final InvoiceItem input) {
-                                                                                                                   return new InvoiceItemModelDao(input);
-                                                                                                               }
-                                                                                                           }));
+        final List<InvoiceItemModelDao> invoiceItemModelDaos = transformToInvoiceModelDao(invoice.getInvoiceItems());
         invoiceModelDao.addInvoiceItems(invoiceItemModelDaos);
         final InvoiceItemModelDao cbaItem = invoiceDao.doCBAComplexity(invoiceModelDao, context);
         return cbaItem != null ? InvoiceItemFactory.fromModelDao(cbaItem) : null;
@@ -1001,7 +971,7 @@ public class InvoiceDispatcher {
         private final boolean isRescheduled;
 
         public FutureAccountNotifications() {
-            this(ImmutableMap.<LocalDate, Set<UUID>>of(), ImmutableMap.<LocalDate, Set<UUID>>of(), false);
+            this(Collections.emptyMap(), Collections.emptyMap(), false);
         }
 
         public FutureAccountNotifications(final Map<LocalDate, Set<UUID>> notificationListForTrigger, final Map<LocalDate, Set<UUID>> notificationListForDryRun, final boolean isRescheduled) {
@@ -1047,11 +1017,11 @@ public class InvoiceDispatcher {
             }
 
             public Map<LocalDate, Set<UUID>> getNotificationListForTrigger() {
-                return MoreObjects.firstNonNull(notificationListForTrigger, ImmutableMap.<LocalDate, Set<UUID>>of());
+                return Objects.requireNonNullElse(notificationListForTrigger, Collections.emptyMap());
             }
 
             public Map<LocalDate, Set<UUID>> getNotificationListForDryRun() {
-                return MoreObjects.firstNonNull(notificationListForDryRun, ImmutableMap.<LocalDate, Set<UUID>>of());
+                return Objects.requireNonNullElse(notificationListForDryRun, Collections.emptyMap());
             }
 
             public boolean isRescheduled() {
@@ -1073,7 +1043,7 @@ public class InvoiceDispatcher {
 
         final Iterable<DateTime> nextScheduledSubscriptionsEvents;
         if (!Iterables.isEmpty(filteredSubscriptionIds)) {
-            final List<DateTime> tmp = new ArrayList<DateTime>();
+            final List<DateTime> tmp = new ArrayList<>();
             for (final Entry<UUID, DateTime> entry : nextScheduledSubscriptionsEventMap.entrySet()) {
                 if (Iterables.contains(filteredSubscriptionIds, entry.getKey())) {
                     tmp.add(entry.getValue());
@@ -1084,18 +1054,15 @@ public class InvoiceDispatcher {
             nextScheduledSubscriptionsEvents = nextScheduledSubscriptionsEventMap.values();
         }
 
-        return Sets.newTreeSet(Iterables.transform(Iterables.<DateTime>concat(nextScheduledInvoiceDates, nextScheduledSubscriptionsEvents),
-                                                   new Function<DateTime, LocalDate>() {
-                                                       @Override
-                                                       public LocalDate apply(final DateTime input) {
-                                                           return internalCallContext.toLocalDate(input);
-                                                       }
-                                                   }));
+        final Iterable<DateTime> combinedDateTime = Iterables.concat(nextScheduledInvoiceDates, nextScheduledSubscriptionsEvents);
+        return Iterables.toStream(combinedDateTime)
+                        .map(internalCallContext::toLocalDate)
+                        .collect(Collectors.toCollection(TreeSet::new));
     }
 
     private Iterable<DateTime> getNextScheduledInvoiceEffectiveDate(final Iterable<NotificationEventWithMetadata<NextBillingDateNotificationKey>> futureNotifications,
                                                                     final Iterable<UUID> filteredSubscriptionIds) {
-        final Collection<DateTime> effectiveDates = new LinkedList<DateTime>();
+        final Collection<DateTime> effectiveDates = new LinkedList<>();
         for (final NotificationEventWithMetadata<NextBillingDateNotificationKey> input : futureNotifications) {
 
             // If we don't specify a filter list of subscriptionIds, we look at all events.
@@ -1211,7 +1178,7 @@ public class InvoiceDispatcher {
             final List<InvoiceModelDao> invoices = new ArrayList<InvoiceModelDao>();
             invoices.add(draftParentInvoice);
             log.info("Adding new itemId='{}', amount='{}' on existing DRAFT invoiceId='{}'", parentInvoiceItem.getId(), childInvoiceAmount, draftParentInvoice.getId());
-            invoiceDao.createInvoices(invoices, null, ImmutableSet.of(), parentContext);
+            invoiceDao.createInvoices(invoices, null, Collections.emptySet(), parentContext);
         } else {
             if (shouldIgnoreChildInvoice(childInvoice, childInvoiceAmount)) {
                 return;
@@ -1223,7 +1190,7 @@ public class InvoiceDispatcher {
             draftParentInvoice.addInvoiceItem(new InvoiceItemModelDao(parentInvoiceItem));
 
             log.info("Adding new itemId='{}', amount='{}' on new DRAFT invoiceId='{}'", parentInvoiceItem.getId(), childInvoiceAmount, draftParentInvoice.getId());
-            invoiceDao.createInvoices(ImmutableList.<InvoiceModelDao>of(draftParentInvoice), null, ImmutableSet.of(), parentContext);
+            invoiceDao.createInvoices(List.of(draftParentInvoice), null, Collections.emptySet(), parentContext);
         }
 
         // save parent child invoice relation
@@ -1282,20 +1249,15 @@ public class InvoiceDispatcher {
         final String description = "Adjustment for account ".concat(account.getExternalKey());
 
         // find PARENT_SUMMARY invoice item for this child account
-        final InvoiceItemModelDao parentSummaryInvoiceItem = Iterables.find(parentInvoiceModelDao.getInvoiceItems(), new Predicate<InvoiceItemModelDao>() {
-            @Override
-            public boolean apply(final InvoiceItemModelDao input) {
-                return input.getType().equals(InvoiceItemType.PARENT_SUMMARY)
-                       && input.getChildAccountId().equals(childInvoiceModelDao.getAccountId());
-            }
-        });
+        final InvoiceItemModelDao parentSummaryInvoiceItem = parentInvoiceModelDao.getInvoiceItems().stream()
+                .filter(input -> input.getType().equals(InvoiceItemType.PARENT_SUMMARY) &&
+                                 input.getChildAccountId().equals(childInvoiceModelDao.getAccountId()))
+                .findFirst()
+                .get();
 
-        final Iterable<InvoiceItemModelDao> childAdjustments = Iterables.filter(childInvoiceModelDao.getInvoiceItems(), new Predicate<InvoiceItemModelDao>() {
-            @Override
-            public boolean apply(final InvoiceItemModelDao input) {
-                return input.getType().equals(InvoiceItemType.ITEM_ADJ);
-            }
-        });
+        final List<InvoiceItemModelDao> childAdjustments = childInvoiceModelDao.getInvoiceItems().stream()
+                .filter(input -> input.getType().equals(InvoiceItemType.ITEM_ADJ))
+                .collect(Collectors.toUnmodifiableList());
 
         //  childAdjustments can be empty if event was a result of a CBA_ADJ
         if (Iterables.isEmpty(childAdjustments)) {
@@ -1303,12 +1265,9 @@ public class InvoiceDispatcher {
         }
 
         // find last ITEM_ADJ invoice added in child invoice
-        final InvoiceItemModelDao lastChildInvoiceItemAdjustment = Collections.max(Lists.newArrayList(childAdjustments), new Comparator<InvoiceItemModelDao>() {
-            @Override
-            public int compare(final InvoiceItemModelDao o1, final InvoiceItemModelDao o2) {
-                return o1.getCreatedDate().compareTo(o2.getCreatedDate());
-            }
-        });
+        final InvoiceItemModelDao lastChildInvoiceItemAdjustment = Collections.max(
+                childAdjustments,
+                Comparator.comparing(EntityBase::getCreatedDate));
 
         final BigDecimal childInvoiceAdjustmentAmount = lastChildInvoiceItemAdjustment.getAmount();
 
@@ -1324,7 +1283,7 @@ public class InvoiceDispatcher {
                                                                   parentSummaryInvoiceItem.getId(),
                                                                   null);
             parentInvoiceModelDao.addInvoiceItem(new InvoiceItemModelDao(adj));
-            invoiceDao.createInvoices(ImmutableList.<InvoiceModelDao>of(parentInvoiceModelDao), null, ImmutableSet.of(), parentContext);
+            invoiceDao.createInvoices(List.of(parentInvoiceModelDao), null, Collections.emptySet(), parentContext);
             return;
         }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -22,6 +22,8 @@ package org.killbill.billing.invoice;
 import java.util.Objects;
 import java.util.UUID;
 
+import javax.inject.Inject;
+
 import org.joda.time.DateTime;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.account.api.Account;
@@ -56,9 +58,9 @@ import org.killbill.queue.retry.RetryableSubscriber.SubscriberQueueHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// FIXME-1615 : EventBus - Back to this later. AllowConcurrentEvents is easy. Subscribe? I believe I missed some conversation about that.
 import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.Subscribe;
-import com.google.inject.Inject;
 
 @SuppressWarnings("TypeMayBeWeakened")
 public class InvoiceListener extends RetryableService implements InvoiceListenerService {

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -53,23 +54,20 @@ import org.killbill.billing.invoice.plugin.api.PriorInvoiceResult;
 import org.killbill.billing.osgi.api.OSGIServiceRegistration;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.util.UUIDs;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-
 public class InvoicePluginDispatcher {
 
     private static final Logger log = LoggerFactory.getLogger(InvoicePluginDispatcher.class);
 
-    public static final Collection<InvoiceItemType> ALLOWED_INVOICE_ITEM_TYPES = ImmutableList.<InvoiceItemType>of(InvoiceItemType.EXTERNAL_CHARGE,
-                                                                                                                   InvoiceItemType.ITEM_ADJ,
-                                                                                                                   InvoiceItemType.CREDIT_ADJ,
-                                                                                                                   InvoiceItemType.TAX);
+    public static final Collection<InvoiceItemType> ALLOWED_INVOICE_ITEM_TYPES = List.of(InvoiceItemType.EXTERNAL_CHARGE,
+                                                                                         InvoiceItemType.ITEM_ADJ,
+                                                                                         InvoiceItemType.CREDIT_ADJ,
+                                                                                         InvoiceItemType.TAX);
 
     private final OSGIServiceRegistration<InvoicePluginApi> pluginRegistry;
     private final InvoiceConfig invoiceConfig;
@@ -236,10 +234,11 @@ public class InvoicePluginDispatcher {
             throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_TYPE_INVALID, additionalInvoiceItem.getInvoiceItemType());
         }
 
-        final UUID invoiceId = MoreObjects.firstNonNull(mutableField("invoiceId", existingItem != null ? existingItem.getInvoiceId() : null, additionalInvoiceItem.getInvoiceId(), invoicePlugin),
-                                                        originalInvoiceId);
+        final UUID invoiceId = Objects.requireNonNullElse(
+                mutableField("invoiceId", (existingItem != null ? existingItem.getInvoiceId() : null), additionalInvoiceItem.getInvoiceId(), invoicePlugin),
+                originalInvoiceId);
 
-        final UUID additionalInvoiceId = MoreObjects.firstNonNull(additionalInvoiceItem.getId(), UUIDs.randomUUID());
+        final UUID additionalInvoiceId = Objects.requireNonNullElse(additionalInvoiceItem.getId(), UUIDs.randomUUID());
         final InvoiceItemCatalogBase tmp = new InvoiceItemCatalogBase(additionalInvoiceId,
                                           mutableField("createdDate", existingItem != null ? existingItem.getCreatedDate() : null, additionalInvoiceItem.getCreatedDate(), invoicePlugin),
                                           invoiceId,
@@ -327,7 +326,7 @@ public class InvoicePluginDispatcher {
         if (configuredPlugins == null || configuredPlugins.isEmpty()) {
             return registeredPlugins;
         } else {
-            final List<String> result = new ArrayList<String>(configuredPlugins.size());
+            final List<String> result = new ArrayList<>(configuredPlugins.size());
             for (final String name : configuredPlugins) {
                 if (pluginRegistry.getServiceForName(name) != null) {
                     result.add(name);

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceTagHandler.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceTagHandler.java
@@ -20,6 +20,8 @@ package org.killbill.billing.invoice;
 
 import java.util.UUID;
 
+import javax.inject.Inject;
+
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.events.ControlTagDeletionInternalEvent;
@@ -43,9 +45,9 @@ import org.killbill.queue.retry.RetryableSubscriber.SubscriberQueueHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// FIXME-1615 : EventBus - Back to this later. AllowConcurrentEvents is easy. Subscribe? I believe I missed some conversation about that.
 import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.Subscribe;
-import com.google.inject.Inject;
 
 @SuppressWarnings("TypeMayBeWeakened")
 public class InvoiceTagHandler extends RetryableService implements KillbillService {

--- a/invoice/src/main/java/org/killbill/billing/invoice/ParkedAccountsManager.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/ParkedAccountsManager.java
@@ -19,17 +19,14 @@ package org.killbill.billing.invoice;
 
 import java.util.UUID;
 
+import javax.inject.Inject;
+
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.tag.TagInternalApi;
 import org.killbill.billing.util.api.TagApiException;
 import org.killbill.billing.util.api.TagDefinitionApiException;
-import org.killbill.billing.util.tag.Tag;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.inject.Inject;
 
 import static org.killbill.billing.util.tag.dao.SystemTags.PARK_TAG_DEFINITION_ID;
 
@@ -58,12 +55,8 @@ public class ParkedAccountsManager {
     }
 
     public boolean isParked(final InternalCallContext internalCallContext) throws TagApiException {
-        return Iterables.<Tag>tryFind(tagApi.getTagsForAccountType(ObjectType.ACCOUNT, false, internalCallContext),
-                                      new Predicate<Tag>() {
-                                          @Override
-                                          public boolean apply(final Tag input) {
-                                              return PARK_TAG_DEFINITION_ID.equals(input.getTagDefinitionId());
-                                          }
-                                      }).orNull() != null;
+        return tagApi.getTagsForAccountType(ObjectType.ACCOUNT, false, internalCallContext)
+                     .stream()
+                     .anyMatch(input -> PARK_TAG_DEFINITION_ID.equals(input.getTagDefinitionId()));
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java
@@ -19,11 +19,14 @@ package org.killbill.billing.invoice.api;
 
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -32,7 +35,6 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.callcontext.InternalCallContext;
-import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.InvoicePluginDispatcher;
 import org.killbill.billing.invoice.dao.InvoiceDao;
@@ -50,21 +52,10 @@ import org.killbill.billing.util.globallocker.LockerType;
 import org.killbill.commons.locker.GlobalLock;
 import org.killbill.commons.locker.GlobalLocker;
 import org.killbill.commons.locker.LockFailedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class InvoiceApiHelper {
-
-    private static final Logger log = LoggerFactory.getLogger(InvoiceApiHelper.class);
 
     private final InvoicePluginDispatcher invoicePluginDispatcher;
     private final InvoiceDao dao;
@@ -123,7 +114,7 @@ public class InvoiceApiHelper {
                 invoiceModelDaos.add(invoiceModelDao);
             }
 
-            final List<InvoiceItemModelDao> createdInvoiceItems = dao.createInvoices(invoiceModelDaos, null, ImmutableSet.of(), internalCallContext);
+            final List<InvoiceItemModelDao> createdInvoiceItems = dao.createInvoices(invoiceModelDaos, null, Collections.emptySet(), internalCallContext);
             success = true;
 
             return fromInvoiceItemModelDao(createdInvoiceItems);
@@ -163,19 +154,14 @@ public class InvoiceApiHelper {
                                             final String description,
                                             @Nullable final String itemDetails,
                                             final InternalCallContext context) throws InvoiceApiException {
-        final InvoiceItem invoiceItemToBeAdjusted = Iterables.<InvoiceItem>tryFind(invoiceToBeAdjusted.getInvoiceItems(),
-                                                                                   new Predicate<InvoiceItem>() {
-                                                                                       @Override
-                                                                                       public boolean apply(final InvoiceItem input) {
-                                                                                           return input.getId().equals(invoiceItemId);
-                                                                                       }
-                                                                                   }).orNull();
-        if (invoiceItemToBeAdjusted == null) {
-            throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId);
-        }
+
+        final InvoiceItem invoiceItemToBeAdjusted = invoiceToBeAdjusted.getInvoiceItems().stream()
+                .filter(input -> input.getId().equals(invoiceItemId))
+                .findFirst()
+                .orElseThrow(() -> new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId));
 
         // Check the specified currency matches the one of the existing invoice
-        final Currency currencyForAdjustment = MoreObjects.firstNonNull(currency, invoiceItemToBeAdjusted.getCurrency());
+        final Currency currencyForAdjustment = Objects.requireNonNullElse(currency, invoiceItemToBeAdjusted.getCurrency());
         if (invoiceItemToBeAdjusted.getCurrency() != currencyForAdjustment) {
             throw new InvoiceApiException(ErrorCode.CURRENCY_INVALID, currency, invoiceItemToBeAdjusted.getCurrency());
         }
@@ -219,22 +205,14 @@ public class InvoiceApiHelper {
     }
 
     private List<InvoiceItem> fromInvoiceItemModelDao(final Collection<InvoiceItemModelDao> invoiceItemModelDaos) {
-        return ImmutableList.<InvoiceItem>copyOf(Collections2.transform(invoiceItemModelDaos,
-                                                                        new Function<InvoiceItemModelDao, InvoiceItem>() {
-                                                                            @Override
-                                                                            public InvoiceItem apply(final InvoiceItemModelDao input) {
-                                                                                return InvoiceItemFactory.fromModelDao(input);
-                                                                            }
-                                                                        }));
+        return invoiceItemModelDaos.stream()
+                .map(InvoiceItemFactory::fromModelDao)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     private List<InvoiceItemModelDao> toInvoiceItemModelDao(final Collection<InvoiceItem> invoiceItems) {
-        return ImmutableList.copyOf(Collections2.transform(invoiceItems,
-                                                           new Function<InvoiceItem, InvoiceItemModelDao>() {
-                                                               @Override
-                                                               public InvoiceItemModelDao apply(final InvoiceItem input) {
-                                                                   return new InvoiceItemModelDao(input);
-                                                               }
-                                                           }));
+        return invoiceItems.stream()
+                .map(InvoiceItemModelDao::new)
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java
@@ -49,6 +49,7 @@ import org.killbill.billing.invoice.dao.InvoicePaymentModelDao;
 import org.killbill.billing.invoice.model.DefaultInvoice;
 import org.killbill.billing.invoice.model.DefaultInvoicePayment;
 import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
@@ -164,7 +165,8 @@ public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
         return dao.computeItemAdjustments(invoicePayment.getInvoiceId().toString(), idWithAmount, context);
     }
 
-    private InvoicePayment getInvoicePayment(final UUID paymentId, final InvoicePaymentType type, final InternalTenantContext context) throws InvoiceApiException {
+    @VisibleForTesting
+    InvoicePayment getInvoicePayment(final UUID paymentId, final InvoicePaymentType type, final InternalTenantContext context) throws InvoiceApiException {
         final List<InvoicePaymentModelDao> invoicePayments = dao.getInvoicePaymentsByPaymentId(paymentId, context);
         return invoicePayments.stream()
                 .filter(input -> input.getType() == type && input.getSuccess())

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -54,12 +55,6 @@ import org.killbill.billing.util.callcontext.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-
 public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultInvoiceInternalApi.class);
@@ -89,7 +84,7 @@ public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
     @Override
     public Collection<Invoice> getUnpaidInvoicesByAccountId(final UUID accountId, final LocalDate upToDate, final InternalTenantContext context) {
         final List<InvoiceModelDao> unpaidInvoicesByAccountId = dao.getUnpaidInvoicesByAccountId(accountId, null, upToDate, context);
-        final Collection<Invoice> invoices = new LinkedList<Invoice>();
+        final Collection<Invoice> invoices = new LinkedList<>();
         for (final InvoiceModelDao invoiceModelDao : unpaidInvoicesByAccountId) {
             invoices.add(new DefaultInvoice(invoiceModelDao));
         }
@@ -139,7 +134,7 @@ public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
         final WithAccountLock withAccountLock = new WithAccountLock() {
             @Override
             public Iterable<DefaultInvoice> prepareInvoices() throws InvoiceApiException {
-                return ImmutableList.<DefaultInvoice>of(invoice);
+                return List.of(invoice);
             }
         };
 
@@ -162,7 +157,7 @@ public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
     @Override
     public Map<UUID, BigDecimal> validateInvoiceItemAdjustments(final UUID paymentId, final Map<UUID, BigDecimal> idWithAmount, final InternalTenantContext context) throws InvoiceApiException {
         // We want to validate that only refund with invoice *item* adjustments are allowed (as opposed to refund with invoice adjustment)
-        if (idWithAmount.size() == 0) {
+        if (idWithAmount.isEmpty()) {
             throw new InvoiceApiException(ErrorCode.INVOICE_ITEMS_ADJUSTMENT_MISSING);
         }
         final InvoicePayment invoicePayment = getInvoicePayment(paymentId, InvoicePaymentType.ATTEMPT, context);
@@ -170,16 +165,12 @@ public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
     }
 
     private InvoicePayment getInvoicePayment(final UUID paymentId, final InvoicePaymentType type, final InternalTenantContext context) throws InvoiceApiException {
-
         final List<InvoicePaymentModelDao> invoicePayments = dao.getInvoicePaymentsByPaymentId(paymentId, context);
-        final InvoicePaymentModelDao resultOrNull = Iterables.tryFind(invoicePayments, new Predicate<InvoicePaymentModelDao>() {
-            @Override
-            public boolean apply(final InvoicePaymentModelDao input) {
-                return input.getType() == type &&
-                       input.getSuccess();
-            }
-        }).orNull();
-        return resultOrNull != null ? new DefaultInvoicePayment(resultOrNull) : null;
+        return invoicePayments.stream()
+                .filter(input -> input.getType() == type && input.getSuccess())
+                .findFirst()
+                .map(DefaultInvoicePayment::new)
+                .orElse(null);
     }
 
     @Override
@@ -195,38 +186,28 @@ public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
 
     @Override
     public List<InvoicePayment> getInvoicePayments(final UUID paymentId, final TenantContext context) {
-        return ImmutableList.<InvoicePayment>copyOf(Collections2.transform(dao.getInvoicePaymentsByPaymentId(paymentId, internalCallContextFactory.createInternalTenantContext(paymentId, ObjectType.PAYMENT, context)),
-                                                                           new Function<InvoicePaymentModelDao, InvoicePayment>() {
-                                                                               @Override
-                                                                               public InvoicePayment apply(final InvoicePaymentModelDao input) {
-                                                                                   return new DefaultInvoicePayment(input);
-                                                                               }
-                                                                           }
-                                                                          ));
+        final InternalTenantContext ctx = internalCallContextFactory.createInternalTenantContext(paymentId, ObjectType.PAYMENT, context);
+        final List<InvoicePaymentModelDao> invoicePayments = dao.getInvoicePaymentsByPaymentId(paymentId, ctx);
+        return invoicePayments.stream()
+                .map(DefaultInvoicePayment::new)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     @Override
     public List<InvoicePayment> getInvoicePaymentsByAccount(final UUID accountId, final TenantContext context) {
-        return ImmutableList.<InvoicePayment>copyOf(Collections2.transform(dao.getInvoicePaymentsByAccount(internalCallContextFactory.createInternalTenantContext(accountId, ObjectType.ACCOUNT, context)),
-                                                                           new Function<InvoicePaymentModelDao, InvoicePayment>() {
-                                                                               @Override
-                                                                               public InvoicePayment apply(final InvoicePaymentModelDao input) {
-                                                                                   return new DefaultInvoicePayment(input);
-                                                                               }
-                                                                           }
-                                                                          ));
+        final InternalTenantContext ctx = internalCallContextFactory.createInternalTenantContext(accountId, ObjectType.ACCOUNT, context);
+        final List<InvoicePaymentModelDao> invoicePayments = dao.getInvoicePaymentsByAccount(ctx);
+        return invoicePayments.stream()
+                .map(DefaultInvoicePayment::new)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     @Override
     public List<InvoicePayment> getInvoicePaymentsByInvoice(final UUID invoiceId, final InternalTenantContext context) {
-        return ImmutableList.<InvoicePayment>copyOf(Collections2.transform(dao.getInvoicePaymentsByInvoice(invoiceId, context),
-                                                                           new Function<InvoicePaymentModelDao, InvoicePayment>() {
-                                                                               @Override
-                                                                               public InvoicePayment apply(final InvoicePaymentModelDao input) {
-                                                                                   return new DefaultInvoicePayment(input);
-                                                                               }
-                                                                           }
-                                                                          ));
+        final List<InvoicePaymentModelDao> invoicePayments = dao.getInvoicePaymentsByInvoice(invoiceId, context);
+        return invoicePayments.stream()
+                .map(DefaultInvoicePayment::new)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -22,13 +22,17 @@ package org.killbill.billing.invoice.api.user;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.LocalDate;
 import org.killbill.billing.ErrorCode;
@@ -67,6 +71,7 @@ import org.killbill.billing.invoice.template.HtmlInvoice;
 import org.killbill.billing.invoice.template.HtmlInvoiceGenerator;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.tag.TagInternalApi;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.billing.util.UUIDs;
 import org.killbill.billing.util.api.AuditLevel;
 import org.killbill.billing.util.api.TagApiException;
@@ -74,6 +79,7 @@ import org.killbill.billing.util.audit.AuditLogWithHistory;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.billing.util.entity.Pagination;
 import org.killbill.billing.util.entity.dao.DefaultPaginationHelper.SourcePaginationBuilder;
 import org.killbill.billing.util.optimizer.BusOptimizer;
@@ -83,15 +89,8 @@ import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// FIXME-1615 : DefaultPaginationHelper
 import com.google.common.base.Function;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.inject.Inject;
 
 import static org.killbill.billing.util.entity.dao.DefaultPaginationHelper.getEntityPaginationNoException;
 
@@ -134,23 +133,19 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     }
 
     private static List<InvoiceItem> negateCreditItems(final List<InvoiceItem> input) {
-        final Iterable<InvoiceItem> tmp = Iterables.transform(input, new Function<InvoiceItem, InvoiceItem>() {
-            @Override
-            public InvoiceItem apply(final InvoiceItem creditItem) {
-                return new CreditAdjInvoiceItem(creditItem.getId(),
-                                                creditItem.getCreatedDate(),
-                                                creditItem.getInvoiceId(),
-                                                creditItem.getAccountId(),
-                                                creditItem.getStartDate(),
-                                                creditItem.getDescription(),
-                                                creditItem.getAmount().negate(),
-                                                creditItem.getRate(),
-                                                creditItem.getCurrency(),
-                                                creditItem.getQuantity(),
-                                                creditItem.getItemDetails());
-            }
-        });
-        return ImmutableList.copyOf(tmp);
+        return input.stream()
+                    .map(creditItem -> new CreditAdjInvoiceItem(creditItem.getId(),
+                                                                creditItem.getCreatedDate(),
+                                                                creditItem.getInvoiceId(),
+                                                                creditItem.getAccountId(),
+                                                                creditItem.getStartDate(),
+                                                                creditItem.getDescription(),
+                                                                creditItem.getAmount().negate(),
+                                                                creditItem.getRate(),
+                                                                creditItem.getCurrency(),
+                                                                creditItem.getQuantity(),
+                                                                creditItem.getItemDetails()))
+                    .collect(Collectors.toUnmodifiableList());
     }
 
     @Override
@@ -192,6 +187,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                       return dao.get(offset, limit, internalCallContextFactory.createInternalTenantContextWithoutAccountRecordId(context));
                                                   }
                                               },
+                                              // FIXME-1615 : DefaultPaginationHelper
                                               new Function<InvoiceModelDao, Invoice>() {
                                                   @Override
                                                   public Invoice apply(final InvoiceModelDao invoiceModelDao) {
@@ -211,6 +207,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                       return dao.searchInvoices(searchKey, offset, limit, internalCallContextFactory.createInternalTenantContextWithoutAccountRecordId(context));
                                                   }
                                               },
+                                              // FIXME-1615 : DefaultPaginationHelper
                                               new Function<InvoiceModelDao, Invoice>() {
                                                   @Override
                                                   public Invoice apply(final InvoiceModelDao invoiceModelDao) {
@@ -335,9 +332,9 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                    final boolean autoCommit,
                                                    final Iterable<PluginProperty> originalProperties,
                                                    final CallContext context) throws InvoiceApiException {
-        final LinkedList<PluginProperty> properties = new LinkedList<PluginProperty>();
+        final LinkedList<PluginProperty> properties = new LinkedList<>();
         if (originalProperties != null) {
-            properties.addAll(ImmutableList.<PluginProperty>copyOf(originalProperties));
+            originalProperties.forEach(properties::add);
         }
         return insertItems(accountId, effectiveDate, InvoiceItemType.EXTERNAL_CHARGE, charges, autoCommit, properties, context);
     }
@@ -349,9 +346,9 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                             final boolean autoCommit,
                                             final Iterable<PluginProperty> originalProperties,
                                             final CallContext context) throws InvoiceApiException {
-        final LinkedList<PluginProperty> properties = new LinkedList<PluginProperty>();
+        final LinkedList<PluginProperty> properties = new LinkedList<>();
         if (originalProperties != null) {
-            properties.addAll(ImmutableList.<PluginProperty>copyOf(originalProperties));
+            originalProperties.forEach(properties::add);
         }
 
         return insertItems(accountId, effectiveDate, InvoiceItemType.TAX, taxItems, autoCommit, properties, context);
@@ -363,7 +360,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
         if (creditItem == null) {
             throw new InvoiceApiException(ErrorCode.INVOICE_NO_SUCH_CREDIT, creditId);
         }
-        return negateCreditItems(ImmutableList.of(creditItem)).get(0);
+        return negateCreditItems(List.of(creditItem)).get(0);
     }
 
     @Override
@@ -373,9 +370,9 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                            final boolean autoCommit,
                                            final Iterable<PluginProperty> originalProperties,
                                            final CallContext context) throws InvoiceApiException {
-        final LinkedList<PluginProperty> properties = new LinkedList<PluginProperty>();
+        final LinkedList<PluginProperty> properties = new LinkedList<>();
         if (originalProperties != null) {
-            properties.addAll(ImmutableList.<PluginProperty>copyOf(originalProperties));
+            originalProperties.forEach(properties::add);
         }
 
         final List<InvoiceItem> items = insertItems(accountId, effectiveDate, InvoiceItemType.CREDIT_ADJ, creditItems, autoCommit, properties, context);
@@ -431,22 +428,22 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                     invoice.addInvoiceItem(adjustmentItem);
                 }
 
-                return ImmutableList.<DefaultInvoice>of(invoice);
+                return List.<DefaultInvoice>of(invoice);
             }
         };
 
-        final LinkedList<PluginProperty> properties = new LinkedList<PluginProperty>();
+        final LinkedList<PluginProperty> properties = new LinkedList<>();
+
         if (originalProperties != null) {
-            properties.addAll(ImmutableList.<PluginProperty>copyOf(originalProperties));
+            originalProperties.forEach(properties::add);
         }
 
-        final Collection<InvoiceItem> adjustmentInvoiceItems = Collections2.<InvoiceItem>filter(invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context),
-                                                                                                new Predicate<InvoiceItem>() {
-                                                                                                    @Override
-                                                                                                    public boolean apply(final InvoiceItem invoiceItem) {
-                                                                                                        return InvoiceItemType.ITEM_ADJ.equals(invoiceItem.getInvoiceItemType());
-                                                                                                    }
-                                                                                                });
+        final Collection<InvoiceItem> dispatchedInvoiceItems = invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context);
+
+        final Collection<InvoiceItem> adjustmentInvoiceItems = dispatchedInvoiceItems.stream()
+                .filter(invoiceItem -> InvoiceItemType.ITEM_ADJ.equals(invoiceItem.getInvoiceItemType()))
+                .collect(Collectors.toUnmodifiableList());
+
         Preconditions.checkState(adjustmentInvoiceItems.size() <= 1, "Should have created a single adjustment item: " + adjustmentInvoiceItems);
 
         return adjustmentInvoiceItems.iterator().hasNext() ? adjustmentInvoiceItems.iterator().next() : null;
@@ -488,34 +485,30 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
         final InternalCallContext internalCallContext = internalCallContextFactory.createInternalCallContext(accountId, context);
         final LocalDate invoiceDate = internalCallContext.toLocalDate(internalCallContext.getCreatedDate());
         final InvoiceModelDao migrationInvoice = new InvoiceModelDao(accountId, invoiceDate, targetDate, items.iterator().next().getCurrency(), true);
+        final List<InvoiceItemModelDao> itemModelDaos = Iterables.toStream(items)
+                .map(input -> new InvoiceItemModelDao(internalCallContext.getCreatedDate(),
+                                                      input.getInvoiceItemType(),
+                                                      migrationInvoice.getId(),
+                                                      accountId,
+                                                      input.getBundleId(),
+                                                      input.getSubscriptionId(),
+                                                      input.getDescription(),
+                                                      input.getProductName(),
+                                                      input.getPlanName(),
+                                                      input.getPhaseName(),
+                                                      input.getUsageName(),
+                                                      input.getCatalogEffectiveDate(),
+                                                      input.getStartDate(),
+                                                      input.getEndDate(),
+                                                      input.getAmount(),
+                                                      input.getRate(),
+                                                      input.getCurrency(),
+                                                      input.getLinkedItemId()))
+                .collect(Collectors.toUnmodifiableList());
 
-        final List<InvoiceItemModelDao> itemModelDaos = ImmutableList.copyOf(Iterables.transform(items, new Function<InvoiceItem, InvoiceItemModelDao>() {
-            @Override
-            public InvoiceItemModelDao apply(final InvoiceItem input) {
-                return new InvoiceItemModelDao(internalCallContext.getCreatedDate(),
-                                               input.getInvoiceItemType(),
-                                               migrationInvoice.getId(),
-                                               accountId,
-                                               input.getBundleId(),
-                                               input.getSubscriptionId(),
-                                               input.getDescription(),
-                                               input.getProductName(),
-                                               input.getPlanName(),
-                                               input.getPhaseName(),
-                                               input.getUsageName(),
-                                               input.getCatalogEffectiveDate(),
-                                               input.getStartDate(),
-                                               input.getEndDate(),
-                                               input.getAmount(),
-                                               input.getRate(),
-                                               input.getCurrency(),
-                                               input.getLinkedItemId());
-
-            }
-        }));
         migrationInvoice.addInvoiceItems(itemModelDaos);
 
-        dao.createInvoices(ImmutableList.<InvoiceModelDao>of(migrationInvoice), null, ImmutableSet.of(), internalCallContext);
+        dao.createInvoices(List.<InvoiceModelDao>of(migrationInvoice), null, Collections.emptySet(), internalCallContext);
         return migrationInvoice.getId();
     }
 
@@ -608,7 +601,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                                            inputItem.getPrettyPlanName(),
                                                                            inputItem.getPrettyPhaseName(),
                                                                            inputItem.getDescription(),
-                                                                           MoreObjects.firstNonNull(inputItem.getStartDate(), effectiveDate),
+                                                                           Objects.requireNonNullElse(inputItem.getStartDate(), effectiveDate),
                                                                            inputItem.getEndDate(),
                                                                            inputItem.getAmount(),
                                                                            inputItem.getRate(),
@@ -639,7 +632,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                                                                 accountId,
                                                                 inputItem.getBundleId(),
                                                                 inputItem.getDescription(),
-                                                                MoreObjects.firstNonNull(inputItem.getStartDate(), effectiveDate),
+                                                                Objects.requireNonNullElse(inputItem.getStartDate(), effectiveDate),
                                                                 inputItem.getAmount(),
                                                                 accountCurrency);
                             break;
@@ -684,7 +677,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                 dao.changeInvoiceStatus(invoiceId, InvoiceStatus.COMMITTED, internalCallContext);
                 final DefaultInvoice invoice = getInvoiceInternal(invoiceId, context);
                 dispatcher.setChargedThroughDates(invoice, internalCallContext);
-                return ImmutableList.<DefaultInvoice>of(invoice);
+                return List.of(invoice);
             }
         };
 
@@ -723,15 +716,11 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     @Override
     public List<InvoiceItem> getInvoiceItemsByParentInvoice(final UUID parentInvoiceId, final TenantContext context) throws InvoiceApiException {
         final InternalTenantContext internalTenantContext = internalCallContextFactory.createInternalTenantContext(parentInvoiceId, ObjectType.INVOICE, context);
-
         final VersionedCatalog catalog = getCatalogSafelyForPrettyNames(internalTenantContext);
-        return ImmutableList.copyOf(Collections2.transform(dao.getInvoiceItemsByParentInvoice(parentInvoiceId, internalTenantContext),
-                                                           new Function<InvoiceItemModelDao, InvoiceItem>() {
-                                                               @Override
-                                                               public InvoiceItem apply(final InvoiceItemModelDao input) {
-                                                                   return InvoiceItemFactory.fromModelDaoWithCatalog(input, catalog);
-                                                               }
-                                                           }));
+        final List<InvoiceItemModelDao> invoiceItems = dao.getInvoiceItemsByParentInvoice(parentInvoiceId, internalTenantContext);
+        return invoiceItems.stream()
+                .map(input -> InvoiceItemFactory.fromModelDaoWithCatalog(input, catalog))
+                .collect(Collectors.toUnmodifiableList());
     }
 
     private VersionedCatalog getCatalogSafelyForPrettyNames(final InternalTenantContext internalTenantContext) {
@@ -753,16 +742,12 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
 
     private void checkInvoiceDoesContainUsedGeneratedCredit(final UUID accountId, final InvoiceModelDao invoice, final CallContext context) throws InvoiceApiException {
         final BigDecimal accountCBA = dao.getAccountCBA(accountId, internalCallContextFactory.createInternalTenantContext(accountId, context));
-        final InvoiceItemModelDao largeCreditGen = Iterables.tryFind(invoice.getInvoiceItems(), new Predicate<InvoiceItemModelDao>() {
-            @Override
-            public boolean apply(final InvoiceItemModelDao invoiceItemModelDao) {
-                // Positive CBA
-                return InvoiceItemType.CBA_ADJ == invoiceItemModelDao.getType() && /* CBA item */
-                       invoiceItemModelDao.getAmount().compareTo(BigDecimal.ZERO) > 0 && /* Credit generation */
-                       invoiceItemModelDao.getAmount().compareTo(accountCBA) > 0; /* Some of it was used already */
-            }
-        }).orNull();
-        if (largeCreditGen != null) {
+        final boolean largeCreditGenExist = invoice.getInvoiceItems().stream()
+                .anyMatch(invoiceItemModelDao -> /* Positive CBA */
+                                  InvoiceItemType.CBA_ADJ == invoiceItemModelDao.getType() && /* CBA item */
+                                  invoiceItemModelDao.getAmount().compareTo(BigDecimal.ZERO) > 0 && /* Credit generation */
+                                  invoiceItemModelDao.getAmount().compareTo(accountCBA) > 0 /* Some of it was used already */);
+        if (largeCreditGenExist) {
             // TODO ErrorCode https://github.com/killbill/killbill/issues/1501
             throw new IllegalStateException(String.format("Cannot void invoice %s because it contains credit items (credit generation)", invoice.getId()));
         }
@@ -788,12 +773,12 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
                 dao.changeInvoiceStatus(invoiceId, InvoiceStatus.VOID, internalCallContext);
 
                 final DefaultInvoice invoice = getInvoiceInternal(invoiceId, context);
-                return ImmutableList.of(invoice);
+                return List.of(invoice);
             }
         };
 
 
-        final LinkedList<PluginProperty> properties = new LinkedList<PluginProperty>();
+        final LinkedList<PluginProperty> properties = new LinkedList<>();
         properties.add(new PluginProperty(INVOICE_OPERATION, "void", false));
 
         invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context);

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
@@ -100,6 +100,7 @@ public class CBADao {
     BigDecimal getInvoiceBalance(final InvoiceModelDao invoice) {
         if (isParentExistAndRawBalanceIsZero(invoice)) {
             final BigDecimal parentInvoiceAmountChargedForChild = invoice.getParentInvoice().getInvoiceItems().stream()
+                    .filter(input -> input.getChildAccountId().equals(invoice.getAccountId()))
                     .map(InvoiceItemModelDao::getAmount)
                     .reduce(BigDecimal.ZERO, BigDecimal::add);
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
@@ -20,11 +20,13 @@ package org.killbill.billing.invoice.dao;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -35,14 +37,9 @@ import org.killbill.billing.entity.EntityPersistenceException;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.invoice.model.CreditBalanceAdjInvoiceItem;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
 import org.killbill.billing.util.tag.Tag;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
 
 public class CBADao {
 
@@ -88,26 +85,27 @@ public class CBADao {
         }
     }
 
-    private BigDecimal getInvoiceBalance(final InvoiceModelDao invoice) {
+    @VisibleForTesting
+    boolean isParentExistAndRawBalanceIsZero(final InvoiceModelDao invoice) {
+        return invoice.getParentInvoice() != null &&
+               InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(invoice.getParentInvoice()).compareTo(BigDecimal.ZERO) == 0;
+    }
 
-        final InvoiceModelDao parentInvoice = invoice.getParentInvoice();
-        if ((parentInvoice != null) && (InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(parentInvoice).compareTo(BigDecimal.ZERO) == 0)) {
-            final Iterable<InvoiceItemModelDao> items = Iterables.filter(parentInvoice.getInvoiceItems(), new Predicate<InvoiceItemModelDao>() {
-                @Override
-                public boolean apply(final InvoiceItemModelDao input) {
-                    return input.getChildAccountId().equals(invoice.getAccountId());
-                }
-            });
+    @VisibleForTesting
+    BigDecimal getChildInvoiceAmountCharged(final InvoiceModelDao invoice) {
+        return InvoiceModelDaoHelper.getAmountCharged(invoice);
+    }
 
-            final BigDecimal childInvoiceAmountCharged = InvoiceModelDaoHelper.getAmountCharged(invoice);
-            BigDecimal parentInvoiceAmountChargedForChild = BigDecimal.ZERO;
+    @VisibleForTesting
+    BigDecimal getInvoiceBalance(final InvoiceModelDao invoice) {
+        if (isParentExistAndRawBalanceIsZero(invoice)) {
+            final BigDecimal parentInvoiceAmountChargedForChild = invoice.getParentInvoice().getInvoiceItems().stream()
+                    .map(InvoiceItemModelDao::getAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-            for (InvoiceItemModelDao itemModel : items) {
-                parentInvoiceAmountChargedForChild = parentInvoiceAmountChargedForChild.add(itemModel.getAmount());
-            }
+            final BigDecimal childInvoiceAmountCharged = getChildInvoiceAmountCharged(invoice);
 
             return childInvoiceAmountCharged.add(parentInvoiceAmountChargedForChild.negate());
-
         }
 
         return InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(invoice);
@@ -133,7 +131,7 @@ public class CBADao {
     public Set<UUID> doCBAComplexityFromTransaction(final List<Tag> invoicesTags,
                                                                     final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
                                                                     final InternalCallContext context) throws EntityPersistenceException, InvoiceApiException {
-        return doCBAComplexityFromTransaction(ImmutableSet.of(), invoicesTags, entitySqlDaoWrapperFactory, context);
+        return doCBAComplexityFromTransaction(Collections.emptySet(), invoicesTags, entitySqlDaoWrapperFactory, context);
     }
 
     // Note! We expect an *up-to-date* invoice, with all the items and payments except the CBA, that we will compute in that method
@@ -175,7 +173,7 @@ public class CBADao {
                                                                     final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
                                                                     final InternalCallContext context) throws InvoiceApiException, EntityPersistenceException {
         if (accountCBA.compareTo(BigDecimal.ZERO) <= 0) {
-            return ImmutableList.of();
+            return Collections.emptyList();
         }
 
         final List<InvoiceItemModelDao> result = new ArrayList<>();
@@ -185,12 +183,9 @@ public class CBADao {
         final List<InvoiceModelDao> allInvoices = invoiceDaoHelper.getAllInvoicesByAccountFromTransaction(false, invoicesTags, entitySqlDaoWrapperFactory, context);
         final List<InvoiceModelDao> unpaidInvoices = invoiceDaoHelper.getUnpaidInvoicesByAccountFromTransaction(allInvoices, null, null);
         // We order the same os BillingStateCalculator-- should really share the comparator
-        final List<InvoiceModelDao> orderedUnpaidInvoices = Ordering.from(new Comparator<InvoiceModelDao>() {
-            @Override
-            public int compare(final InvoiceModelDao i1, final InvoiceModelDao i2) {
-                return i1.getInvoiceDate().compareTo(i2.getInvoiceDate());
-            }
-        }).immutableSortedCopy(unpaidInvoices);
+        final List<InvoiceModelDao> orderedUnpaidInvoices = unpaidInvoices.stream()
+                .sorted(Comparator.comparing(InvoiceModelDao::getInvoiceDate))
+                .collect(Collectors.toUnmodifiableList());
 
         BigDecimal remainingAccountCBA = accountCBA;
         for (final InvoiceModelDao unpaidInvoice : orderedUnpaidInvoices) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -22,6 +22,8 @@ package org.killbill.billing.invoice.dao;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -31,8 +33,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.joda.time.DateTime;
@@ -65,7 +69,9 @@ import org.killbill.billing.invoice.notification.NextBillingDatePoster;
 import org.killbill.billing.invoice.notification.ParentInvoiceCommitmentPoster;
 import org.killbill.billing.junction.BillingEventSet;
 import org.killbill.billing.tag.TagInternalApi;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.billing.util.UUIDs;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 import org.killbill.billing.util.api.AuditLevel;
 import org.killbill.billing.util.audit.AuditLogWithHistory;
 import org.killbill.billing.util.audit.dao.AuditDao;
@@ -73,6 +79,8 @@ import org.killbill.billing.util.cache.Cachable.CacheType;
 import org.killbill.billing.util.cache.CacheController;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.collect.Iterables;
+import org.killbill.billing.util.collect.Sets;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.dao.NonEntityDao;
 import org.killbill.billing.util.dao.TableName;
@@ -80,7 +88,6 @@ import org.killbill.billing.util.entity.Pagination;
 import org.killbill.billing.util.entity.dao.DefaultPaginationSqlDaoHelper;
 import org.killbill.billing.util.entity.dao.DefaultPaginationSqlDaoHelper.PaginationIteratorBuilder;
 import org.killbill.billing.util.entity.dao.EntityDaoBase;
-import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
 import org.killbill.billing.util.optimizer.BusOptimizer;
@@ -92,37 +99,22 @@ import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
-import com.google.inject.Inject;
-
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 
 public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, InvoiceApiException> implements InvoiceDao {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultInvoiceDao.class);
 
-    private static final Ordering<InvoiceModelDao> INVOICE_MODEL_DAO_ORDERING = Ordering.natural()
-                                                                                        .onResultOf(new Function<InvoiceModelDao, Comparable>() {
-                                                                                            @Override
-                                                                                            public Comparable apply(final InvoiceModelDao invoice) {
-                                                                                                return invoice.getTargetDate() == null ? invoice.getCreatedDate().toLocalDate() : invoice.getTargetDate();
-                                                                                            }
-                                                                                        });
+    private static final Comparator<InvoiceModelDao> INVOICE_MODEL_DAO_COMPARATOR = Comparator.comparing(invoice -> invoice.getTargetDate() == null ?
+                                                                                                                    invoice.getCreatedDate().toLocalDate() :
+                                                                                                                    invoice.getTargetDate());
 
-    private static final Collection<InvoiceItemType> INVOICE_ITEM_TYPES_ADJUSTABLE = ImmutableList.<InvoiceItemType>of(InvoiceItemType.EXTERNAL_CHARGE,
-                                                                                                                       InvoiceItemType.FIXED,
-                                                                                                                       InvoiceItemType.RECURRING,
-                                                                                                                       InvoiceItemType.TAX,
-                                                                                                                       InvoiceItemType.USAGE,
-                                                                                                                       InvoiceItemType.PARENT_SUMMARY);
+    private static final Collection<InvoiceItemType> INVOICE_ITEM_TYPES_ADJUSTABLE = List.of(InvoiceItemType.EXTERNAL_CHARGE,
+                                                                                             InvoiceItemType.FIXED,
+                                                                                             InvoiceItemType.RECURRING,
+                                                                                             InvoiceItemType.TAX,
+                                                                                             InvoiceItemType.USAGE,
+                                                                                             InvoiceItemType.PARENT_SUMMARY);
 
     private final NextBillingDatePoster nextBillingDatePoster;
     private final BusOptimizer eventBus;
@@ -130,7 +122,6 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     private final InvoiceDaoHelper invoiceDaoHelper;
     private final CBADao cbaDao;
     private final InvoiceConfig invoiceConfig;
-    private final Clock clock;
     private final CacheController<String, UUID> objectIdCacheController;
     private final NonEntityDao nonEntityDao;
     private final ParentInvoiceCommitmentPoster parentInvoiceCommitmentPoster;
@@ -161,7 +152,6 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         this.invoiceDaoHelper = invoiceDaoHelper;
         this.cbaDao = cbaDao;
         this.auditDao = auditDao;
-        this.clock = clock;
         this.objectIdCacheController = cacheControllerDispatcher.getCacheController(CacheType.OBJECT_ID);
         this.nonEntityDao = nonEntityDao;
         this.parentInvoiceCommitmentPoster = parentInvoiceCommitmentPoster;
@@ -176,84 +166,70 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final InternalTenantContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoiceModelDao>>() {
-            @Override
-            public List<InvoiceModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
-                final List<InvoiceModelDao> invoices = ImmutableList.<InvoiceModelDao>copyOf(INVOICE_MODEL_DAO_ORDERING.sortedCopy(Iterables.<InvoiceModelDao>filter(invoiceSqlDao.getByAccountRecordId(context),
-                                                                                                                                                                     new Predicate<InvoiceModelDao>() {
-                                                                                                                                                                         @Override
-                                                                                                                                                                         public boolean apply(final InvoiceModelDao invoice) {
-                                                                                                                                                                             return !invoice.isMigrated() &&
-                                                                                                                                                                                    (includeVoidedInvoices ? true : !InvoiceStatus.VOID.equals(invoice.getStatus()));
-                                                                                                                                                                         }
-                                                                                                                                                                     })));
-                invoiceDaoHelper.populateChildren(invoices, invoicesTags, entitySqlDaoWrapperFactory, context);
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+            final List<InvoiceModelDao> invoicesByAccountRecordId = invoiceSqlDao.getByAccountRecordId(context);
+            final List<InvoiceModelDao> invoices = invoicesByAccountRecordId.stream()
+                    .filter(invoice -> !invoice.isMigrated() &&
+                                       (includeVoidedInvoices || !InvoiceStatus.VOID.equals(invoice.getStatus())))
+                    .sorted(INVOICE_MODEL_DAO_COMPARATOR)
+                    .collect(Collectors.toUnmodifiableList());
 
-                return invoices;
-            }
+            invoiceDaoHelper.populateChildren(invoices, invoicesTags, entitySqlDaoWrapperFactory, context);
+
+            return invoices;
         });
     }
 
     @Override
     public List<InvoiceModelDao> getAllInvoicesByAccount(final Boolean includeVoidedInvoices, final InternalTenantContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
-
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoiceModelDao>>() {
-            @Override
-            public List<InvoiceModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return invoiceDaoHelper.getAllInvoicesByAccountFromTransaction(includeVoidedInvoices, invoicesTags, entitySqlDaoWrapperFactory, context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> invoiceDaoHelper.getAllInvoicesByAccountFromTransaction(includeVoidedInvoices, invoicesTags, entitySqlDaoWrapperFactory, context));
     }
 
     @Override
     public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final LocalDate fromDate, final LocalDate upToDate, final InternalTenantContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoiceModelDao>>() {
-            @Override
-            public List<InvoiceModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
-                final List<InvoiceModelDao> invoices = getAllNonMigratedInvoicesByAccountAfterDate(includeVoidedInvoices, invoiceDao, fromDate, upToDate, context);
-                invoiceDaoHelper.populateChildren(invoices, invoicesTags, entitySqlDaoWrapperFactory, context);
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+            final List<InvoiceModelDao> invoices = getAllNonMigratedInvoicesByAccountAfterDate(includeVoidedInvoices, invoiceDao, fromDate, upToDate, context);
+            invoiceDaoHelper.populateChildren(invoices, invoicesTags, entitySqlDaoWrapperFactory, context);
 
-                return invoices;
-            }
+            return invoices;
         });
     }
 
-    private List<InvoiceModelDao> getAllNonMigratedInvoicesByAccountAfterDate(final Boolean includeVoidedInvoices, final InvoiceSqlDao invoiceSqlDao, final LocalDate fromDate, final LocalDate upToDate, final InternalTenantContext context) {
+    private List<InvoiceModelDao> getAllNonMigratedInvoicesByAccountAfterDate(final Boolean includeVoidedInvoices,
+                                                                              final InvoiceSqlDao invoiceSqlDao,
+                                                                              final LocalDate fromDate,
+                                                                              final LocalDate upToDate,
+                                                                              final InternalTenantContext context) {
         final List<InvoiceModelDao> candidates = fromDate != null ?
                                                  invoiceSqlDao.getInvoiceByAccountRecordIdAfter(fromDate, context) :
                                                  invoiceSqlDao.getByAccountRecordId(context);
 
-        return ImmutableList.<InvoiceModelDao>copyOf(INVOICE_MODEL_DAO_ORDERING.sortedCopy(Iterables.<InvoiceModelDao>filter(candidates, new Predicate<InvoiceModelDao>() {
-            @Override
-            public boolean apply(final InvoiceModelDao invoice) {
-                return !invoice.isMigrated() &&
-                       (upToDate == null || invoice.getTargetDate().compareTo(upToDate) <= 0) &&
-                       (includeVoidedInvoices ? true : !InvoiceStatus.VOID.equals(invoice.getStatus()));
-            }
-        })));
+        return candidates.stream()
+                .filter(invoice -> !invoice.isMigrated() &&
+                                   (upToDate == null || invoice.getTargetDate().compareTo(upToDate) <= 0) &&
+                                   (includeVoidedInvoices || !InvoiceStatus.VOID.equals(invoice.getStatus())))
+                .sorted(INVOICE_MODEL_DAO_COMPARATOR)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     @Override
     public InvoiceModelDao getById(final UUID invoiceId, final InternalTenantContext context) throws InvoiceApiException {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(true, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoiceModelDao>() {
-            @Override
-            public InvoiceModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+        return transactionalSqlDao.execute(true, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
 
-                final InvoiceModelDao invoice = invoiceSqlDao.getById(invoiceId.toString(), context);
-                if (invoice == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_NOT_FOUND, invoiceId);
-                }
-                invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
-                return invoice;
+            final InvoiceModelDao invoice = invoiceSqlDao.getById(invoiceId.toString(), context);
+            if (invoice == null) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_NOT_FOUND, invoiceId);
             }
+            invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
+            return invoice;
         });
     }
 
@@ -265,23 +241,20 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
 
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(true, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoiceModelDao>() {
-            @Override
-            public InvoiceModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+        return transactionalSqlDao.execute(true, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
 
-                final InvoiceModelDao invoice = invoiceDao.getByRecordId(number.longValue(), context);
-                if (invoice == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_NUMBER_NOT_FOUND, number.longValue());
-                }
-
-                // The context may not contain the account record id at this point - we couldn't do it in the API above
-                // as we couldn't get access to the invoice object until now.
-                final InternalTenantContext contextWithAccountRecordId = internalCallContextFactory.createInternalTenantContext(invoice.getAccountId(), context);
-                invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, contextWithAccountRecordId);
-
-                return invoice;
+            final InvoiceModelDao invoice = invoiceDao.getByRecordId(number.longValue(), context);
+            if (invoice == null) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_NUMBER_NOT_FOUND, number.longValue());
             }
+
+            // The context may not contain the account record id at this point - we couldn't do it in the API above
+            // as we couldn't get access to the invoice object until now.
+            final InternalTenantContext contextWithAccountRecordId = internalCallContextFactory.createInternalTenantContext(invoice.getAccountId(), context);
+            invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, contextWithAccountRecordId);
+
+            return invoice;
         });
     }
 
@@ -290,44 +263,35 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
 
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoiceModelDao>() {
-            @Override
-            public InvoiceModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
-                final InvoiceModelDao invoice = invoiceSqlDao.getInvoiceByInvoiceItemId(invoiceItemId.toString(), context);
-                if (invoice == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId);
-                }
-
-                final InternalTenantContext contextWithAccountRecordId = internalCallContextFactory.createInternalTenantContext(invoice.getAccountId(), context);
-                invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, contextWithAccountRecordId);
-                return invoice;
+        return transactionalSqlDao.execute(false, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+            final InvoiceModelDao invoice = invoiceSqlDao.getInvoiceByInvoiceItemId(invoiceItemId.toString(), context);
+            if (invoice == null) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId);
             }
+
+            final InternalTenantContext contextWithAccountRecordId = internalCallContextFactory.createInternalTenantContext(invoice.getAccountId(), context);
+            invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, contextWithAccountRecordId);
+            return invoice;
         });
     }
 
     @Override
-    public void setFutureAccountNotificationsForEmptyInvoice(final UUID accountId, final FutureAccountNotifications callbackDateTimePerSubscriptions,
+    public void setFutureAccountNotificationsForEmptyInvoice(final UUID accountId,
+                                                             final FutureAccountNotifications callbackDateTimePerSubscriptions,
                                                              final InternalCallContext context) {
 
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                notifyOfFutureBillingEvents(entitySqlDaoWrapperFactory, accountId, callbackDateTimePerSubscriptions, context);
-                return null;
-            }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            notifyOfFutureBillingEvents(entitySqlDaoWrapperFactory, accountId, callbackDateTimePerSubscriptions, context);
+            return null;
         });
     }
 
     @Override
     public void rescheduleInvoiceNotification(final UUID accountId, final DateTime nextRescheduleDt, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                nextBillingDatePoster.insertNextBillingNotificationFromTransaction(entitySqlDaoWrapperFactory, accountId, ImmutableSet.<UUID>of(), nextRescheduleDt, true, context);
-                return null;
-            }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            nextBillingDatePoster.insertNextBillingNotificationFromTransaction(entitySqlDaoWrapperFactory, accountId, Collections.emptySet(), nextRescheduleDt, true, context);
+            return null;
         });
     }
 
@@ -338,7 +302,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                               final FutureAccountNotifications callbackDateTimePerSubscriptions,
                               final ExistingInvoiceMetadata existingInvoiceMetadata,
                               final InternalCallContext context) {
-        createInvoices(ImmutableList.<InvoiceModelDao>of(invoice), billingEvents, trackingIds, callbackDateTimePerSubscriptions, existingInvoiceMetadata, false, context);
+        createInvoices(List.of(invoice), billingEvents, trackingIds, callbackDateTimePerSubscriptions, existingInvoiceMetadata, false, context);
     }
 
     @Override
@@ -357,156 +321,148 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                                      final boolean returnCreatedInvoiceItems,
                                                      final InternalCallContext context) {
         // Track invoices that are being created
-        final Set<UUID> createdInvoiceIds = new HashSet<UUID>();
+        final Set<UUID> createdInvoiceIds = new HashSet<>();
         // Track invoices that already exist but are being committed -- AUTO_INVOICING_REUSE_DRAFT mode
-        final Set<UUID> committedReusedInvoiceId = new HashSet<UUID>();
+        final Set<UUID> committedReusedInvoiceId = new HashSet<>();
         // Track all invoices that are referenced through all invoiceItems
-        final Set<UUID> allInvoiceIds = new HashSet<UUID>();
+        final Set<UUID> allInvoiceIds = new HashSet<>();
         // Track invoices that are committed but were not created or reused -- to sent the InvoiceAdjustment bus event
-        final Set<UUID> adjustedCommittedInvoiceIds = new HashSet<UUID>();
+        final Set<UUID> adjustedCommittedInvoiceIds = new HashSet<>();
 
-        final Collection<UUID> invoiceIdsReferencedFromItems = new HashSet<UUID>();
-        for (final InvoiceModelDao invoiceModelDao : invoices) {
-            for (final InvoiceItemModelDao invoiceItemModelDao : invoiceModelDao.getInvoiceItems()) {
-                invoiceIdsReferencedFromItems.add(invoiceItemModelDao.getInvoiceId());
-            }
-        }
+        final Collection<UUID> invoiceIdsReferencedFromItems = new HashSet<>();
+        Iterables.toStream(invoices)
+                 .flatMap(invoiceModelDao -> invoiceModelDao.getInvoiceItems().stream())
+                 .forEach(invoiceItemModelDao -> invoiceIdsReferencedFromItems.add(invoiceItemModelDao.getInvoiceId()));
 
         if (Iterables.isEmpty(invoices)) {
-            return ImmutableList.<InvoiceItemModelDao>of();
+            return Collections.emptyList();
         }
         final UUID accountId = invoices.iterator().next().getAccountId();
 
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        final Map<UUID, InvoiceModelDao> invoiceByInvoiceId = new HashMap<UUID, InvoiceModelDao>();
-        return transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<List<InvoiceItemModelDao>>() {
-            @Override
-            public List<InvoiceItemModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
-                final InvoiceItemSqlDao transInvoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-                final InvoiceBillingEventSqlDao billingEventSqlDao = entitySqlDaoWrapperFactory.become(InvoiceBillingEventSqlDao.class);
+        final Map<UUID, InvoiceModelDao> invoiceByInvoiceId = new HashMap<>();
+        return transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+            final InvoiceItemSqlDao transInvoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
+            final InvoiceBillingEventSqlDao billingEventSqlDao = entitySqlDaoWrapperFactory.become(InvoiceBillingEventSqlDao.class);
 
-                final ExistingInvoiceMetadata existingInvoiceMetadata;
-                if (existingInvoiceMetadataOrNull == null) {
-                    existingInvoiceMetadata = new ExistingInvoiceMetadata(invoiceSqlDao, transInvoiceItemSqlDao);
-                } else {
-                    existingInvoiceMetadata = existingInvoiceMetadataOrNull;
-                }
+            final ExistingInvoiceMetadata existingInvoiceMetadata;
+            if (existingInvoiceMetadataOrNull == null) {
+                existingInvoiceMetadata = new ExistingInvoiceMetadata(invoiceSqlDao, transInvoiceItemSqlDao);
+            } else {
+                existingInvoiceMetadata = existingInvoiceMetadataOrNull;
+            }
 
-                final List<InvoiceItemModelDao> invoiceItemsToCreate = new LinkedList<InvoiceItemModelDao>();
-                for (final InvoiceModelDao invoiceModelDao : invoices) {
-                    invoiceByInvoiceId.put(invoiceModelDao.getId(), invoiceModelDao);
-                    final boolean isNotShellInvoice = invoiceIdsReferencedFromItems.remove(invoiceModelDao.getId());
+            final List<InvoiceItemModelDao> invoiceItemsToCreate = new LinkedList<InvoiceItemModelDao>();
+            for (final InvoiceModelDao invoiceModelDao : invoices) {
+                invoiceByInvoiceId.put(invoiceModelDao.getId(), invoiceModelDao);
+                final boolean isNotShellInvoice = invoiceIdsReferencedFromItems.remove(invoiceModelDao.getId());
 
-                    final InvoiceModelDao invoiceOnDisk = existingInvoiceMetadata.getExistingInvoice(invoiceModelDao.getId(), context);
-                    if (isNotShellInvoice) {
-                        // Create the invoice if this is not a shell invoice and it does not already exist
-                        if (invoiceOnDisk == null) {
-                            createAndRefresh(invoiceSqlDao, invoiceModelDao, context);
-                            if (billingEvents != null) {
-                                billingEventSqlDao.create(new InvoiceBillingEventModelDao(invoiceModelDao.getId(), BillingEventSerializer.serialize(billingEvents), context.getCreatedDate()), context);
-                            }
-                            createdInvoiceIds.add(invoiceModelDao.getId());
-                        } else {
-
-                            // Allow transition from DRAFT to COMMITTED or keep current status
-                            InvoiceStatus newStatus = invoiceOnDisk.getStatus();
-                            boolean statusUpdated = false;
-                            if (InvoiceStatus.COMMITTED == invoiceModelDao.getStatus() && InvoiceStatus.DRAFT == invoiceOnDisk.getStatus()) {
-                                statusUpdated = true;
-                                newStatus = InvoiceStatus.COMMITTED;
-                            }
-
-                            // Update if target date is specified and prev targetDate was either null or prior to new date
-                            LocalDate newTargetDate = invoiceOnDisk.getTargetDate();
-                            boolean targetDateUpdated = false;
-                            if (invoiceModelDao.getTargetDate() != null &&
-                                (invoiceOnDisk.getTargetDate() == null || invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) < 0)) {
-                                targetDateUpdated = true;
-                                newTargetDate = invoiceModelDao.getTargetDate();
-                            }
-
-                            if (statusUpdated || targetDateUpdated) {
-                                invoiceSqlDao.updateStatusAndTargetDate(invoiceModelDao.getId().toString(), newStatus.toString(), newTargetDate, context);
-                                committedReusedInvoiceId.add(invoiceModelDao.getId());
-                            }
+                final InvoiceModelDao invoiceOnDisk = existingInvoiceMetadata.getExistingInvoice(invoiceModelDao.getId(), context);
+                if (isNotShellInvoice) {
+                    // Create the invoice if this is not a shell invoice and it does not already exist
+                    if (invoiceOnDisk == null) {
+                        createAndRefresh(invoiceSqlDao, invoiceModelDao, context);
+                        if (billingEvents != null) {
+                            billingEventSqlDao.create(new InvoiceBillingEventModelDao(invoiceModelDao.getId(), BillingEventSerializer.serialize(billingEvents), context.getCreatedDate()), context);
                         }
-                    }
-
-                    // Create the invoice items if needed (note: they may not necessarily belong to that invoice)
-                    for (final InvoiceItemModelDao invoiceItemModelDao : invoiceModelDao.getInvoiceItems()) {
-                        final InvoiceItemModelDao existingInvoiceItem = existingInvoiceMetadata.getExistingInvoiceItem(invoiceItemModelDao.getId(), context);
-                        // Because of AUTO_INVOICING_REUSE_DRAFT we expect an invoice were items might already exist.
-                        // Also for ALLOWED_INVOICE_ITEM_TYPES, we expect plugins to potentially modify the amount
-                        if (existingInvoiceItem == null) {
-                            invoiceItemsToCreate.add(invoiceItemModelDao);
-                            allInvoiceIds.add(invoiceItemModelDao.getInvoiceId());
-                        } else if (InvoicePluginDispatcher.ALLOWED_INVOICE_ITEM_TYPES.contains(invoiceItemModelDao.getType()) &&
-                                   // The restriction on the amount is to deal with https://github.com/killbill/killbill/issues/993 - and ensure that duplicate
-                                   // items would not be re-written
-                                   (invoiceItemModelDao.getAmount().compareTo(existingInvoiceItem.getAmount()) != 0)) {
-                            if (checkAgainstExistingInvoiceItemState(existingInvoiceItem, invoiceItemModelDao)) {
-                                transInvoiceItemSqlDao.updateItemFields(invoiceItemModelDao.getId().toString(), invoiceItemModelDao.getAmount(), invoiceItemModelDao.getDescription(), invoiceItemModelDao.getItemDetails(), context);
-                            }
-                        }
-                    }
-                    final boolean wasInvoiceCreatedOrCommitted = createdInvoiceIds.contains(invoiceModelDao.getId()) ||
-                                                                 committedReusedInvoiceId.contains(invoiceModelDao.getId());
-
-                    final boolean hasInvoiceBeenAdjusted = allInvoiceIds.contains(invoiceModelDao.getId());
-
-                    if (InvoiceStatus.COMMITTED.equals(invoiceModelDao.getStatus())) {
-                        if (wasInvoiceCreatedOrCommitted) {
-                            notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, invoiceModelDao, context);
-                        } else if (hasInvoiceBeenAdjusted) {
-                            adjustedCommittedInvoiceIds.add(invoiceModelDao.getId());
-                        }
-                    } else if (wasInvoiceCreatedOrCommitted && invoiceModelDao.isParentInvoice()) {
-                        notifyOfParentInvoiceCreation(entitySqlDaoWrapperFactory, invoiceModelDao, context);
-                    }
-
-                    // We always add the future notifications when the callbackDateTimePerSubscriptions is not empty (incl. DRAFT invoices containing RECURRING items created using AUTO_INVOICING_DRAFT feature)
-                    notifyOfFutureBillingEvents(entitySqlDaoWrapperFactory, invoiceModelDao.getAccountId(), callbackDateTimePerSubscriptions, context);
-                }
-
-                // Bulk insert the invoice items
-                createInvoiceItemsFromTransaction(transInvoiceItemSqlDao, invoiceItemsToCreate, context);
-
-                // CBA COMPLEXITY...
-                //
-                // Optimized path where we don't need to refresh invoices
-                final CBALogicWrapper cbaWrapper = new CBALogicWrapper(accountId, invoicesTags, context, entitySqlDaoWrapperFactory);
-                if (createdInvoiceIds.equals(allInvoiceIds)) {
-                    final List<InvoiceModelDao> cbaInvoicesInput = new ArrayList<>();
-                    for (final UUID id : createdInvoiceIds) {
-                        cbaInvoicesInput.add(invoiceByInvoiceId.get(id));
-                    }
-                    cbaWrapper.runCBALogicWithNotificationEvents(adjustedCommittedInvoiceIds, createdInvoiceIds, cbaInvoicesInput);
-                } else {
-                    cbaWrapper.runCBALogicWithNotificationEvents(adjustedCommittedInvoiceIds, createdInvoiceIds, allInvoiceIds);
-                }
-
-                if (trackingIds != null && !trackingIds.isEmpty()) {
-                    final InvoiceTrackingSqlDao trackingIdsSqlDao = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
-                    trackingIdsSqlDao.create(trackingIds, context);
-                }
-
-                if (returnCreatedInvoiceItems) {
-                    if (invoiceItemsToCreate.isEmpty()) {
-                        return ImmutableList.<InvoiceItemModelDao>of();
+                        createdInvoiceIds.add(invoiceModelDao.getId());
                     } else {
-                        return transInvoiceItemSqlDao.getByIds(Collections2.<InvoiceItemModelDao, String>transform(invoiceItemsToCreate, new Function<InvoiceItemModelDao, String>() {
-                                                                   @Override
-                                                                   public String apply(final InvoiceItemModelDao input) {
-                                                                       return input.getId().toString();
-                                                                   }
-                                                               }),
-                                                               context);
+
+                        // Allow transition from DRAFT to COMMITTED or keep current status
+                        InvoiceStatus newStatus = invoiceOnDisk.getStatus();
+                        boolean statusUpdated = false;
+                        if (InvoiceStatus.COMMITTED == invoiceModelDao.getStatus() && InvoiceStatus.DRAFT == invoiceOnDisk.getStatus()) {
+                            statusUpdated = true;
+                            newStatus = InvoiceStatus.COMMITTED;
+                        }
+
+                        // Update if target date is specified and prev targetDate was either null or prior to new date
+                        LocalDate newTargetDate = invoiceOnDisk.getTargetDate();
+                        boolean targetDateUpdated = false;
+                        if (invoiceModelDao.getTargetDate() != null &&
+                            (invoiceOnDisk.getTargetDate() == null || invoiceOnDisk.getTargetDate().compareTo(invoiceModelDao.getTargetDate()) < 0)) {
+                            targetDateUpdated = true;
+                            newTargetDate = invoiceModelDao.getTargetDate();
+                        }
+
+                        if (statusUpdated || targetDateUpdated) {
+                            invoiceSqlDao.updateStatusAndTargetDate(invoiceModelDao.getId().toString(), newStatus.toString(), newTargetDate, context);
+                            committedReusedInvoiceId.add(invoiceModelDao.getId());
+                        }
                     }
-                } else {
-                    return null;
                 }
+
+                // Create the invoice items if needed (note: they may not necessarily belong to that invoice)
+                for (final InvoiceItemModelDao invoiceItemModelDao : invoiceModelDao.getInvoiceItems()) {
+                    final InvoiceItemModelDao existingInvoiceItem = existingInvoiceMetadata.getExistingInvoiceItem(invoiceItemModelDao.getId(), context);
+                    // Because of AUTO_INVOICING_REUSE_DRAFT we expect an invoice were items might already exist.
+                    // Also for ALLOWED_INVOICE_ITEM_TYPES, we expect plugins to potentially modify the amount
+                    if (existingInvoiceItem == null) {
+                        invoiceItemsToCreate.add(invoiceItemModelDao);
+                        allInvoiceIds.add(invoiceItemModelDao.getInvoiceId());
+                    } else if (InvoicePluginDispatcher.ALLOWED_INVOICE_ITEM_TYPES.contains(invoiceItemModelDao.getType()) &&
+                               // The restriction on the amount is to deal with https://github.com/killbill/killbill/issues/993 - and ensure that duplicate
+                               // items would not be re-written
+                               (invoiceItemModelDao.getAmount().compareTo(existingInvoiceItem.getAmount()) != 0)) {
+                        if (checkAgainstExistingInvoiceItemState(existingInvoiceItem, invoiceItemModelDao)) {
+                            transInvoiceItemSqlDao.updateItemFields(invoiceItemModelDao.getId().toString(), invoiceItemModelDao.getAmount(), invoiceItemModelDao.getDescription(), invoiceItemModelDao.getItemDetails(), context);
+                        }
+                    }
+                }
+                final boolean wasInvoiceCreatedOrCommitted = createdInvoiceIds.contains(invoiceModelDao.getId()) ||
+                                                             committedReusedInvoiceId.contains(invoiceModelDao.getId());
+
+                final boolean hasInvoiceBeenAdjusted = allInvoiceIds.contains(invoiceModelDao.getId());
+
+                if (InvoiceStatus.COMMITTED.equals(invoiceModelDao.getStatus())) {
+                    if (wasInvoiceCreatedOrCommitted) {
+                        notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, invoiceModelDao, context);
+                    } else if (hasInvoiceBeenAdjusted) {
+                        adjustedCommittedInvoiceIds.add(invoiceModelDao.getId());
+                    }
+                } else if (wasInvoiceCreatedOrCommitted && invoiceModelDao.isParentInvoice()) {
+                    notifyOfParentInvoiceCreation(entitySqlDaoWrapperFactory, invoiceModelDao, context);
+                }
+
+                // We always add the future notifications when the callbackDateTimePerSubscriptions is not empty (incl. DRAFT invoices containing RECURRING items created using AUTO_INVOICING_DRAFT feature)
+                notifyOfFutureBillingEvents(entitySqlDaoWrapperFactory, invoiceModelDao.getAccountId(), callbackDateTimePerSubscriptions, context);
+            }
+
+            // Bulk insert the invoice items
+            createInvoiceItemsFromTransaction(transInvoiceItemSqlDao, invoiceItemsToCreate, context);
+
+            // CBA COMPLEXITY...
+            //
+            // Optimized path where we don't need to refresh invoices
+            final CBALogicWrapper cbaWrapper = new CBALogicWrapper(accountId, invoicesTags, context, entitySqlDaoWrapperFactory);
+            if (createdInvoiceIds.equals(allInvoiceIds)) {
+                final List<InvoiceModelDao> cbaInvoicesInput = new ArrayList<>();
+                for (final UUID id : createdInvoiceIds) {
+                    cbaInvoicesInput.add(invoiceByInvoiceId.get(id));
+                }
+                cbaWrapper.runCBALogicWithNotificationEvents(adjustedCommittedInvoiceIds, createdInvoiceIds, cbaInvoicesInput);
+            } else {
+                cbaWrapper.runCBALogicWithNotificationEvents(adjustedCommittedInvoiceIds, createdInvoiceIds, allInvoiceIds);
+            }
+
+            if (trackingIds != null && !trackingIds.isEmpty()) {
+                final InvoiceTrackingSqlDao trackingIdsSqlDao = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
+                trackingIdsSqlDao.create(trackingIds, context);
+            }
+
+            if (returnCreatedInvoiceItems) {
+                if (invoiceItemsToCreate.isEmpty()) {
+                    return Collections.emptyList();
+                } else {
+                    final List<String> inovoiceIds = invoiceItemsToCreate.stream()
+                            .map(input -> input.getId().toString())
+                            .collect(Collectors.toUnmodifiableList());
+                    return transInvoiceItemSqlDao.getByIds(inovoiceIds, context);
+                }
+            } else {
+                return null;
             }
         });
     }
@@ -515,16 +471,13 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     public List<InvoiceModelDao> getInvoicesBySubscription(final UUID subscriptionId, final InternalTenantContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoiceModelDao>>() {
-            @Override
-            public List<InvoiceModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
 
-                final List<InvoiceModelDao> invoices = invoiceDao.getInvoicesBySubscription(subscriptionId.toString(), context);
-                invoiceDaoHelper.populateChildren(invoices, invoicesTags, entitySqlDaoWrapperFactory, context);
+            final List<InvoiceModelDao> invoices = invoiceDao.getInvoicesBySubscription(subscriptionId.toString(), context);
+            invoiceDaoHelper.populateChildren(invoices, invoicesTags, entitySqlDaoWrapperFactory, context);
 
-                return invoices;
-            }
+            return invoices;
         });
     }
 
@@ -548,10 +501,10 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                                   public Iterator<InvoiceModelDao> build(final InvoiceSqlDao invoiceSqlDao, final Long offset, final Long limit, final DefaultPaginationSqlDaoHelper.Ordering ordering, final InternalTenantContext context) {
                                                       try {
                                                           return invoiceNumber != null ?
-                                                                 ImmutableList.<InvoiceModelDao>of(getByNumber(invoiceNumber, context)).iterator() :
+                                                                 List.<InvoiceModelDao>of(getByNumber(invoiceNumber, context)).iterator() :
                                                                  invoiceSqlDao.search(searchKey, String.format("%%%s%%", searchKey), offset, limit, ordering.toString(), context);
                                                       } catch (final InvoiceApiException ignored) {
-                                                          return ImmutableSet.<InvoiceModelDao>of().iterator();
+                                                          return Collections.emptyIterator();
                                                       }
                                                   }
                                               },
@@ -565,236 +518,186 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     public BigDecimal getAccountBalance(final UUID accountId, final InternalTenantContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<BigDecimal>() {
-            @Override
-            public BigDecimal inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                BigDecimal cba = BigDecimal.ZERO;
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            BigDecimal cba = BigDecimal.ZERO;
 
-                BigDecimal accountBalance = BigDecimal.ZERO;
-                final List<InvoiceModelDao> invoices = invoiceDaoHelper.getAllInvoicesByAccountFromTransaction(false, invoicesTags, entitySqlDaoWrapperFactory, context);
-                for (final InvoiceModelDao cur : invoices) {
+            BigDecimal accountBalance = BigDecimal.ZERO;
+            final List<InvoiceModelDao> invoices = invoiceDaoHelper.getAllInvoicesByAccountFromTransaction(false, invoicesTags, entitySqlDaoWrapperFactory, context);
+            for (final InvoiceModelDao cur : invoices) {
 
-                    // Skip DRAFT OR VOID invoices
-                    if (cur.getStatus().equals(InvoiceStatus.DRAFT) || cur.getStatus().equals(InvoiceStatus.VOID)) {
-                        continue;
-                    }
-
-                    final boolean hasZeroParentBalance =
-                            cur.getParentInvoice() != null &&
-                            (cur.getParentInvoice().isWrittenOff() ||
-                             cur.getParentInvoice().getStatus() == InvoiceStatus.DRAFT ||
-                             cur.getParentInvoice().getStatus() == InvoiceStatus.VOID ||
-                             InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(cur.getParentInvoice()).compareTo(BigDecimal.ZERO) == 0);
-
-                    // invoices that are WRITTEN_OFF or paid children invoices are excluded from balance computation but the cba summation needs to be included
-                    accountBalance = cur.isWrittenOff() || hasZeroParentBalance ? BigDecimal.ZERO : accountBalance.add(InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(cur));
-                    cba = cba.add(InvoiceModelDaoHelper.getCBAAmount(cur));
+                // Skip DRAFT OR VOID invoices
+                if (cur.getStatus().equals(InvoiceStatus.DRAFT) || cur.getStatus().equals(InvoiceStatus.VOID)) {
+                    continue;
                 }
-                return accountBalance.subtract(cba);
+
+                final boolean hasZeroParentBalance =
+                        cur.getParentInvoice() != null &&
+                        (cur.getParentInvoice().isWrittenOff() ||
+                         cur.getParentInvoice().getStatus() == InvoiceStatus.DRAFT ||
+                         cur.getParentInvoice().getStatus() == InvoiceStatus.VOID ||
+                         InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(cur.getParentInvoice()).compareTo(BigDecimal.ZERO) == 0);
+
+                // invoices that are WRITTEN_OFF or paid children invoices are excluded from balance computation but the cba summation needs to be included
+                accountBalance = cur.isWrittenOff() || hasZeroParentBalance ? BigDecimal.ZERO : accountBalance.add(InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(cur));
+                cba = cba.add(InvoiceModelDaoHelper.getCBAAmount(cur));
             }
+            return accountBalance.subtract(cba);
         });
     }
 
     @Override
     public BigDecimal getAccountCBA(final UUID accountId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<BigDecimal>() {
-            @Override
-            public BigDecimal inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return cbaDao.getAccountCBAFromTransaction(entitySqlDaoWrapperFactory, context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entityWrapperFactory -> cbaDao.getAccountCBAFromTransaction(entityWrapperFactory, context));
     }
 
     @Override
-    public List<InvoiceModelDao> getUnpaidInvoicesByAccountId(final UUID accountId, @Nullable LocalDate startDate, @Nullable final LocalDate upToDate, final InternalTenantContext context) {
+    public List<InvoiceModelDao> getUnpaidInvoicesByAccountId(final UUID accountId, @Nullable final LocalDate startDate, @Nullable final LocalDate upToDate, final InternalTenantContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoiceModelDao>>() {
-            @Override
-            public List<InvoiceModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return invoiceDaoHelper.getUnpaidInvoicesByAccountFromTransaction(accountId, invoicesTags, entitySqlDaoWrapperFactory, startDate, upToDate, context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entityWrapperFactory -> invoiceDaoHelper.getUnpaidInvoicesByAccountFromTransaction(accountId, invoicesTags, entityWrapperFactory, startDate, upToDate, context));
     }
 
     @Override
     public UUID getInvoiceIdByPaymentId(final UUID paymentId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<UUID>() {
-            @Override
-            public UUID inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class).getInvoiceIdByPaymentId(paymentId.toString(), context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class).getInvoiceIdByPaymentId(paymentId.toString(), context));
     }
 
     @Override
     public List<InvoicePaymentModelDao> getInvoicePaymentsByPaymentId(final UUID paymentId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoicePaymentModelDao>>() {
-            @Override
-            public List<InvoicePaymentModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getInvoicePayments(paymentId.toString(), context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getInvoicePayments(paymentId.toString(), context));
     }
 
     @Override
     public List<InvoicePaymentModelDao> getInvoicePaymentsByAccount(final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoicePaymentModelDao>>() {
-            @Override
-            public List<InvoicePaymentModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getByAccountRecordId(context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getByAccountRecordId(context));
     }
 
     @Override
     public List<InvoicePaymentModelDao> getInvoicePaymentsByInvoice(final UUID invoiceId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoicePaymentModelDao>>() {
-            @Override
-            public List<InvoicePaymentModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getAllPaymentsForInvoiceIncludedInit(invoiceId.toString(), context);
-            }
-        });
+        return transactionalSqlDao.execute(true, daoWrapperFactory ->  daoWrapperFactory.become(InvoicePaymentSqlDao.class).getAllPaymentsForInvoiceIncludedInit(invoiceId.toString(), context));
     }
 
     @Override
     public InvoicePaymentModelDao getInvoicePaymentByCookieId(final String cookieId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<InvoicePaymentModelDao>() {
-            @Override
-            public InvoicePaymentModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getPaymentForCookieId(cookieId, context);
-            }
-        });
+        return transactionalSqlDao.execute(true, daoWrapperFactory -> daoWrapperFactory.become(InvoicePaymentSqlDao.class).getPaymentForCookieId(cookieId, context));
     }
 
     @Override
     public InvoicePaymentModelDao getInvoicePayment(final UUID invoicePaymentId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<InvoicePaymentModelDao>() {
-            @Override
-            public InvoicePaymentModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getById(invoicePaymentId.toString(), context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getById(invoicePaymentId.toString(), context));
     }
 
     @Override
-    public InvoicePaymentModelDao createRefund(final UUID paymentId, final UUID paymentAttemptId, final BigDecimal requestedRefundAmount, final boolean isInvoiceAdjusted,
+    public InvoicePaymentModelDao createRefund(final UUID paymentId, final UUID paymentAttemptId,
+                                               final BigDecimal requestedRefundAmount, final boolean isInvoiceAdjusted,
                                                final Map<UUID, BigDecimal> invoiceItemIdsWithNullAmounts, final String transactionExternalKey,
                                                final boolean success, final InternalCallContext context) throws InvoiceApiException {
 
-        if (isInvoiceAdjusted && invoiceItemIdsWithNullAmounts.size() == 0) {
+        if (isInvoiceAdjusted && invoiceItemIdsWithNullAmounts.isEmpty()) {
             throw new InvoiceApiException(ErrorCode.INVOICE_ITEMS_ADJUSTMENT_MISSING);
         }
 
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoicePaymentModelDao>() {
-            @Override
-            public InvoicePaymentModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
+        return transactionalSqlDao.execute(false, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
 
-                final InvoiceSqlDao transInvoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+            final InvoiceSqlDao transInvoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
 
-                final List<InvoicePaymentModelDao> paymentsForId = transactional.getByPaymentId(paymentId.toString(), context);
-                final InvoicePaymentModelDao payment = Iterables.tryFind(paymentsForId, new Predicate<InvoicePaymentModelDao>() {
-                    @Override
-                    public boolean apply(final InvoicePaymentModelDao input) {
-                        return input.getType() == InvoicePaymentType.ATTEMPT && input.getSuccess();
-                    }
-                }).orNull();
-                if (payment == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_PAYMENT_BY_ATTEMPT_NOT_FOUND, paymentId);
+            final List<InvoicePaymentModelDao> paymentsForId = transactional.getByPaymentId(paymentId.toString(), context);
+            final InvoicePaymentModelDao payment = paymentsForId.stream()
+                                                                .filter(input -> input.getType() == InvoicePaymentType.ATTEMPT && input.getSuccess())
+                                                                .findFirst()
+                                                                .orElseThrow(() -> new InvoiceApiException(ErrorCode.INVOICE_PAYMENT_BY_ATTEMPT_NOT_FOUND, paymentId));
+
+            // Retrieve the amounts to adjust, if needed
+            final Map<UUID, BigDecimal> invoiceItemIdsWithAmounts = invoiceDaoHelper.computeItemAdjustments(payment.getInvoiceId().toString(),
+                                                                                                            invoicesTags,
+                                                                                                            entitySqlDaoWrapperFactory,
+                                                                                                            invoiceItemIdsWithNullAmounts,
+                                                                                                            context);
+
+            // Compute the actual amount to refund
+            final BigDecimal requestedPositiveAmount = invoiceDaoHelper.computePositiveRefundAmount(payment, requestedRefundAmount, invoiceItemIdsWithAmounts);
+
+            InvoicePaymentModelDao result;
+
+            // Before we go further, check if that refund already got inserted -- the payment system keeps a state machine
+            // and so this call may be called several time for the same  paymentCookieId (which is really the refundId)
+            final InvoicePaymentModelDao existingRefund = transactional.getPaymentForCookieId(transactionExternalKey, context);
+            if (existingRefund != null) {
+
+                Preconditions.checkState(existingRefund.getAmount().compareTo(requestedPositiveAmount.negate()) == 0,
+                                         "Found refund for transactionExternalKey=" + transactionExternalKey + ", amount=" + existingRefund.getAmount() +
+                                         "and does not match input amount=" + requestedPositiveAmount.negate());
+
+                Preconditions.checkState(existingRefund.getPaymentId().compareTo(paymentId) == 0,
+                                         "Found refund for transactionExternalKey=" + transactionExternalKey + ", paymentId=" + existingRefund.getPaymentId() +
+                                         "and does not match input paymentId=" + paymentId);
+
+                // The pending entry already exists, bail out (no need to send events, or compute cba logic)
+                if (!existingRefund.getSuccess() && !success) {
+                    return existingRefund;
                 }
 
-                // Retrieve the amounts to adjust, if needed
-                final Map<UUID, BigDecimal> invoiceItemIdsWithAmounts = invoiceDaoHelper.computeItemAdjustments(payment.getInvoiceId().toString(),
-                                                                                                                invoicesTags,
-                                                                                                                entitySqlDaoWrapperFactory,
-                                                                                                                invoiceItemIdsWithNullAmounts,
-                                                                                                                context);
-
-                // Compute the actual amount to refund
-                final BigDecimal requestedPositiveAmount = invoiceDaoHelper.computePositiveRefundAmount(payment, requestedRefundAmount, invoiceItemIdsWithAmounts);
-
-                InvoicePaymentModelDao result;
-
-                // Before we go further, check if that refund already got inserted -- the payment system keeps a state machine
-                // and so this call may be called several time for the same  paymentCookieId (which is really the refundId)
-                final InvoicePaymentModelDao existingRefund = transactional.getPaymentForCookieId(transactionExternalKey, context);
-                if (existingRefund != null) {
-
-                    Preconditions.checkState(existingRefund.getAmount().compareTo(requestedPositiveAmount.negate()) == 0,
-                                             "Found refund for transactionExternalKey=" + transactionExternalKey + ", amount=" + existingRefund.getAmount() +
-                                             "and does not match input amount=" + requestedPositiveAmount.negate());
-
-                    Preconditions.checkState(existingRefund.getPaymentId().compareTo(paymentId) == 0,
-                                             "Found refund for transactionExternalKey=" + transactionExternalKey + ", paymentId=" + existingRefund.getPaymentId() +
-                                             "and does not match input paymentId=" + paymentId);
-
-                    // The pending entry already exists, bail out (no need to send events, or compute cba logic)
-                    if (!existingRefund.getSuccess() && !success) {
-                        return existingRefund;
-                    }
-
-                    // At this point, we expect the request to be a transition PENDING -> SUCCESS (SUCCESS -> SUCCESS is also tolerated)
-                    Preconditions.checkState(success, "Found successful refund for transactionExternalKey=" + transactionExternalKey + "and does not match pending input");
-                    // We only update date and the status
-                    existingRefund.setSuccess(true);
-                    existingRefund.setPaymentDate(context.getCreatedDate());
-                    transactional.updateAttempt(existingRefund.getId().toString(),
-                                                existingRefund.getPaymentId().toString(),
-                                                existingRefund.getPaymentDate().toDate(),
-                                                existingRefund.getAmount(),
-                                                existingRefund.getCurrency(),
-                                                existingRefund.getProcessedCurrency(),
-                                                existingRefund.getPaymentCookieId(),
-                                                existingRefund.getLinkedInvoicePaymentId().toString(),
-                                                existingRefund.getSuccess(),
-                                                context);
-                    result = existingRefund;
-                } else {
-                    final InvoicePaymentModelDao refund = new InvoicePaymentModelDao(UUIDs.randomUUID(), context.getCreatedDate(), InvoicePaymentType.REFUND,
-                                                                                     payment.getInvoiceId(), paymentId,
-                                                                                     context.getCreatedDate(), requestedPositiveAmount.negate(),
-                                                                                     payment.getCurrency(), payment.getProcessedCurrency(), transactionExternalKey, payment.getId(), success);
-                    result = createAndRefresh(transactional, refund, context);
-                }
-
-                if (success) {
-                    // Retrieve invoice after the Refund
-                    final InvoiceModelDao invoice = transInvoiceDao.getById(payment.getInvoiceId().toString(), context);
-                    Preconditions.checkState(invoice != null, "Invoice shouldn't be null for payment " + payment.getId());
-                    invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
-
-                    final InvoiceItemSqlDao transInvoiceItemDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-
-                    // At this point, we created the refund which made the invoice balance positive and applied any existing
-                    // available CBA to that invoice.
-                    // We now need to adjust the invoice and/or invoice items if needed and specified.
-                    final Set<UUID> initSet = new HashSet<>();
-                    if (isInvoiceAdjusted) {
-                        // Invoice item adjustment
-                        for (final Entry<UUID, BigDecimal> entry : invoiceItemIdsWithAmounts.entrySet()) {
-                            final BigDecimal adjAmount = entry.getValue();
-                            final InvoiceItemModelDao item = invoiceDaoHelper.createAdjustmentItem(entitySqlDaoWrapperFactory, invoice.getId(), entry.getKey(), adjAmount,
-                                                                                                   invoice.getCurrency(), context.getCreatedDate().toLocalDate(),
-                                                                                                   context);
-
-                            createInvoiceItemFromTransaction(transInvoiceItemDao, item, context);
-                            invoice.addInvoiceItem(item);
-                        }
-                        initSet.add(invoice.getId());
-                    }
-
-                    // The invoice object has been kept up-to-date, we can pass it to CBA complexity
-                    final CBALogicWrapper cbaWrapper = new CBALogicWrapper(invoice.getAccountId(), invoicesTags, context, entitySqlDaoWrapperFactory);
-                    cbaWrapper.runCBALogicWithNotificationEvents(initSet, ImmutableSet.of(), ImmutableList.of(invoice));
-
-                }
-                final UUID accountId = transactional.getAccountIdFromInvoicePaymentId(result.getId().toString(), context);
-                notifyBusOfInvoicePayment(entitySqlDaoWrapperFactory, result, accountId, paymentAttemptId, context.getUserToken(), context);
-                return result;
+                // At this point, we expect the request to be a transition PENDING -> SUCCESS (SUCCESS -> SUCCESS is also tolerated)
+                Preconditions.checkState(success, "Found successful refund for transactionExternalKey=" + transactionExternalKey + "and does not match pending input");
+                // We only update date and the status
+                existingRefund.setSuccess(true);
+                existingRefund.setPaymentDate(context.getCreatedDate());
+                transactional.updateAttempt(existingRefund.getId().toString(),
+                                            existingRefund.getPaymentId().toString(),
+                                            existingRefund.getPaymentDate().toDate(),
+                                            existingRefund.getAmount(),
+                                            existingRefund.getCurrency(),
+                                            existingRefund.getProcessedCurrency(),
+                                            existingRefund.getPaymentCookieId(),
+                                            existingRefund.getLinkedInvoicePaymentId().toString(),
+                                            existingRefund.getSuccess(),
+                                            context);
+                result = existingRefund;
+            } else {
+                final InvoicePaymentModelDao refund = new InvoicePaymentModelDao(UUIDs.randomUUID(), context.getCreatedDate(), InvoicePaymentType.REFUND,
+                                                                                 payment.getInvoiceId(), paymentId,
+                                                                                 context.getCreatedDate(), requestedPositiveAmount.negate(),
+                                                                                 payment.getCurrency(), payment.getProcessedCurrency(), transactionExternalKey, payment.getId(), success);
+                result = createAndRefresh(transactional, refund, context);
             }
+
+            if (success) {
+                // Retrieve invoice after the Refund
+                final InvoiceModelDao invoice = transInvoiceDao.getById(payment.getInvoiceId().toString(), context);
+                Preconditions.checkState(invoice != null, "Invoice shouldn't be null for payment " + payment.getId());
+                invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
+
+                final InvoiceItemSqlDao transInvoiceItemDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
+
+                // At this point, we created the refund which made the invoice balance positive and applied any existing
+                // available CBA to that invoice.
+                // We now need to adjust the invoice and/or invoice items if needed and specified.
+                final Set<UUID> initSet = new HashSet<>();
+                if (isInvoiceAdjusted) {
+                    // Invoice item adjustment
+                    for (final Entry<UUID, BigDecimal> entry : invoiceItemIdsWithAmounts.entrySet()) {
+                        final BigDecimal adjAmount = entry.getValue();
+                        final InvoiceItemModelDao item = invoiceDaoHelper.createAdjustmentItem(entitySqlDaoWrapperFactory, invoice.getId(), entry.getKey(), adjAmount,
+                                                                                               invoice.getCurrency(), context.getCreatedDate().toLocalDate(),
+                                                                                               context);
+
+                        createInvoiceItemFromTransaction(transInvoiceItemDao, item, context);
+                        invoice.addInvoiceItem(item);
+                    }
+                    initSet.add(invoice.getId());
+                }
+
+                // The invoice object has been kept up-to-date, we can pass it to CBA complexity
+                final CBALogicWrapper cbaWrapper = new CBALogicWrapper(invoice.getAccountId(), invoicesTags, context, entitySqlDaoWrapperFactory);
+                cbaWrapper.runCBALogicWithNotificationEvents(initSet, Collections.emptySet(), List.of(invoice));
+
+            }
+            final UUID accountId = transactional.getAccountIdFromInvoicePaymentId(result.getId().toString(), context);
+            notifyBusOfInvoicePayment(entitySqlDaoWrapperFactory, result, accountId, paymentAttemptId, context.getUserToken(), context);
+            return result;
         });
     }
 
@@ -802,55 +705,49 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     public InvoicePaymentModelDao postChargeback(final UUID paymentId, final UUID paymentAttemptId, final String chargebackTransactionExternalKey, final BigDecimal amount, final Currency currency, final InternalCallContext context) throws InvoiceApiException {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoicePaymentModelDao>() {
-            @Override
-            public InvoicePaymentModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
+        return transactionalSqlDao.execute(false, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
 
-                final List<InvoicePaymentModelDao> invoicePayments = transactional.getByPaymentId(paymentId.toString(), context);
-                final InvoicePaymentModelDao invoicePayment = Iterables.tryFind(invoicePayments, new Predicate<InvoicePaymentModelDao>() {
-                    @Override
-                    public boolean apply(final InvoicePaymentModelDao input) {
-                        return input.getType() == InvoicePaymentType.ATTEMPT;
-                    }
-                }).orNull();
-                if (invoicePayment == null) {
-                    throw new InvoiceApiException(ErrorCode.PAYMENT_NO_SUCH_PAYMENT, paymentId);
-                }
-                // We expect the code to correctly pass the account currency -- the payment code, more generic accept chargeBack in different currencies,
-                // but this is only for direct payment (no invoice)
-                Preconditions.checkArgument(invoicePayment.getCurrency() == currency, String.format("Invoice payment currency %s doesn't match chargeback currency %s", invoicePayment.getCurrency(), currency));
+            final List<InvoicePaymentModelDao> invoicePayments = transactional.getByPaymentId(paymentId.toString(), context);
+            final InvoicePaymentModelDao invoicePayment = invoicePayments.stream()
+                                                                         .filter(input -> input.getType() == InvoicePaymentType.ATTEMPT)
+                                                                         .findFirst()
+                                                                         .orElseThrow(() -> new InvoiceApiException(ErrorCode.PAYMENT_NO_SUCH_PAYMENT, paymentId));
 
-                final UUID invoicePaymentId = invoicePayment.getId();
-                final BigDecimal maxChargedBackAmount = invoiceDaoHelper.getRemainingAmountPaidFromTransaction(invoicePaymentId, entitySqlDaoWrapperFactory, context);
-                final BigDecimal requestedChargedBackAmount = (amount == null) ? maxChargedBackAmount : amount;
-                if (requestedChargedBackAmount.compareTo(BigDecimal.ZERO) <= 0) {
-                    throw new InvoiceApiException(ErrorCode.CHARGE_BACK_AMOUNT_IS_NEGATIVE);
-                }
-                if (requestedChargedBackAmount.compareTo(maxChargedBackAmount) > 0) {
-                    throw new InvoiceApiException(ErrorCode.CHARGE_BACK_AMOUNT_TOO_HIGH, requestedChargedBackAmount, maxChargedBackAmount);
-                }
+            // We expect the code to correctly pass the account currency -- the payment code, more generic accept chargeBack in different currencies,
+            // but this is only for direct payment (no invoice)
+            Preconditions.checkArgument(invoicePayment.getCurrency() == currency, String.format("Invoice payment currency %s doesn't match chargeback currency %s", invoicePayment.getCurrency(), currency));
 
-                final InvoicePaymentModelDao payment = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getById(invoicePaymentId.toString(), context);
-                if (payment == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_PAYMENT_NOT_FOUND, invoicePaymentId.toString());
-                }
-                final InvoicePaymentModelDao chargeBack = new InvoicePaymentModelDao(UUIDs.randomUUID(), context.getCreatedDate(), InvoicePaymentType.CHARGED_BACK,
-                                                                                     payment.getInvoiceId(), payment.getPaymentId(), context.getCreatedDate(),
-                                                                                     requestedChargedBackAmount.negate(), payment.getCurrency(), payment.getProcessedCurrency(),
-                                                                                     chargebackTransactionExternalKey, payment.getId(), true);
-                createAndRefresh(transactional, chargeBack, context);
-
-                // Notify the bus since the balance of the invoice changed
-                final UUID accountId = transactional.getAccountIdFromInvoicePaymentId(chargeBack.getId().toString(), context);
-
-                final CBALogicWrapper cbaWrapper = new CBALogicWrapper(accountId, invoicesTags, context, entitySqlDaoWrapperFactory);
-                cbaWrapper.runCBALogicWithNotificationEvents(ImmutableSet.<UUID>of(payment.getInvoiceId()));
-
-                notifyBusOfInvoicePayment(entitySqlDaoWrapperFactory, chargeBack, accountId, paymentAttemptId, context.getUserToken(), context);
-
-                return chargeBack;
+            final UUID invoicePaymentId = invoicePayment.getId();
+            final BigDecimal maxChargedBackAmount = invoiceDaoHelper.getRemainingAmountPaidFromTransaction(invoicePaymentId, entitySqlDaoWrapperFactory, context);
+            final BigDecimal requestedChargedBackAmount = (amount == null) ? maxChargedBackAmount : amount;
+            if (requestedChargedBackAmount.compareTo(BigDecimal.ZERO) <= 0) {
+                throw new InvoiceApiException(ErrorCode.CHARGE_BACK_AMOUNT_IS_NEGATIVE);
             }
+            if (requestedChargedBackAmount.compareTo(maxChargedBackAmount) > 0) {
+                throw new InvoiceApiException(ErrorCode.CHARGE_BACK_AMOUNT_TOO_HIGH, requestedChargedBackAmount, maxChargedBackAmount);
+            }
+
+            final InvoicePaymentModelDao payment = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getById(invoicePaymentId.toString(), context);
+            if (payment == null) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_PAYMENT_NOT_FOUND, invoicePaymentId.toString());
+            }
+            final InvoicePaymentModelDao chargeBack = new InvoicePaymentModelDao(UUIDs.randomUUID(), context.getCreatedDate(), InvoicePaymentType.CHARGED_BACK,
+                                                                                 payment.getInvoiceId(), payment.getPaymentId(), context.getCreatedDate(),
+                                                                                 requestedChargedBackAmount.negate(), payment.getCurrency(), payment.getProcessedCurrency(),
+                                                                                 chargebackTransactionExternalKey, payment.getId(), true);
+            createAndRefresh(transactional, chargeBack, context);
+
+            // Notify the bus since the balance of the invoice changed
+            // FIXME-1615 : Intellij report that this line and another line in #postChargebackReversal() contains the same logic
+            final UUID accountId = transactional.getAccountIdFromInvoicePaymentId(chargeBack.getId().toString(), context);
+
+            final CBALogicWrapper cbaWrapper = new CBALogicWrapper(accountId, invoicesTags, context, entitySqlDaoWrapperFactory);
+            cbaWrapper.runCBALogicWithNotificationEvents(Set.of(payment.getInvoiceId()));
+
+            notifyBusOfInvoicePayment(entitySqlDaoWrapperFactory, chargeBack, accountId, paymentAttemptId, context.getUserToken(), context);
+
+            return chargeBack;
         });
     }
 
@@ -858,136 +755,105 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     public InvoicePaymentModelDao postChargebackReversal(final UUID paymentId, final UUID paymentAttemptId, final String chargebackTransactionExternalKey, final InternalCallContext context) throws InvoiceApiException {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoicePaymentModelDao>() {
-            @Override
-            public InvoicePaymentModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
+        return transactionalSqlDao.execute(false, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
 
-                final InvoicePaymentModelDao invoicePayment = transactional.getPaymentForCookieId(chargebackTransactionExternalKey, context);
-                if (invoicePayment == null) {
-                    throw new InvoiceApiException(ErrorCode.PAYMENT_NO_SUCH_PAYMENT, paymentId);
-                }
-
-                transactional.updateAttempt(invoicePayment.getId().toString(),
-                                            invoicePayment.getPaymentId().toString(),
-                                            invoicePayment.getPaymentDate().toDate(),
-                                            invoicePayment.getAmount(),
-                                            invoicePayment.getCurrency(),
-                                            invoicePayment.getProcessedCurrency(),
-                                            invoicePayment.getPaymentCookieId(),
-                                            invoicePayment.getLinkedInvoicePaymentId() == null ? null : invoicePayment.getLinkedInvoicePaymentId().toString(),
-                                            false,
-                                            context);
-                final InvoicePaymentModelDao chargebackReversed = transactional.getByRecordId(invoicePayment.getRecordId(), context);
-
-                // Notify the bus since the balance of the invoice changed
-                final UUID accountId = transactional.getAccountIdFromInvoicePaymentId(chargebackReversed.getId().toString(), context);
-
-                final CBALogicWrapper cbaWrapper = new CBALogicWrapper(accountId, invoicesTags, context, entitySqlDaoWrapperFactory);
-                cbaWrapper.runCBALogicWithNotificationEvents(ImmutableSet.of(chargebackReversed.getInvoiceId()));
-
-                notifyBusOfInvoicePayment(entitySqlDaoWrapperFactory, chargebackReversed, accountId, paymentAttemptId, context.getUserToken(), context);
-
-                return chargebackReversed;
+            final InvoicePaymentModelDao invoicePayment = transactional.getPaymentForCookieId(chargebackTransactionExternalKey, context);
+            if (invoicePayment == null) {
+                throw new InvoiceApiException(ErrorCode.PAYMENT_NO_SUCH_PAYMENT, paymentId);
             }
+
+            transactional.updateAttempt(invoicePayment.getId().toString(),
+                                        invoicePayment.getPaymentId().toString(),
+                                        invoicePayment.getPaymentDate().toDate(),
+                                        invoicePayment.getAmount(),
+                                        invoicePayment.getCurrency(),
+                                        invoicePayment.getProcessedCurrency(),
+                                        invoicePayment.getPaymentCookieId(),
+                                        invoicePayment.getLinkedInvoicePaymentId() == null ? null : invoicePayment.getLinkedInvoicePaymentId().toString(),
+                                        false,
+                                        context);
+            final InvoicePaymentModelDao chargebackReversed = transactional.getByRecordId(invoicePayment.getRecordId(), context);
+
+            // Notify the bus since the balance of the invoice changed
+            final UUID accountId = transactional.getAccountIdFromInvoicePaymentId(chargebackReversed.getId().toString(), context);
+
+            final CBALogicWrapper cbaWrapper = new CBALogicWrapper(accountId, invoicesTags, context, entitySqlDaoWrapperFactory);
+            cbaWrapper.runCBALogicWithNotificationEvents(Set.of(chargebackReversed.getInvoiceId()));
+
+            notifyBusOfInvoicePayment(entitySqlDaoWrapperFactory, chargebackReversed, accountId, paymentAttemptId, context.getUserToken(), context);
+
+            return chargebackReversed;
         });
     }
 
     @Override
     public InvoiceItemModelDao doCBAComplexity(final InvoiceModelDao invoice, final InternalCallContext context) throws InvoiceApiException {
-        return transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoiceItemModelDao>() {
-            @Override
-            public InvoiceItemModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceItemModelDao cbaNewItem = cbaDao.computeCBAComplexity(invoice, null, entitySqlDaoWrapperFactory, context);
-                return cbaNewItem;
-            }
-        });
+        return transactionalSqlDao.execute(false, InvoiceApiException.class, entitySqlDaoWrapperFactory -> cbaDao.computeCBAComplexity(invoice, null, entitySqlDaoWrapperFactory, context));
     }
 
     @Override
     public Map<UUID, BigDecimal> computeItemAdjustments(final String invoiceId, final Map<UUID, BigDecimal> invoiceItemIdsWithNullAmounts, final InternalTenantContext context) throws InvoiceApiException {
         final List<Tag> invoicesTags = getInvoicesTags(context);
-
-        return transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<Map<UUID, BigDecimal>>() {
-            @Override
-            public Map<UUID, BigDecimal> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return invoiceDaoHelper.computeItemAdjustments(invoiceId, invoicesTags, entitySqlDaoWrapperFactory, invoiceItemIdsWithNullAmounts, context);
-            }
-        });
+        return transactionalSqlDao.execute(false, InvoiceApiException.class, sqlWrapperFactory -> invoiceDaoHelper.computeItemAdjustments(invoiceId, invoicesTags, sqlWrapperFactory, invoiceItemIdsWithNullAmounts, context));
     }
 
     @Override
     public BigDecimal getRemainingAmountPaid(final UUID invoicePaymentId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<BigDecimal>() {
-            @Override
-            public BigDecimal inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return invoiceDaoHelper.getRemainingAmountPaidFromTransaction(invoicePaymentId, entitySqlDaoWrapperFactory, context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> invoiceDaoHelper.getRemainingAmountPaidFromTransaction(invoicePaymentId, entitySqlDaoWrapperFactory, context));
     }
 
     @Override
     public UUID getAccountIdFromInvoicePaymentId(final UUID invoicePaymentId, final InternalTenantContext context) throws InvoiceApiException {
-        return transactionalSqlDao.execute(true, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<UUID>() {
-            @Override
-            public UUID inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final UUID accountId = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getAccountIdFromInvoicePaymentId(invoicePaymentId.toString(), context);
-                if (accountId == null) {
-                    throw new InvoiceApiException(ErrorCode.CHARGE_BACK_COULD_NOT_FIND_ACCOUNT_ID, invoicePaymentId);
-                } else {
-                    return accountId;
-                }
+        return transactionalSqlDao.execute(true, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final UUID accountId = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getAccountIdFromInvoicePaymentId(invoicePaymentId.toString(), context);
+            if (accountId == null) {
+                throw new InvoiceApiException(ErrorCode.CHARGE_BACK_COULD_NOT_FIND_ACCOUNT_ID, invoicePaymentId);
+            } else {
+                return accountId;
             }
         });
     }
 
     @Override
     public List<InvoicePaymentModelDao> getChargebacksByAccountId(final UUID accountId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoicePaymentModelDao>>() {
-            @Override
-            public List<InvoicePaymentModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getChargeBacksByAccountId(accountId.toString(), context);
-            }
-        });
+        return transactionalSqlDao.execute(true, sqlWrapperFactory -> sqlWrapperFactory.become(InvoicePaymentSqlDao.class).getChargeBacksByAccountId(accountId.toString(), context));
     }
 
     @Override
     public List<InvoicePaymentModelDao> getChargebacksByPaymentId(final UUID paymentId, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoicePaymentModelDao>>() {
-            @Override
-            public List<InvoicePaymentModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                return entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getChargebacksByPaymentId(paymentId.toString(), context);
-            }
-        });
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getChargebacksByPaymentId(paymentId.toString(), context));
     }
 
     @Override
     public InvoicePaymentModelDao getChargebackById(final UUID chargebackId, final InternalTenantContext context) throws InvoiceApiException {
-        return transactionalSqlDao.execute(true, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoicePaymentModelDao>() {
-            @Override
-            public InvoicePaymentModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoicePaymentModelDao chargeback = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getById(chargebackId.toString(), context);
-                if (chargeback == null) {
-                    throw new InvoiceApiException(ErrorCode.CHARGE_BACK_DOES_NOT_EXIST, chargebackId);
-                } else {
-                    return chargeback;
-                }
+        return transactionalSqlDao.execute(true, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoicePaymentModelDao chargeback = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class).getById(chargebackId.toString(), context);
+            if (chargeback == null) {
+                throw new InvoiceApiException(ErrorCode.CHARGE_BACK_DOES_NOT_EXIST, chargebackId);
+            } else {
+                return chargeback;
             }
         });
     }
 
     @Override
     public InvoiceItemModelDao getExternalChargeById(final UUID externalChargeId, final InternalTenantContext context) throws InvoiceApiException {
-        return transactionalSqlDao.execute(true, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoiceItemModelDao>() {
-            @Override
-            public InvoiceItemModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceItemSqlDao invoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-                final InvoiceItemModelDao invoiceItemModelDao = invoiceItemSqlDao.getById(externalChargeId.toString(), context);
-                if (invoiceItemModelDao == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, externalChargeId.toString());
-                }
-                return invoiceItemModelDao;
+        return getInvoiceItemById(externalChargeId, context);
+    }
+
+    /**
+     * {@link #getExternalChargeById(UUID, InternalTenantContext)} and {@link #getCreditById(UUID, InternalTenantContext)}
+     * contains the same logic, thus unify them here.
+     */
+    private InvoiceItemModelDao getInvoiceItemById(final UUID invoiceItemId, final InternalTenantContext context) throws InvoiceApiException {
+        return transactionalSqlDao.execute(true, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoiceItemSqlDao invoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
+            final InvoiceItemModelDao invoiceItemModelDao = invoiceItemSqlDao.getById(invoiceItemId.toString(), context);
+            if (invoiceItemModelDao == null) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId.toString());
             }
+            return invoiceItemModelDao;
         });
     }
 
@@ -1002,81 +868,71 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     }
 
     private void notifyOfPaymentCompletionInternal(final InvoicePaymentModelDao invoicePayment, final UUID paymentAttemptId, final boolean completion, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
+            //
+            // In case of notifyOfPaymentInit we always want to record the row with success = false
+            // Otherwise, if the payment id is null, the payment wasn't attempted (e.g. no payment method so we don't record an attempt but send
+            // an event nonetheless (e.g. for Overdue))
+            //
+            if (!completion || invoicePayment.getPaymentId() != null) {
                 //
-                // In case of notifyOfPaymentInit we always want to record the row with success = false
-                // Otherwise, if the payment id is null, the payment wasn't attempted (e.g. no payment method so we don't record an attempt but send
-                // an event nonetheless (e.g. for Overdue))
+                // extract entries by invoiceId (which is always set, as opposed to paymentId) and then filter based on type and
+                // paymentCookieId = transactionExternalKey
                 //
-                if (!completion || invoicePayment.getPaymentId() != null) {
-                    //
-                    // extract entries by invoiceId (which is always set, as opposed to paymentId) and then filter based on type and
-                    // paymentCookieId = transactionExternalKey
-                    //
-                    final List<InvoicePaymentModelDao> invoicePayments = transactional.getAllPaymentsForInvoiceIncludedInit(invoicePayment.getInvoiceId().toString(), context);
-                    final InvoicePaymentModelDao existingAttempt = Iterables.tryFind(invoicePayments, new Predicate<InvoicePaymentModelDao>() {
-                        @Override
-                        public boolean apply(final InvoicePaymentModelDao input) {
-                            return input.getType() == InvoicePaymentType.ATTEMPT &&
-                                   input.getPaymentCookieId().equals(invoicePayment.getPaymentCookieId());
-                        }
-                    }).orNull();
+                final List<InvoicePaymentModelDao> invoicePayments = transactional.getAllPaymentsForInvoiceIncludedInit(invoicePayment.getInvoiceId().toString(), context);
+                final InvoicePaymentModelDao existingAttempt = invoicePayments.stream()
+                                                                              .filter(input -> input.getType() == InvoicePaymentType.ATTEMPT &&
+                                                                                               input.getPaymentCookieId().equals(invoicePayment.getPaymentCookieId()))
+                                                                              .findFirst()
+                                                                              .orElse(null);
 
-                    if (existingAttempt == null) {
-                        createAndRefresh(transactional, invoicePayment, context);
+                if (existingAttempt == null) {
+                    createAndRefresh(transactional, invoicePayment, context);
+                } else {
+                    final UUID updatedPaymentId;
+                    if (invoicePayment.getPaymentId() == null) {
+                        // Likely invalid state (https://github.com/killbill/killbill/issues/1230) but go ahead nonetheless to run the payment state machine validations
+                        updatedPaymentId = existingAttempt.getPaymentId();
+                    } else if (existingAttempt.getPaymentId() == null) {
+                        updatedPaymentId = invoicePayment.getPaymentId();
                     } else {
-                        final UUID updatedPaymentId;
-                        if (invoicePayment.getPaymentId() == null) {
-                            // Likely invalid state (https://github.com/killbill/killbill/issues/1230) but go ahead nonetheless to run the payment state machine validations
-                            updatedPaymentId = existingAttempt.getPaymentId();
-                        } else if (existingAttempt.getPaymentId() == null) {
-                            updatedPaymentId = invoicePayment.getPaymentId();
-                        } else {
-                            Preconditions.checkState(invoicePayment.getPaymentId().equals(existingAttempt.getPaymentId()),
-                                                     "PaymentAttempt cannot change paymentId: attemptId=%s, newInvoicePaymentId=%s, existingPaymentId=%s", existingAttempt.getId(), invoicePayment.getPaymentId(), existingAttempt.getPaymentId());
-                            updatedPaymentId = invoicePayment.getPaymentId();
-                        }
-                        transactional.updateAttempt(existingAttempt.getId().toString(),
-                                                    updatedPaymentId == null ? null : updatedPaymentId.toString(),
-                                                    invoicePayment.getPaymentDate().toDate(),
-                                                    invoicePayment.getAmount(),
-                                                    invoicePayment.getCurrency(),
-                                                    invoicePayment.getProcessedCurrency(),
-                                                    invoicePayment.getPaymentCookieId(),
-                                                    null,
-                                                    invoicePayment.getSuccess(),
-                                                    context);
+                        Preconditions.checkState(invoicePayment.getPaymentId().equals(existingAttempt.getPaymentId()),
+                                                 "PaymentAttempt cannot change paymentId: attemptId=%s, newInvoicePaymentId=%s, existingPaymentId=%s", existingAttempt.getId(), invoicePayment.getPaymentId(), existingAttempt.getPaymentId());
+                        updatedPaymentId = invoicePayment.getPaymentId();
                     }
+                    transactional.updateAttempt(existingAttempt.getId().toString(),
+                                                updatedPaymentId == null ? null : updatedPaymentId.toString(),
+                                                invoicePayment.getPaymentDate().toDate(),
+                                                invoicePayment.getAmount(),
+                                                invoicePayment.getCurrency(),
+                                                invoicePayment.getProcessedCurrency(),
+                                                invoicePayment.getPaymentCookieId(),
+                                                null,
+                                                invoicePayment.getSuccess(),
+                                                context);
                 }
-
-                if (completion) {
-                    final UUID accountId = nonEntityDao.retrieveIdFromObjectInTransaction(context.getAccountRecordId(), ObjectType.ACCOUNT, objectIdCacheController, entitySqlDaoWrapperFactory.getHandle());
-                    notifyBusOfInvoicePayment(entitySqlDaoWrapperFactory, invoicePayment, accountId, paymentAttemptId, context.getUserToken(), context);
-                }
-                return null;
             }
+
+            if (completion) {
+                final UUID accountId = nonEntityDao.retrieveIdFromObjectInTransaction(context.getAccountRecordId(), ObjectType.ACCOUNT, objectIdCacheController, entitySqlDaoWrapperFactory.getHandle());
+                notifyBusOfInvoicePayment(entitySqlDaoWrapperFactory, invoicePayment, accountId, paymentAttemptId, context.getUserToken(), context);
+            }
+            return null;
         });
     }
 
     @Override
     public InvoiceItemModelDao getCreditById(final UUID creditId, final InternalTenantContext context) throws InvoiceApiException {
-        return transactionalSqlDao.execute(true, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoiceItemModelDao>() {
-            @Override
-            public InvoiceItemModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceItemSqlDao invoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-                final InvoiceItemModelDao invoiceItemModelDao = invoiceItemSqlDao.getById(creditId.toString(), context);
-                if (invoiceItemModelDao == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, creditId.toString());
-                }
-                return invoiceItemModelDao;
-            }
-        });
+        return getInvoiceItemById(creditId, context);
     }
 
-    private BigDecimal reclaimCreditFromTransaction(final UUID accountId, final BigDecimal amountToReclaim, final Set<UUID> invoiceIds, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalCallContext context) throws InvoiceApiException, EntityPersistenceException {
+    // FIXME-1615 : accountId not used
+    private BigDecimal reclaimCreditFromTransaction(final UUID accountId,
+                                                    final BigDecimal amountToReclaim,
+                                                    final Set<UUID> invoiceIds,
+                                                    final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
+                                                    final InternalCallContext context) throws InvoiceApiException, EntityPersistenceException {
 
         final InvoiceItemSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
         final List<InvoiceItemModelDao> cbaUsedItems = transactional.getConsumedCBAItems(context);
@@ -1104,65 +960,62 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         final List<Tag> invoicesTags = getInvoicesTags(context);
         final Set<UUID> invoiceIds = new HashSet<>();
 
-        transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+        transactionalSqlDao.execute(false, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
 
-                // Retrieve the invoice and make sure it belongs to the right account
-                final InvoiceModelDao invoice = invoiceSqlDao.getById(invoiceId.toString(), context);
-                if (invoice == null ||
-                    !invoice.getAccountId().equals(accountId) ||
-                    invoice.isMigrated() ||
-                    invoice.getStatus() != InvoiceStatus.COMMITTED) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_NOT_FOUND, invoiceId);
-                }
-                invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
-
-                // Retrieve the invoice item and make sure it belongs to the right invoice
-                final InvoiceItemSqlDao invoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-                final InvoiceItemModelDao cbaItem = invoiceItemSqlDao.getById(invoiceItemId.toString(), context);
-                if (cbaItem == null || !cbaItem.getInvoiceId().equals(invoice.getId())) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId);
-                }
-
-                if (cbaItem.getAmount().compareTo(BigDecimal.ZERO) < 0) { /* Credit consumption */
-
-                    invoiceItemSqlDao.updateItemFields(cbaItem.getId().toString(), BigDecimal.ZERO, "Delete used credit", null, context);
-                    invoiceIds.add(invoice.getId());
-                } else if (cbaItem.getAmount().compareTo(BigDecimal.ZERO) > 0) {  /* Credit generation */
-                    final InvoiceItemModelDao creditItem = Iterables.tryFind(invoice.getInvoiceItems(), new Predicate<InvoiceItemModelDao>() {
-                        @Override
-                        public boolean apply(final InvoiceItemModelDao targetItem) {
-                            return targetItem.getType() == InvoiceItemType.CREDIT_ADJ && targetItem.getAmount().negate().compareTo(cbaItem.getAmount()) >= 0;
-                        }
-                    }).orNull();
-
-                    // In case this is a credit invoice (pure credit, or mixed), we allow to 'delete' credit generation
-                    if (creditItem != null) { /* Credit Invoice */
-                            final BigDecimal accountCBA = cbaDao.getAccountCBAFromTransaction(entitySqlDaoWrapperFactory, context);
-                        // If we don't have enough credit left on the account, we reclaim what is necessary
-                        if (accountCBA.compareTo(cbaItem.getAmount()) < 0) {
-                            final BigDecimal amountToReclaim = cbaItem.getAmount().subtract(accountCBA);
-                            final BigDecimal reclaimed = reclaimCreditFromTransaction(accountId, amountToReclaim, invoiceIds, entitySqlDaoWrapperFactory, context);
-                            Preconditions.checkState(reclaimed.compareTo(amountToReclaim) == 0,
-                                                     String.format("Unexpected state, reclaimed used credit [%s/%s]", reclaimed, amountToReclaim));
-                        }
-
-                        invoiceItemSqlDao.updateItemFields(cbaItem.getId().toString(), BigDecimal.ZERO, "Delete gen credit", null, context);
-                        final BigDecimal adjustedCreditAmount = creditItem.getAmount().add(cbaItem.getAmount());
-                        invoiceItemSqlDao.updateItemFields(creditItem.getId().toString(), adjustedCreditAmount, "Delete gen credit", null, context);
-                        invoiceIds.add(invoice.getId());
-                    } else /* System generated credit, e.g Repair invoice */ {
-                        // TODO Add missing error https://github.com/killbill/killbill/issues/1501
-                        throw new IllegalStateException("Cannot delete system generated credit");
-                    }
-                }
-                for (final UUID invoiceId : invoiceIds) {
-                    notifyBusOfInvoiceAdjustment(entitySqlDaoWrapperFactory, invoiceId, accountId, context.getUserToken(), context);
-                }
-                return null;
+            // Retrieve the invoice and make sure it belongs to the right account
+            final InvoiceModelDao invoice = invoiceSqlDao.getById(invoiceId.toString(), context);
+            if (invoice == null ||
+                !invoice.getAccountId().equals(accountId) ||
+                invoice.isMigrated() ||
+                invoice.getStatus() != InvoiceStatus.COMMITTED) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_NOT_FOUND, invoiceId);
             }
+            invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
+
+            // Retrieve the invoice item and make sure it belongs to the right invoice
+            final InvoiceItemSqlDao invoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
+            final InvoiceItemModelDao cbaItem = invoiceItemSqlDao.getById(invoiceItemId.toString(), context);
+            if (cbaItem == null || !cbaItem.getInvoiceId().equals(invoice.getId())) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId);
+            }
+
+            if (cbaItem.getAmount().compareTo(BigDecimal.ZERO) < 0) { /* Credit consumption */
+
+                invoiceItemSqlDao.updateItemFields(cbaItem.getId().toString(), BigDecimal.ZERO, "Delete used credit", null, context);
+                invoiceIds.add(invoice.getId());
+            } else if (cbaItem.getAmount().compareTo(BigDecimal.ZERO) > 0) {  /* Credit generation */
+                final InvoiceItemModelDao creditItem = invoice.getInvoiceItems().stream()
+                                                              .filter(targetItem -> targetItem.getType() == InvoiceItemType.CREDIT_ADJ &&
+                                                                                    targetItem.getAmount().negate().compareTo(cbaItem.getAmount()) >= 0)
+                                                              .findFirst()
+                                                              .orElse(null);
+
+                // In case this is a credit invoice (pure credit, or mixed), we allow to 'delete' credit generation
+                if (creditItem != null) { /* Credit Invoice */
+                    final BigDecimal accountCBA = cbaDao.getAccountCBAFromTransaction(entitySqlDaoWrapperFactory, context);
+                    // If we don't have enough credit left on the account, we reclaim what is necessary
+                    if (accountCBA.compareTo(cbaItem.getAmount()) < 0) {
+                        final BigDecimal amountToReclaim = cbaItem.getAmount().subtract(accountCBA);
+                        final BigDecimal reclaimed = reclaimCreditFromTransaction(accountId, amountToReclaim, invoiceIds, entitySqlDaoWrapperFactory, context);
+                        Preconditions.checkState(reclaimed.compareTo(amountToReclaim) == 0,
+                                                 String.format("Unexpected state, reclaimed used credit [%s/%s]", reclaimed, amountToReclaim));
+                    }
+
+                    invoiceItemSqlDao.updateItemFields(cbaItem.getId().toString(), BigDecimal.ZERO, "Delete gen credit", null, context);
+                    final BigDecimal adjustedCreditAmount = creditItem.getAmount().add(cbaItem.getAmount());
+                    invoiceItemSqlDao.updateItemFields(creditItem.getId().toString(), adjustedCreditAmount, "Delete gen credit", null, context);
+                    invoiceIds.add(invoice.getId());
+                } else /* System generated credit, e.g Repair invoice */ {
+                    // TODO Add missing error https://github.com/killbill/killbill/issues/1501
+                    throw new IllegalStateException("Cannot delete system generated credit");
+                }
+            }
+            // renamed to 'invId' because: Variable 'invoiceId' is already defined in the scope
+            for (final UUID invId : invoiceIds) {
+                notifyBusOfInvoiceAdjustment(entitySqlDaoWrapperFactory, invId, accountId, context.getUserToken(), context);
+            }
+            return null;
         });
     }
 
@@ -1170,12 +1023,9 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     public void consumeExstingCBAOnAccountWithUnpaidInvoices(final UUID accountId, final InternalCallContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                cbaDao.doCBAComplexityFromTransaction(invoicesTags, entitySqlDaoWrapperFactory, context);
-                return null;
-            }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            cbaDao.doCBAComplexityFromTransaction(invoicesTags, entitySqlDaoWrapperFactory, context);
+            return null;
         });
     }
 
@@ -1195,24 +1045,36 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                 final DateTime notificationDateTime = internalCallContext.toUTCDateTime(notificationDate);
                 if (notificationDateTime.compareTo(internalCallContext.getCreatedDate()) > 0) {
                     final Set<UUID> subscriptionIds = callbackDateTimePerSubscriptions.getNotificationsForDryRun().get(notificationDate);
-                    nextBillingDatePoster.insertNextBillingDryRunNotificationFromTransaction(entitySqlDaoWrapperFactory, accountId, subscriptionIds, notificationDateTime, notificationDateTime.plusMillis((int) dryRunNotificationTime), internalCallContext);
+                    nextBillingDatePoster.insertNextBillingDryRunNotificationFromTransaction(entitySqlDaoWrapperFactory,
+                                                                                             accountId,
+                                                                                             subscriptionIds,
+                                                                                             notificationDateTime,
+                                                                                             notificationDateTime.plusMillis((int) dryRunNotificationTime),
+                                                                                             internalCallContext);
                 }
             }
         }
     }
 
-    private void notifyBusOfInvoiceAdjustment(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final UUID invoiceId, final UUID accountId,
+    private void notifyBusOfInvoiceAdjustment(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
+                                              final UUID invoiceId, final UUID accountId,
                                               final UUID userToken, final InternalCallContext context) {
         try {
-            eventBus.postFromTransaction(new DefaultInvoiceAdjustmentEvent(invoiceId, accountId, context.getAccountRecordId(), context.getTenantRecordId(), userToken),
+            eventBus.postFromTransaction(new DefaultInvoiceAdjustmentEvent(invoiceId,
+                                                                           accountId,
+                                                                           context.getAccountRecordId(),
+                                                                           context.getTenantRecordId(),
+                                                                           userToken),
                                          entitySqlDaoWrapperFactory.getHandle().getConnection());
         } catch (final EventBusException e) {
             log.warn("Failed to post adjustment event for invoiceId='{}'", invoiceId, e);
         }
     }
 
-    private void notifyBusOfInvoicePayment(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InvoicePaymentModelDao invoicePaymentModelDao,
-                                           final UUID accountId, final UUID paymentAttemptId, final UUID userToken, final InternalCallContext context) {
+    private void notifyBusOfInvoicePayment(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
+                                           final InvoicePaymentModelDao invoicePaymentModelDao,
+                                           final UUID accountId, final UUID paymentAttemptId, final UUID userToken,
+                                           final InternalCallContext context) {
         final BusEvent busEvent;
         if (Boolean.TRUE.equals(invoicePaymentModelDao.getSuccess())) {
             busEvent = new DefaultInvoicePaymentInfoEvent(accountId,
@@ -1290,55 +1152,48 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     }
 
     @Override
-    public void changeInvoiceStatus(final UUID invoiceId, final InvoiceStatus newStatus,
-                                    final InternalCallContext context) throws InvoiceApiException {
+    public void changeInvoiceStatus(final UUID invoiceId, final InvoiceStatus newStatus, final InternalCallContext context) throws InvoiceApiException {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+        transactionalSqlDao.execute(false, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
 
-                // Retrieve the invoice and make sure it belongs to the right account
-                final InvoiceModelDao invoice = transactional.getById(invoiceId.toString(), context);
+            // Retrieve the invoice and make sure it belongs to the right account
+            final InvoiceModelDao invoice = transactional.getById(invoiceId.toString(), context);
 
-                if (invoice == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_NOT_FOUND, invoiceId);
-                }
-
-                if (invoice.getStatus().equals(newStatus) || invoice.getStatus().equals(InvoiceStatus.VOID)) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_INVALID_STATUS, newStatus, invoiceId, invoice.getStatus());
-                }
-
-                transactional.updateStatusAndTargetDate(invoiceId.toString(), newStatus.toString(), invoice.getTargetDate(), context);
-
-                // Run through all invoices
-                // Current invoice could be a credit item that needs to be rebalanced
-                cbaDao.doCBAComplexityFromTransaction(invoicesTags, entitySqlDaoWrapperFactory, context);
-
-                // Invoice creation event sent on COMMITTED
-                if (InvoiceStatus.COMMITTED.equals(newStatus)) {
-                    notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, invoice, context);
-                } else if (InvoiceStatus.VOID.equals(newStatus)) {
-                    // https://github.com/killbill/killbill/issues/1448
-                    notifyBusOfInvoiceAdjustment(entitySqlDaoWrapperFactory, invoiceId, invoice.getAccountId(), context.getUserToken(), context);
-
-                    // Deactivate any usage trackingIds if necessary
-                    final InvoiceTrackingSqlDao trackingSqlDao = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
-                    final List<InvoiceTrackingModelDao> invoiceTrackingModelDaos = trackingSqlDao.getTrackingsForInvoices(ImmutableList.of(invoiceId.toString()), context);
-                    if (!invoiceTrackingModelDaos.isEmpty()) {
-                        final Collection<String> invoiceTrackingIdsToDeactivate = Collections2.<InvoiceTrackingModelDao, String>transform(invoiceTrackingModelDaos,
-                                                                                                                                          new Function<InvoiceTrackingModelDao, String>() {
-                                                                                                                                              @Override
-                                                                                                                                              public String apply(final InvoiceTrackingModelDao input) {
-                                                                                                                                                  return input.getId().toString();
-                                                                                                                                              }
-                                                                                                                                          });
-                        trackingSqlDao.deactivateByIds(invoiceTrackingIdsToDeactivate, context);
-                    }
-                }
-                return null;
+            if (invoice == null) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_NOT_FOUND, invoiceId);
             }
+
+            if (invoice.getStatus().equals(newStatus) || invoice.getStatus().equals(InvoiceStatus.VOID)) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_INVALID_STATUS, newStatus, invoiceId, invoice.getStatus());
+            }
+
+            transactional.updateStatusAndTargetDate(invoiceId.toString(), newStatus.toString(), invoice.getTargetDate(), context);
+
+            // Run through all invoices
+            // Current invoice could be a credit item that needs to be rebalanced
+            cbaDao.doCBAComplexityFromTransaction(invoicesTags, entitySqlDaoWrapperFactory, context);
+
+            // Invoice creation event sent on COMMITTED
+            if (InvoiceStatus.COMMITTED.equals(newStatus)) {
+                notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, invoice, context);
+            } else if (InvoiceStatus.VOID.equals(newStatus)) {
+                // https://github.com/killbill/killbill/issues/1448
+                notifyBusOfInvoiceAdjustment(entitySqlDaoWrapperFactory, invoiceId, invoice.getAccountId(), context.getUserToken(), context);
+
+                // Deactivate any usage trackingIds if necessary
+                final InvoiceTrackingSqlDao trackingSqlDao = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
+                final List<InvoiceTrackingModelDao> invoiceTrackingModelDaos = trackingSqlDao.getTrackingsForInvoices(List.of(invoiceId.toString()), context);
+                if (!invoiceTrackingModelDaos.isEmpty()) {
+                    final Collection<String> invoiceTrackingIdsToDeactivate = invoiceTrackingModelDaos.stream()
+                            .map(input -> input.getId().toString())
+                            .collect(Collectors.toUnmodifiableList());
+
+                    trackingSqlDao.deactivateByIds(invoiceTrackingIdsToDeactivate, context);
+                }
+            }
+            return null;
         });
     }
 
@@ -1346,9 +1201,12 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         try {
             // This is called for a new COMMITTED invoice (which cannot be writtenOff as it does not exist yet, so rawBalance == balance)
             final BigDecimal rawBalance = InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(invoice);
-            final DefaultInvoiceCreationEvent event = new DefaultInvoiceCreationEvent(invoice.getId(), invoice.getAccountId(),
-                                                                                      rawBalance, invoice.getCurrency(),
-                                                                                      context.getAccountRecordId(), context.getTenantRecordId(),
+            final DefaultInvoiceCreationEvent event = new DefaultInvoiceCreationEvent(invoice.getId(),
+                                                                                      invoice.getAccountId(),
+                                                                                      rawBalance,
+                                                                                      invoice.getCurrency(),
+                                                                                      context.getAccountRecordId(),
+                                                                                      context.getTenantRecordId(),
                                                                                       context.getUserToken());
             eventBus.postFromTransaction(event, entitySqlDaoWrapperFactory.getHandle().getConnection());
         } catch (final EventBusException e) {
@@ -1371,24 +1229,18 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
 
     @Override
     public void createParentChildInvoiceRelation(final InvoiceParentChildModelDao invoiceRelation, final InternalCallContext context) throws InvoiceApiException {
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceParentChildrenSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceParentChildrenSqlDao.class);
-                createAndRefresh(transactional, invoiceRelation, context);
-                return null;
-            }
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final InvoiceParentChildrenSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceParentChildrenSqlDao.class);
+            createAndRefresh(transactional, invoiceRelation, context);
+            return null;
         });
     }
 
     @Override
     public List<InvoiceParentChildModelDao> getChildInvoicesByParentInvoiceId(final UUID parentInvoiceId, final InternalCallContext context) throws InvoiceApiException {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoiceParentChildModelDao>>() {
-            @Override
-            public List<InvoiceParentChildModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceParentChildrenSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceParentChildrenSqlDao.class);
-                return transactional.getChildInvoicesByParentInvoiceId(parentInvoiceId.toString(), context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoiceParentChildrenSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceParentChildrenSqlDao.class);
+            return transactional.getChildInvoicesByParentInvoiceId(parentInvoiceId.toString(), context);
         });
     }
 
@@ -1396,36 +1248,30 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     public InvoiceModelDao getParentDraftInvoice(final UUID parentAccountId, final InternalCallContext context) throws InvoiceApiException {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
-        return transactionalSqlDao.execute(true, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<InvoiceModelDao>() {
-            @Override
-            public InvoiceModelDao inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
-                InvoiceModelDao invoice = invoiceSqlDao.getParentDraftInvoice(parentAccountId.toString(), context);
-                if (invoice != null) {
-                    invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
-                }
-                return invoice;
+        return transactionalSqlDao.execute(true, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+            final InvoiceModelDao invoice = invoiceSqlDao.getParentDraftInvoice(parentAccountId.toString(), context);
+            if (invoice != null) {
+                invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
             }
+            return invoice;
         });
     }
 
     @Override
     public void updateInvoiceItemAmount(final UUID invoiceItemId, final BigDecimal amount, final InternalCallContext context) throws InvoiceApiException {
-        transactionalSqlDao.execute(false, InvoiceApiException.class, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceItemSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
+        transactionalSqlDao.execute(false, InvoiceApiException.class, entitySqlDaoWrapperFactory -> {
+            final InvoiceItemSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
 
-                // Retrieve the invoice and make sure it belongs to the right account
-                final InvoiceItemModelDao invoiceItem = transactional.getById(invoiceItemId.toString(), context);
+            // Retrieve the invoice and make sure it belongs to the right account
+            final InvoiceItemModelDao invoiceItem = transactional.getById(invoiceItemId.toString(), context);
 
-                if (invoiceItem == null) {
-                    throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId);
-                }
-
-                transactional.updateItemFields(invoiceItemId.toString(), amount, null, null, context);
-                return null;
+            if (invoiceItem == null) {
+                throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_NOT_FOUND, invoiceItemId);
             }
+
+            transactional.updateItemFields(invoiceItemId.toString(), amount, null, null, context);
+            return null;
         });
     }
 
@@ -1439,145 +1285,127 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         final List<Tag> parentInvoicesTags = getInvoicesTags(parentAccountContext);
         final List<Tag> childInvoicesTags = getInvoicesTags(childAccountContext);
 
-        transactionalSqlDao.execute(false, new EntitySqlDaoTransactionWrapper<Void>() {
-            @Override
-            public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
-                final InvoiceItemSqlDao transInvoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
+        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao invoiceSqlDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+            final InvoiceItemSqlDao transInvoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
 
-                // create child and parent invoices
+            // create child and parent invoices
 
-                final DateTime childCreatedDate = childAccountContext.getCreatedDate();
-                final BigDecimal accountCBA = getAccountCBA(childAccount.getId(), childAccountContext);
+            final DateTime childCreatedDate = childAccountContext.getCreatedDate();
+            final BigDecimal accountCBA = getAccountCBA(childAccount.getId(), childAccountContext);
 
-                // create external charge to child account
-                final LocalDate childInvoiceDate = childAccountContext.toLocalDate(childAccountContext.getCreatedDate());
-                final Invoice invoiceForExternalCharge = new DefaultInvoice(childAccount.getId(),
-                                                                            childInvoiceDate,
-                                                                            childCreatedDate.toLocalDate(),
-                                                                            childAccount.getCurrency(),
-                                                                            InvoiceStatus.COMMITTED);
-                final String chargeDescription = "Charge to move credit from child to parent account";
-                final InvoiceItem externalChargeItem = new ExternalChargeInvoiceItem(UUIDs.randomUUID(),
-                                                                                     childCreatedDate,
-                                                                                     invoiceForExternalCharge.getId(),
-                                                                                     childAccount.getId(),
-                                                                                     null,
-                                                                                     chargeDescription,
-                                                                                     childCreatedDate.toLocalDate(),
-                                                                                     childCreatedDate.toLocalDate(),
-                                                                                     accountCBA,
-                                                                                     childAccount.getCurrency(),
-                                                                                     null);
-                invoiceForExternalCharge.addInvoiceItem(externalChargeItem);
-
-                // create credit to parent account
-                final LocalDate parentInvoiceDate = parentAccountContext.toLocalDate(parentAccountContext.getCreatedDate());
-                final Invoice invoiceForCredit = new DefaultInvoice(childAccount.getParentAccountId(),
-                                                                    parentInvoiceDate,
-                                                                    childCreatedDate.toLocalDate(),
-                                                                    childAccount.getCurrency(),
-                                                                    InvoiceStatus.COMMITTED);
-                final String creditDescription = "Credit migrated from child account " + childAccount.getId();
-                final InvoiceItem creditItem = new CreditAdjInvoiceItem(UUIDs.randomUUID(),
-                                                                        childCreatedDate,
-                                                                        invoiceForCredit.getId(),
-                                                                        childAccount.getParentAccountId(),
+            // create external charge to child account
+            final LocalDate childInvoiceDate = childAccountContext.toLocalDate(childAccountContext.getCreatedDate());
+            final Invoice invoiceForExternalCharge = new DefaultInvoice(childAccount.getId(),
+                                                                        childInvoiceDate,
                                                                         childCreatedDate.toLocalDate(),
-                                                                        creditDescription,
-                                                                        // Note! The amount is negated here!
-                                                                        accountCBA.negate(),
                                                                         childAccount.getCurrency(),
-                                                                        null);
-                invoiceForCredit.addInvoiceItem(creditItem);
+                                                                        InvoiceStatus.COMMITTED);
+            final String chargeDescription = "Charge to move credit from child to parent account";
+            final InvoiceItem externalChargeItem = new ExternalChargeInvoiceItem(UUIDs.randomUUID(),
+                                                                                 childCreatedDate,
+                                                                                 invoiceForExternalCharge.getId(),
+                                                                                 childAccount.getId(),
+                                                                                 null,
+                                                                                 chargeDescription,
+                                                                                 childCreatedDate.toLocalDate(),
+                                                                                 childCreatedDate.toLocalDate(),
+                                                                                 accountCBA,
+                                                                                 childAccount.getCurrency(),
+                                                                                 null);
+            invoiceForExternalCharge.addInvoiceItem(externalChargeItem);
 
-                // save invoices and invoice items
-                final InvoiceModelDao childInvoice = new InvoiceModelDao(invoiceForExternalCharge);
-                createAndRefresh(invoiceSqlDao, childInvoice, childAccountContext);
-                final InvoiceItemModelDao childExternalChargeItem = new InvoiceItemModelDao(externalChargeItem);
-                createInvoiceItemFromTransaction(transInvoiceItemSqlDao, childExternalChargeItem, childAccountContext);
-                // Keep invoice up-to-date for CBA below
-                childInvoice.addInvoiceItem(childExternalChargeItem);
+            // create credit to parent account
+            final LocalDate parentInvoiceDate = parentAccountContext.toLocalDate(parentAccountContext.getCreatedDate());
+            final Invoice invoiceForCredit = new DefaultInvoice(childAccount.getParentAccountId(),
+                                                                parentInvoiceDate,
+                                                                childCreatedDate.toLocalDate(),
+                                                                childAccount.getCurrency(),
+                                                                InvoiceStatus.COMMITTED);
+            final String creditDescription = "Credit migrated from child account " + childAccount.getId();
+            final InvoiceItem creditItem = new CreditAdjInvoiceItem(UUIDs.randomUUID(),
+                                                                    childCreatedDate,
+                                                                    invoiceForCredit.getId(),
+                                                                    childAccount.getParentAccountId(),
+                                                                    childCreatedDate.toLocalDate(),
+                                                                    creditDescription,
+                                                                    // Note! The amount is negated here!
+                                                                    accountCBA.negate(),
+                                                                    childAccount.getCurrency(),
+                                                                    null);
+            invoiceForCredit.addInvoiceItem(creditItem);
 
-                final InvoiceModelDao parentInvoice = new InvoiceModelDao(invoiceForCredit);
-                createAndRefresh(invoiceSqlDao, parentInvoice, parentAccountContext);
-                final InvoiceItemModelDao parentCreditItem = new InvoiceItemModelDao(creditItem);
-                createInvoiceItemFromTransaction(transInvoiceItemSqlDao, parentCreditItem, parentAccountContext);
-                // Keep invoice up-to-date for CBA below
-                parentInvoice.addInvoiceItem(parentCreditItem);
+            // save invoices and invoice items
+            final InvoiceModelDao childInvoice = new InvoiceModelDao(invoiceForExternalCharge);
+            createAndRefresh(invoiceSqlDao, childInvoice, childAccountContext);
+            final InvoiceItemModelDao childExternalChargeItem = new InvoiceItemModelDao(externalChargeItem);
+            createInvoiceItemFromTransaction(transInvoiceItemSqlDao, childExternalChargeItem, childAccountContext);
+            // Keep invoice up-to-date for CBA below
+            childInvoice.addInvoiceItem(childExternalChargeItem);
 
-                // Create Mapping relation
-                final InvoiceParentChildrenSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceParentChildrenSqlDao.class);
-                final InvoiceParentChildModelDao invoiceRelation = new InvoiceParentChildModelDao(parentInvoice.getId(), childInvoice.getId(), childInvoice.getAccountId());
-                createAndRefresh(transactional, invoiceRelation, parentAccountContext);
+            final InvoiceModelDao parentInvoice = new InvoiceModelDao(invoiceForCredit);
+            createAndRefresh(invoiceSqlDao, parentInvoice, parentAccountContext);
+            final InvoiceItemModelDao parentCreditItem = new InvoiceItemModelDao(creditItem);
+            createInvoiceItemFromTransaction(transInvoiceItemSqlDao, parentCreditItem, parentAccountContext);
+            // Keep invoice up-to-date for CBA below
+            parentInvoice.addInvoiceItem(parentCreditItem);
 
-                // Add child CBA complexity and notify bus on child invoice creation
-                final CBALogicWrapper childCbaWrapper = new CBALogicWrapper(childAccount.getId(), childInvoicesTags, childAccountContext, entitySqlDaoWrapperFactory);
-                childCbaWrapper.runCBALogicWithNotificationEvents(ImmutableSet.of(), ImmutableSet.of(childInvoice.getId()), ImmutableList.of(childInvoice));
-                notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, childInvoice, childAccountContext);
+            // Create Mapping relation
+            final InvoiceParentChildrenSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceParentChildrenSqlDao.class);
+            final InvoiceParentChildModelDao invoiceRelation = new InvoiceParentChildModelDao(parentInvoice.getId(), childInvoice.getId(), childInvoice.getAccountId());
+            createAndRefresh(transactional, invoiceRelation, parentAccountContext);
 
-                // Add parent CBA complexity and notify bus on child invoice creation
-                final CBALogicWrapper cbaWrapper = new CBALogicWrapper(childAccount.getParentAccountId(), parentInvoicesTags, parentAccountContext, entitySqlDaoWrapperFactory);
-                cbaWrapper.runCBALogicWithNotificationEvents(ImmutableSet.of(), ImmutableSet.of(parentInvoice.getId()), ImmutableList.of(parentInvoice));
-                notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, parentInvoice, parentAccountContext);
+            // Add child CBA complexity and notify bus on child invoice creation
+            final CBALogicWrapper childCbaWrapper = new CBALogicWrapper(childAccount.getId(), childInvoicesTags, childAccountContext, entitySqlDaoWrapperFactory);
+            childCbaWrapper.runCBALogicWithNotificationEvents(Collections.emptySet(), Set.of(childInvoice.getId()), List.of(childInvoice));
+            notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, childInvoice, childAccountContext);
 
-                return null;
-            }
+            // Add parent CBA complexity and notify bus on child invoice creation
+            final CBALogicWrapper cbaWrapper = new CBALogicWrapper(childAccount.getParentAccountId(), parentInvoicesTags, parentAccountContext, entitySqlDaoWrapperFactory);
+            cbaWrapper.runCBALogicWithNotificationEvents(Collections.emptySet(), Set.of(parentInvoice.getId()), List.of(parentInvoice));
+            notifyBusOfInvoiceCreation(entitySqlDaoWrapperFactory, parentInvoice, parentAccountContext);
+
+            return null;
         });
     }
 
     @Override
     public List<InvoiceItemModelDao> getInvoiceItemsByParentInvoice(final UUID parentInvoiceId, final InternalTenantContext context) throws InvoiceApiException {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoiceItemModelDao>>() {
-            @Override
-            public List<InvoiceItemModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceItemSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-                return transactional.getInvoiceItemsByParentInvoice(parentInvoiceId.toString(), context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoiceItemSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
+            return transactional.getInvoiceItemsByParentInvoice(parentInvoiceId.toString(), context);
         });
     }
 
     @Override
     public List<InvoiceTrackingModelDao> getTrackingsByDateRange(final LocalDate startDate, final LocalDate endDate, final InternalCallContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<InvoiceTrackingModelDao>>() {
-            @Override
-            public List<InvoiceTrackingModelDao> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                final InvoiceTrackingSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
-                return transactional.getTrackingsByDateRange(startDate.toDate(), endDate.toDate(), context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoiceTrackingSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
+            return transactional.getTrackingsByDateRange(startDate.toDate(), endDate.toDate(), context);
         });
     }
 
     @Override
     public List<AuditLogWithHistory> getInvoiceAuditLogsWithHistoryForId(final UUID invoiceId, final AuditLevel auditLevel, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLogWithHistory>>() {
-            @Override
-            public List<AuditLogWithHistory> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) {
-                final InvoiceSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
-                return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.INVOICES, invoiceId, auditLevel, context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoiceSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
+            return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.INVOICES, invoiceId, auditLevel, context);
         });
     }
 
     @Override
     public List<AuditLogWithHistory> getInvoiceItemAuditLogsWithHistoryForId(final UUID invoiceItemId, final AuditLevel auditLevel, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLogWithHistory>>() {
-            @Override
-            public List<AuditLogWithHistory> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) {
-                final InvoiceItemSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-                return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.INVOICE_ITEMS, invoiceItemId, auditLevel, context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoiceItemSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
+            return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.INVOICE_ITEMS, invoiceItemId, auditLevel, context);
         });
     }
 
     @Override
     public List<AuditLogWithHistory> getInvoicePaymentAuditLogsWithHistoryForId(final UUID invoicePaymentId, final AuditLevel auditLevel, final InternalTenantContext context) {
-        return transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<List<AuditLogWithHistory>>() {
-            @Override
-            public List<AuditLogWithHistory> inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) {
-                final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
-                return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.INVOICE_PAYMENTS, invoicePaymentId, auditLevel, context);
-            }
+        return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
+            final InvoicePaymentSqlDao transactional = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
+            return auditDao.getAuditLogsWithHistoryForId(transactional, TableName.INVOICE_PAYMENTS, invoicePaymentId, auditLevel, context);
         });
     }
 
@@ -1596,7 +1424,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         }
 
         public void runCBALogicWithNotificationEvents(final Set<UUID> allInvoiceIds) throws EntityPersistenceException, InvoiceApiException {
-            runCBALogicWithNotificationEventsInternal(ImmutableSet.of(), ImmutableSet.of(), runCBALogicWithInvoiceIds(allInvoiceIds));
+            runCBALogicWithNotificationEventsInternal(Collections.emptySet(), Collections.emptySet(), runCBALogicWithInvoiceIds(allInvoiceIds));
         }
 
         public void runCBALogicWithNotificationEvents(final Set<UUID> initSet, final Set<UUID> excludedSet, final Set<UUID> allInvoiceIds) throws EntityPersistenceException, InvoiceApiException {
@@ -1604,7 +1432,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         }
 
         public void runCBALogicWithNotificationEvents(final List<InvoiceModelDao> invoices) throws EntityPersistenceException, InvoiceApiException {
-            runCBALogicWithNotificationEvents(ImmutableSet.of(), ImmutableSet.of(), invoices);
+            runCBALogicWithNotificationEvents(Collections.emptySet(), Collections.emptySet(), invoices);
         }
 
         public void runCBALogicWithNotificationEvents(final Set<UUID> initSet, final Set<UUID> excludedSet, final List<InvoiceModelDao> invoices) throws EntityPersistenceException, InvoiceApiException {
@@ -1612,14 +1440,12 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         }
 
         private void runCBALogicWithNotificationEventsInternal(final Set<UUID> initSet, final Set<UUID> excludedSet, final Set<UUID> resCbaInvoiceIds) {
-
             final Set<UUID> candidateModifiedInvoiceIds = new HashSet<>(initSet);
             candidateModifiedInvoiceIds.addAll(resCbaInvoiceIds);
             final Set<UUID> modifiedInvoiceIds = Sets.difference(candidateModifiedInvoiceIds, excludedSet);
             for (UUID id : modifiedInvoiceIds) {
                 notifyBusOfInvoiceAdjustment(entitySqlDaoWrapperFactory, id, accountId, context.getUserToken(), context);
             }
-
         }
 
         private Set<UUID> runCBALogicWithInvoices(final List<InvoiceModelDao> invoices) throws EntityPersistenceException, InvoiceApiException {
@@ -1632,7 +1458,8 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     }
 
     // PERF: fetch tags once. See also https://github.com/killbill/killbill/issues/720.
-    private List<Tag> getInvoicesTags(final InternalTenantContext context) {
+    @VisibleForTesting
+    List<Tag> getInvoicesTags(final InternalTenantContext context) {
         return tagInternalApi.getTagsForAccountType(ObjectType.INVOICE, false, context);
     }
 
@@ -1640,9 +1467,9 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         boolean itemShouldBeUpdated = false;
         if (inputInvoiceItem.getAmount() != null) {
             itemShouldBeUpdated = existingInvoiceItem.getAmount() == null /* unlikely */ || inputInvoiceItem.getAmount().compareTo(existingInvoiceItem.getAmount()) != 0;
-        } else if (!itemShouldBeUpdated && inputInvoiceItem.getDescription() != null) {
+        } else if (inputInvoiceItem.getDescription() != null) {
             itemShouldBeUpdated = existingInvoiceItem.getDescription() == null || inputInvoiceItem.getDescription().compareTo(existingInvoiceItem.getDescription()) != 0;
-        } else if (!itemShouldBeUpdated && inputInvoiceItem.getItemDetails() != null) {
+        } else if (inputInvoiceItem.getItemDetails() != null) {
             itemShouldBeUpdated = existingInvoiceItem.getItemDetails() == null || inputInvoiceItem.getItemDetails().compareTo(existingInvoiceItem.getItemDetails()) != 0;
         }
         return itemShouldBeUpdated;

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceTrackingModelDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceTrackingModelDao.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.invoice.dao;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -28,8 +29,6 @@ import org.killbill.billing.util.dao.TableName;
 import org.killbill.billing.util.entity.Entity;
 import org.killbill.billing.util.entity.dao.EntityModelDao;
 import org.killbill.billing.util.entity.dao.EntityModelDaoBase;
-
-import com.google.common.base.Objects;
 
 public class InvoiceTrackingModelDao extends EntityModelDaoBase implements EntityModelDao<Entity> {
 
@@ -123,17 +122,17 @@ public class InvoiceTrackingModelDao extends EntityModelDaoBase implements Entit
             return false;
         }
         final InvoiceTrackingModelDao that = (InvoiceTrackingModelDao) o;
-        return Objects.equal(trackingId, that.trackingId) &&
-               Objects.equal(invoiceId, that.invoiceId) &&
-               Objects.equal(isActive, that.isActive) &&
-               Objects.equal(subscriptionId, that.subscriptionId) &&
-               Objects.equal(unitType, that.unitType) &&
-               Objects.equal(recordDate, that.recordDate);
+        return Objects.equals(trackingId, that.trackingId) &&
+               Objects.equals(invoiceId, that.invoiceId) &&
+               Objects.equals(isActive, that.isActive) &&
+               Objects.equals(subscriptionId, that.subscriptionId) &&
+               Objects.equals(unitType, that.unitType) &&
+               Objects.equals(recordDate, that.recordDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(super.hashCode(), trackingId, invoiceId, subscriptionId, unitType, recordDate, isActive);
+        return Objects.hash(super.hashCode(), trackingId, invoiceId, subscriptionId, unitType, recordDate, isActive);
     }
 
     @Override

--- a/invoice/src/test/java/org/killbill/billing/invoice/api/svcs/TestDefaultInvoiceInternalApiUnit.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/api/svcs/TestDefaultInvoiceInternalApiUnit.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.svcs;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.killbill.billing.invoice.api.InvoiceApiException;
+import org.killbill.billing.invoice.api.InvoiceApiHelper;
+import org.killbill.billing.invoice.api.InvoicePayment;
+import org.killbill.billing.invoice.api.InvoicePaymentType;
+import org.killbill.billing.invoice.dao.InvoiceDao;
+import org.killbill.billing.invoice.dao.InvoicePaymentModelDao;
+import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestDefaultInvoiceInternalApiUnit extends InvoiceTestSuiteNoDB {
+
+    private final InvoiceDao invoiceDao = mock(InvoiceDao.class);
+    private final InvoiceApiHelper invoiceApiHelper = mock(InvoiceApiHelper.class);
+    private final InternalCallContextFactory internalCallContextFactory = mock(InternalCallContextFactory.class);
+
+    private DefaultInvoiceInternalApi createInvoiceInternalApi() {
+        final DefaultInvoiceInternalApi toSpy = new DefaultInvoiceInternalApi(invoiceDao, invoiceApiHelper, internalCallContextFactory);
+        return Mockito.spy(toSpy);
+    }
+
+    private InvoicePaymentModelDao createMockedInvoicePaymentModelDaoWithTypeAndSuccess(final InvoicePaymentType type, final Boolean success) {
+        final InvoicePaymentModelDao modelDao = mock(InvoicePaymentModelDao.class);
+        when(modelDao.getType()).thenReturn(type);
+        when(modelDao.getSuccess()).thenReturn(success);
+        return modelDao;
+    }
+
+    // Belongs to testGetInvoicePayment()
+    private List<InvoicePaymentModelDao> testGetInvoicePaymentModels() {
+        final List<InvoicePaymentModelDao> result = new LinkedList<>();
+
+        final AtomicInteger paymentCookie = new AtomicInteger(1);
+        List.of(InvoicePaymentType.ATTEMPT, InvoicePaymentType.ATTEMPT, InvoicePaymentType.ATTEMPT, InvoicePaymentType.REFUND)
+            .forEach(type -> {
+                final InvoicePaymentModelDao modelDao = createMockedInvoicePaymentModelDaoWithTypeAndSuccess(type, Boolean.TRUE);
+                // Only used to make sure in test, that we get the first data from the list
+                when(modelDao.getPaymentCookieId()).thenReturn(String.valueOf(paymentCookie.getAndIncrement()));
+                result.add(modelDao);
+            });
+        // Scenario: find with CHARGED_BACK will return null because getSuccess() is FALSE
+        final InvoicePaymentModelDao modelDao = createMockedInvoicePaymentModelDaoWithTypeAndSuccess(InvoicePaymentType.CHARGED_BACK, Boolean.FALSE);
+        result.add(modelDao);
+
+        return result;
+    }
+
+    @Test(groups = "fast")
+    public void testGetInvoicePayment() throws InvoiceApiException {
+        final List<InvoicePaymentModelDao> invoicePayments = testGetInvoicePaymentModels();
+        when(invoiceDao.getInvoicePaymentsByPaymentId(any(), any())).thenReturn(invoicePayments);
+
+        // Trick for mockito because any() is not working
+        final UUID anyPaymentId = UUID.randomUUID();
+        final InternalTenantContext anyCtx = mock(InternalTenantContext.class);
+
+        final DefaultInvoiceInternalApi invoiceInternalApi = createInvoiceInternalApi();
+        InvoicePayment result = invoiceInternalApi.getInvoicePayment(anyPaymentId, InvoicePaymentType.ATTEMPT, anyCtx);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.isSuccess(), Boolean.TRUE);
+        Assert.assertEquals(result.getType(), InvoicePaymentType.ATTEMPT);
+        Assert.assertEquals(result.getPaymentCookieId(), "1"); // See comment in testGetInvoicePaymentModels()
+
+        result = invoiceInternalApi.getInvoicePayment(anyPaymentId, InvoicePaymentType.REFUND, anyCtx);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.isSuccess(), Boolean.TRUE);
+        Assert.assertEquals(result.getType(), InvoicePaymentType.REFUND);
+
+        // See comment about CHARGED_BACK type in testGetInvoicePaymentModels()
+        result = invoiceInternalApi.getInvoicePayment(anyPaymentId, InvoicePaymentType.CHARGED_BACK, anyCtx);
+
+        Assert.assertNull(result);
+    }
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestCBADaoUnit.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestCBADaoUnit.java
@@ -28,9 +28,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-/**
- * Add "Unit" in the end of class name to indicate that this is unit/fast test.
- */
 public class TestCBADaoUnit extends InvoiceTestSuiteNoDB {
 
     /**
@@ -68,15 +65,17 @@ public class TestCBADaoUnit extends InvoiceTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void testGetInvoiceBalance() {
+    public void testGetInvoiceBalance() {
         final UUID accountId = UUID.randomUUID();
-        final BigDecimal doesntMatter = BigDecimal.ZERO; // current invoice item amount calculation mocked by 'childInvoiceAmountCharged'
+        // current invoice item amount calculation mocked by 'childInvoiceAmountCharged'. See {@link #getCBADao(BigDecimal)}
+        final BigDecimal doesntMatter = BigDecimal.ZERO;
         InvoiceModelDao parent = createInvoiceWithItems(accountId, null, new BigDecimal("10"), new BigDecimal("20"));
         InvoiceModelDao toTest = createInvoiceWithItems(accountId, parent, doesntMatter);
 
         CBADao dao = getCBADao(new BigDecimal("100"));
         Assert.assertEquals(dao.getInvoiceBalance(toTest).compareTo(new BigDecimal("70")), 0);
 
+        // total items amount here: 80.000
         parent = createInvoiceWithItems(accountId, null,
                                         new BigDecimal("3000"), new BigDecimal("12000"), new BigDecimal("5000"),
                                         new BigDecimal("1000"), new BigDecimal("2000"), new BigDecimal("17000"),

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestCBADaoUnit.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestCBADaoUnit.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.dao;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Add "Unit" in the end of class name to indicate that this is unit/fast test.
+ */
+public class TestCBADaoUnit extends InvoiceTestSuiteNoDB {
+
+    /**
+     * @param accountId needed to be the same when testing {@link CBADao#getInvoiceBalance(InvoiceModelDao)}
+     * @param parent to calculate
+     * @param itemAmounts Will create {@link org.killbill.billing.invoice.api.InvoiceItem} as much as itemAmounts value
+     */
+    private InvoiceModelDao createInvoiceWithItems(final UUID accountId, final InvoiceModelDao parent, final BigDecimal... itemAmounts) {
+        final InvoiceModelDao invoiceModelDao = new InvoiceModelDao();
+        invoiceModelDao.setAccountId(accountId);
+        invoiceModelDao.addParentInvoice(parent);
+
+        final List<InvoiceItemModelDao> items = Arrays.stream(itemAmounts)
+                .map(amount -> {
+                    final InvoiceItemModelDao item = new InvoiceItemModelDao();
+                    item.setAmount(amount);
+                    item.setChildAccountId(accountId);
+                    return item;
+                })
+                .collect(Collectors.toUnmodifiableList());
+
+        invoiceModelDao.setInvoiceItems(items);
+
+        return invoiceModelDao;
+    }
+
+    private CBADao getCBADao(final BigDecimal childInvoiceAmountCharged) {
+        final CBADao dao = new CBADao(super.invoiceDaoHelper);
+        final CBADao spied = Mockito.spy(dao);
+
+        Mockito.doReturn(true).when(spied).isParentExistAndRawBalanceIsZero(Mockito.any());
+        Mockito.doReturn(childInvoiceAmountCharged).when(spied).getChildInvoiceAmountCharged(Mockito.any());
+
+        return spied;
+    }
+
+    @Test(groups = "fast")
+    void testGetInvoiceBalance() {
+        final UUID accountId = UUID.randomUUID();
+        final BigDecimal doesntMatter = BigDecimal.ZERO; // current invoice item amount calculation mocked by 'childInvoiceAmountCharged'
+        InvoiceModelDao parent = createInvoiceWithItems(accountId, null, new BigDecimal("10"), new BigDecimal("20"));
+        InvoiceModelDao toTest = createInvoiceWithItems(accountId, parent, doesntMatter);
+
+        CBADao dao = getCBADao(new BigDecimal("100"));
+        Assert.assertEquals(dao.getInvoiceBalance(toTest).compareTo(new BigDecimal("70")), 0);
+
+        parent = createInvoiceWithItems(accountId, null,
+                                        new BigDecimal("3000"), new BigDecimal("12000"), new BigDecimal("5000"),
+                                        new BigDecimal("1000"), new BigDecimal("2000"), new BigDecimal("17000"),
+                                        new BigDecimal("9000"), new BigDecimal("9000"), new BigDecimal("2000"),
+                                        new BigDecimal("5000"), new BigDecimal("10000"), new BigDecimal("5000"));
+        toTest = createInvoiceWithItems(accountId, parent, doesntMatter);
+
+        dao = getCBADao(new BigDecimal("100000"));
+        Assert.assertEquals(dao.getInvoiceBalance(toTest).compareTo(new BigDecimal("20000")), 0);
+    }
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestCBADaoUnit.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestCBADaoUnit.java
@@ -31,6 +31,12 @@ import org.testng.annotations.Test;
 public class TestCBADaoUnit extends InvoiceTestSuiteNoDB {
 
     /**
+     * Used inside of test {@link CBADao#getInvoiceBalance(InvoiceModelDao)} tests, where the amount of invoice item
+     * doesn't matter because it's mocked by {@code childInvoiceAmountCharged}. See {@link #getCBADao(BigDecimal)}.
+     */
+    private static final BigDecimal DOESNT_MATTER = BigDecimal.ZERO;
+
+    /**
      * @param accountId needed to be the same when testing {@link CBADao#getInvoiceBalance(InvoiceModelDao)}
      * @param parent to calculate
      * @param itemAmounts Will create {@link org.killbill.billing.invoice.api.InvoiceItem} as much as itemAmounts value
@@ -67,13 +73,11 @@ public class TestCBADaoUnit extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testGetInvoiceBalance() {
         final UUID accountId = UUID.randomUUID();
-        // current invoice item amount calculation mocked by 'childInvoiceAmountCharged'. See {@link #getCBADao(BigDecimal)}
-        final BigDecimal doesntMatter = BigDecimal.ZERO;
         InvoiceModelDao parent = createInvoiceWithItems(accountId, null, new BigDecimal("10"), new BigDecimal("20"));
-        InvoiceModelDao toTest = createInvoiceWithItems(accountId, parent, doesntMatter);
+        InvoiceModelDao toTest = createInvoiceWithItems(accountId, parent, DOESNT_MATTER);
 
         CBADao dao = getCBADao(new BigDecimal("100"));
-        Assert.assertEquals(dao.getInvoiceBalance(toTest).compareTo(new BigDecimal("70")), 0);
+        Assert.assertEquals(dao.getInvoiceBalance(toTest).compareTo(new BigDecimal("70")), 0); // 100 - 30 = 70
 
         // total items amount here: 80.000
         parent = createInvoiceWithItems(accountId, null,
@@ -81,9 +85,34 @@ public class TestCBADaoUnit extends InvoiceTestSuiteNoDB {
                                         new BigDecimal("1000"), new BigDecimal("2000"), new BigDecimal("17000"),
                                         new BigDecimal("9000"), new BigDecimal("9000"), new BigDecimal("2000"),
                                         new BigDecimal("5000"), new BigDecimal("10000"), new BigDecimal("5000"));
-        toTest = createInvoiceWithItems(accountId, parent, doesntMatter);
+        toTest = createInvoiceWithItems(accountId, parent, DOESNT_MATTER);
 
         dao = getCBADao(new BigDecimal("100000"));
         Assert.assertEquals(dao.getInvoiceBalance(toTest).compareTo(new BigDecimal("20000")), 0);
+    }
+
+    @Test(groups = "fast")
+    public void testGetInvoiceBalanceWithDifferentChildAccountId() {
+        final UUID accountId = UUID.randomUUID();
+        final UUID differentChildAccountId = UUID.randomUUID();
+
+        // total items amount here: 600 ....
+        final InvoiceModelDao parent = createInvoiceWithItems(accountId, null,
+                                                              new BigDecimal("30"), new BigDecimal("120"), new BigDecimal("50"),
+                                                              new BigDecimal("10"), new BigDecimal("20"), new BigDecimal("170"),
+                                                              new BigDecimal("90"), new BigDecimal("90"), new BigDecimal("20"));
+        // .... But some of item's childAccountId modified to test that we only calculate
+        // invoice parent's item.childAccountId that equals with invoice.accountId . (See CBADao around line 103)
+        // So actual total item amount = 600 - 40 = 560. (40 comes from the fact that we have 2 item with amount=20)
+        parent.getInvoiceItems().stream()
+              .filter(item -> item.getAmount().compareTo(new BigDecimal("20")) == 0)
+              .forEach(item -> item.setChildAccountId(differentChildAccountId));
+
+        final InvoiceModelDao toTest = createInvoiceWithItems(accountId, parent, DOESNT_MATTER);
+
+        final CBADao dao = getCBADao(new BigDecimal("1000"));
+        final BigDecimal actualBalance = dao.getInvoiceBalance(toTest);
+        System.out.println("actualBalance = " + actualBalance);
+        Assert.assertEquals(actualBalance.compareTo(new BigDecimal("440")), 0);
     }
 }

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestDefaultInvoiceDaoUnit.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestDefaultInvoiceDaoUnit.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 
 public class TestDefaultInvoiceDaoUnit extends InvoiceTestSuiteNoDB {
 
+    // FIXME-1615 : Should we move this to TestInvoiceHelperUnit? AFAIK non of DefaultInvoiceDao methods involved here.
     @Test(groups = "fast")
     public void testComputePositiveRefundAmount() throws Exception {
         // Verify the cases with no adjustment first

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDao.java
@@ -139,23 +139,58 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         invoiceUtil.checkInvoicesEqual(invoiceForExternalCharge, invoice);
     }
 
+    // Return persisted invoice
+    private Invoice createAndGetInvoice(final LocalDate invoiceDate, final LocalDate targetDate) throws EntityPersistenceException {
+        final UUID accountId = account.getId();
+        final Invoice invoice = new DefaultInvoice(accountId, invoiceDate, targetDate, Currency.USD);
+        invoiceUtil.createInvoice(invoice, context);
+
+        return invoice;
+    }
+
     @Test(groups = "slow")
     public void testCreationAndRetrievalByAccount() throws EntityPersistenceException {
-        final UUID accountId = account.getId();
-        final Invoice invoice = new DefaultInvoice(accountId, clock.getUTCToday(), clock.getUTCToday(), Currency.USD);
-        final LocalDate invoiceDate = invoice.getInvoiceDate();
-
-        invoiceUtil.createInvoice(invoice, context);
+        final Invoice createdInvoice = createAndGetInvoice(clock.getUTCToday(), clock.getUTCToday());
 
         final List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, context);
         assertNotNull(invoices);
         assertEquals(invoices.size(), 1);
         final InvoiceModelDao thisInvoice = invoices.get(0);
-        assertEquals(invoice.getAccountId(), accountId);
-        assertTrue(thisInvoice.getInvoiceDate().compareTo(invoiceDate) == 0);
+        assertEquals(createdInvoice.getAccountId(), account.getId());
+        assertEquals(thisInvoice.getInvoiceDate().compareTo(createdInvoice.getInvoiceDate()), 0);
         assertEquals(thisInvoice.getCurrency(), Currency.USD);
         assertEquals(thisInvoice.getInvoiceItems().size(), 0);
-        assertTrue(InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(thisInvoice).compareTo(BigDecimal.ZERO) == 0);
+        assertEquals(InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(thisInvoice).compareTo(BigDecimal.ZERO), 0);
+    }
+
+    @Test(groups = "slow")
+    public void testGetInvoicesByAccountSorted() throws EntityPersistenceException {
+        final Invoice invoice1 = createAndGetInvoice(clock.getUTCToday(), clock.getUTCToday());
+        final Invoice invoice2 = createAndGetInvoice(clock.getUTCToday().minusDays(1), clock.getUTCToday().minusDays(1));
+        final Invoice invoice3 = createAndGetInvoice(clock.getUTCToday().minusDays(2), clock.getUTCToday().minusDays(2));
+        final Invoice invoice4 = createAndGetInvoice(clock.getUTCToday().minusDays(4), clock.getUTCToday().minusDays(4));
+        // although labeled "invoice5", the clock use "minusDays(3)", so in assertion, this should be in 2nd element.
+        final Invoice invoice5 = createAndGetInvoice(clock.getUTCToday().minusDays(3), clock.getUTCToday().minusDays(3));
+
+        final List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, context);
+
+        assertNotNull(invoices);
+        assertEquals(invoices.size(), 5);
+
+        assertEquals(invoice4.getId(), invoices.get(0).getId());
+        assertEquals(invoice4.getTargetDate().compareTo(invoices.get(0).getTargetDate()), 0);
+
+        assertEquals(invoice5.getId(), invoices.get(1).getId());
+        assertEquals(invoice5.getTargetDate().compareTo(invoices.get(1).getTargetDate()), 0);
+
+        assertEquals(invoice3.getId(), invoices.get(2).getId());
+        assertEquals(invoice3.getTargetDate().compareTo(invoices.get(2).getTargetDate()), 0);
+
+        assertEquals(invoice2.getId(), invoices.get(3).getId());
+        assertEquals(invoice2.getTargetDate().compareTo(invoices.get(3).getTargetDate()), 0);
+
+        assertEquals(invoice1.getId(), invoices.get(4).getId());
+        assertEquals(invoice1.getTargetDate().compareTo(invoices.get(4).getTargetDate()), 0);
     }
 
     @Test(groups = "slow")

--- a/util/src/main/java/org/killbill/billing/util/collect/Iterables.java
+++ b/util/src/main/java/org/killbill/billing/util/collect/Iterables.java
@@ -117,4 +117,31 @@ public final class Iterables {
                ? ((Collection<?>) iterable).size()
                : Iterators.size(iterable.iterator());
     }
+
+    /**
+     * Returns {@code true} if {@code iterable} contains any element {@code o} for which {@code
+     * Objects.equals(o, element)} would return {@code true}. Otherwise returns {@code false}, even in
+     * cases where {@link Collection#contains} might throw {@link NullPointerException} or {@link
+     * ClassCastException}.
+     */
+    public static boolean contains(final Iterable<?> iterable, final Object element) {
+        if (iterable instanceof Collection) {
+            final Collection<?> collection = (Collection<?>) iterable;
+            return safeContains(collection, element);
+        }
+        return Iterators.contains(iterable.iterator(), element);
+    }
+
+    /**
+     * Delegates to {@link Collection#contains}. Returns {@code false} if the {@code contains} method
+     * throws a {@code ClassCastException} or {@code NullPointerException}.
+     */
+    private static boolean safeContains(final Collection<?> collection, final Object object) {
+        Preconditions.checkNotNull(collection);
+        try {
+            return collection.contains(object);
+        } catch (final ClassCastException | NullPointerException e) {
+            return false;
+        }
+    }
 }

--- a/util/src/main/java/org/killbill/billing/util/collect/Iterators.java
+++ b/util/src/main/java/org/killbill/billing/util/collect/Iterators.java
@@ -28,6 +28,8 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import javax.annotation.CheckForNull;
+
 import org.killbill.billing.util.Preconditions;
 
 /**
@@ -117,5 +119,23 @@ public final class Iterators {
      */
     public static <E> Stream<E> toStream(final Iterator<E> iterator) {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
+    }
+
+    /** Returns {@code true} if {@code iterator} contains {@code element}. */
+    public static boolean contains(final Iterator<?> iterator, @CheckForNull final Object element) {
+        if (element == null) {
+            while (iterator.hasNext()) {
+                if (iterator.next() == null) {
+                    return true;
+                }
+            }
+        } else {
+            while (iterator.hasNext()) {
+                if (element.equals(iterator.next())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/collect/Sets.java
+++ b/util/src/main/java/org/killbill/billing/util/collect/Sets.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.collect;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.killbill.billing.util.Preconditions;
+
+public final class Sets {
+
+    /**
+     * Will return a set of elements that exists in {@code set1} but not exist in {@code set2}. Both parameters cannot
+     * be null.
+     */
+    public static <E> Set<E> difference(final Set<E> set1, final Set<E> set2) {
+        Preconditions.checkNotNull(set1, "set1 in Sets#difference() is null");
+        Preconditions.checkNotNull(set2, "set2 in Sets#difference() is null");
+        return set1.stream()
+                   .filter(element -> !set2.contains(element))
+                   .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/util/src/test/java/org/killbill/billing/util/collect/TestIterables.java
+++ b/util/src/test/java/org/killbill/billing/util/collect/TestIterables.java
@@ -91,4 +91,20 @@ public class TestIterables extends UtilTestSuiteNoDB {
         assertEquals(Iterables.size(a), 3);
         assertEquals(Iterables.size(b), 0);
     }
+
+    @Test
+    void contains() {
+        final Iterable<String> strings = List.of("a", "b", "c");
+        final Iterable<String> empty = Collections.emptyList();
+        final Iterable<KeyValue> keyValues = List.of(new KeyValue("a", "1"),
+                                                     new KeyValue("b", "2"));
+
+        assertTrue(Iterables.contains(strings, "a"));
+        assertFalse(Iterables.contains(strings, "d"));
+
+        assertFalse(Iterables.contains(empty, "a"));
+
+        assertTrue(Iterables.contains(keyValues, new KeyValue("b", "2")));
+        assertFalse(Iterables.contains(keyValues, new KeyValue("a", "2")));
+    }
 }

--- a/util/src/test/java/org/killbill/billing/util/collect/TestIterables.java
+++ b/util/src/test/java/org/killbill/billing/util/collect/TestIterables.java
@@ -33,7 +33,7 @@ import static org.testng.Assert.fail;
 public class TestIterables extends UtilTestSuiteNoDB {
 
     @Test(groups = "fast")
-    public void getLast() {
+    public void testGetLast() {
         final List<KeyValue> keyValues = List.of(new KeyValue("a", "1"), new KeyValue("b", "2"), new KeyValue("c", "3"));
         final KeyValue last = Iterables.getLast(keyValues);
 
@@ -43,7 +43,7 @@ public class TestIterables extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void getLastWithEmptyList() {
+    public void testGetLastWithEmptyList() {
         final List<KeyValue> keyValues = Collections.emptyList();
         try {
             Iterables.getLast(keyValues);
@@ -52,7 +52,7 @@ public class TestIterables extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void concat() {
+    public void testConcat() {
         final Iterable<String> a = List.of("a", "b", "c");
         final Iterable<String> b = List.of("d", "e");
         final Iterable<String> c = List.of("1", "2", "3");
@@ -64,7 +64,7 @@ public class TestIterables extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void concatWithNullElement() {
+    public void testConcatWithNullElement() {
         final Iterable<String> a = List.of("a", "b", "c");
         final Iterable<String> b = List.of("1", "2", "3");
 
@@ -75,7 +75,7 @@ public class TestIterables extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void isEmpty() {
+    public void testIsEmpty() {
         final Iterable<String> a = List.of("a", "b", "c");
         final Iterable<String> b = Collections.emptyList();
 
@@ -84,7 +84,7 @@ public class TestIterables extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void size() {
+    public void testSize() {
         final Iterable<String> a = List.of("a", "b", "c");
         final Iterable<String> b = Collections.emptyList();
 
@@ -92,8 +92,8 @@ public class TestIterables extends UtilTestSuiteNoDB {
         assertEquals(Iterables.size(b), 0);
     }
 
-    @Test
-    void contains() {
+    @Test(groups = "fast")
+    public void testContains() {
         final Iterable<String> strings = List.of("a", "b", "c");
         final Iterable<String> empty = Collections.emptyList();
         final Iterable<KeyValue> keyValues = List.of(new KeyValue("a", "1"),

--- a/util/src/test/java/org/killbill/billing/util/collect/TestIterators.java
+++ b/util/src/test/java/org/killbill/billing/util/collect/TestIterators.java
@@ -28,6 +28,7 @@ import org.killbill.billing.util.UtilTestSuiteNoDB;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
@@ -82,5 +83,22 @@ public class TestIterators extends UtilTestSuiteNoDB {
         final List<String> strings = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
         final int size = Iterators.size(strings.iterator());
         assertEquals(size, 10);
+    }
+
+    @Test
+    void contains() {
+        final Iterator<String> strings = List.of("a", "b", "c").iterator();
+        final Iterator<String> empty = Collections.emptyIterator();
+        final Iterator<KeyValue> keyValues = List.of(new KeyValue("a", "1"),
+                                                     new KeyValue("b", "2"))
+                                                 .iterator();
+
+        assertTrue(Iterators.contains(strings, "a"));
+        assertFalse(Iterators.contains(strings, "d"));
+
+        assertFalse(Iterators.contains(empty, "a"));
+
+        assertTrue(Iterators.contains(keyValues, new KeyValue("b", "2")));
+        assertFalse(Iterators.contains(keyValues, new KeyValue("a", "2")));
     }
 }

--- a/util/src/test/java/org/killbill/billing/util/collect/TestIterators.java
+++ b/util/src/test/java/org/killbill/billing/util/collect/TestIterators.java
@@ -36,7 +36,7 @@ import static org.testng.Assert.fail;
 public class TestIterators extends UtilTestSuiteNoDB {
 
     @Test(groups = "fast")
-    public void getLast() {
+    public void testGetLast() {
         final List<KeyValue> keyValues = List.of(new KeyValue("a", "1"), new KeyValue("b", "2"), new KeyValue("c", "3"));
         final KeyValue last = Iterators.getLast(keyValues.iterator());
 
@@ -46,7 +46,7 @@ public class TestIterators extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void getLastWithEmptyList() {
+    public void testGetLastWithEmptyList() {
         final List<KeyValue> keyValues = Collections.emptyList();
         try {
             Iterators.getLast(keyValues.iterator());
@@ -55,7 +55,7 @@ public class TestIterators extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void transform() {
+    public void testTransform() {
         final List<KeyValue> list = List.of(new KeyValue("a", "1"), new KeyValue("b", "2"), new KeyValue("c", "3"));
         final Iterator<String> keyOnly = Iterators.transform(list.iterator(), KeyValue::getKey);
         assertEquals(keyOnly.next(), "a");
@@ -64,7 +64,7 @@ public class TestIterators extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void toUnmodifiableList() {
+    public void testToUnmodifiableList() {
         final Collection<KeyValue> set = new HashSet<>();
         set.add(new KeyValue("a", "1"));
         set.add(new KeyValue("b", "2"));
@@ -79,14 +79,14 @@ public class TestIterators extends UtilTestSuiteNoDB {
     }
 
     @Test(groups = "fast")
-    void size() {
+    public void testSize() {
         final List<String> strings = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
         final int size = Iterators.size(strings.iterator());
         assertEquals(size, 10);
     }
 
-    @Test
-    void contains() {
+    @Test(groups = "fast")
+    public void testContains() {
         final Iterator<String> strings = List.of("a", "b", "c").iterator();
         final Iterator<String> empty = Collections.emptyIterator();
         final Iterator<KeyValue> keyValues = List.of(new KeyValue("a", "1"),

--- a/util/src/test/java/org/killbill/billing/util/collect/TestSets.java
+++ b/util/src/test/java/org/killbill/billing/util/collect/TestSets.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 public class TestSets extends UtilTestSuiteNoDB {
 
     @Test(groups = "fast")
-    public void difference() {
+    public void testDifference() {
         final Set<String> s1 = Set.of("a", "b", "c", "d", "e");
         final Set<String> s2 = Set.of("a", "c", "d");
 

--- a/util/src/test/java/org/killbill/billing/util/collect/TestSets.java
+++ b/util/src/test/java/org/killbill/billing/util/collect/TestSets.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.collect;
+
+import java.util.Set;
+
+import org.killbill.billing.util.UtilTestSuiteNoDB;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestSets extends UtilTestSuiteNoDB {
+
+    @Test(groups = "fast")
+    public void difference() {
+        final Set<String> s1 = Set.of("a", "b", "c", "d", "e");
+        final Set<String> s2 = Set.of("a", "c", "d");
+
+        final Set<String> diff = Sets.difference(s1, s2);
+
+        Assert.assertEquals(diff.size(), 2);
+        Assert.assertEquals(diff, Set.of("b", "e"));
+    }
+}


### PR DESCRIPTION
I decided to create more than 1 PRs for `killbill-invoice`. For this PR, these are something that I found maybe important (and perhaps make review easier):

- `DefaultInvoiceUserApi#checkInvoiceDoesContainUsedGeneratedCredit()` : Logic changed a bit, but cross checked with `TestDefaultInvoiceUserApi#testVoidInvoice()` and result keep consistent when test running before vs after refactor.

- `CBADao#getInvoiceBalance()` : Use stream's map reduce. `TestUnitCBADao` added to test before and after refactor behavior.

- `getInvoicesByAccount#getInvoicesByAccount()` : Refactored, covered by test `TestInvoiceDao#testGetInvoicesByAccountSorted()`

- Following methods seems have a big refactor, but no. Actually I just cut the method body inside anonymous class, change it with functional style, then paste it back.
    - `DefaultInvoiceDao#createInvoices() `
    - `DefaultInvoiceDao#createRefund() `
    - `DefaultInvoiceDao#postChargeback() `
    - `DefaultInvoiceDao#postChargebackReversal() `
    - `DefaultInvoiceDao#notifyOfPaymentCompletionInternal() `
    - `DefaultInvoiceDao#deleteCBA() `
    - `DefaultInvoiceDao#transferChildCreditToParent()`
