### PR TITLE
1615 invoice part 2

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/calculator/InvoiceCalculatorUtils.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/calculator/InvoiceCalculatorUtils.java
@@ -20,6 +20,7 @@ package org.killbill.billing.invoice.calculator;
 
 import java.math.BigDecimal;
 import java.util.Iterator;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -29,10 +30,8 @@ import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoicePayment;
 import org.killbill.billing.invoice.api.InvoicePaymentType;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.billing.util.currency.KillBillMoney;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 
 public abstract class InvoiceCalculatorUtils {
 
@@ -45,7 +44,7 @@ public abstract class InvoiceCalculatorUtils {
 
     private static boolean isCreditInvoice(final Iterable<InvoiceItem> invoiceItems) { 
 
-        if (Iterables.size(invoiceItems) != 2) { 
+        if (Iterables.size(invoiceItems) != 2) {
             return false;
         }
 
@@ -115,12 +114,9 @@ public abstract class InvoiceCalculatorUtils {
             return BigDecimal.ZERO;
         }
 
-        final Iterable<InvoiceItem> chargeItems = Iterables.filter(invoiceItems, new Predicate<InvoiceItem>() {
-            @Override
-            public boolean apply(final InvoiceItem input) {
-                return isCharge(input);
-            }
-        });
+        final Iterable<InvoiceItem> chargeItems = Iterables.toStream(invoiceItems)
+                .filter(InvoiceCalculatorUtils::isCharge)
+                .collect(Collectors.toUnmodifiableList());
 
         if (Iterables.isEmpty(chargeItems)) {
             // return only credit amount to be subtracted to parent item amount
@@ -143,10 +139,10 @@ public abstract class InvoiceCalculatorUtils {
 
         if (isCreditInvoice(invoiceItems)) { //if the invoice corresponds to a CREDIT, include its amount
 
-            Iterator<InvoiceItem> itr = invoiceItems.iterator();
+            final Iterator<InvoiceItem> itr = invoiceItems.iterator();
 
-            InvoiceItem item1 = itr.next();
-            InvoiceItem item2 = itr.next();
+            final InvoiceItem item1 = itr.next();
+            final InvoiceItem item2 = itr.next();
 
             if (InvoiceItemType.CREDIT_ADJ.equals(item1.getInvoiceItemType())) {
                 amountAdjusted = amountAdjusted.add(item1.getAmount());

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDaoHelper.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDaoHelper.java
@@ -21,14 +21,18 @@ package org.killbill.billing.invoice.dao;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -42,22 +46,15 @@ import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.billing.util.dao.CounterMappings;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
 import org.killbill.billing.util.tag.ControlTagType;
 import org.killbill.billing.util.tag.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Function;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 
 public class InvoiceDaoHelper {
 
@@ -89,7 +86,7 @@ public class InvoiceDaoHelper {
                                                         final Map<UUID, BigDecimal> invoiceItemIdsWithNullAmounts,
                                                         final InternalTenantContext context) throws InvoiceApiException {
         // Populate the missing amounts for individual items, if needed
-        final Map<UUID, BigDecimal> outputItemIdsWithAmounts = new HashMap<UUID, BigDecimal>();
+        final Map<UUID, BigDecimal> outputItemIdsWithAmounts = new HashMap<>();
         // Retrieve invoice before the Refund
         final InvoiceModelDao invoice = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class).getById(invoiceId, context);
         if (invoice != null) {
@@ -108,7 +105,10 @@ public class InvoiceDaoHelper {
         return outputItemIdsWithAmounts;
     }
 
-    private static void computeItemAdjustmentsForTargetInvoiceItem(final InvoiceItemModelDao targetInvoiceItem, final List<InvoiceItemModelDao> adjustedOrRepairedItems, final Map<UUID, BigDecimal> inputAdjInvoiceItem, final Map<UUID, BigDecimal> outputAdjInvoiceItem) throws InvoiceApiException {
+    private static void computeItemAdjustmentsForTargetInvoiceItem(final InvoiceItemModelDao targetInvoiceItem,
+                                                                   final List<InvoiceItemModelDao> adjustedOrRepairedItems,
+                                                                   final Map<UUID, BigDecimal> inputAdjInvoiceItem,
+                                                                   final Map<UUID, BigDecimal> outputAdjInvoiceItem) throws InvoiceApiException {
         final BigDecimal originalItemAmount = targetInvoiceItem.getAmount();
         final BigDecimal maxAdjLeftAmount = computeItemAdjustmentAmount(originalItemAmount, adjustedOrRepairedItems);
 
@@ -117,7 +117,7 @@ public class InvoiceDaoHelper {
             throw new InvoiceApiException(ErrorCode.INVOICE_ITEM_ADJUSTMENT_AMOUNT_INVALID, proposedItemAmount, maxAdjLeftAmount);
         }
 
-        final BigDecimal itemAmountToAdjust = MoreObjects.firstNonNull(proposedItemAmount, maxAdjLeftAmount);
+        final BigDecimal itemAmountToAdjust = Objects.requireNonNullElse(proposedItemAmount, maxAdjLeftAmount);
         if (itemAmountToAdjust.compareTo(BigDecimal.ZERO) > 0) {
             outputAdjInvoiceItem.put(targetInvoiceItem.getId(), itemAmountToAdjust);
         }
@@ -170,25 +170,29 @@ public class InvoiceDaoHelper {
         return requestedPositiveAmount;
     }
 
-    public List<InvoiceModelDao> getUnpaidInvoicesByAccountFromTransaction(final UUID accountId, final List<Tag> invoicesTags, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, @Nullable LocalDate startDate, final LocalDate upToDate, final InternalTenantContext context) {
+    public List<InvoiceModelDao> getUnpaidInvoicesByAccountFromTransaction(final UUID accountId,
+                                                                           final List<Tag> invoicesTags,
+                                                                           final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
+                                                                           @Nullable final LocalDate startDate,
+                                                                           final LocalDate upToDate,
+                                                                           final InternalTenantContext context) {
         final List<InvoiceModelDao> invoices = getAllInvoicesByAccountFromTransaction(false, invoicesTags, entitySqlDaoWrapperFactory, context);
         log.debug("Found invoices={} for accountId={}", invoices, accountId);
         return getUnpaidInvoicesByAccountFromTransaction(invoices, startDate, upToDate);
     }
 
-    public List<InvoiceModelDao> getUnpaidInvoicesByAccountFromTransaction(final List<InvoiceModelDao> invoices,  @Nullable LocalDate startDate, @Nullable final LocalDate upToDate) {
-        final Collection<InvoiceModelDao> unpaidInvoices = Collections2.filter(invoices, new Predicate<InvoiceModelDao>() {
-            @Override
-            public boolean apply(final InvoiceModelDao in) {
-                final InvoiceModelDao invoice = (in.getParentInvoice() == null) ? in : in.getParentInvoice();
-                final BigDecimal balance = InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(invoice);
-                log.debug("Computed balance={} for invoice={}", balance, in);
-                return InvoiceStatus.COMMITTED.equals(in.getStatus()) &&
-                       (balance.compareTo(BigDecimal.ZERO) >= 1 && !in.isWrittenOff()) &&
-                       (startDate == null || in.getTargetDate() == null || in.getTargetDate().compareTo(startDate) >= 0) &&
-                       (upToDate == null || in.getTargetDate() == null || in.getTargetDate().compareTo(upToDate) <= 0);
-            }
-        });
+    public List<InvoiceModelDao> getUnpaidInvoicesByAccountFromTransaction(final List<InvoiceModelDao> invoices, @Nullable final LocalDate startDate, @Nullable final LocalDate upToDate) {
+        final Collection<InvoiceModelDao> unpaidInvoices = invoices.stream()
+                .filter(in -> {
+                    final InvoiceModelDao invoice = (in.getParentInvoice() == null) ? in : in.getParentInvoice();
+                    final BigDecimal balance = InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(invoice);
+                    log.debug("Computed balance={} for invoice={}", balance, in);
+                    return InvoiceStatus.COMMITTED.equals(in.getStatus()) &&
+                           (balance.compareTo(BigDecimal.ZERO) >= 1 && !in.isWrittenOff()) &&
+                           (startDate == null || in.getTargetDate() == null || in.getTargetDate().compareTo(startDate) >= 0) &&
+                           (upToDate == null || in.getTargetDate() == null || in.getTargetDate().compareTo(upToDate) <= 0);
+                })
+                .collect(Collectors.toUnmodifiableList());
         return new ArrayList<InvoiceModelDao>(unpaidInvoices);
 
     }
@@ -219,9 +223,9 @@ public class InvoiceDaoHelper {
         }
 
         // Retrieve the amount and currency if needed
-        final BigDecimal amountToAdjust = MoreObjects.firstNonNull(positiveAdjAmount, invoiceItemToBeAdjusted.getAmount());
+        final BigDecimal amountToAdjust = Objects.requireNonNullElse(positiveAdjAmount, invoiceItemToBeAdjusted.getAmount());
         // TODO - should we enforce the currency (and respect the original one) here if the amount passed was null?
-        final Currency currencyForAdjustment = MoreObjects.firstNonNull(currency, invoiceItemToBeAdjusted.getCurrency());
+        final Currency currencyForAdjustment = Objects.requireNonNullElse(currency, invoiceItemToBeAdjusted.getCurrency());
 
         // Finally, create the adjustment
         // Note! The amount is negated here!
@@ -254,30 +258,24 @@ public class InvoiceDaoHelper {
         setInvoicesWrittenOff(invoices, invoicesTags);
         setInvoicesRepaired(invoices, entitySqlDaoWrapperFactory, context);
 
-        final Iterable<InvoiceModelDao> nonParentInvoices = Iterables.<InvoiceModelDao>filter(invoices, new Predicate<InvoiceModelDao>() {
-            @Override
-            public boolean apply(final InvoiceModelDao invoice) {
-                return !invoice.isParentInvoice();
-            }
-        });
+        final Iterable<InvoiceModelDao> nonParentInvoices = Iterables.toStream(invoices)
+                .filter(invoice -> !invoice.isParentInvoice())
+                .collect(Collectors.toUnmodifiableList());
 
         if (!Iterables.isEmpty(nonParentInvoices)) {
-            setParentInvoice(nonParentInvoices,
-                             invoicesTags,
-                             entitySqlDaoWrapperFactory,
-                             context);
+            setParentInvoice(nonParentInvoices, invoicesTags, entitySqlDaoWrapperFactory, context);
         }
     }
 
-    public List<InvoiceModelDao> getAllInvoicesByAccountFromTransaction(final Boolean includeVoidedInvoices, final List<Tag> invoicesTags, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext context) {
-        final List<InvoiceModelDao> invoices = ImmutableList.<InvoiceModelDao>copyOf(Iterables.<InvoiceModelDao>filter(entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class).getByAccountRecordId(context),
-                                                                                 new Predicate<InvoiceModelDao>() {
-                                                                                     @Override
-                                                                                     public boolean apply(final InvoiceModelDao invoice) {
-                                                                                         return includeVoidedInvoices ? true : !InvoiceStatus.VOID.equals(invoice.getStatus());
-                                                                                     }
-                                                                                 }));
-        populateChildren(invoices, invoicesTags, entitySqlDaoWrapperFactory, context);
+    public List<InvoiceModelDao> getAllInvoicesByAccountFromTransaction(final Boolean includeVoidedInvoices,
+                                                                        final List<Tag> invoicesTags,
+                                                                        final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory,
+                                                                        final InternalTenantContext context) {
+        final List<InvoiceModelDao> invoices = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class).getByAccountRecordId(context);
+        final List<InvoiceModelDao> filtered = invoices.stream()
+                .filter(invoice -> includeVoidedInvoices || !InvoiceStatus.VOID.equals(invoice.getStatus()))
+                .collect(Collectors.toUnmodifiableList());
+        populateChildren(filtered, invoicesTags, entitySqlDaoWrapperFactory, context);
         return invoices;
     }
 
@@ -289,24 +287,27 @@ public class InvoiceDaoHelper {
 
     private void setInvoiceItemsWithinTransaction(final InvoiceModelDao invoice, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext context) {
         final InvoiceItemSqlDao invoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-        final List<InvoiceItemModelDao> invoiceItems = invoiceItemSqlDao.getInvoiceItemsForInvoices(ImmutableList.of(invoice.getId()), context);
+        final List<InvoiceItemModelDao> invoiceItems = invoiceItemSqlDao.getInvoiceItemsForInvoices(List.of(invoice.getId()), context);
         // Make sure to set invoice items to a non-null value
-        final List<InvoiceItemModelDao> invoiceItemsForInvoice = MoreObjects.firstNonNull(invoiceItems, ImmutableList.<InvoiceItemModelDao>of());
+        final List<InvoiceItemModelDao> invoiceItemsForInvoice = Objects.requireNonNullElse(invoiceItems, Collections.emptyList());
         log.debug("Found items={} for invoice={}", invoiceItemsForInvoice, invoice);
         invoice.addInvoiceItems(invoiceItemsForInvoice);
     }
 
 
+    private Iterable<UUID> mapInvoicesToInvoiceIds(final Iterable<InvoiceModelDao> invoices) {
+        return Iterables.toStream(invoices)
+                .map(InvoiceModelDao::getId)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+
     private void setInvoiceItemsWithinTransaction(final Iterable<InvoiceModelDao> invoices, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext context) {
         final InvoiceItemSqlDao invoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-        final List<InvoiceItemModelDao> invoiceItemsForAccount = invoiceItemSqlDao.getInvoiceItemsForInvoices(ImmutableSet.copyOf(Iterables.transform(invoices, new Function<InvoiceModelDao, UUID>() {
-            @Override
-            public UUID apply(final InvoiceModelDao invoiceModelDao) {
-                return invoiceModelDao.getId();
-            }
-        })), context);
+        final Iterable<UUID> invoiceIds = mapInvoicesToInvoiceIds(invoices);
+        final List<InvoiceItemModelDao> invoiceItemsForAccount = invoiceItemSqlDao.getInvoiceItemsForInvoices(invoiceIds, context);
 
-        final Map<UUID, List<InvoiceItemModelDao>> invoiceItemsPerInvoiceId = new HashMap<UUID, List<InvoiceItemModelDao>>();
+        final Map<UUID, List<InvoiceItemModelDao>> invoiceItemsPerInvoiceId = new HashMap<>();
         for (final InvoiceItemModelDao item : invoiceItemsForAccount) {
             if (invoiceItemsPerInvoiceId.get(item.getInvoiceId()) == null) {
                 invoiceItemsPerInvoiceId.put(item.getInvoiceId(), new LinkedList<InvoiceItemModelDao>());
@@ -316,7 +317,7 @@ public class InvoiceDaoHelper {
 
         for (final InvoiceModelDao invoice : invoices) {
             // Make sure to set invoice items to a non-null value
-            final List<InvoiceItemModelDao> invoiceItemsForInvoice = MoreObjects.firstNonNull(invoiceItemsPerInvoiceId.get(invoice.getId()), ImmutableList.<InvoiceItemModelDao>of());
+            final List<InvoiceItemModelDao> invoiceItemsForInvoice = Objects.requireNonNullElse(invoiceItemsPerInvoiceId.get(invoice.getId()), Collections.emptyList());
             log.debug("Found items={} for invoice={}", invoiceItemsForInvoice, invoice);
             invoice.addInvoiceItems(invoiceItemsForInvoice);
         }
@@ -339,14 +340,10 @@ public class InvoiceDaoHelper {
 
     private void setInvoicePaymentsWithinTransaction(final Iterable<InvoiceModelDao> invoices, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext context) {
         final InvoicePaymentSqlDao invoicePaymentSqlDao = entitySqlDaoWrapperFactory.become(InvoicePaymentSqlDao.class);
-        final List<InvoicePaymentModelDao> invoicePaymentsForAccount = invoicePaymentSqlDao.getPaymentsForInvoices(ImmutableSet.copyOf(Iterables.transform(invoices, new Function<InvoiceModelDao, UUID>() {
-            @Override
-            public UUID apply(final InvoiceModelDao invoiceModelDao) {
-                return invoiceModelDao.getId();
-            }
-        })), context);
+        final Iterable<UUID> invoiceIds = mapInvoicesToInvoiceIds(invoices);
+        final List<InvoicePaymentModelDao> invoicePaymentsForAccount = invoicePaymentSqlDao.getPaymentsForInvoices(invoiceIds, context);
 
-        final Map<UUID, List<InvoicePaymentModelDao>> invoicePaymentsPerInvoiceId = new HashMap<UUID, List<InvoicePaymentModelDao>>();
+        final Map<UUID, List<InvoicePaymentModelDao>> invoicePaymentsPerInvoiceId = new HashMap<>();
         for (final InvoicePaymentModelDao invoicePayment : invoicePaymentsForAccount) {
             if (invoicePaymentsPerInvoiceId.get(invoicePayment.getInvoiceId()) == null) {
                 invoicePaymentsPerInvoiceId.put(invoicePayment.getInvoiceId(), new LinkedList<InvoicePaymentModelDao>());
@@ -356,7 +353,7 @@ public class InvoiceDaoHelper {
 
         for (final InvoiceModelDao invoice : invoices) {
             // Make sure to set payments to a non-null value
-            final List<InvoicePaymentModelDao> invoicePaymentsForInvoice = MoreObjects.firstNonNull(invoicePaymentsPerInvoiceId.get(invoice.getId()), ImmutableList.<InvoicePaymentModelDao>of());
+            final List<InvoicePaymentModelDao> invoicePaymentsForInvoice = Objects.requireNonNullElse(invoicePaymentsPerInvoiceId.get(invoice.getId()), Collections.emptyList());
             log.debug("Found payments={} for invoice={}", invoicePaymentsForInvoice, invoice);
             invoice.addPayments(invoicePaymentsForInvoice);
 
@@ -371,41 +368,32 @@ public class InvoiceDaoHelper {
     }
 
     private void setInvoiceWrittenOff(final InvoiceModelDao invoice, final List<Tag> invoicesTags) {
-        setInvoicesWrittenOff(ImmutableList.of(invoice), invoicesTags);
+        setInvoicesWrittenOff(List.of(invoice), invoicesTags);
     }
 
     private void setInvoiceRepaired(final InvoiceModelDao invoice, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext context) {
-        setInvoicesRepaired(ImmutableList.of(invoice), entitySqlDaoWrapperFactory, context);
+        setInvoicesRepaired(List.of(invoice), entitySqlDaoWrapperFactory, context);
     }
 
     private void setInvoicesWrittenOff(final Iterable<InvoiceModelDao> invoices, final List<Tag> invoicesTags) {
-        final Iterable<Tag> writtenOffTags = filterForWrittenOff(invoicesTags);
-        for (final Tag cur : writtenOffTags) {
-            final InvoiceModelDao foundInvoice = Iterables.tryFind(invoices, new Predicate<InvoiceModelDao>() {
-                @Override
-                public boolean apply(final InvoiceModelDao input) {
-                    return input.getId().equals(cur.getObjectId());
-                }
-            }).orNull();
-            if (foundInvoice != null) {
-                foundInvoice.setIsWrittenOff(true);
-            }
-        }
+        filterForWrittenOff(invoicesTags).forEach(tag -> Iterables.toStream(invoices)
+                                                                  .filter(input -> input.getId().equals(tag.getObjectId()))
+                                                                  .findFirst()
+                                                                  .ifPresent(foundInvoice -> foundInvoice.setIsWrittenOff(true)));
+    }
+
+    private Stream<String> mapInvoicesToInvoiceIdsStream(final Iterable<InvoiceModelDao> invoices) {
+        return Iterables.toStream(invoices).map(input -> input.getId().toString());
     }
 
     private void setInvoicesRepaired(final Iterable<InvoiceModelDao> invoices, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext context) {
         final InvoiceItemSqlDao invoiceItemSqlDao = entitySqlDaoWrapperFactory.become(InvoiceItemSqlDao.class);
-        final Iterable<String> invoiceIds = Iterables.transform(invoices, new Function<InvoiceModelDao, String>() {
-            @Override
-            public String apply(final InvoiceModelDao invoiceModelDao) {
-                return invoiceModelDao.getId().toString();
-            }
-        });
+        final Iterable<String> invoiceIds = mapInvoicesToInvoiceIdsStream(invoices).collect(Collectors.toUnmodifiableList());
         if (Iterables.isEmpty(invoiceIds)) {
             return;
         }
 
-        final Iterable<CounterMappings> repairedMapRes = invoiceItemSqlDao.getRepairMap(ImmutableList.copyOf(invoiceIds), context);
+        final Iterable<CounterMappings> repairedMapRes = invoiceItemSqlDao.getRepairMap(invoiceIds, context);
         final Map<String, Integer> repairedMap = CounterMappings.toMap(repairedMapRes);
         for (final InvoiceModelDao cur : invoices) {
             final Integer repairedItems = repairedMap.get(cur.getId().toString());
@@ -417,23 +405,17 @@ public class InvoiceDaoHelper {
 
 
     private void setTrackingIdsFromTransaction(final InvoiceModelDao invoice, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext context) {
-        setTrackingIdsFromTransaction(ImmutableList.of(invoice), entitySqlDaoWrapperFactory, context);
+        setTrackingIdsFromTransaction(List.of(invoice), entitySqlDaoWrapperFactory, context);
     }
 
     private void setTrackingIdsFromTransaction(final Iterable<InvoiceModelDao> invoices, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext context) {
-
-        final Set<String> invoiceIds = ImmutableSet.<String>copyOf(Iterables.transform(invoices, new Function<InvoiceModelDao, String>() {
-            @Override
-            public String apply(final InvoiceModelDao input) {
-                return input.getId().toString();
-            }
-        }));
+        final Set<String> invoiceIds = mapInvoicesToInvoiceIdsStream(invoices).collect(Collectors.toUnmodifiableSet());
 
         final InvoiceTrackingSqlDao invoiceTrackingidSqlDao = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
         final List<InvoiceTrackingModelDao> trackingIds = invoiceTrackingidSqlDao.getTrackingsForInvoices(invoiceIds, context);
 
-        final Map<UUID, List<InvoiceTrackingModelDao>> invoiceTrackingIdsPerInvoiceId = new HashMap<UUID, List<InvoiceTrackingModelDao>>();
-        for (InvoiceTrackingModelDao cur : trackingIds) {
+        final Map<UUID, List<InvoiceTrackingModelDao>> invoiceTrackingIdsPerInvoiceId = new HashMap<>();
+        for (final InvoiceTrackingModelDao cur : trackingIds) {
             if (invoiceTrackingIdsPerInvoiceId.get(cur.getInvoiceId()) == null) {
                 invoiceTrackingIdsPerInvoiceId.put(cur.getInvoiceId(), new LinkedList<>());
             }
@@ -443,29 +425,23 @@ public class InvoiceDaoHelper {
         for (final InvoiceModelDao invoice : invoices) {
             if (invoiceTrackingIdsPerInvoiceId.get(invoice.getId()) != null) {
                 final List<InvoiceTrackingModelDao> perInvoiceTrackingIds = invoiceTrackingIdsPerInvoiceId.get(invoice.getId());
-                final Iterable<String> transform = Iterables.transform(perInvoiceTrackingIds, new Function<InvoiceTrackingModelDao, String>() {
-                    @Override
-                    public String apply(final InvoiceTrackingModelDao input) {
-                        return input.getTrackingId();
-                    }
-                });
-                invoice.addTrackingIds(ImmutableSet.<String>copyOf(transform));
+                final Set<String> transform = perInvoiceTrackingIds.stream()
+                        .map(InvoiceTrackingModelDao::getTrackingId)
+                        .collect(Collectors.toUnmodifiableSet());
+                invoice.addTrackingIds(transform);
             }
         }
     }
 
     private Iterable<Tag> filterForWrittenOff(final List<Tag> tags) {
-        return Iterables.filter(tags, new Predicate<Tag>() {
-            @Override
-            public boolean apply(final Tag input) {
-                return input.getTagDefinitionId().equals(ControlTagType.WRITTEN_OFF.getId());
-            }
-        });
+        return tags.stream()
+                .filter(input -> input.getTagDefinitionId().equals(ControlTagType.WRITTEN_OFF.getId()))
+                .collect(Collectors.toUnmodifiableList());
     }
 
     private void setParentInvoice(final InvoiceModelDao invoice, final List<Tag> invoicesTags, final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory, final InternalTenantContext childContext) {
         final InvoiceParentChildrenSqlDao invoiceParentChildrenSqlDao = entitySqlDaoWrapperFactory.become(InvoiceParentChildrenSqlDao.class);
-        final List<InvoiceParentChildModelDao> mappings = invoiceParentChildrenSqlDao.getParentChildMappingsByChildInvoiceIds(ImmutableList.of(invoice.getId().toString()), childContext);
+        final List<InvoiceParentChildModelDao> mappings = invoiceParentChildrenSqlDao.getParentChildMappingsByChildInvoiceIds(List.of(invoice.getId().toString()), childContext);
         if (mappings.isEmpty()) {
             return;
         }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceModelDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceModelDao.java
@@ -36,8 +36,6 @@ import org.killbill.billing.util.dao.TableName;
 import org.killbill.billing.util.entity.dao.EntityModelDao;
 import org.killbill.billing.util.entity.dao.EntityModelDaoBase;
 
-import com.google.common.collect.ImmutableList;
-
 public class InvoiceModelDao extends EntityModelDaoBase implements EntityModelDao<Invoice> {
 
     private UUID accountId;
@@ -99,7 +97,7 @@ public class InvoiceModelDao extends EntityModelDaoBase implements EntityModelDa
     }
 
     public List<String> getTrackingIds() {
-        return ImmutableList.copyOf(trackingIds);
+        return List.copyOf(trackingIds);
     }
 
     public void addTrackingIds(final Set<String> trackingIds) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -20,16 +20,20 @@ package org.killbill.billing.invoice.generator;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
+import org.joda.time.Interval;
 import org.joda.time.LocalDate;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.account.api.ImmutableAccountData;
@@ -53,20 +57,15 @@ import org.killbill.billing.invoice.optimizer.InvoiceOptimizerBase.AccountInvoic
 import org.killbill.billing.invoice.tree.AccountItemTree;
 import org.killbill.billing.junction.BillingEvent;
 import org.killbill.billing.junction.BillingEventSet;
+import org.killbill.billing.util.Preconditions;
+import org.killbill.billing.util.annotation.VisibleForTesting;
+import org.killbill.billing.util.collect.MultiValueHashMap;
+import org.killbill.billing.util.collect.MultiValueMap;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.currency.KillBillMoney;
 import org.killbill.clock.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Range;
-import com.google.inject.Inject;
 
 import static org.killbill.billing.invoice.generator.InvoiceDateUtils.calculateNumberOfWholeBillingPeriods;
 import static org.killbill.billing.invoice.generator.InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate;
@@ -89,7 +88,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
                                                 final Currency targetCurrency, final Map<UUID, SubscriptionFutureNotificationDates> perSubscriptionFutureNotificationDate,
                                                 final DryRunInfo dryRunInfo,
                                                 final InternalCallContext internalCallContext) throws InvoiceApiException {
-        final Multimap<UUID, LocalDate> createdItemsPerDayPerSubscription = LinkedListMultimap.<UUID, LocalDate>create();
+        final MultiValueMap<UUID, LocalDate> createdItemsPerDayPerSubscription = new MultiValueHashMap<>();
 
 
         final InvoicePruner invoicePruner = new InvoicePruner(existingInvoices);
@@ -112,7 +111,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         }
 
         // Generate list of proposed invoice items based on billing events from junction-- proposed items are ALL items since beginning of time
-        final List<InvoiceItem> proposedItems = new ArrayList<InvoiceItem>();
+        final List<InvoiceItem> proposedItems = new ArrayList<>();
         processRecurringBillingEvents(invoiceId, account.getId(), eventSet, targetDate, targetCurrency, proposedItems, perSubscriptionFutureNotificationDate, internalCallContext);
         processFixedBillingEvents(invoiceId, account.getId(), eventSet, targetDate, targetCurrency, proposedItems, internalCallContext);
 
@@ -129,7 +128,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         final List<InvoiceItem> resultingItems = accountItemTree.getResultingItemList();
         safetyBounds(resultingItems, createdItemsPerDayPerSubscription, internalCallContext);
 
-        return new InvoiceGeneratorResult(resultingItems, ImmutableSet.of());
+        return new InvoiceGeneratorResult(resultingItems, Collections.emptySet());
     }
 
     private void processRecurringBillingEvents(final UUID invoiceId, final UUID accountId, final BillingEventSet events,
@@ -439,36 +438,17 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
     }
 
     @VisibleForTesting
-    void safetyBounds(final Iterable<InvoiceItem> resultingItems, final Multimap<UUID, LocalDate> createdItemsPerDayPerSubscription, final InternalCallContext internalCallContext) throws InvoiceApiException {
+    void safetyBounds(final Iterable<InvoiceItem> resultingItems, final MultiValueMap<UUID, LocalDate> createdItemsPerDayPerSubscription, final InternalCallContext internalCallContext) throws InvoiceApiException {
         // Trigger an exception if we detect the creation of similar items for a given subscription
         // See https://github.com/killbill/killbill/issues/664
         if (config.isSanitySafetyBoundEnabled(internalCallContext)) {
-            final Map<UUID, Multimap<LocalDate, InvoiceItem>> fixedItemsPerDateAndSubscription = new HashMap<UUID, Multimap<LocalDate, InvoiceItem>>();
-            final Map<UUID, Multimap<Range<LocalDate>, InvoiceItem>> recurringItemsPerServicePeriodAndSubscription = new HashMap<UUID, Multimap<Range<LocalDate>, InvoiceItem>>();
+            final Map<UUID, MultiValueMap<LocalDate, InvoiceItem>> fixedItemsPerDateAndSubscription = new HashMap<>();
+            final Map<UUID, MultiValueMap<Interval, InvoiceItem>> recurringItemsPerServicePeriodAndSubscription = new HashMap<>();
             for (final InvoiceItem resultingItem : resultingItems) {
                 if (resultingItem.getInvoiceItemType() == InvoiceItemType.FIXED) {
-                    if (fixedItemsPerDateAndSubscription.get(resultingItem.getSubscriptionId()) == null) {
-                        fixedItemsPerDateAndSubscription.put(resultingItem.getSubscriptionId(), LinkedListMultimap.<LocalDate, InvoiceItem>create());
-                    }
-                    fixedItemsPerDateAndSubscription.get(resultingItem.getSubscriptionId()).put(resultingItem.getStartDate(), resultingItem);
-
-                    final Collection<InvoiceItem> resultingInvoiceItems = fixedItemsPerDateAndSubscription.get(resultingItem.getSubscriptionId()).get(resultingItem.getStartDate());
-                    if (resultingInvoiceItems.size() > 1) {
-                        throw new InvoiceApiException(ErrorCode.UNEXPECTED_ERROR, String.format("SAFETY BOUND TRIGGERED Multiple FIXED items for subscriptionId='%s', startDate='%s', resultingItems=%s",
-                                                                                                resultingItem.getSubscriptionId(), resultingItem.getStartDate(), resultingInvoiceItems));
-                    }
+                    validateSafeBoundsWithFixedInvoiceItem(fixedItemsPerDateAndSubscription, resultingItem);
                 } else if (resultingItem.getInvoiceItemType() == InvoiceItemType.RECURRING) {
-                    if (recurringItemsPerServicePeriodAndSubscription.get(resultingItem.getSubscriptionId()) == null) {
-                        recurringItemsPerServicePeriodAndSubscription.put(resultingItem.getSubscriptionId(), LinkedListMultimap.<Range<LocalDate>, InvoiceItem>create());
-                    }
-                    final Range<LocalDate> interval = Range.<LocalDate>closedOpen(resultingItem.getStartDate(), resultingItem.getEndDate());
-                    recurringItemsPerServicePeriodAndSubscription.get(resultingItem.getSubscriptionId()).put(interval, resultingItem);
-
-                    final Collection<InvoiceItem> resultingInvoiceItems = recurringItemsPerServicePeriodAndSubscription.get(resultingItem.getSubscriptionId()).get(interval);
-                    if (resultingInvoiceItems.size() > 1) {
-                        throw new InvoiceApiException(ErrorCode.UNEXPECTED_ERROR, String.format("SAFETY BOUND TRIGGERED Multiple RECURRING items for subscriptionId='%s', startDate='%s', endDate='%s', resultingItems=%s",
-                                                                                                resultingItem.getSubscriptionId(), resultingItem.getStartDate(), resultingItem.getEndDate(), resultingInvoiceItems));
-                    }
+                    validateSafeBoundsWithRecurringInvoiceItem(recurringItemsPerServicePeriodAndSubscription, resultingItem);
                 }
             }
         }
@@ -499,14 +479,43 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         }
     }
 
-    private LocalDate trackInvoiceItemCreatedDay(final InvoiceItem invoiceItem, final Multimap<UUID, LocalDate> createdItemsPerDayPerSubscription, final InternalCallContext internalCallContext) {
+    private void validateSafeBoundsWithFixedInvoiceItem(final Map<UUID, MultiValueMap<LocalDate, InvoiceItem>> fixedItemsPerDateAndSubscription,
+                                                        final InvoiceItem resultingItem) throws InvoiceApiException {
+        if (fixedItemsPerDateAndSubscription.get(resultingItem.getSubscriptionId()) == null) {
+            fixedItemsPerDateAndSubscription.put(resultingItem.getSubscriptionId(), new MultiValueHashMap<>());
+        }
+        fixedItemsPerDateAndSubscription.get(resultingItem.getSubscriptionId()).putElement(resultingItem.getStartDate(), resultingItem);
+
+        final Collection<InvoiceItem> resultingInvoiceItems = fixedItemsPerDateAndSubscription.get(resultingItem.getSubscriptionId()).get(resultingItem.getStartDate());
+        if (resultingInvoiceItems.size() > 1) {
+            throw new InvoiceApiException(ErrorCode.UNEXPECTED_ERROR, String.format("SAFETY BOUND TRIGGERED Multiple FIXED items for subscriptionId='%s', startDate='%s', resultingItems=%s",
+                                                                                    resultingItem.getSubscriptionId(), resultingItem.getStartDate(), resultingInvoiceItems));
+        }
+    }
+
+    private void validateSafeBoundsWithRecurringInvoiceItem(final Map<UUID, MultiValueMap<Interval, InvoiceItem>> recurringItemsPerServicePeriodAndSubscription,
+                                                            final InvoiceItem resultingItem) throws InvoiceApiException {
+        if (recurringItemsPerServicePeriodAndSubscription.get(resultingItem.getSubscriptionId()) == null) {
+            recurringItemsPerServicePeriodAndSubscription.put(resultingItem.getSubscriptionId(), new MultiValueHashMap<>());
+        }
+        final Interval interval = new Interval(resultingItem.getStartDate().toDateTimeAtStartOfDay(), resultingItem.getEndDate().toDateTimeAtStartOfDay());
+        recurringItemsPerServicePeriodAndSubscription.get(resultingItem.getSubscriptionId()).putElement(interval, resultingItem);
+
+        final Collection<InvoiceItem> resultingInvoiceItems = recurringItemsPerServicePeriodAndSubscription.get(resultingItem.getSubscriptionId()).get(interval);
+        if (resultingInvoiceItems.size() > 1) {
+            throw new InvoiceApiException(ErrorCode.UNEXPECTED_ERROR, String.format("SAFETY BOUND TRIGGERED Multiple RECURRING items for subscriptionId='%s', startDate='%s', endDate='%s', resultingItems=%s",
+                                                                                    resultingItem.getSubscriptionId(), resultingItem.getStartDate(), resultingItem.getEndDate(), resultingInvoiceItems));
+        }
+    }
+
+    private LocalDate trackInvoiceItemCreatedDay(final InvoiceItem invoiceItem, final MultiValueMap<UUID, LocalDate> createdItemsPerDayPerSubscription, final InternalCallContext internalCallContext) {
         final UUID subscriptionId = invoiceItem.getSubscriptionId();
         if (subscriptionId == null) {
             return null;
         }
 
-        final LocalDate createdDay = internalCallContext.toLocalDate(MoreObjects.firstNonNull(invoiceItem.getCreatedDate(), internalCallContext.getCreatedDate()));
-        createdItemsPerDayPerSubscription.put(subscriptionId, createdDay);
+        final LocalDate createdDay = internalCallContext.toLocalDate(Objects.requireNonNullElse(invoiceItem.getCreatedDate(), internalCallContext.getCreatedDate()));
+        createdItemsPerDayPerSubscription.putElement(subscriptionId, createdDay);
         return createdDay;
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoicePruner.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoicePruner.java
@@ -19,26 +19,23 @@ package org.killbill.billing.invoice.generator;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
-import org.killbill.billing.invoice.model.ItemAdjInvoiceItem;
-import org.killbill.billing.invoice.model.RepairAdjInvoiceItem;
 import org.killbill.billing.invoice.optimizer.InvoiceOptimizerBase.AccountInvoices;
-
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
+import org.killbill.billing.util.Preconditions;
+import org.killbill.billing.util.collect.Iterables;
 
 //
 // This is invoked prior we build the tree of existing items to make sure we simplify the view,
@@ -236,15 +233,10 @@ public class InvoicePruner {
 
         private Set<UUID> getIds(final Iterable<? extends InvoiceItem> items) {
             if (items == null) {
-                return ImmutableSet.of();
+                return Collections.emptySet();
             }
 
-            return ImmutableSet.copyOf(Iterables.transform(items, new Function<InvoiceItem, UUID>() {
-                @Override
-                public UUID apply(final InvoiceItem input) {
-                    return input.getId();
-                }
-            }));
+            return Iterables.toStream(items).map(InvoiceItem::getId).collect(Collectors.toUnmodifiableSet());
         }
 
         private BigDecimal sumAmounts(final Iterable<? extends InvoiceItem> items) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/AccountItemTree.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/AccountItemTree.java
@@ -29,10 +29,8 @@ import java.util.UUID;
 
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
-
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
+import org.killbill.billing.util.Preconditions;
+import org.killbill.billing.util.collect.Iterables;
 
 /**
  * Tree of invoice items for a given account.
@@ -74,7 +72,7 @@ public class AccountItemTree {
     public void build() {
         Preconditions.checkState(!isBuilt);
 
-        if (pendingItemAdj.size() > 0) {
+        if (!pendingItemAdj.isEmpty()) {
             for (final InvoiceItem item : pendingItemAdj) {
                 addExistingItem(item, true);
             }
@@ -183,12 +181,9 @@ public class AccountItemTree {
     }
 
     private InvoiceItem getLinkedInvoiceItem(final InvoiceItem item, final Iterable<InvoiceItem> allItems) {
-        return Iterables.tryFind(allItems, new Predicate<InvoiceItem>() {
-            @Override
-            public boolean apply(final InvoiceItem input) {
-                return input.getId().equals(item.getLinkedItemId());
-            }
-        }).orNull();
+        return Iterables.toStream(allItems)
+                .filter(input -> input.getId().equals(item.getLinkedItemId()))
+                .findFirst().orElse(null);
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.invoice.tree;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -29,10 +30,9 @@ import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.generator.InvoiceDateUtils;
 import org.killbill.billing.invoice.model.RecurringInvoiceItem;
 import org.killbill.billing.invoice.model.RepairAdjInvoiceItem;
+import org.killbill.billing.util.Preconditions;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 
 /**
  * An generic invoice item that contains all pertinent fields regarding of its InvoiceItemType.
@@ -255,9 +255,9 @@ public class Item {
                // following conditions: same type, subscription, start date. Depending on the catalog configuration, the end
                // date check could also match (e.g. repair from annual to monthly). For that scenario, we need to default
                // to catalog checks (the rate check is a lame check for versioned catalogs).
-               MoreObjects.firstNonNull(planName, "").equals(MoreObjects.firstNonNull(otherItem.getPlanName(), "")) &&
-               MoreObjects.firstNonNull(phaseName, "").equals(MoreObjects.firstNonNull(otherItem.getPhaseName(), "")) &&
-               MoreObjects.firstNonNull(rate, BigDecimal.ZERO).compareTo(MoreObjects.firstNonNull(otherItem.getRate(), BigDecimal.ZERO)) == 0;
+               Objects.requireNonNullElse(planName, "").equals(Objects.requireNonNullElse(otherItem.getPlanName(), "")) &&
+               Objects.requireNonNullElse(phaseName, "").equals(Objects.requireNonNullElse(otherItem.getPhaseName(), "")) &&
+               Objects.requireNonNullElse(rate, BigDecimal.ZERO).compareTo(Objects.requireNonNullElse(otherItem.getRate(), BigDecimal.ZERO)) == 0;
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
@@ -35,12 +35,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.tree.Item.ItemAction;
+import org.killbill.billing.util.Preconditions;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 import org.killbill.billing.util.jackson.ObjectMapper;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 
 /**
  * Node in the SubscriptionItemTree

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/NodeInterval.java
@@ -22,9 +22,9 @@ package org.killbill.billing.invoice.tree;
 import javax.annotation.Nullable;
 
 import org.joda.time.LocalDate;
+import org.killbill.billing.util.Preconditions;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Preconditions;
 
 public class NodeInterval {
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/SubscriptionItemTree.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/SubscriptionItemTree.java
@@ -23,27 +23,25 @@ import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.tree.Item.ItemAction;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
+import org.killbill.billing.util.Preconditions;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 
 /**
  * Tree of invoice items for a given subscription
  */
 public class SubscriptionItemTree {
 
-    private final List<Item> items = new LinkedList<Item>();
-    private final List<InvoiceItem> existingIgnoredItems = new LinkedList<InvoiceItem>();
-    private final List<InvoiceItem> remainingIgnoredItems = new LinkedList<InvoiceItem>();
-    private final List<InvoiceItem> pendingItemAdj = new LinkedList<InvoiceItem>();
+    private final List<Item> items = new LinkedList<>();
+    private final List<InvoiceItem> existingIgnoredItems = new LinkedList<>();
+    private final List<InvoiceItem> remainingIgnoredItems = new LinkedList<>();
+    private final List<InvoiceItem> pendingItemAdj = new LinkedList<>();
 
     private final UUID targetInvoiceId;
     private final UUID subscriptionId;
@@ -121,13 +119,10 @@ public class SubscriptionItemTree {
 
         for (final InvoiceItem item : pendingItemAdj) {
             // If the linked item was ignored, ignore this adjustment too
-            final InvoiceItem ignoredLinkedItem = Iterables.tryFind(existingIgnoredItems, new Predicate<InvoiceItem>() {
-                @Override
-                public boolean apply(final InvoiceItem input) {
-                    return input.getId().equals(item.getLinkedItemId());
-                }
-            }).orNull();
-            if (ignoredLinkedItem == null) {
+            final boolean isLinkedItemExist = existingIgnoredItems
+                    .stream()
+                    .anyMatch(input -> input.getId().equals(item.getLinkedItemId()));
+            if (!isLinkedItemExist) {
                 root.addAdjustment(item);
             }
         }
@@ -168,13 +163,8 @@ public class SubscriptionItemTree {
         Preconditions.checkState(!isBuilt, "Tree already built, unable to add new invoiceItem=%s", invoiceItem);
 
         // Check if it was an existing item ignored for tree purposes (e.g. FIXED or $0 RECURRING, both of which aren't repaired)
-        final InvoiceItem existingItem = Iterables.tryFind(existingIgnoredItems, new Predicate<InvoiceItem>() {
-            @Override
-            public boolean apply(final InvoiceItem input) {
-                return input.matches(invoiceItem);
-            }
-        }).orNull();
-        if (existingItem != null) {
+        final boolean isItemExist = existingIgnoredItems.stream().anyMatch(input -> input.matches(invoiceItem));
+        if (isItemExist) {
             return;
         }
 
@@ -214,16 +204,10 @@ public class SubscriptionItemTree {
      * @return a flat view of the items in the tree.
      */
     public List<InvoiceItem> getView() {
+        final List<InvoiceItem> tmp = new LinkedList<>(remainingIgnoredItems);
+        items.stream().filter(Objects::nonNull).forEach(item -> tmp.add(item.toInvoiceItem()));
 
-        final List<InvoiceItem> tmp = new LinkedList<InvoiceItem>();
-        tmp.addAll(remainingIgnoredItems);
-        for (final Item item : items) {
-            if (item != null) {
-                tmp.add(item.toInvoiceItem());
-            }
-        }
-
-        final List<InvoiceItem> result = Ordering.<InvoiceItem>from(INVOICE_ITEM_COMPARATOR).sortedCopy(tmp);
+        final List<InvoiceItem> result = tmp.stream().sorted(INVOICE_ITEM_COMPARATOR).collect(Collectors.toUnmodifiableList());
         checkItemsListState(result);
         return result;
     }

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestDefaultInvoiceDaoUnit.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestDefaultInvoiceDaoUnit.java
@@ -17,6 +17,7 @@
 package org.killbill.billing.invoice.dao;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
@@ -28,15 +29,13 @@ import org.killbill.billing.ErrorCode;
 import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 
-import com.google.common.collect.ImmutableMap;
-
 public class TestDefaultInvoiceDaoUnit extends InvoiceTestSuiteNoDB {
 
-    // FIXME-1615 : Should we move this to TestInvoiceHelperUnit? AFAIK non of DefaultInvoiceDao methods involved here.
+    // FIXME-1615 : Should we move this to TestInvoiceHelperUnit? AFAIK none of DefaultInvoiceDao methods involved here.
     @Test(groups = "fast")
     public void testComputePositiveRefundAmount() throws Exception {
         // Verify the cases with no adjustment first
-        final Map<UUID, BigDecimal> noItemAdjustment = ImmutableMap.<UUID, BigDecimal>of();
+        final Map<UUID, BigDecimal> noItemAdjustment = Collections.emptyMap();
         verifyComputedRefundAmount(null, null, noItemAdjustment, BigDecimal.ZERO);
         verifyComputedRefundAmount(null, BigDecimal.ZERO, noItemAdjustment, BigDecimal.ZERO);
         verifyComputedRefundAmount(BigDecimal.TEN, null, noItemAdjustment, BigDecimal.TEN);
@@ -44,25 +43,27 @@ public class TestDefaultInvoiceDaoUnit extends InvoiceTestSuiteNoDB {
         try {
             verifyComputedRefundAmount(BigDecimal.ONE, BigDecimal.TEN, noItemAdjustment, BigDecimal.TEN);
             Assert.fail("Shouldn't have been able to compute a refund amount");
-        } catch (InvoiceApiException e) {
+        } catch (final InvoiceApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.REFUND_AMOUNT_TOO_HIGH.getCode());
         }
 
         // Try with adjustments now
-        final Map<UUID, BigDecimal> itemAdjustments = ImmutableMap.<UUID, BigDecimal>of(UUID.randomUUID(), BigDecimal.ONE,
-                                                                                        UUID.randomUUID(), BigDecimal.TEN,
-                                                                                        UUID.randomUUID(), BigDecimal.ZERO);
+        final Map<UUID, BigDecimal> itemAdjustments = Map.of(UUID.randomUUID(), BigDecimal.ONE,
+                                                             UUID.randomUUID(), BigDecimal.TEN,
+                                                             UUID.randomUUID(), BigDecimal.ZERO);
         verifyComputedRefundAmount(new BigDecimal("100"), new BigDecimal("11"), itemAdjustments, new BigDecimal("11"));
         try {
             verifyComputedRefundAmount(new BigDecimal("100"), BigDecimal.TEN, itemAdjustments, BigDecimal.TEN);
             Assert.fail("Shouldn't have been able to compute a refund amount");
-        } catch (InvoiceApiException e) {
+        } catch (final InvoiceApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.REFUND_AMOUNT_DONT_MATCH_ITEMS_TO_ADJUST.getCode());
         }
     }
 
-    private void verifyComputedRefundAmount(final BigDecimal paymentAmount, final BigDecimal requestedAmount,
-                                            final Map<UUID, BigDecimal> invoiceItemIdsWithAmounts, final BigDecimal expectedRefundAmount) throws InvoiceApiException {
+    private void verifyComputedRefundAmount(final BigDecimal paymentAmount,
+                                            final BigDecimal requestedAmount,
+                                            final Map<UUID, BigDecimal> invoiceItemIdsWithAmounts,
+                                            final BigDecimal expectedRefundAmount) throws InvoiceApiException {
         final InvoicePaymentModelDao invoicePayment = Mockito.mock(InvoicePaymentModelDao.class);
         Mockito.when(invoicePayment.getAmount()).thenReturn(paymentAmount);
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDaoHelper.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDaoHelper.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.invoice.dao;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,9 +51,6 @@ import org.killbill.billing.util.tag.Tag;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-
 
 //
 // Regression suite to verify that our optimized logic to either read invoice state per account recordId or per invoiceId
@@ -93,7 +91,7 @@ public class TestInvoiceDaoHelper extends InvoiceTestSuiteWithEmbeddedDB {
         inputInvoice.addInvoiceItem(invoiceItem);
         invoiceUtil.createInvoice(inputInvoice, internalAccountContext);
 
-        final List<Tag> tags = ImmutableList.of();
+        final List<Tag> tags = Collections.emptyList();
         final InvoiceModelDao invoice1 = getRawInvoice(inputInvoice.getId(), internalAccountContext);
         populateChildrenByInvoiceId(invoice1, tags);
 
@@ -116,7 +114,7 @@ public class TestInvoiceDaoHelper extends InvoiceTestSuiteWithEmbeddedDB {
         final InvoicePayment payment = new DefaultInvoicePayment(InvoicePaymentType.ATTEMPT, UUID.randomUUID(), inputInvoice.getId(), new DateTime(), BigDecimal.TEN, Currency.USD, Currency.USD, null, true);
         invoiceUtil.createPayment(payment, internalAccountContext);
 
-        final List<Tag> tags = ImmutableList.of();
+        final List<Tag> tags = Collections.emptyList();
         final InvoiceModelDao invoice1 = getRawInvoice(inputInvoice.getId(), internalAccountContext);
         populateChildrenByInvoiceId(invoice1, tags);
 
@@ -144,10 +142,10 @@ public class TestInvoiceDaoHelper extends InvoiceTestSuiteWithEmbeddedDB {
         invoiceUtil.createInvoice(inputInvoice, internalAccountContext);
 
         final InvoiceTrackingSqlDao trackingSqlDao = dbi.onDemand(InvoiceTrackingSqlDao.class);
-        trackingSqlDao.create(ImmutableList.of(new InvoiceTrackingModelDao("12345", inputInvoice.getId(), UUID.randomUUID(), "foo", today)), internalAccountContext);
+        trackingSqlDao.create(List.of(new InvoiceTrackingModelDao("12345", inputInvoice.getId(), UUID.randomUUID(), "foo", today)), internalAccountContext);
 
 
-        final List<Tag> tags = ImmutableList.of();
+        final List<Tag> tags = Collections.emptyList();
         final InvoiceModelDao invoice1 = getRawInvoice(inputInvoice.getId(), internalAccountContext);
         populateChildrenByInvoiceId(invoice1, tags);
 
@@ -173,7 +171,7 @@ public class TestInvoiceDaoHelper extends InvoiceTestSuiteWithEmbeddedDB {
 
         invoiceUtil.createInvoice(inputInvoice, internalAccountContext);
 
-        final List<Tag> tags = ImmutableList.of(new DefaultControlTag(ControlTagType.WRITTEN_OFF, ObjectType.INVOICE, inputInvoice.getId(), clock.getUTCNow()));
+        final List<Tag> tags = List.of(new DefaultControlTag(ControlTagType.WRITTEN_OFF, ObjectType.INVOICE, inputInvoice.getId(), clock.getUTCNow()));
         final InvoiceModelDao invoice1 = getRawInvoice(inputInvoice.getId(), internalAccountContext);
         populateChildrenByInvoiceId(invoice1, tags);
 
@@ -213,7 +211,7 @@ public class TestInvoiceDaoHelper extends InvoiceTestSuiteWithEmbeddedDB {
 
         ////
 
-        final List<Tag> tags = ImmutableList.of();
+        final List<Tag> tags = Collections.emptyList();
         final InvoiceModelDao invoice1 = getRawInvoice(childInvoice.getId(), internalAccountContext);
         populateChildrenByInvoiceId(invoice1, tags);
 
@@ -232,7 +230,7 @@ public class TestInvoiceDaoHelper extends InvoiceTestSuiteWithEmbeddedDB {
         transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<Void>() {
             @Override
             public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                invoiceDaoHelper.populateChildren(ImmutableList.of(invoice), tags, entitySqlDaoWrapperFactory, internalAccountContext);
+                invoiceDaoHelper.populateChildren(List.of(invoice), tags, entitySqlDaoWrapperFactory, internalAccountContext);
                 return null;
             }
         });

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDaoHelperUnit.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDaoHelperUnit.java
@@ -29,9 +29,8 @@ import org.killbill.billing.ErrorCode;
 import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 
-public class TestDefaultInvoiceDaoUnit extends InvoiceTestSuiteNoDB {
+public class TestInvoiceDaoHelperUnit extends InvoiceTestSuiteNoDB {
 
-    // FIXME-1615 : Should we move this to TestInvoiceHelperUnit? AFAIK none of DefaultInvoiceDao methods involved here.
     @Test(groups = "fast")
     public void testComputePositiveRefundAmount() throws Exception {
         // Verify the cases with no adjustment first

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -22,6 +22,8 @@ package org.killbill.billing.invoice.tree;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,9 +39,6 @@ import org.killbill.billing.invoice.model.RepairAdjInvoiceItem;
 import org.killbill.billing.util.jackson.ObjectMapper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -84,8 +83,8 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed2);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
-        expectedResult.addAll(ImmutableList.of());
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
+        expectedResult.addAll(Collections.emptyList());
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -117,7 +116,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed2);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem expected1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem1StartPeriod, existingItemStartPeriod, new BigDecimal("1"), monthlyRate, currency);
         expectedResult.add(expected1);
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItemEndPeriod, proposedItem2EndPeriod, new BigDecimal("9.03"), monthlyRate, currency);
@@ -165,7 +164,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed4);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem expected1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem2EndPeriod, proposedItem3EndPeriod, new BigDecimal("1"), monthlyRate, currency);
         expectedResult.add(expected1);
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, proposedItem3EndPeriod, proposedItem4EndPeriod, new BigDecimal("7"), monthlyRate, currency);
@@ -217,7 +216,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed3);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -237,7 +236,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, startAnnual2, endAnnual1, annualRate1.negate(), currency, annual1.getId());
         final InvoiceItem annual2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startAnnual2, endAnnual2, annualRate2, annualRate2, currency);
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem annual1Prorated = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startAnnual1, startAnnual2, new BigDecimal("10.0"), annualRate1, currency);
         expectedResult.add(annual1Prorated);
         expectedResult.add(annual2);
@@ -282,8 +281,8 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem expected1 = new RepairAdjInvoiceItem(invoiceId, accountId, startBlock, endBlock, new BigDecimal("-6.85"), currency, annual.getId());
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endDate, newEndDate, new BigDecimal("7.79"), yearlyAmount, currency);
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
-        expectedResult.addAll(ImmutableList.of(expected1, expected2));
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
+        expectedResult.addAll(List.of(expected1, expected2));
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -319,8 +318,8 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed2);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
-        expectedResult.addAll(ImmutableList.of());
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
+        expectedResult.addAll(Collections.emptyList());
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -341,7 +340,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.addItem(repair1);
         tree.build();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         expectedResult.add(new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, blockDate, new BigDecimal("5.99"), rate, currency));
 
         verifyResult(tree.getView(), expectedResult);
@@ -350,7 +349,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.buildForMerge();
 
         expectedResult.clear();
-        expectedResult.addAll(ImmutableList.of(new RepairAdjInvoiceItem(invoiceId, accountId, startDate, blockDate, new BigDecimal("-5.99"), currency, recurring1.getId())));
+        expectedResult.addAll(List.of(new RepairAdjInvoiceItem(invoiceId, accountId, startDate, blockDate, new BigDecimal("-5.99"), currency, recurring1.getId())));
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -424,7 +423,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem newItem = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, "someelse", "someelse", "someelse", null, repairDate, endDate, amount2, rate2, currency);
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, repairDate, endDate, amount1.negate(), currency, initial.getId());
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem expected1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, repairDate, new BigDecimal("8.52"), rate1, currency);
         expectedResult.add(expected1);
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, "someelse", "someelse", "someelse", null, repairDate, endDate, amount2, rate2, currency);
@@ -493,7 +492,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem newItem2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, repairDate2, endDate, amount3, rate3, currency);
         final InvoiceItem repair2 = new RepairAdjInvoiceItem(invoiceId, accountId, repairDate2, endDate, amount2.negate(), currency, newItem1.getId());
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem expected1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, repairDate1, new BigDecimal("8.52"), rate1, currency);
         expectedResult.add(expected1);
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, repairDate1, repairDate2, new BigDecimal("4.95"), rate2, currency);
@@ -531,7 +530,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem block1 = new RepairAdjInvoiceItem(invoiceId, accountId, blockStart1, unblockStart1, amount1.negate(), currency, initial.getId());
         final InvoiceItem block2 = new RepairAdjInvoiceItem(invoiceId, accountId, blockStart2, unblockStart2, amount1.negate(), currency, initial.getId());
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem expected1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, blockStart1, new BigDecimal("2.71"), rate1, currency);
         expectedResult.add(expected1);
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, unblockStart1, blockStart2, new BigDecimal("2.71"), rate1, currency);
@@ -565,7 +564,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem block1 = new RepairAdjInvoiceItem(invoiceId, accountId, blockDate, startDate2, amount1.negate(), currency, first.getId());
         final InvoiceItem block2 = new RepairAdjInvoiceItem(invoiceId, accountId, startDate2, unblockDate, amount1.negate(), currency, first.getId());
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem expected1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate1, blockDate, new BigDecimal("9.29"), rate1, currency);
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, unblockDate, endDate, new BigDecimal("9.43"), rate1, currency);
         expectedResult.add(expected1);
@@ -601,7 +600,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem leadingAnnualProration = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, switchToAnnualDate, endMonthly2, yearlyAmount, yearlyRate, currency);
         final InvoiceItem annual = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endMonthly2, endDate, yearlyAmount, yearlyRate, currency);
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         expectedResult.add(monthly1);
         final InvoiceItem monthly2Prorated = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endMonthly1, switchToAnnualDate, new BigDecimal("9.43"), monthlyRate, currency);
         expectedResult.add(monthly2Prorated);
@@ -639,7 +638,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, switchToAnnualDate, endMonthly2, monthlyAmount.negate(), currency, monthly2.getId());
         final InvoiceItem annual = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, switchToAnnualDate, endDate, yearlyAmount, yearlyRate, currency);
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         expectedResult.add(monthly1);
         final InvoiceItem monthly2Prorated = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endMonthly1, switchToAnnualDate, new BigDecimal("9.43"), monthlyRate, currency);
         expectedResult.add(monthly2Prorated);
@@ -735,7 +734,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed1);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         expectedResult.add(proposed1);
         verifyResult(tree.getView(), expectedResult);
     }
@@ -759,7 +758,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed1);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -785,7 +784,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed1);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, startDate, endDate, monthlyAmount1.negate(), currency, monthly1.getId());
         expectedResult.add(proposed1);
         expectedResult.add(repair);
@@ -812,7 +811,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed1);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, startDate, blockDate, new BigDecimal("-9.29"), currency, monthly1.getId());
         expectedResult.add(repair);
         verifyResult(tree.getView(), expectedResult);
@@ -837,7 +836,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed1);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, cancelDate, endDate, new BigDecimal("-2.71"), currency, monthly1.getId());
         expectedResult.add(repair);
         verifyResult(tree.getView(), expectedResult);
@@ -866,7 +865,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed2);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, blockDate, unblockDate, new BigDecimal("-4.65"), currency, monthly1.getId());
         expectedResult.add(repair);
         verifyResult(tree.getView(), expectedResult);
@@ -899,7 +898,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed3);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair1 = new RepairAdjInvoiceItem(invoiceId, accountId, blockDate1, unblockDate1, new BigDecimal("-2.32"), currency, monthly.getId());
         final InvoiceItem repair2 = new RepairAdjInvoiceItem(invoiceId, accountId, blockDate2, unblockDate2, new BigDecimal("-3.10"), currency, monthly.getId());
         expectedResult.add(repair1);
@@ -948,7 +947,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed2);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, upgradeDate, endDate, new BigDecimal("-2.71"), currency, monthly1.getId());
         expectedResult.add(proposed2);
         expectedResult.add(repair);
@@ -990,7 +989,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed3);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair2 = new RepairAdjInvoiceItem(invoiceId, accountId, change2, endDate, new BigDecimal("-7.70"), currency, initial.getId());
         expectedResult.add(proposed3);
         expectedResult.add(repair2);
@@ -1019,7 +1018,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(fixed);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -1044,7 +1043,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(fixed);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         expectedResult.add(fixed);
         verifyResult(tree.getView(), expectedResult);
     }
@@ -1072,7 +1071,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed1);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair1 = new RepairAdjInvoiceItem(invoiceId, accountId, cancelDate, endDate, new BigDecimal("-3.48"), currency, initial.getId());
         expectedResult.add(repair1);
 
