### PR TITLE
1615 killbill invoice part 3

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceWithMetadata.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceWithMetadata.java
@@ -19,13 +19,16 @@ package org.killbill.billing.invoice.generator;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -38,12 +41,7 @@ import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.invoice.model.DefaultInvoice;
-
-import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
+import org.killbill.billing.util.collect.Iterables;
 
 public class InvoiceWithMetadata {
 
@@ -94,15 +92,13 @@ public class InvoiceWithMetadata {
         if (invoice != null ) {
             // Filter $0 USAGE items if specified by config
             if (filterZeroUsageItems) {
-                final Iterable<InvoiceItem> resultingItems = Iterables.filter(invoice.getInvoiceItems(), new Predicate<InvoiceItem>() {
-                    @Override
-                    public boolean apply(final InvoiceItem invoiceItem) {
-                        return invoiceItem.getInvoiceItemType() != InvoiceItemType.USAGE ||
-                               invoiceItem.getAmount().compareTo(BigDecimal.ZERO) != 0 ||
-                               (invoiceItem.getQuantity() != null &&  invoiceItem.getQuantity().compareTo(BigDecimal.ZERO) > 0);
-                    }
-                });
-                final ImmutableList<InvoiceItem> filteredItems = ImmutableList.copyOf(resultingItems);
+                final List<InvoiceItem> filteredItems = invoice
+                        .getInvoiceItems()
+                        .stream()
+                        .filter(invoiceItem -> invoiceItem.getInvoiceItemType() != InvoiceItemType.USAGE ||
+                                               invoiceItem.getAmount().compareTo(BigDecimal.ZERO) != 0 ||
+                                               (invoiceItem.getQuantity() != null &&  invoiceItem.getQuantity().compareTo(BigDecimal.ZERO) > 0))
+                        .collect(Collectors.toUnmodifiableList());
                 // Reset invoice items with filtered list
                 invoice.getInvoiceItems().clear();
                 invoice.addInvoiceItems(filteredItems);
@@ -142,7 +138,7 @@ public class InvoiceWithMetadata {
                 }
             }
         } else {
-            chargedThroughDates = ImmutableMap.of();
+            chargedThroughDates = Collections.emptyMap();
         }
 
         final Map<DateTime, List<UUID>> perDateCTDs = new HashMap<>();
@@ -157,24 +153,21 @@ public class InvoiceWithMetadata {
         return perDateCTDs;
     }
 
+    private boolean isInvoiceItemsMatchCondition(final Predicate<? super InvoiceItem> condition) {
+        return invoice != null &&
+               invoice.getInvoiceItems() != null &&
+               !invoice.getInvoiceItems().isEmpty() &&
+               invoice.getInvoiceItems().stream().anyMatch(condition);
+    }
+
     private boolean hasItemsForSubscription(final UUID subscriptionId, final InvoiceItemType invoiceItemType) {
-        return invoice != null && Iterables.any(invoice.getInvoiceItems(), new Predicate<InvoiceItem>() {
-            @Override
-            public boolean apply(final InvoiceItem input) {
-                return input.getInvoiceItemType() == invoiceItemType &&
-                       input.getSubscriptionId().equals(subscriptionId);
-            }
-        });
+        return isInvoiceItemsMatchCondition(input -> input.getInvoiceItemType() == invoiceItemType &&
+                                                     input.getSubscriptionId().equals(subscriptionId));
     }
 
     private boolean hasItemsForDate(final LocalDate date) {
-        return invoice != null && Iterables.any(invoice.getInvoiceItems(), new Predicate<InvoiceItem>() {
-            @Override
-            public boolean apply(final InvoiceItem input) {
-                return (input.getStartDate() != null && input.getStartDate().compareTo(date) == 0) ||
-                       (input.getEndDate() != null && input.getEndDate().compareTo(date) == 0);
-            }
-        });
+        return isInvoiceItemsMatchCondition(input -> (input.getStartDate() != null && input.getStartDate().compareTo(date) == 0) ||
+                                                     (input.getEndDate() != null && input.getEndDate().compareTo(date) == 0));
     }
 
     public Set<TrackingRecordId> getTrackingIds() {
@@ -234,10 +227,10 @@ public class InvoiceWithMetadata {
                 return false;
             }
             final TrackingRecordId that = (TrackingRecordId) o;
-            return Objects.equal(trackingId, that.trackingId) &&
-                   Objects.equal(subscriptionId, that.subscriptionId) &&
-                   Objects.equal(unitType, that.unitType) &&
-                   Objects.equal(recordDate, that.recordDate);
+            return Objects.equals(trackingId, that.trackingId) &&
+                   Objects.equals(subscriptionId, that.subscriptionId) &&
+                   Objects.equals(unitType, that.unitType) &&
+                   Objects.equals(recordDate, that.recordDate);
         }
 
         @Override
@@ -249,16 +242,16 @@ public class InvoiceWithMetadata {
                 return false;
             }
             final TrackingRecordId that = (TrackingRecordId) o;
-            return Objects.equal(trackingId, that.trackingId) &&
-                   Objects.equal(invoiceId, that.invoiceId) &&
-                   Objects.equal(subscriptionId, that.subscriptionId) &&
-                   Objects.equal(unitType, that.unitType) &&
-                   Objects.equal(recordDate, that.recordDate);
+            return Objects.equals(trackingId, that.trackingId) &&
+                   Objects.equals(invoiceId, that.invoiceId) &&
+                   Objects.equals(subscriptionId, that.subscriptionId) &&
+                   Objects.equals(unitType, that.unitType) &&
+                   Objects.equals(recordDate, that.recordDate);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(trackingId, invoiceId, subscriptionId, unitType, recordDate);
+            return Objects.hash(trackingId, invoiceId, subscriptionId, unitType, recordDate);
         }
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/UsageInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/UsageInvoiceItemGenerator.java
@@ -17,17 +17,20 @@
 
 package org.killbill.billing.invoice.generator;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -51,18 +54,14 @@ import org.killbill.billing.invoice.usage.SubscriptionUsageInArrear;
 import org.killbill.billing.invoice.usage.SubscriptionUsageInArrear.SubscriptionUsageInArrearItemsAndNextNotificationDate;
 import org.killbill.billing.junction.BillingEvent;
 import org.killbill.billing.junction.BillingEventSet;
+import org.killbill.billing.util.annotation.VisibleForTesting;
+import org.killbill.billing.util.collect.Iterables;
+import org.killbill.billing.util.collect.MultiValueHashMap;
+import org.killbill.billing.util.collect.MultiValueMap;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.config.definition.InvoiceConfig.UsageDetailMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.inject.Inject;
 
 public class UsageInvoiceItemGenerator extends InvoiceItemGenerator {
 
@@ -96,12 +95,12 @@ public class UsageInvoiceItemGenerator extends InvoiceItemGenerator {
             final LocalDate minBillingEventDate = getMinBillingEventDate(eventSet, internalCallContext);
 
             final Set<TrackingRecordId> trackingIds = new HashSet<>();
-            final List<InvoiceItem> items = Lists.newArrayList();
+            final List<InvoiceItem> items = new ArrayList<>();
             final Iterator<BillingEvent> events = eventSet.iterator();
 
             final boolean isDryRun = dryRunInfo != null;
             RawUsageOptimizerResult rawUsgRes = null;
-            List<BillingEvent> curEvents = Lists.newArrayList();
+            List<BillingEvent> curEvents = new ArrayList<>();
             UUID curSubscriptionId = null;
             while (events.hasNext()) {
                 final BillingEvent event = events.next();
@@ -112,14 +111,12 @@ public class UsageInvoiceItemGenerator extends InvoiceItemGenerator {
                 }
 
                 // Optimize to do the usage query only once after we know there are indeed some usage items
-                if (rawUsgRes == null &&
-                    Iterables.any(event.getUsages(), new Predicate<Usage>() {
-                        @Override
-                        public boolean apply(final Usage input) {
-                            return input.getBillingMode() == BillingMode.IN_ARREAR;
-                        }
-                    })) {
-                    rawUsgRes = rawUsageOptimizer.getInArrearUsage(minBillingEventDate, targetDate, Iterables.concat(perSubscriptionInArrearUsageItems.values()), eventSet.getUsages(), dryRunInfo, internalCallContext);
+                if (rawUsgRes == null && event.getUsages().stream().anyMatch(input -> input.getBillingMode() == BillingMode.IN_ARREAR)) {
+                    final Iterable<InvoiceItem> existingUsageItems = perSubscriptionInArrearUsageItems.values().stream()
+                            .flatMap(Collection::stream)
+                            .collect(Collectors.toUnmodifiableList());
+
+                    rawUsgRes = rawUsageOptimizer.getInArrearUsage(minBillingEventDate, targetDate, existingUsageItems, eventSet.getUsages(), dryRunInfo, internalCallContext);
 
                     // Check existingInvoices#cutoffDate <= rawUsgRes#rawUsageStartDate + 1 P, where P = max{all Periods available} (e.g MONTHLY)
                     // To make it simpler we check existingInvoices#cutoffDate <= rawUsgRes#rawUsageStartDate, and warn if this is not the case
@@ -145,13 +142,13 @@ public class UsageInvoiceItemGenerator extends InvoiceItemGenerator {
                     final SubscriptionUsageInArrear subscriptionUsageInArrear = new SubscriptionUsageInArrear(account.getId(), invoiceId, curEvents, rawUsgRes.getRawUsage(), rawUsgRes.getExistingTrackingIds(), targetDate, rawUsgRes.getRawUsageStartDate(), usageDetailMode, invoiceConfig, internalCallContext);
                     final List<InvoiceItem> usageInArrearItems = perSubscriptionInArrearUsageItems.get(curSubscriptionId);
 
-                    final SubscriptionUsageInArrearItemsAndNextNotificationDate subscriptionResult = subscriptionUsageInArrear.computeMissingUsageInvoiceItems(usageInArrearItems != null ? usageInArrearItems : ImmutableList.<InvoiceItem>of(), invoiceItemGeneratorLogger, isDryRun);
+                    final SubscriptionUsageInArrearItemsAndNextNotificationDate subscriptionResult = subscriptionUsageInArrear.computeMissingUsageInvoiceItems(usageInArrearItems != null ? usageInArrearItems : Collections.emptyList(), invoiceItemGeneratorLogger, isDryRun);
                     final List<InvoiceItem> newInArrearUsageItems = subscriptionResult.getInvoiceItems();
                     items.addAll(newInArrearUsageItems);
                     trackingIds.addAll(subscriptionResult.getTrackingIds());
 
                     updatePerSubscriptionNextNotificationUsageDate(curSubscriptionId, subscriptionResult.getPerUsageNotificationDates(), BillingMode.IN_ARREAR, perSubscriptionFutureNotificationDates);
-                    curEvents = Lists.newArrayList();
+                    curEvents = new ArrayList<>();
                 }
                 curSubscriptionId = subscriptionId;
                 curEvents.add(event);
@@ -160,7 +157,7 @@ public class UsageInvoiceItemGenerator extends InvoiceItemGenerator {
                 final SubscriptionUsageInArrear subscriptionUsageInArrear = new SubscriptionUsageInArrear(account.getId(), invoiceId, curEvents, rawUsgRes.getRawUsage(), rawUsgRes.getExistingTrackingIds(), targetDate, rawUsgRes.getRawUsageStartDate(), usageDetailMode, invoiceConfig, internalCallContext);
                 final List<InvoiceItem> usageInArrearItems = perSubscriptionInArrearUsageItems.get(curSubscriptionId);
 
-                final SubscriptionUsageInArrearItemsAndNextNotificationDate subscriptionResult = subscriptionUsageInArrear.computeMissingUsageInvoiceItems(usageInArrearItems != null ? usageInArrearItems : ImmutableList.<InvoiceItem>of(), invoiceItemGeneratorLogger, isDryRun);
+                final SubscriptionUsageInArrearItemsAndNextNotificationDate subscriptionResult = subscriptionUsageInArrear.computeMissingUsageInvoiceItems(usageInArrearItems != null ? usageInArrearItems : Collections.emptyList(), invoiceItemGeneratorLogger, isDryRun);
                 final List<InvoiceItem> newInArrearUsageItems = subscriptionResult.getInvoiceItems();
                 items.addAll(newInArrearUsageItems);
                 trackingIds.addAll(subscriptionResult.getTrackingIds());
@@ -199,37 +196,33 @@ public class UsageInvoiceItemGenerator extends InvoiceItemGenerator {
         }
     }
 
-    private Map<UUID, List<InvoiceItem>> extractPerSubscriptionExistingInArrearUsageItems(final Map<String, Usage> knownUsage, @Nullable final Iterable<Invoice> existingInvoices) {
+    @VisibleForTesting
+    Map<UUID, List<InvoiceItem>> extractPerSubscriptionExistingInArrearUsageItems(final Map<String, Usage> knownUsage, @Nullable final Iterable<Invoice> existingInvoices) {
         if (existingInvoices == null || Iterables.isEmpty(existingInvoices)) {
-            return ImmutableMap.of();
+            return Collections.emptyMap();
         }
 
-        final Map<UUID, List<InvoiceItem>> result = new HashMap<UUID, List<InvoiceItem>>();
-        final Iterable<InvoiceItem> usageInArrearItems = Iterables.concat(Iterables.transform(existingInvoices, new Function<Invoice, Iterable<InvoiceItem>>() {
-            @Override
-            public Iterable<InvoiceItem> apply(final Invoice input) {
+        final Iterable<InvoiceItem> usageInArrearItems = getUsageInArrearItems(knownUsage, existingInvoices);
 
-                return Iterables.filter(input.getInvoiceItems(), new Predicate<InvoiceItem>() {
-                    @Override
-                    public boolean apply(final InvoiceItem input) {
-                        if (input.getInvoiceItemType() == InvoiceItemType.USAGE) {
-                            final Usage usage = knownUsage.get(input.getUsageName());
-                            return usage != null && usage.getBillingMode() == BillingMode.IN_ARREAR;
-                        }
-                        return false;
-                    }
-                });
-            }
-        }));
-
+        final MultiValueMap<UUID, InvoiceItem> result = new MultiValueHashMap<>();
         for (final InvoiceItem cur : usageInArrearItems) {
-            List<InvoiceItem> perSubscriptionUsageItems = result.get(cur.getSubscriptionId());
-            if (perSubscriptionUsageItems == null) {
-                perSubscriptionUsageItems = new LinkedList<InvoiceItem>();
-                result.put(cur.getSubscriptionId(), perSubscriptionUsageItems);
-            }
-            perSubscriptionUsageItems.add(cur);
+            result.putElement(cur.getSubscriptionId(), cur);
         }
         return result;
+    }
+
+    @VisibleForTesting
+    Iterable<InvoiceItem> getUsageInArrearItems(final Map<String, Usage> knownUsage, final Iterable<Invoice> existingInvoices) {
+        return Iterables.toStream(existingInvoices)
+                        .map(Invoice::getInvoiceItems)
+                        .flatMap(Collection::stream)
+                        .filter(input -> {
+                            if (input.getInvoiceItemType() == InvoiceItemType.USAGE) {
+                                final Usage usage = knownUsage.get(input.getUsageName());
+                                return usage != null && usage.getBillingMode() == BillingMode.IN_ARREAR;
+                            }
+                            return false;
+                        })
+                        .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/CreditAdjInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/CreditAdjInvoiceItem.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -28,8 +29,6 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.util.UUIDs;
-
-import com.google.common.base.MoreObjects;
 
 public class CreditAdjInvoiceItem extends AdjInvoiceItem {
 
@@ -50,7 +49,7 @@ public class CreditAdjInvoiceItem extends AdjInvoiceItem {
 
     @Override
     public String getDescription() {
-        return MoreObjects.firstNonNull(description, "Invoice adjustment");
+        return Objects.requireNonNullElse(description, "Invoice adjustment");
     }
 
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemFactory.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemFactory.java
@@ -37,10 +37,9 @@ import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.dao.InvoiceItemModelDao;
+import org.killbill.billing.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Preconditions;
 
 public class InvoiceItemFactory {
 
@@ -169,7 +168,7 @@ public class InvoiceItemFactory {
                         prettyPlanName = plan.getPrettyName();
 
                         if (productName != null) {
-                            Preconditions.checkState(plan.getProduct().getName().equals(productName));
+                            Preconditions.checkState(plan.getProduct().getName().equals(productName), "#computePrettyName(): Plan's product name is not equal to productName");
                             prettyProductName = plan.getProduct().getPrettyName();
                         }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemFactory.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemFactory.java
@@ -168,7 +168,7 @@ public class InvoiceItemFactory {
                         prettyPlanName = plan.getPrettyName();
 
                         if (productName != null) {
-                            Preconditions.checkState(plan.getProduct().getName().equals(productName), "#computePrettyName(): Plan's product name is not equal to productName");
+                            Preconditions.checkState(plan.getProduct().getName().equals(productName), "#computePrettyName(): plan.product.name: %s is not equal to productName: %s", plan.getProduct().getName(), productName);
                             prettyProductName = plan.getProduct().getPrettyName();
                         }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/ItemAdjInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/ItemAdjInvoiceItem.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -29,8 +30,6 @@ import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.util.UUIDs;
-
-import com.google.common.base.MoreObjects;
 
 public class ItemAdjInvoiceItem extends AdjInvoiceItem {
 
@@ -52,6 +51,6 @@ public class ItemAdjInvoiceItem extends AdjInvoiceItem {
 
     @Override
     public String getDescription() {
-        return MoreObjects.firstNonNull(description, "Invoice item adjustment");
+        return Objects.requireNonNullElse(description, "Invoice item adjustment");
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/ParentInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/ParentInvoiceItem.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -25,8 +26,6 @@ import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItemType;
-
-import com.google.common.base.MoreObjects;
 
 public class ParentInvoiceItem extends InvoiceItemBase {
 
@@ -37,7 +36,7 @@ public class ParentInvoiceItem extends InvoiceItemBase {
 
     @Override
     public String getDescription() {
-        return MoreObjects.firstNonNull(description, "Parent summary item");
+        return Objects.requireNonNullElse(description, "Parent summary item");
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/RecurringInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/RecurringInvoiceItem.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -28,8 +29,6 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.util.UUIDs;
-
-import com.google.common.base.MoreObjects;
 
 public class RecurringInvoiceItem extends InvoiceItemCatalogBase {
 
@@ -89,7 +88,7 @@ public class RecurringInvoiceItem extends InvoiceItemCatalogBase {
     @Override
     public String getDescription() {
         final String resolvedPhaseName = getPrettyPhaseName() != null ? getPrettyPhaseName() : getPhaseName();
-        return MoreObjects.firstNonNull(description, resolvedPhaseName);
+        return Objects.requireNonNullElse(description, resolvedPhaseName);
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/RepairAdjInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/RepairAdjInvoiceItem.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -28,8 +29,6 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.util.UUIDs;
-
-import com.google.common.base.MoreObjects;
 
 public class RepairAdjInvoiceItem extends AdjInvoiceItem {
 
@@ -50,6 +49,6 @@ public class RepairAdjInvoiceItem extends AdjInvoiceItem {
 
     @Override
     public String getDescription() {
-        return MoreObjects.firstNonNull(description, "Adjustment (subscription change)");
+        return Objects.requireNonNullElse(description, "Adjustment (subscription change)");
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/UsageInvoiceItem.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.invoice.model;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -27,9 +28,7 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.util.UUIDs;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 
 public class UsageInvoiceItem extends InvoiceItemCatalogBase {
 
@@ -85,6 +84,6 @@ public class UsageInvoiceItem extends InvoiceItemCatalogBase {
     @Override
     public String getDescription() {
         final String resolvedUsageName = getPrettyUsageName() != null ? getPrettyUsageName() : getUsageName();
-        return MoreObjects.firstNonNull(description, resolvedUsageName);
+        return Objects.requireNonNullElse(description, resolvedUsageName);
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/notification/DefaultNextBillingDatePoster.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/notification/DefaultNextBillingDatePoster.java
@@ -23,10 +23,14 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.UUID;
 
+import javax.inject.Inject;
+
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.platform.api.KillbillService.KILLBILL_SERVICES;
+import org.killbill.billing.util.collect.Iterables;
+import org.killbill.billing.util.collect.Sets;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationEventWithMetadata;
@@ -35,11 +39,6 @@ import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
-import com.google.inject.Inject;
 
 import static org.killbill.billing.invoice.InvoiceDispatcher.MAX_NB_ITEMS_TO_PRINT;
 
@@ -140,7 +139,7 @@ public class DefaultNextBillingDatePoster implements NextBillingDatePoster {
                                                                          newNotificationEvent, internalCallContext.getUserToken(),
                                                                          internalCallContext.getAccountRecordId(), internalCallContext.getTenantRecordId());
             } else {
-                final SetView<UUID> difference = Sets.difference(subscriptionIds, ImmutableSet.copyOf(existingNotificationForEffectiveDate.getEvent().getUuidKeys()));
+                final Set<UUID> difference = Sets.difference(subscriptionIds, Iterables.toUnmodifiableSet(existingNotificationForEffectiveDate.getEvent().getUuidKeys()));
                 if (difference.isEmpty()) {
                     log.debug("Ignoring duplicate next billing date notification event at {} for subscriptionId {}", futureNotificationTime, subscriptionIdsAsStringBuilder);
                 } else {

--- a/invoice/src/main/java/org/killbill/billing/invoice/notification/NextBillingDateNotificationKey.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/notification/NextBillingDateNotificationKey.java
@@ -18,16 +18,15 @@
 
 package org.killbill.billing.invoice.notification;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.notificationq.DefaultUUIDNotificationKey;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 
 public class NextBillingDateNotificationKey extends DefaultUUIDNotificationKey {
 
@@ -52,7 +51,7 @@ public class NextBillingDateNotificationKey extends DefaultUUIDNotificationKey {
     public NextBillingDateNotificationKey(final NextBillingDateNotificationKey existing,
                                           final Iterable<UUID> newUUIDKeys) {
         super(null);
-        this.uuidKeys = ImmutableSet.copyOf(Iterables.concat(existing.getUuidKeys(), newUUIDKeys));
+        this.uuidKeys = Iterables.toUnmodifiableSet(Iterables.concat(existing.getUuidKeys(), newUUIDKeys));
         this.targetDate = existing.getTargetDate();
         this.isDryRunForInvoiceNotification = existing.isDryRunForInvoiceNotification();
         this.isRescheduled = existing.isRescheduled();
@@ -75,7 +74,7 @@ public class NextBillingDateNotificationKey extends DefaultUUIDNotificationKey {
     public final Iterable<UUID> getUuidKeys() {
         // Deprecated mode
         if (getUuidKey() != null) {
-            return ImmutableList.of(getUuidKey());
+            return List.of(getUuidKey());
         }
         return uuidKeys;
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerBase.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerBase.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.invoice.optimizer;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -27,11 +28,9 @@ import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.dao.InvoiceDao;
 import org.killbill.billing.junction.BillingEventSet;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.clock.Clock;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 
 public abstract class InvoiceOptimizerBase implements InvoiceOptimizer {
 
@@ -63,7 +62,7 @@ public abstract class InvoiceOptimizerBase implements InvoiceOptimizer {
         }
 
         public AccountInvoices() {
-            this(null, null, ImmutableList.of());
+            this(null, null, Collections.emptyList());
         }
 
         public LocalDate getCutoffDate() {

--- a/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerExp.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerExp.java
@@ -163,8 +163,10 @@ public class InvoiceOptimizerExp extends InvoiceOptimizerBase {
                         return true;
                     } else {
                         for (final Invoice inv : invoices) {
-                            final boolean existingItemExists = inv.getInvoiceItems()
-                                    .stream()
+                            final boolean existingItemExists = inv.getInvoiceItems().stream()
+                                    // If we find a similar item in the 'existing' list, i.e same subscription, same start date,
+                                    // we keep it so it cancels out in the tree later.
+                                    // We don't include the end date to catch trailing pro-ration (early cancellation)
                                     .anyMatch(item -> (item.getInvoiceItemType() == InvoiceItemType.RECURRING &&
                                                        item.getSubscriptionId().equals(invoiceItem.getSubscriptionId()) &&
                                                        item.getStartDate().compareTo(invoiceItem.getStartDate()) == 0));

--- a/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerExp.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerExp.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -42,22 +43,18 @@ import org.killbill.billing.invoice.dao.InvoiceModelDao;
 import org.killbill.billing.invoice.model.DefaultInvoice;
 import org.killbill.billing.junction.BillingEvent;
 import org.killbill.billing.junction.BillingEventSet;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.clock.Clock;
 import org.skife.config.TimeSpan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-
 public class InvoiceOptimizerExp extends InvoiceOptimizerBase {
 
-    private static Logger logger = LoggerFactory.getLogger(InvoiceOptimizerExp.class);
+    private static final Logger logger = LoggerFactory.getLogger(InvoiceOptimizerExp.class);
 
-    private static Period UNSPECIFIED_PERIOD = new Period(InvoiceConfig.DEFAULT_NULL_PERIOD);
+    private static final Period UNSPECIFIED_PERIOD = new Period(InvoiceConfig.DEFAULT_NULL_PERIOD);
 
     @Inject
     public InvoiceOptimizerExp(final InvoiceDao invoiceDao,
@@ -125,72 +122,62 @@ public class InvoiceOptimizerExp extends InvoiceOptimizerBase {
                 final Map<String, BillingMode> billingModes = new HashMap<>();
                 // Comes from the PlanPhase
                 final Map<String, BillingPeriod> billingPeriods = new HashMap<>();
-                final Iterable<InvoiceItem> filtered = Iterables.filter(proposedItems, new Predicate<InvoiceItem>() {
-                    @Override
-                    public boolean apply(final InvoiceItem invoiceItem) {
-                        if (invoiceItem.getInvoiceItemType() == InvoiceItemType.FIXED) {
-                            return invoiceItem.getStartDate().compareTo(cutoffDate) >= 0;
-                        }
-                        Preconditions.checkState(invoiceItem.getInvoiceItemType() == InvoiceItemType.RECURRING, "Expected (proposed) item %s to be a RECURRING invoice item", invoiceItem);
+                final List<InvoiceItem> filtered = proposedItems.stream().filter(invoiceItem -> {
+                    if (invoiceItem.getInvoiceItemType() == InvoiceItemType.FIXED) {
+                        return invoiceItem.getStartDate().compareTo(cutoffDate) >= 0;
+                    }
+                    Preconditions.checkState(invoiceItem.getInvoiceItemType() == InvoiceItemType.RECURRING, "Expected (proposed) item %s to be a RECURRING invoice item", invoiceItem);
 
-                        // Extract Plan info associated with item by correlating with list of billing events
-                        // From plan info, retrieve billing mode.
-                        BillingMode billingMode = billingModes.get(invoiceItem.getPlanName());
-                        BillingPeriod billingPeriod = billingPeriods.get(invoiceItem.getPhaseName());
-                        if (billingMode == null || billingPeriod == null) {
-                            // Best effort logic to find the correct billing event ('be'):
-                            // We could simplify and look for any 'be' whose Plan matches the one from the invoiceItem,
-                            // but in unlikely scenarios where there are multiple Plans across catalog versions with different BillingMode,
-                            // we could end up with the wrong billing event (and therefore billing mode). Therefore, the complexity.
-                            // (all this because catalog is not available in this layer)
-                            //
-                            final Iterator<BillingEvent> it = ((NavigableSet<BillingEvent>) eventSet).descendingIterator();
-                            while (it.hasNext()) {
-                                final BillingEvent be = it.next();
-                                if (!be.getSubscriptionId().equals(invoiceItem.getSubscriptionId()) /* wrong subscription ID */ ||
-                                        /* Not the correct plan */
-                                    !(be.getPlan() != null && be.getPlan().getName().equals(invoiceItem.getPlanName())) ||
-                                        /* Whether in-advance or in-arrear (what we are trying to find out), the 'be' we want is the one where ii.endDate >= be.effDt */
-                                    invoiceItem.getEndDate().compareTo(internalCallContext.toLocalDate(be.getEffectiveDate())) < 0) {
-                                    continue;
-                                }
-                                billingMode = be.getPlan().getRecurringBillingMode();
-                                billingModes.put(invoiceItem.getPlanName(), billingMode);
-
-                                billingPeriod = be.getPlanPhase().getRecurring().getBillingPeriod();
-                                billingPeriods.put(invoiceItem.getPhaseName(), billingPeriod);
-                                break;
+                    // Extract Plan info associated with item by correlating with list of billing events
+                    // From plan info, retrieve billing mode.
+                    BillingMode billingMode = billingModes.get(invoiceItem.getPlanName());
+                    BillingPeriod billingPeriod = billingPeriods.get(invoiceItem.getPhaseName());
+                    if (billingMode == null || billingPeriod == null) {
+                        // Best effort logic to find the correct billing event ('be'):
+                        // We could simplify and look for any 'be' whose Plan matches the one from the invoiceItem,
+                        // but in unlikely scenarios where there are multiple Plans across catalog versions with different BillingMode,
+                        // we could end up with the wrong billing event (and therefore billing mode). Therefore, the complexity.
+                        // (all this because catalog is not available in this layer)
+                        //
+                        final Iterator<BillingEvent> it = ((NavigableSet<BillingEvent>) eventSet).descendingIterator();
+                        while (it.hasNext()) {
+                            final BillingEvent be = it.next();
+                            if (!be.getSubscriptionId().equals(invoiceItem.getSubscriptionId()) /* wrong subscription ID */ ||
+                                    /* Not the correct plan */
+                                !(be.getPlan() != null && be.getPlan().getName().equals(invoiceItem.getPlanName())) ||
+                                    /* Whether in-advance or in-arrear (what we are trying to find out), the 'be' we want is the one where ii.endDate >= be.effDt */
+                                invoiceItem.getEndDate().compareTo(internalCallContext.toLocalDate(be.getEffectiveDate())) < 0) {
+                                continue;
                             }
-                        }
+                            billingMode = be.getPlan().getRecurringBillingMode();
+                            billingModes.put(invoiceItem.getPlanName(), billingMode);
 
-                        if ((billingMode == BillingMode.IN_ADVANCE && invoiceItem.getStartDate().compareTo(cutoffDate) >= 0) ||
-                            (billingMode == BillingMode.IN_ARREAR && invoiceItem.getEndDate().compareTo(cutoffDate) >= 0)) {
-                            return true;
-                        } else {
-                            for (final Invoice inv : invoices) {
-                                final InvoiceItem existingItem = Iterables.tryFind(inv.getInvoiceItems(), new Predicate<InvoiceItem>() {
-                                    @Override
-                                    public boolean apply(final InvoiceItem item) {
-                                        // If we find a similar item in the 'existing' list, i.e same subscription, same start date,
-                                        // we keep it so it cancels out in the tree later.
-                                        // We don't include the end date to catch trailing pro-ration (early cancellation)
-                                        //
-                                        return (item.getInvoiceItemType() == InvoiceItemType.RECURRING &&
-                                                item.getSubscriptionId().equals(invoiceItem.getSubscriptionId()) &&
-                                                item.getStartDate().compareTo(invoiceItem.getStartDate()) == 0);
-                                    }
-                                }).orNull();
-                                if (existingItem != null) {
-                                    return true;
-                                }
-                            }
-                            return false;
+                            billingPeriod = be.getPlanPhase().getRecurring().getBillingPeriod();
+                            billingPeriods.put(invoiceItem.getPhaseName(), billingPeriod);
+                            break;
                         }
                     }
-                });
-                final List<InvoiceItem> filteredProposed = ImmutableList.copyOf(filtered);
+
+                    if ((billingMode == BillingMode.IN_ADVANCE && invoiceItem.getStartDate().compareTo(cutoffDate) >= 0) ||
+                        (billingMode == BillingMode.IN_ARREAR && invoiceItem.getEndDate().compareTo(cutoffDate) >= 0)) {
+                        return true;
+                    } else {
+                        for (final Invoice inv : invoices) {
+                            final boolean existingItemExists = inv.getInvoiceItems()
+                                    .stream()
+                                    .anyMatch(item -> (item.getInvoiceItemType() == InvoiceItemType.RECURRING &&
+                                                       item.getSubscriptionId().equals(invoiceItem.getSubscriptionId()) &&
+                                                       item.getStartDate().compareTo(invoiceItem.getStartDate()) == 0));
+                            if (existingItemExists) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    }
+                }).collect(Collectors.toUnmodifiableList());
+
                 proposedItems.clear();
-                proposedItems.addAll(filteredProposed);
+                proposedItems.addAll(filtered);
             }
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/template/formatters/DefaultInvoiceFormatter.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/template/formatters/DefaultInvoiceFormatter.java
@@ -23,9 +23,10 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.joda.money.CurrencyUnit;
@@ -49,13 +50,10 @@ import org.killbill.billing.invoice.api.formatters.ResourceBundleFactory;
 import org.killbill.billing.invoice.model.CreditAdjInvoiceItem;
 import org.killbill.billing.invoice.model.CreditBalanceAdjInvoiceItem;
 import org.killbill.billing.invoice.model.DefaultInvoice;
+import org.killbill.billing.util.Strings;
 import org.killbill.billing.util.template.translation.TranslatorConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 
 /**
  * Format invoice fields
@@ -86,7 +84,7 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
 
     @Override
     public Integer getInvoiceNumber() {
-        return MoreObjects.firstNonNull(invoice.getInvoiceNumber(), 0);
+        return Objects.requireNonNullElse(invoice.getInvoiceNumber(), 0);
     }
 
     @Override
@@ -124,7 +122,7 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
 
     @Override
     public List<String> getTrackingIds() {
-        return MoreObjects.firstNonNull(invoice.getTrackingIds(), ImmutableList.<String>of());
+        return Objects.requireNonNullElse(invoice.getTrackingIds(), Collections.emptyList());
     }
 
     @Override
@@ -174,7 +172,7 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
 
     @Override
     public <T extends InvoiceItem> List<InvoiceItem> getInvoiceItems(final Class<T> clazz) {
-        return MoreObjects.firstNonNull(invoice.getInvoiceItems(clazz), ImmutableList.<InvoiceItem>of());
+        return Objects.requireNonNullElse(invoice.getInvoiceItems(clazz), Collections.emptyList());
     }
 
     @Override
@@ -194,7 +192,7 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
 
     @Override
     public List<InvoicePayment> getPayments() {
-        return MoreObjects.firstNonNull(invoice.getPayments(), ImmutableList.<InvoicePayment>of());
+        return Objects.requireNonNullElse(invoice.getPayments(), Collections.emptyList());
     }
 
     @Override
@@ -209,17 +207,17 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
 
     @Override
     public BigDecimal getChargedAmount() {
-        return MoreObjects.firstNonNull(invoice.getChargedAmount(), BigDecimal.ZERO);
+        return Objects.requireNonNullElse(invoice.getChargedAmount(), BigDecimal.ZERO);
     }
 
     @Override
     public BigDecimal getOriginalChargedAmount() {
-        return MoreObjects.firstNonNull(invoice.getOriginalChargedAmount(), BigDecimal.ZERO);
+        return Objects.requireNonNullElse(invoice.getOriginalChargedAmount(), BigDecimal.ZERO);
     }
 
     @Override
     public BigDecimal getBalance() {
-        return MoreObjects.firstNonNull(invoice.getBalance(), BigDecimal.ZERO);
+        return Objects.requireNonNullElse(invoice.getBalance(), BigDecimal.ZERO);
     }
 
     @Override
@@ -275,9 +273,7 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
         }
         // If there were multiple payments (and refunds) we pick chose the last one
         DateTime latestPaymentDate = null;
-        final Iterator<InvoicePayment> paymentIterator = invoice.getPayments().iterator();
-        while (paymentIterator.hasNext()) {
-            final InvoicePayment cur = paymentIterator.next();
+        for (final InvoicePayment cur : invoice.getPayments()) {
             latestPaymentDate = latestPaymentDate != null && latestPaymentDate.isAfter(cur.getPaymentDate()) ?
                                 latestPaymentDate : cur.getPaymentDate();
 
@@ -319,7 +315,7 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
 
     @Override
     public BigDecimal getPaidAmount() {
-        return MoreObjects.firstNonNull(invoice.getPaidAmount(), BigDecimal.ZERO);
+        return Objects.requireNonNullElse(invoice.getPaidAmount(), BigDecimal.ZERO);
     }
 
     @Override
@@ -395,11 +391,11 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
 
     @Override
     public BigDecimal getCreditedAmount() {
-        return MoreObjects.firstNonNull(invoice.getCreditedAmount(), BigDecimal.ZERO);
+        return Objects.requireNonNullElse(invoice.getCreditedAmount(), BigDecimal.ZERO);
     }
 
     @Override
     public BigDecimal getRefundedAmount() {
-        return MoreObjects.firstNonNull(invoice.getRefundedAmount(), BigDecimal.ZERO);
+        return Objects.requireNonNullElse(invoice.getRefundedAmount(), BigDecimal.ZERO);
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/template/formatters/DefaultInvoiceItemFormatter.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/template/formatters/DefaultInvoiceItemFormatter.java
@@ -19,6 +19,7 @@ package org.killbill.billing.invoice.template.formatters;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.UUID;
 
@@ -33,12 +34,10 @@ import org.killbill.billing.invoice.api.formatters.InvoiceItemFormatter;
 import org.killbill.billing.invoice.api.formatters.ResourceBundleFactory;
 import org.killbill.billing.invoice.api.formatters.ResourceBundleFactory.ResourceBundleType;
 import org.killbill.billing.util.LocaleUtils;
+import org.killbill.billing.util.Strings;
 import org.killbill.billing.util.template.translation.DefaultCatalogTranslator;
 import org.killbill.billing.util.template.translation.Translator;
 import org.killbill.billing.util.template.translation.TranslatorConfig;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
 
 /**
  * Format invoice item fields
@@ -67,7 +66,7 @@ public class DefaultInvoiceItemFormatter implements InvoiceItemFormatter {
 
     @Override
     public BigDecimal getAmount() {
-        return MoreObjects.firstNonNull(item.getAmount(), BigDecimal.ZERO);
+        return Objects.requireNonNullElse(item.getAmount(), BigDecimal.ZERO);
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -86,9 +87,9 @@ public class ItemsInterval {
     }
 
     public void cancelItems(final Item item) {
-        Preconditions.checkState(item.getAction() == ItemAction.ADD);
-        Preconditions.checkState(items.size() == 1);
-        Preconditions.checkState(items.get(0).getAction() == ItemAction.CANCEL);
+        Preconditions.checkState((item.getAction() == ItemAction.ADD), "item.getAction != ADD");
+        Preconditions.checkState(items.size() == 1, "items.size() != 1");
+        Preconditions.checkState((items.get(0).getAction() == ItemAction.CANCEL), "item.get(0).getAction() != CANCEL");
         items.clear();
     }
 
@@ -177,7 +178,7 @@ public class ItemsInterval {
                     addItemsCancelled.add(cancelItem.getLinkedId());
                 }
             }
-            final Set<UUID> addItemsToBeCancelled = new HashSet<UUID>();
+            final Set<UUID> addItemsToBeCancelled = new HashSet<>();
             checkDoubleBilling(addItemsCancelled, addItemsToBeCancelled);
         }
 
@@ -213,13 +214,11 @@ public class ItemsInterval {
         parentItemsInterval.checkDoubleBilling(addItemsCancelled, addItemsToBeCancelled);
     }
 
-    // FIXME-1615: Use import statement
-    private Item findItem(final java.util.function.Predicate<? super Item> filter) {
+    private Item findItem(final Predicate<? super Item> filter) {
         return items.stream().filter(filter).findFirst().orElse(null);
     }
 
-    // FIXME-1615: Use import statement
-    private List<Item> findItems(final java.util.function.Predicate<? super Item> filter) {
+    private List<Item> findItems(final Predicate<? super Item> filter) {
         return items.stream().filter(filter).collect(Collectors.toUnmodifiableList());
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java
@@ -24,18 +24,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
 import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.tree.Item.ItemAction;
-
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import org.killbill.billing.util.Preconditions;
+import org.killbill.billing.util.collect.Iterables;
 
 /**
  * Keeps track of all the items existing on a specified ItemsNodeInterval
@@ -52,7 +49,7 @@ public class ItemsInterval {
 
     public ItemsInterval(final ItemsNodeInterval interval, final Item initialItem) {
         this.interval = interval;
-        this.items = Lists.newLinkedList();
+        this.items = new LinkedList<>();
         if (initialItem != null) {
             items.add(initialItem);
         }
@@ -63,41 +60,23 @@ public class ItemsInterval {
     }
 
     public Iterable<Item> get_ADD_items() {
-        return findItems(ItemAction.ADD);
+        return findItems(input -> input.getAction() == ItemAction.ADD);
     }
 
     public Iterable<Item> get_CANCEL_items() {
-        return findItems(ItemAction.CANCEL);
+        return findItems(input -> input.getAction() == ItemAction.CANCEL);
     }
 
     public Item getCancellingItemIfExists(final UUID targetId) {
-        return Iterables.tryFind(items,
-                                 new Predicate<Item>() {
-                                     @Override
-                                     public boolean apply(final Item input) {
-                                         return input.getAction() == ItemAction.CANCEL && input.getLinkedId().equals(targetId);
-                                     }
-                                 }).orNull();
+        return findItem(input -> input.getAction() == ItemAction.CANCEL && input.getLinkedId().equals(targetId));
     }
 
     public Item getCancelledItemIfExists(final UUID linkedId) {
-        return Iterables.tryFind(items,
-                                 new Predicate<Item>() {
-                                     @Override
-                                     public boolean apply(final Item input) {
-                                         return input.getAction() == ItemAction.ADD && input.getId().equals(linkedId);
-                                     }
-                                 }).orNull();
+        return findItem(input -> input.getAction() == ItemAction.ADD && input.getId().equals(linkedId));
     }
 
     public Item findItem(final UUID targetId) {
-        final Collection<Item> matchingItems = Collections2.<Item>filter(items,
-                                                                         new Predicate<Item>() {
-                                                                             @Override
-                                                                             public boolean apply(final Item input) {
-                                                                                 return input.getId().equals(targetId);
-                                                                             }
-                                                                         });
+        final Collection<Item> matchingItems = findItems(input -> input.getId().equals(targetId));
         Preconditions.checkState(matchingItems.size() < 2, "Too many items matching id='%s' among items='%s'", targetId, items);
         return matchingItems.size() == 1 ? matchingItems.iterator().next() : null;
     }
@@ -168,7 +147,7 @@ public class ItemsInterval {
     }
 
     private Item getResulting_CANCEL_ItemNoChecks() {
-        return findItem(ItemAction.CANCEL);
+        return findItem(input -> input.getAction() == ItemAction.CANCEL);
     }
 
     private Item getResulting_ADD_Item() {
@@ -180,15 +159,15 @@ public class ItemsInterval {
         //
         Preconditions.checkState(items.size() <= 2, "Double billing detected: %s", items);
 
-        final Collection<Item> addItems = findItems(ItemAction.ADD);
-        Preconditions.checkState(addItems.size() <= 1, "Double billing detected: %s", items);
+        final Iterable<Item> addItems = get_ADD_items();
+        Preconditions.checkState(Iterables.size(addItems) <= 1, "Double billing detected: %s", items);
 
-        Item item = findItem(ItemAction.ADD);
+        Item item = findItem(input -> input.getAction() == ItemAction.ADD);
 
         // Double billing sanity check across nodes
         if (item != null) {
-            final Set<UUID> addItemsCancelled = new HashSet<UUID>();
-            final Item cancelItem = findItem(ItemAction.CANCEL);
+            final Set<UUID> addItemsCancelled = new HashSet<>();
+            final Item cancelItem = findItem(input -> input.getAction() == ItemAction.CANCEL);
             if (cancelItem != null) {
                 Preconditions.checkState(cancelItem.getLinkedId() != null, "Invalid CANCEL item=%s", cancelItem);
                 if (cancelItem.getLinkedId().equals(item.getId())) {
@@ -234,19 +213,14 @@ public class ItemsInterval {
         parentItemsInterval.checkDoubleBilling(addItemsCancelled, addItemsToBeCancelled);
     }
 
-    private Item findItem(final ItemAction itemAction) {
-        final Collection<Item> matchingItems = findItems(itemAction);
-        return matchingItems.size() == 1 ? matchingItems.iterator().next() : null;
+    // FIXME-1615: Use import statement
+    private Item findItem(final java.util.function.Predicate<? super Item> filter) {
+        return items.stream().filter(filter).findFirst().orElse(null);
     }
 
-    private Collection<Item> findItems(final ItemAction itemAction) {
-        return Collections2.<Item>filter(items,
-                                         new Predicate<Item>() {
-                                             @Override
-                                             public boolean apply(final Item input) {
-                                                 return input.getAction() == itemAction;
-                                             }
-                                         });
+    // FIXME-1615: Use import statement
+    private List<Item> findItems(final java.util.function.Predicate<? super Item> filter) {
+        return items.stream().filter(filter).collect(Collectors.toUnmodifiableList());
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/TreePrinter.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/TreePrinter.java
@@ -28,7 +28,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.killbill.billing.util.annotation.VisibleForTesting;
 
 public class TreePrinter {
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/InvoiceTestSuiteNoDB.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/InvoiceTestSuiteNoDB.java
@@ -18,6 +18,8 @@
 
 package org.killbill.billing.invoice;
 
+import javax.inject.Inject;
+
 import org.killbill.billing.GuicyKillbillTestSuiteNoDB;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.currency.api.CurrencyConversionApi;
@@ -47,7 +49,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
 import com.google.inject.Guice;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 
 public abstract class InvoiceTestSuiteNoDB extends GuicyKillbillTestSuiteNoDB {

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestUsageInvoiceItemGeneratorUnit.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestUsageInvoiceItemGeneratorUnit.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.generator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+
+import org.killbill.billing.catalog.api.BillingMode;
+import org.killbill.billing.catalog.api.Usage;
+import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.invoice.usage.RawUsageOptimizer;
+import org.killbill.billing.util.UUIDs;
+import org.killbill.billing.util.collect.Iterables;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestUsageInvoiceItemGeneratorUnit extends InvoiceTestSuiteNoDB {
+
+    final Map<String, Usage> DEFAULT_KNOWN_USAGE = Map.of("usage1", createUsage(BillingMode.IN_ARREAR),
+                                                          "usage2", createUsage(BillingMode.IN_ADVANCE), // IN_ADVANCE will get excluded
+                                                          "usage3", createUsage(BillingMode.IN_ARREAR));
+
+    // We have total 4 valid invoice items that match knownUsages
+    final Iterable<Invoice> DEFAULT_EXISTING_INVOICES = List.of(createInvoice(Map.of("usage0", InvoiceItemType.USAGE,      // invalid
+                                                                                     "usage1", InvoiceItemType.ITEM_ADJ)), // invalid
+
+                                                                createInvoice(Map.of("usage1", InvoiceItemType.USAGE)),    // valid
+
+                                                                createInvoice(Map.of("usage1", InvoiceItemType.USAGE,      // valid
+                                                                                     "usage2", InvoiceItemType.FIXED)),    // invalid
+
+                                                                createInvoice(Map.of("usage2", InvoiceItemType.USAGE,      // invalid. "usage2" is IN_ADVANCE
+                                                                                     "usage3", InvoiceItemType.RECURRING)),// invalid
+
+                                                                createInvoice(Map.of("usage1", InvoiceItemType.USAGE,      // valid
+                                                                                     "usage2", InvoiceItemType.TAX,        // invalid
+                                                                                     "usage3", InvoiceItemType.USAGE))     // valid
+                                                      );
+
+    private static UsageInvoiceItemGenerator createGenerator() {
+        final RawUsageOptimizer optimizer = mock(RawUsageOptimizer.class);
+        final InvoiceConfig invoiceConfig = mock(InvoiceConfig.class);
+        final UsageInvoiceItemGenerator generator = new UsageInvoiceItemGenerator(optimizer, invoiceConfig);
+
+        return Mockito.spy(generator);
+    }
+
+    private static Usage createUsage(final BillingMode billingMode) {
+        final Usage usage = mock(Usage.class);
+        when(usage.getBillingMode()).thenReturn(billingMode);
+        return usage;
+    }
+
+    // In this scenario, subscriptionId of invoice.invoiceItems will remain the same.
+    private static Invoice createInvoice(final Map<String, InvoiceItemType> invoiceItemsUsageNameAndType) {
+        final UUID subscriptionId = UUIDs.randomUUID();
+        final List<InvoiceItem> invoiceItems = new ArrayList<>();
+        for (final Entry<String, InvoiceItemType> entry : invoiceItemsUsageNameAndType.entrySet()) {
+            final InvoiceItem item = mock(InvoiceItem.class);
+            when(item.getUsageName()).thenReturn(entry.getKey());
+            when(item.getInvoiceItemType()).thenReturn(entry.getValue());
+            when(item.getSubscriptionId()).thenReturn(subscriptionId);
+            invoiceItems.add(item);
+        }
+        final Invoice invoice = mock(Invoice.class);
+        when(invoice.getId()).thenReturn(UUIDs.randomUUID());
+        when(invoice.getInvoiceItems()).thenReturn(invoiceItems);
+        return invoice;
+    }
+
+    @Test(groups = "fast")
+    public void testGetUsageInArrearItems() {
+        final UsageInvoiceItemGenerator generator = createGenerator();
+        final Iterable<InvoiceItem> invoiceItems = generator.getUsageInArrearItems(DEFAULT_KNOWN_USAGE, DEFAULT_EXISTING_INVOICES);
+        final List<InvoiceItem> list = Iterables.toUnmodifiableList(invoiceItems);
+
+        Assert.assertEquals(list.size(), 4);
+    }
+
+    @Test(groups = "fast")
+    public void testExtractPerSubscriptionExistingInArrearUsageItems() {
+        final UsageInvoiceItemGenerator generator = createGenerator();
+        final Map<UUID, List<InvoiceItem>> items = generator.extractPerSubscriptionExistingInArrearUsageItems(
+                DEFAULT_KNOWN_USAGE,
+                DEFAULT_EXISTING_INVOICES);
+
+        // size = 3. Because in #extractPerSubscriptionExistingInArrearUsageItems(), we grouped invoiceItems by subscriptionId,
+        // and in our scenario (#createInvoice()) subscriptionId for each invoiceItems in an invoice remaining the same.
+        Assert.assertEquals(items.size(), 3);
+    }
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/notification/TestNextBillingDatePoster.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/notification/TestNextBillingDatePoster.java
@@ -116,8 +116,8 @@ public class TestNextBillingDatePoster extends InvoiceTestSuiteWithEmbeddedDB {
         Assert.assertFalse(Iterables.isEmpty(uuidKeys));
         final List<UUID> uuidKeysList = ImmutableList.copyOf(uuidKeys);
         Assert.assertEquals(uuidKeysList.size(), 2);
-        Assert.assertEquals(uuidKeysList.get(0), subscriptionId1);
-        Assert.assertEquals(uuidKeysList.get(1), subscriptionId2);
+        Assert.assertTrue(uuidKeysList.contains(subscriptionId1));
+        Assert.assertTrue(uuidKeysList.contains(subscriptionId2));
     }
 
     @Test(groups = "slow")

--- a/util/src/main/java/org/killbill/billing/util/Preconditions.java
+++ b/util/src/main/java/org/killbill/billing/util/Preconditions.java
@@ -197,12 +197,16 @@ public final class Preconditions {
     }
 
     /**
+     * <p>This method is DEPRECATED, to encourage user put message in precondition. See
+     * <a href="https://github.com/killbill/killbill/pull/1687#discussion_r869565378">this discussion</a>.</p>
+     *
      * Ensures the truth of an expression involving the state of the calling instance, but not
      * involving any parameters to the calling method.
      *
      * @param expression a boolean expression
      * @throws IllegalStateException if {@code expression} is false
      */
+    @Deprecated
     public static void checkState(final boolean expression) {
         if (!expression) {
             throw new IllegalStateException();

--- a/util/src/main/java/org/killbill/billing/util/Strings.java
+++ b/util/src/main/java/org/killbill/billing/util/Strings.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.CheckForNull;
+
 /**
  * Verbatim copy to guava's Strings (v.31.0.1). See https://github.com/killbill/killbill/issues/1615
  */
@@ -54,5 +56,15 @@ public final class Strings {
                 .filter(s -> !s.isBlank())
                 .map(String::trim)
                 .collect(Collectors.toUnmodifiableList());
+    }
+
+    /**
+     * Returns the given string if it is non-null; the empty string otherwise.
+     *
+     * @param string the string to test and possibly return
+     * @return {@code string} itself if it is non-null; {@code ""} if it is null
+     */
+    public static String nullToEmpty(@CheckForNull final String string) {
+        return (string == null) ? "" : string;
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/collect/Iterables.java
+++ b/util/src/main/java/org/killbill/billing/util/collect/Iterables.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.RandomAccess;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -69,6 +70,18 @@ public final class Iterables {
             iterable.forEach(result::add);
         }
         return result;
+    }
+
+    /**
+     * Convert {@link Iterable} to immutable {@link Set}. If any stream operation need to applied to iterable, use
+     * {@link #toStream(Iterable)} instead.
+     *
+     * @param iterable to convert
+     * @param <T> iterable element
+     * @return immutable {@link Set}
+     */
+    public static <T> Set<T> toUnmodifiableSet(final Iterable<? extends T> iterable) {
+        return toStream(iterable).collect(Collectors.toUnmodifiableSet());
     }
 
     /**


### PR DESCRIPTION
Some notes:

- `InvoiceWithMetadata#hasItemsForSubscription()` and `InvoiceWithMetadata#hasItemsForDate()`

Exctract duplicated logic to `isInvoiceItemsMatchCondition()`

- `InvoiceOptimizerExp#filterProposedItems()`

Seems big, but actually just cut-paste. Other part of refactoring covered by unit test.

- `UsageInvoiceItemGenerator` have refactored

`TestUsageInvoiceItemGeneratorUnit` added to cover refactored method.