### PR TITLE
pom.xml: update to killbill-oss-parent 0.145.3-8b2bb84-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-d1d7bd5-SNAPSHOT</version>
+        <version>0.145.3-8b2bb84-SNAPSHOT</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.23.0-SNAPSHOT</version>


### PR DESCRIPTION
This addresses:

```
2022-05-19T15:29:57,310+0000 lvl='INFO', log='DefaultLifecycle', th='localhost-startStop-1', xff='', rId='', tok='', aRId='', tRId='', Killbill lifecycle calling handler initialize for service osgi-service
2022-05-19T15:29:57,434+0000 lvl='WARN', log='DefaultLifecycle', th='localhost-startStop-1', xff='', rId='', tok='', aRId='', tRId='', Killbill lifecycle failed to invoke lifecycle handler
java.lang.reflect.InvocationTargetException: null
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.killbill.billing.lifecycle.DefaultLifecycle.doFireStage(DefaultLifecycle.java:154)
	at org.killbill.billing.lifecycle.DefaultLifecycle.fireSequence(DefaultLifecycle.java:141)
	at org.killbill.billing.lifecycle.DefaultLifecycle.fireStartupSequencePriorEventRegistration(DefaultLifecycle.java:82)
	at org.killbill.billing.server.listeners.KillbillPlatformGuiceListener.startLifecycle(KillbillPlatformGuiceListener.java:210)
	at org.killbill.billing.server.listeners.KillbillPlatformGuiceListener.contextInitialized(KillbillPlatformGuiceListener.java:106)
	at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4763)
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5232)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
	at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:753)
	at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:727)
	at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:695)
	at org.apache.catalina.startup.HostConfig.deployDirectory(HostConfig.java:1177)
	at org.apache.catalina.startup.HostConfig$DeployDirectory.run(HostConfig.java:1925)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.NoSuchMethodError: 'void org.osgi.service.resolver.ResolveContext.onCancel(java.lang.Runnable)'
	at org.apache.felix.resolver.ResolverImpl$ResolveSession.createSession(ResolverImpl.java:99)
	at org.apache.felix.resolver.ResolverImpl.resolve(ResolverImpl.java:419)
	at org.apache.felix.resolver.ResolverImpl.resolve(ResolverImpl.java:374)
	at org.apache.felix.framework.StatefulResolver.resolve(StatefulResolver.java:488)
	at org.apache.felix.framework.Felix.init(Felix.java:778)
	at org.apache.felix.framework.Felix.init(Felix.java:648)
	at org.killbill.billing.osgi.DefaultOSGIService.createAndInitFelixFrameworkWithSystemBundle(DefaultOSGIService.java:174)
	at org.killbill.billing.osgi.DefaultOSGIService.createAndInitFramework(DefaultOSGIService.java:159)
	at org.killbill.billing.osgi.DefaultOSGIService.initialize(DefaultOSGIService.java:92)
	... 22 common frames omitted
```

caused by:

```
tomcat@docker-desktop:~/webapps/ROOT/org.osgi.compendium-5.0.0.jar$ javap org/osgi/service/resolver/ResolveContext.class
Compiled from "ResolveContext.java"
public abstract class org.osgi.service.resolver.ResolveContext {
  public org.osgi.service.resolver.ResolveContext();
  public java.util.Collection<org.osgi.resource.Resource> getMandatoryResources();
  public java.util.Collection<org.osgi.resource.Resource> getOptionalResources();
  public abstract java.util.List<org.osgi.resource.Capability> findProviders(org.osgi.resource.Requirement);
  public abstract int insertHostedCapability(java.util.List<org.osgi.resource.Capability>, org.osgi.service.resolver.HostedCapability);
  public abstract boolean isEffective(org.osgi.resource.Requirement);
  public abstract java.util.Map<org.osgi.resource.Resource, org.osgi.resource.Wiring> getWirings();
}
tomcat@docker-desktop:~/webapps/ROOT/org.apache.felix.framework-7.0.3.jar$ javap org/osgi/service/resolver/ResolveContext.class
Compiled from "ResolveContext.java"
public abstract class org.osgi.service.resolver.ResolveContext {
  public org.osgi.service.resolver.ResolveContext();
  public java.util.Collection<org.osgi.resource.Resource> getMandatoryResources();
  public java.util.Collection<org.osgi.resource.Resource> getOptionalResources();
  public abstract java.util.List<org.osgi.resource.Capability> findProviders(org.osgi.resource.Requirement);
  public abstract int insertHostedCapability(java.util.List<org.osgi.resource.Capability>, org.osgi.service.resolver.HostedCapability);
  public abstract boolean isEffective(org.osgi.resource.Requirement);
  public abstract java.util.Map<org.osgi.resource.Resource, org.osgi.resource.Wiring> getWirings();
  public java.util.Collection<org.osgi.resource.Resource> findRelatedResources(org.osgi.resource.Resource);
  public void onCancel(java.lang.Runnable);
  public java.util.List<org.osgi.resource.Wire> getSubstitutionWires(org.osgi.resource.Wiring);
}
```