@@ -1102,7 +1101,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed1);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair1 = new RepairAdjInvoiceItem(invoiceId, accountId, cancelDate, endDate, new BigDecimal("-2.00"), currency, initial.getId());
         expectedResult.add(repair1);
 
@@ -1136,7 +1135,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, cancelDate, amount1, rate1, currency));
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -1172,7 +1171,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, switchToAnnualDate, endMonthly2, new BigDecimal("-2.57"), currency, monthly2.getId());
         expectedResult.add(proposed);
         expectedResult.add(repair);
@@ -1231,7 +1230,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         //printTree(tree);
 
         // We except to see a repair for the piece cancelled with a $0 price since item was fully adjusted
-        final List<InvoiceItem> expectedResult = ImmutableList.<InvoiceItem>of(new RepairAdjInvoiceItem(invoiceId, accountId, cancelDate, endDate, BigDecimal.ZERO, Currency.USD, existing1.getId()));
+        final List<InvoiceItem> expectedResult = List.of(new RepairAdjInvoiceItem(invoiceId, accountId, cancelDate, endDate, BigDecimal.ZERO, Currency.USD, existing1.getId()));
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -1258,7 +1257,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.buildForMerge();
 
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, cancelDate, endDate, BigDecimal.ONE.negate(), Currency.USD, existing1.getId());
-        final List<InvoiceItem> expectedResult = ImmutableList.<InvoiceItem>of(repair);
+        final List<InvoiceItem> expectedResult = List.of(repair);
         verifyResult(tree.getView(), expectedResult);
     }
 
@@ -1325,7 +1324,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
                                                                 new BigDecimal("0.40"),
                                                                 rate,
                                                                 currency);
-        final List<InvoiceItem> expectedResult = ImmutableList.<InvoiceItem>of(expected);
+        final List<InvoiceItem> expectedResult = List.of(expected);
         verifyResult(tree.getView(), expectedResult);
 
     }
@@ -1349,7 +1348,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposedPayingMonthly2);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = Lists.newLinkedList();
+        final List<InvoiceItem> expectedResult = new LinkedList<>();
         expectedResult.add(proposedPayingMonthly2);
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, startDate, endDate, monthlyRate1.negate(), currency, payingMonthly1.getId());
         expectedResult.add(repair);
@@ -1373,7 +1372,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         tree.mergeProposedItem(proposed1);
         tree.buildForMerge();
 
-        final List<InvoiceItem> expectedResult = ImmutableList.<InvoiceItem>of();
+        final List<InvoiceItem> expectedResult = Collections.emptyList();
         verifyResult(tree.getView(), expectedResult);
     }
 

--- a/util/src/test/java/org/killbill/billing/util/collect/TestMultiValueHashMap.java
+++ b/util/src/test/java/org/killbill/billing/util/collect/TestMultiValueHashMap.java
@@ -37,7 +37,8 @@ public class TestMultiValueHashMap extends UtilTestSuiteNoDB {
 
         multiValueMap.putElement("two", new KeyValue("c", "C")); // same element, to prove that values size will keep increase.
 
-        assertEquals(multiValueMap.get("two").size(), 3);
+        assertEquals(multiValueMap.size(), 2); // The MultiValueMap's size() itself remaining the same ....
+        assertEquals(multiValueMap.get("two").size(), 3); // .... But the value elements is up-to-date.
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
Some highlight:

- `FixedAndRecurringInvoiceItemGenerator#safetyBounds()` : Move some block inside method to dedicated methods (validateSafeBoundsWithFixedInvoiceItem(), validateSafeBoundsWithRecurringInvoiceItem()). Also change `Range` usage to Joda's `Interval`. Tests for safeBounds improved.

- `SubscriptionItemTree#mergeProposedItem()` : Refactored a little bit, but test already covered by `TestSubscriptionItemTree#testAnnualWithBlocking1()`, `TestSubscriptionItemTree#testAnnualWithBlocking2()`

- `SubscriptionItemTree#build()` : Refactored a little bit, but test already covered by current:
    - `TestSubscriptionItemTree#testRepairWithLargeItemAdjustment()`, 
    - `TestSubscriptionItemTree#testPartialProRation()`, 
    - `TestSubscriptionItemTree#testRepairWithFullItemAdjustment()` 
    - `TestSubscriptionItemTree#testMaxedOutProRation()`
