### PR TITLE
1615 payment part 4

### DIFF
--- a/payment/src/test/java/org/killbill/billing/payment/api/TestDefaultAdminPaymentApi.java
+++ b/payment/src/test/java/org/killbill/billing/payment/api/TestDefaultAdminPaymentApi.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.api;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -40,8 +41,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
@@ -99,7 +98,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
             @Override
             public List<String> getPaymentControlPluginNames() {
-                return ImmutableList.<String>of(MockPaymentControlProviderPlugin.PLUGIN_NAME);
+                return List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME);
             }
         };
         final Payment payment = paymentApi.createAuthorizationWithPaymentControl(account,
@@ -110,7 +109,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                                                  null,
                                                                                  UUID.randomUUID().toString(),
                                                                                  UUID.randomUUID().toString(),
-                                                                                 ImmutableList.<PluginProperty>of(),
+                                                                                 Collections.emptyList(),
                                                                                  paymentOptions,
                                                                                  callContext);
         Assert.assertEquals(payment.getTransactions().size(), 1);
@@ -130,9 +129,9 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         Assert.assertEquals(paymentAttemptModelDaos.get(0).getAmount().compareTo(BigDecimal.TEN), 0);
         Assert.assertEquals(paymentAttemptModelDaos.get(0).getCurrency(), Currency.EUR);
 
-        adminPaymentApi.fixPaymentTransactionState(payment, payment.getTransactions().get(0), TransactionStatus.PAYMENT_FAILURE, null, "AUTH_ERRORED", ImmutableList.<PluginProperty>of(), callContext);
+        adminPaymentApi.fixPaymentTransactionState(payment, payment.getTransactions().get(0), TransactionStatus.PAYMENT_FAILURE, null, "AUTH_ERRORED", Collections.emptyList(), callContext);
 
-        Assert.assertEquals(paymentApi.getPayment(payment.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext).getTransactions().size(), 1);
+        Assert.assertEquals(paymentApi.getPayment(payment.getId(), false, false, Collections.emptyList(), callContext).getTransactions().size(), 1);
         final PaymentModelDao refreshedPaymentModelDao = paymentDao.getPayment(payment.getId(), internalCallContext);
         final PaymentTransactionModelDao refreshedPaymentTransactionModelDao = paymentDao.getPaymentTransaction(payment.getTransactions().get(0).getId(), internalCallContext);
         Assert.assertEquals(refreshedPaymentModelDao.getStateName(), "AUTH_ERRORED");
@@ -153,9 +152,9 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertListenerStatus();
 
         // Verify subsequent payment retries work
-        retryService.retryPaymentTransaction(refreshedPaymentTransactionModelDao.getAttemptId(), ImmutableList.<String>of(MockPaymentControlProviderPlugin.PLUGIN_NAME), internalCallContext);
+        retryService.retryPaymentTransaction(refreshedPaymentTransactionModelDao.getAttemptId(), List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME), internalCallContext);
 
-        final Payment retriedPayment = paymentApi.getPayment(payment.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment retriedPayment = paymentApi.getPayment(payment.getId(), false, false, Collections.emptyList(), callContext);
         Assert.assertEquals(retriedPayment.getTransactions().size(), 2);
         final PaymentModelDao retriedPaymentModelDao = paymentDao.getPayment(payment.getId(), internalCallContext);
         final PaymentTransactionModelDao retriedPaymentTransactionModelDao = paymentDao.getPaymentTransaction(retriedPayment.getTransactions().get(1).getId(), internalCallContext);
@@ -186,7 +185,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                                null,
                                                                UUID.randomUUID().toString(),
                                                                UUID.randomUUID().toString(),
-                                                               ImmutableList.<PluginProperty>of(),
+                                                               Collections.emptyList(),
                                                                callContext);
 
         final PaymentModelDao paymentModelDao = paymentDao.getPayment(payment.getId(), internalCallContext);
@@ -201,7 +200,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         try {
             // Since no transaction status is passed, PaymentTransactionInfoPlugin should be set
-            adminPaymentApi.fixPaymentTransactionState(payment, Mockito.mock(DefaultPaymentTransaction.class), null, null, "AUTH_ERRORED", ImmutableList.<PluginProperty>of(), callContext);
+            adminPaymentApi.fixPaymentTransactionState(payment, Mockito.mock(DefaultPaymentTransaction.class), null, null, "AUTH_ERRORED", Collections.emptyList(), callContext);
         } catch (final PaymentApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.PAYMENT_INVALID_PARAMETER.getCode());
         }
@@ -217,7 +216,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                                null,
                                                                UUID.randomUUID().toString(),
                                                                UUID.randomUUID().toString(),
-                                                               ImmutableList.<PluginProperty>of(),
+                                                               Collections.emptyList(),
                                                                callContext);
 
         final PaymentModelDao paymentModelDao = paymentDao.getPayment(payment.getId(), internalCallContext);
@@ -256,7 +255,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                                                        infoPlugin.getGatewayErrorCode(),
                                                                                        infoPlugin.getGatewayError(),
                                                                                        infoPlugin);
-        adminPaymentApi.fixPaymentTransactionState(payment, newPaymentTransaction, null, null, "AUTH_ERRORED", ImmutableList.<PluginProperty>of(), callContext);
+        adminPaymentApi.fixPaymentTransactionState(payment, newPaymentTransaction, null, null, "AUTH_ERRORED", Collections.emptyList(), callContext);
 
         final PaymentModelDao refreshedPaymentModelDao = paymentDao.getPayment(payment.getId(), internalCallContext);
         final PaymentTransactionModelDao refreshedPaymentTransactionModelDao = paymentDao.getPaymentTransaction(payment.getTransactions().get(0).getId(), internalCallContext);
@@ -279,7 +278,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                           null,
                                                           UUID.randomUUID().toString(),
                                                           UUID.randomUUID().toString(),
-                                                          ImmutableList.<PluginProperty>of(),
+                                                          Collections.emptyList(),
                                                           callContext);
 
         final PaymentModelDao paymentModelDao = paymentDao.getPayment(payment.getId(), internalCallContext);
@@ -294,7 +293,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                        payment.getCurrency(),
                                                        null,
                                                        UUID.randomUUID().toString(),
-                                                       ImmutableList.<PluginProperty>of(),
+                                                       Collections.emptyList(),
                                                        callContext);
 
         final PaymentModelDao paymentModelDao2 = paymentDao.getPayment(payment.getId(), internalCallContext);
@@ -308,7 +307,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                    TransactionStatus.PAYMENT_FAILURE,
                                                    null, /* Let Kill Bill figure it out */
                                                    null, /* Let Kill Bill figure it out */
-                                                   ImmutableList.<PluginProperty>of(),
+                                                   Collections.emptyList(),
                                                    callContext);
 
         final PaymentModelDao paymentModelDao3 = paymentDao.getPayment(payment.getId(), internalCallContext);
@@ -328,7 +327,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                           null,
                                                           UUID.randomUUID().toString(),
                                                           UUID.randomUUID().toString(),
-                                                          ImmutableList.<PluginProperty>of(),
+                                                          Collections.emptyList(),
                                                           callContext);
 
         final PaymentModelDao paymentModelDao = paymentDao.getPayment(payment.getId(), internalCallContext);
@@ -343,7 +342,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                        payment.getCurrency(),
                                                        null,
                                                        UUID.randomUUID().toString(),
-                                                       ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.ERROR.toString(), false)),
+                                                       List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.ERROR.toString(), false)),
                                                        callContext);
 
         final PaymentModelDao paymentModelDao2 = paymentDao.getPayment(payment.getId(), internalCallContext);
@@ -357,7 +356,7 @@ public class TestDefaultAdminPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                    TransactionStatus.SUCCESS,
                                                    null, /* Let Kill Bill figure it out */
                                                    null, /* Let Kill Bill figure it out */
-                                                   ImmutableList.<PluginProperty>of(),
+                                                   Collections.emptyList(),
                                                    callContext);
 
         final PaymentModelDao paymentModelDao3 = paymentDao.getPayment(payment.getId(), internalCallContext);

--- a/payment/src/test/java/org/killbill/billing/payment/api/TestDefaultPayment.java
+++ b/payment/src/test/java/org/killbill/billing/payment/api/TestDefaultPayment.java
@@ -26,16 +26,14 @@ import org.killbill.billing.payment.PaymentTestSuiteNoDB;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class TestDefaultPayment extends PaymentTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAmountsCaptureVoided() throws Exception {
         final UUID paymentId = UUID.randomUUID();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.VOID, TransactionStatus.SUCCESS, null));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.VOID, TransactionStatus.SUCCESS, null));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.TEN), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.ZERO), 0);
@@ -46,10 +44,10 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     @Test(groups = "fast")
     public void testAmountsCaptureVoidedAuthReversed() throws Exception {
         final UUID paymentId = UUID.randomUUID();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.VOID, TransactionStatus.SUCCESS, null),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.VOID, TransactionStatus.SUCCESS, null));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.VOID, TransactionStatus.SUCCESS, null),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.VOID, TransactionStatus.SUCCESS, null));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.ZERO), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.ZERO), 0);
@@ -61,9 +59,9 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsCaptureChargeback() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.TEN), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.ZERO), 0);
@@ -75,10 +73,10 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsCaptureChargebackReversed() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.TEN));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.TEN));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.TEN), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.TEN), 0);
@@ -90,10 +88,10 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsCaptureChargebackReversedMultipleCurrencies() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN, Currency.EUR),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN, Currency.USD),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.ONE, Currency.EUR),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.ONE, Currency.EUR));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN, Currency.EUR),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN, Currency.USD),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.ONE, Currency.EUR),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.ONE, Currency.EUR));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getCurrency(), Currency.EUR);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.TEN), 0);
@@ -106,11 +104,11 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsCaptureChargebackReversedAndRefund() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.REFUND, TransactionStatus.SUCCESS, BigDecimal.ONE),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.TEN));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.AUTHORIZE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CAPTURE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.REFUND, TransactionStatus.SUCCESS, BigDecimal.ONE),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.TEN));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.TEN), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.TEN), 0);
@@ -122,8 +120,8 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsPurchaseChargeback() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.ZERO), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.ZERO), 0);
@@ -135,8 +133,8 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsPurchaseChargebackDifferentCurrency() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN, Currency.USD),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.ONE, Currency.EUR));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN, Currency.USD),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.ONE, Currency.EUR));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.ZERO), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.ZERO), 0);
@@ -148,9 +146,9 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsPurchaseChargebackReversed() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.TEN));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.TEN));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.ZERO), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.ZERO), 0);
@@ -162,10 +160,10 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsPurchaseChargebackReversedAndRefund() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.REFUND, TransactionStatus.SUCCESS, BigDecimal.ONE),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.TEN));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.REFUND, TransactionStatus.SUCCESS, BigDecimal.ONE),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.TEN));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.ZERO), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.ZERO), 0);
@@ -177,11 +175,11 @@ public class TestDefaultPayment extends PaymentTestSuiteNoDB {
     public void testAmountsPurchaseMultipleChargebacks() throws Exception {
         final UUID paymentId = UUID.randomUUID();
         final String chargebackExternalKey = UUID.randomUUID().toString();
-        final List<PaymentTransaction> transactions = ImmutableList.<PaymentTransaction>of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.REFUND, TransactionStatus.SUCCESS, BigDecimal.ONE),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.ONE),
-                                                                                           buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.ONE),
-                                                                                           buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.ONE));
+        final List<PaymentTransaction> transactions = List.of(buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.PURCHASE, TransactionStatus.SUCCESS, BigDecimal.TEN),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.REFUND, TransactionStatus.SUCCESS, BigDecimal.ONE),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.ONE),
+                                                              buildPaymentTransaction(paymentId, UUID.randomUUID().toString(), TransactionType.CHARGEBACK, TransactionStatus.SUCCESS, BigDecimal.ONE),
+                                                              buildPaymentTransaction(paymentId, chargebackExternalKey, TransactionType.CHARGEBACK, TransactionStatus.PAYMENT_FAILURE, BigDecimal.ONE));
         final Payment payment = buildPayment(paymentId, transactions);
         Assert.assertEquals(payment.getAuthAmount().compareTo(BigDecimal.ZERO), 0);
         Assert.assertEquals(payment.getCapturedAmount().compareTo(BigDecimal.ZERO), 0);

--- a/payment/src/test/java/org/killbill/billing/payment/api/TestExternalPaymentPlugin.java
+++ b/payment/src/test/java/org/killbill/billing/payment/api/TestExternalPaymentPlugin.java
@@ -17,6 +17,7 @@
 package org.killbill.billing.payment.api;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.killbill.billing.account.api.Account;
@@ -27,11 +28,8 @@ import org.killbill.billing.payment.provider.DefaultNoOpPaymentMethodPlugin;
 import org.killbill.billing.payment.provider.ExternalPaymentProviderPlugin;
 import org.killbill.billing.util.entity.Pagination;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestExternalPaymentPlugin extends PaymentTestSuiteWithEmbeddedDB {
 
@@ -57,10 +55,10 @@ public class TestExternalPaymentPlugin extends PaymentTestSuiteWithEmbeddedDB {
         final String transactionExternalKey = "transactionKey";
 
         final Payment payment = paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null, paymentExternalKey, transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
-        final Payment paymentPluginInfoFalse = paymentApi.getPayment(payment.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext);
-        final Payment paymentPluginInfoTrue = paymentApi.getPayment(payment.getId(), true, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment paymentPluginInfoFalse = paymentApi.getPayment(payment.getId(), false, false, Collections.emptyList(), callContext);
+        final Payment paymentPluginInfoTrue = paymentApi.getPayment(payment.getId(), true, false, Collections.emptyList(), callContext);
 
         Assert.assertEquals(paymentPluginInfoFalse.getAccountId(), paymentPluginInfoTrue.getAccountId());
 
@@ -97,7 +95,7 @@ public class TestExternalPaymentPlugin extends PaymentTestSuiteWithEmbeddedDB {
 
         final Payment payment = paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount,
                                                           Currency.AED, null, paymentExternalKey, transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         final Pagination<PaymentMethod> paymentMethods = paymentApi.getPaymentMethods(0L, 10L, false, null, callContext);
         final Pagination<PaymentMethod> paymentMethodsPlugin = paymentApi.getPaymentMethods(0L, 10L, true, null, callContext);
@@ -123,7 +121,7 @@ public class TestExternalPaymentPlugin extends PaymentTestSuiteWithEmbeddedDB {
             throws Exception {
         final UUID paymentMethodId = paymentApi.addPaymentMethod(account, paymentMethodInfo.getExternalPaymentMethodId(),
                                                                  ExternalPaymentProviderPlugin.PLUGIN_NAME, true,
-                                                                 paymentMethodInfo, ImmutableList.<PluginProperty>of(), callContext);
+                                                                 paymentMethodInfo, Collections.emptyList(), callContext);
         return accountApi.getAccountById(account.getId(), internalCallContext);
     }
 

--- a/payment/src/test/java/org/killbill/billing/payment/api/TestPaymentApi.java
+++ b/payment/src/test/java/org/killbill/billing/payment/api/TestPaymentApi.java
@@ -20,7 +20,7 @@ package org.killbill.billing.payment.api;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
@@ -55,8 +55,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -74,7 +72,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         @Override
         public List<String> getPaymentControlPluginNames() {
-            return ImmutableList.<String>of(InvoicePaymentControlPluginApi.PLUGIN_NAME);
+            return List.<String>of(InvoicePaymentControlPluginApi.PLUGIN_NAME);
         }
     };
     final PaymentOptions CONTROL_PLUGIN_OPTIONS = new PaymentOptions() {
@@ -85,7 +83,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         @Override
         public List<String> getPaymentControlPluginNames() {
-            return Arrays.asList(MockPaymentControlProviderPlugin.PLUGIN_NAME);
+            return List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME);
         }
     };
     private MockPaymentProviderPlugin mockPaymentProviderPlugin;
@@ -133,10 +131,10 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow")
     public void testUniqueExternalPaymentMethod() throws PaymentApiException {
-        paymentApi.addPaymentMethod(account, "thisonewillwork", ExternalPaymentProviderPlugin.PLUGIN_NAME, true, null, ImmutableList.<PluginProperty>of(), callContext);
+        paymentApi.addPaymentMethod(account, "thisonewillwork", ExternalPaymentProviderPlugin.PLUGIN_NAME, true, null, Collections.emptyList(), callContext);
 
         try {
-            paymentApi.addPaymentMethod(account, "thisonewillnotwork", ExternalPaymentProviderPlugin.PLUGIN_NAME, true, null, ImmutableList.<PluginProperty>of(), callContext);
+            paymentApi.addPaymentMethod(account, "thisonewillnotwork", ExternalPaymentProviderPlugin.PLUGIN_NAME, true, null, Collections.emptyList(), callContext);
 
         } catch (PaymentApiException e) {
             assertEquals(e.getCode(), ErrorCode.PAYMENT_EXTERNAL_PAYMENT_METHOD_ALREADY_EXISTS.getCode());
@@ -145,7 +143,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow")
     public void testAddRemovePaymentMethod() throws Exception {
-        final Long baseNbRecords = paymentApi.getPaymentMethods(0L, 1000L, false, ImmutableList.<PluginProperty>of(), callContext).getMaxNbRecords();
+        final Long baseNbRecords = paymentApi.getPaymentMethods(0L, 1000L, false, Collections.emptyList(), callContext).getMaxNbRecords();
         Assert.assertEquals(baseNbRecords, (Long) 1L);
 
         final Account account = testHelper.createTestAccount(UUID.randomUUID().toString(), true);
@@ -153,13 +151,13 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         checkPaymentMethodPagination(paymentMethodId, baseNbRecords + 1, false);
 
-        paymentApi.deletePaymentMethod(account, paymentMethodId, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        paymentApi.deletePaymentMethod(account, paymentMethodId, true, false, Collections.emptyList(), callContext);
 
-        List<PaymentMethod> paymentMethods = paymentApi.getAccountPaymentMethods(account.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext);
+        List<PaymentMethod> paymentMethods = paymentApi.getAccountPaymentMethods(account.getId(), false, false, Collections.emptyList(), callContext);
         assertEquals(paymentMethods.size(), 0);
 
 
-        paymentMethods = paymentApi.getAccountPaymentMethods(account.getId(), true, false, ImmutableList.<PluginProperty>of(), callContext);
+        paymentMethods = paymentApi.getAccountPaymentMethods(account.getId(), true, false, Collections.emptyList(), callContext);
         assertEquals(paymentMethods.size(), 1);
 
         checkPaymentMethodPagination(paymentMethodId, baseNbRecords, true);
@@ -167,7 +165,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow")
     public void testAddRemovePaymentMethodWithForcedDeletion() throws Exception {
-        final Long baseNbRecords = paymentApi.getPaymentMethods(0L, 1000L, false, ImmutableList.<PluginProperty>of(), callContext).getMaxNbRecords();
+        final Long baseNbRecords = paymentApi.getPaymentMethods(0L, 1000L, false, Collections.emptyList(), callContext).getMaxNbRecords();
         Assert.assertEquals(baseNbRecords, (Long) 1L);
 
         final Account account = testHelper.createTestAccount(UUID.randomUUID().toString(), true);
@@ -175,21 +173,21 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         checkPaymentMethodPagination(paymentMethodId, baseNbRecords + 1, false);
 
-        paymentApi.deletePaymentMethod(account, paymentMethodId, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        paymentApi.deletePaymentMethod(account, paymentMethodId, false, true, Collections.emptyList(), callContext);
 
         checkPaymentMethodPagination(paymentMethodId, baseNbRecords, true);
     }
 
     @Test(groups = "slow")
     public void testAddRemovePaymentMethodWithoutForcedDeletion() throws Exception {
-        final Long baseNbRecords = paymentApi.getPaymentMethods(0L, 1000L, false, ImmutableList.<PluginProperty>of(), callContext).getMaxNbRecords();
+        final Long baseNbRecords = paymentApi.getPaymentMethods(0L, 1000L, false, Collections.emptyList(), callContext).getMaxNbRecords();
         Assert.assertEquals(baseNbRecords, (Long) 1L);
 
         final Account account = testHelper.createTestAccount(UUID.randomUUID().toString(), true);
         final UUID paymentMethodId = account.getPaymentMethodId();
 
         try {
-            paymentApi.deletePaymentMethod(account, paymentMethodId, false, false, ImmutableList.<PluginProperty>of(), callContext);
+            paymentApi.deletePaymentMethod(account, paymentMethodId, false, false, Collections.emptyList(), callContext);
         } catch (final PaymentApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.PAYMENT_INTERNAL_ERROR.getCode());
         }
@@ -201,11 +199,11 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         final BigDecimal requestedAmount = BigDecimal.TEN;
         final Payment payment = paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.EUR, null, UUID.randomUUID().toString(), UUID.randomUUID().toString(),
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
-        paymentApi.deletePaymentMethod(account, account.getPaymentMethodId(), false, true, ImmutableList.<PluginProperty>of(), callContext);
+        paymentApi.deletePaymentMethod(account, account.getPaymentMethodId(), false, true, Collections.emptyList(), callContext);
 
-        final Payment newPayment = paymentApi.createRefund(account, payment.getId(),requestedAmount,  Currency.EUR, null, UUID.randomUUID().toString(), ImmutableList.<PluginProperty>of(), callContext);
+        final Payment newPayment = paymentApi.createRefund(account, payment.getId(),requestedAmount,  Currency.EUR, null, UUID.randomUUID().toString(), Collections.emptyList(), callContext);
         Assert.assertEquals(newPayment.getTransactions().size(), 2);
     }
 
@@ -217,7 +215,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final String transactionExternalKey = "krapaut";
 
         final Payment payment = paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null, paymentExternalKey, transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         assertEquals(payment.getExternalKey(), paymentExternalKey);
         assertEquals(payment.getPaymentMethodId(), account.getPaymentMethodId());
@@ -253,7 +251,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
 
         final Payment payment = paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null, paymentExternalKey, transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         assertEquals(payment.getExternalKey(), paymentExternalKey);
         assertEquals(payment.getPaymentMethodId(), account.getPaymentMethodId());
@@ -278,7 +276,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment.getTransactions().get(0).getGatewayErrorCode());
 
         final Payment payment2 = paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null, paymentExternalKey, transactionExternalKey,
-                                                           ImmutableList.<PluginProperty>of(), callContext);
+                                                           Collections.emptyList(), callContext);
 
         assertEquals(payment2.getExternalKey(), paymentExternalKey);
         assertEquals(payment2.getTransactions().get(0).getExternalKey(), transactionExternalKey);
@@ -302,7 +300,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         mockPaymentProviderPlugin.makeNextPaymentFailWithCancellation();
 
         final Payment payment = paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null, paymentExternalKey, transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         assertEquals(payment.getExternalKey(), paymentExternalKey);
         assertEquals(payment.getPaymentMethodId(), account.getPaymentMethodId());
@@ -327,7 +325,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment.getTransactions().get(0).getGatewayErrorCode());
 
         final Payment payment2 = paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null, paymentExternalKey, transactionExternalKey,
-                                                           ImmutableList.<PluginProperty>of(), callContext);
+                                                           Collections.emptyList(), callContext);
 
         assertEquals(payment2.getExternalKey(), paymentExternalKey);
         assertEquals(payment2.getTransactions().get(0).getExternalKey(), transactionExternalKey);
@@ -349,7 +347,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final String transactionExternalKey = "txn external key";
         try {
             paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null,
-                                      paymentExternalKey, transactionExternalKey, ImmutableList.<PluginProperty>of(), callContext);
+                                      paymentExternalKey, transactionExternalKey, Collections.emptyList(), callContext);
             fail();
         } catch (PaymentApiException e) {
             assertTrue(e.getCause() instanceof PaymentPluginApiException);
@@ -367,7 +365,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         try {
             paymentApi.createPurchaseWithPaymentControl(
                     account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null,
-                    paymentExternalKey, transactionExternalKey, ImmutableList.<PluginProperty>of(), CONTROL_PLUGIN_OPTIONS, callContext);
+                    paymentExternalKey, transactionExternalKey, Collections.emptyList(), CONTROL_PLUGIN_OPTIONS, callContext);
             fail();
         } catch (PaymentApiException e) {
             assertTrue(e.getCause() instanceof PaymentPluginApiException);
@@ -385,7 +383,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         try {
             paymentApi.createPurchaseWithPaymentControl(
                     account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null,
-                    paymentExternalKey, transactionExternalKey, ImmutableList.<PluginProperty>of(), CONTROL_PLUGIN_OPTIONS, callContext);
+                    paymentExternalKey, transactionExternalKey, Collections.emptyList(), CONTROL_PLUGIN_OPTIONS, callContext);
             fail();
         } catch (PaymentApiException e) {
             assertTrue(e.getCause() instanceof PaymentControlApiException);
@@ -403,7 +401,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         try {
             paymentApi.createPurchaseWithPaymentControl(
                     account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null,
-                    paymentExternalKey, transactionExternalKey, ImmutableList.<PluginProperty>of(), CONTROL_PLUGIN_OPTIONS, callContext);
+                    paymentExternalKey, transactionExternalKey, Collections.emptyList(), CONTROL_PLUGIN_OPTIONS, callContext);
             fail();
         } catch (PaymentApiException e) {
             assertTrue(e.getCause() instanceof IllegalStateException);
@@ -420,7 +418,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         final Payment payment = paymentApi.createAuthorization(account, account.getPaymentMethodId(), null, authAmount, Currency.AED, null,
                                                                paymentExternalKey, transactionExternalKey,
-                                                               ImmutableList.<PluginProperty>of(), callContext);
+                                                               Collections.emptyList(), callContext);
 
         assertEquals(payment.getExternalKey(), paymentExternalKey);
         assertEquals(payment.getPaymentMethodId(), account.getPaymentMethodId());
@@ -446,7 +444,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment.getTransactions().get(0).getGatewayErrorCode());
 
         // Void the authorization
-        final Payment payment2 = paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey2, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment2 = paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey2, Collections.emptyList(), callContext);
 
         assertEquals(payment2.getExternalKey(), paymentExternalKey);
         assertEquals(payment2.getPaymentMethodId(), account.getPaymentMethodId());
@@ -473,7 +471,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         try {
             // Verify further VOIDs are prohibited (see https://github.com/killbill/killbill/issues/514)
-            paymentApi.createVoid(account, payment.getId(), null, UUID.randomUUID().toString(), ImmutableList.<PluginProperty>of(), callContext);
+            paymentApi.createVoid(account, payment.getId(), null, UUID.randomUUID().toString(), Collections.emptyList(), callContext);
             Assert.fail();
         } catch (final PaymentApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.PAYMENT_INVALID_OPERATION.getCode());
@@ -496,7 +494,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         final Payment payment = paymentApi.createAuthorization(account, account.getPaymentMethodId(), null, authAmount, Currency.AED, null,
                                                                paymentExternalKey, transactionExternalKey,
-                                                               ImmutableList.<PluginProperty>of(), callContext);
+                                                               Collections.emptyList(), callContext);
 
         assertEquals(payment.getExternalKey(), paymentExternalKey);
         assertEquals(payment.getPaymentMethodId(), account.getPaymentMethodId());
@@ -522,7 +520,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment.getTransactions().get(0).getGatewayErrorCode());
 
         final Payment payment2 = paymentApi.createCapture(account, payment.getId(), captureAmount, Currency.AED, null, transactionExternalKey2,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         assertEquals(payment2.getExternalKey(), paymentExternalKey);
         assertEquals(payment2.getPaymentMethodId(), account.getPaymentMethodId());
@@ -548,7 +546,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment2.getTransactions().get(1).getGatewayErrorCode());
 
         // Void the capture
-        final Payment payment3 = paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey3, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment3 = paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey3, Collections.emptyList(), callContext);
 
         assertEquals(payment3.getExternalKey(), paymentExternalKey);
         assertEquals(payment3.getPaymentMethodId(), account.getPaymentMethodId());
@@ -575,7 +573,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         // Capture again
         final Payment payment4 = paymentApi.createCapture(account, payment.getId(), captureAmount, Currency.AED, null, transactionExternalKey4,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         assertEquals(payment4.getExternalKey(), paymentExternalKey);
         assertEquals(payment4.getPaymentMethodId(), account.getPaymentMethodId());
@@ -613,7 +611,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         final Payment payment = paymentApi.createAuthorization(account, account.getPaymentMethodId(), null, authAmount, Currency.AED, null,
                                                                paymentExternalKey, transactionExternalKey,
-                                                               ImmutableList.<PluginProperty>of(), callContext);
+                                                               Collections.emptyList(), callContext);
 
         assertEquals(payment.getExternalKey(), paymentExternalKey);
         assertEquals(payment.getPaymentMethodId(), account.getPaymentMethodId());
@@ -639,7 +637,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment.getTransactions().get(0).getGatewayErrorCode());
 
         final Payment payment2 = paymentApi.createCapture(account, payment.getId(), captureAmount, Currency.AED, null, transactionExternalKey2,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         assertEquals(payment2.getExternalKey(), paymentExternalKey);
         assertEquals(payment2.getPaymentMethodId(), account.getPaymentMethodId());
@@ -666,7 +664,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         try {
             // Voiding a capture is prohibited by default
-            paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey3, ImmutableList.<PluginProperty>of(), callContext);
+            paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey3, Collections.emptyList(), callContext);
             Assert.fail();
         } catch (final PaymentApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.PAYMENT_INVALID_OPERATION.getCode());
@@ -689,7 +687,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         final Payment payment = paymentApi.createAuthorization(account, account.getPaymentMethodId(), null, authAmount, Currency.AED, null,
                                                                paymentExternalKey, transactionExternalKey,
-                                                               ImmutableList.<PluginProperty>of(), callContext);
+                                                               Collections.emptyList(), callContext);
 
         assertEquals(payment.getExternalKey(), paymentExternalKey);
         assertEquals(payment.getPaymentMethodId(), account.getPaymentMethodId());
@@ -715,7 +713,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment.getTransactions().get(0).getGatewayErrorCode());
 
         final Payment payment2 = paymentApi.createCapture(account, payment.getId(), captureAmount, Currency.AED, null, transactionExternalKey2,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         assertEquals(payment2.getExternalKey(), paymentExternalKey);
         assertEquals(payment2.getPaymentMethodId(), account.getPaymentMethodId());
@@ -741,7 +739,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment2.getTransactions().get(1).getGatewayErrorCode());
 
         // Void the capture
-        final Payment payment3 = paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey3, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment3 = paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey3, Collections.emptyList(), callContext);
 
         assertEquals(payment3.getExternalKey(), paymentExternalKey);
         assertEquals(payment3.getPaymentMethodId(), account.getPaymentMethodId());
@@ -767,7 +765,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertNotNull(payment3.getTransactions().get(2).getGatewayErrorCode());
 
         // Void the authorization
-        final Payment payment4 = paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey4, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment4 = paymentApi.createVoid(account, payment.getId(), null, transactionExternalKey4, Collections.emptyList(), callContext);
 
         assertEquals(payment4.getExternalKey(), paymentExternalKey);
         assertEquals(payment4.getPaymentMethodId(), account.getPaymentMethodId());
@@ -806,13 +804,13 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final String transactionExternalKey4 = "sioux4";
 
         final Payment payment = paymentApi.createAuthorization(account, account.getPaymentMethodId(), null, authAmount, Currency.USD, null, paymentExternalKey, transactionExternalKey,
-                                                               ImmutableList.<PluginProperty>of(), callContext);
+                                                               Collections.emptyList(), callContext);
 
         paymentApi.createCapture(account, payment.getId(), captureAmount, Currency.USD, null, transactionExternalKey2,
-                                 ImmutableList.<PluginProperty>of(), callContext);
+                                 Collections.emptyList(), callContext);
 
         final Payment payment3 = paymentApi.createCapture(account, payment.getId(), captureAmount, Currency.USD, null, transactionExternalKey3,
-                                                          ImmutableList.<PluginProperty>of(), callContext);
+                                                          Collections.emptyList(), callContext);
 
         assertEquals(payment3.getExternalKey(), paymentExternalKey);
         assertEquals(payment3.getPaymentMethodId(), account.getPaymentMethodId());
@@ -824,7 +822,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         assertEquals(payment3.getCurrency(), Currency.USD);
         assertEquals(payment3.getTransactions().size(), 3);
 
-        final Payment payment4 = paymentApi.createRefund(account, payment3.getId(), payment3.getCapturedAmount(), Currency.USD, null, transactionExternalKey4, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment4 = paymentApi.createRefund(account, payment3.getId(), payment3.getCapturedAmount(), Currency.USD, null, transactionExternalKey4, Collections.emptyList(), callContext);
         assertEquals(payment4.getAuthAmount().compareTo(authAmount), 0);
         assertEquals(payment4.getCapturedAmount().compareTo(captureAmount.add(captureAmount)), 0);
         assertEquals(payment4.getPurchasedAmount().compareTo(BigDecimal.ZERO), 0);
@@ -875,14 +873,14 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                           null,
                                                           paymentExternalKey,
                                                           transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(),
+                                                          Collections.emptyList(),
                                                           /*
                                                            * We explicitly don't pass InvoicePaymentControlPluginApi.PLUGIN_NAME
                                                              to verify it it automatically added
                                                           */
                                                           CONTROL_PLUGIN_OPTIONS,
                                                           callContext);
-        final Payment payment = paymentApi.getPaymentByExternalKey(paymentExternalKey, false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment = paymentApi.getPaymentByExternalKey(paymentExternalKey, false, false, Collections.emptyList(), callContext);
         assertEquals(payment.getExternalKey(), paymentExternalKey);
         assertEquals(payment.getPaymentMethodId(), account.getPaymentMethodId());
         assertEquals(payment.getAccountId(), account.getId());
@@ -930,7 +928,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                               null,
                                                               paymentExternalKey,
                                                               transactionExternalKey,
-                                                              ImmutableList.<PluginProperty>of(),
+                                                              Collections.emptyList(),
                                                               INVOICE_PAYMENT,
                                                               callContext);
             Assert.fail();
@@ -973,14 +971,14 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                               null,
                                                               paymentExternalKey,
                                                               transactionExternalKey,
-                                                              ImmutableList.<PluginProperty>of(),
+                                                              Collections.emptyList(),
                                                               INVOICE_PAYMENT,
                                                               callContext);
         } catch (final PaymentApiException expected) {
             assertTrue(true);
         }
 
-        final List<Payment> accountPayments = paymentApi.getAccountPayments(account.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final List<Payment> accountPayments = paymentApi.getAccountPayments(account.getId(), false, false, Collections.emptyList(), callContext);
         assertEquals(accountPayments.size(), 1);
         final Payment payment = accountPayments.get(0);
         assertEquals(payment.getExternalKey(), paymentExternalKey);
@@ -1038,14 +1036,14 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                               null,
                                                               paymentExternalKey,
                                                               transactionExternalKey,
-                                                              ImmutableList.<PluginProperty>of(),
+                                                              Collections.emptyList(),
                                                               INVOICE_PAYMENT,
                                                               callContext);
         } catch (final PaymentApiException expected) {
             assertTrue(true);
         }
 
-        final List<Payment> accountPayments = paymentApi.getAccountPayments(account.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final List<Payment> accountPayments = paymentApi.getAccountPayments(account.getId(), false, false, Collections.emptyList(), callContext);
         assertEquals(accountPayments.size(), 1);
         final Payment payment = accountPayments.get(0);
         assertEquals(payment.getExternalKey(), paymentExternalKey);
@@ -1078,11 +1076,11 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                           null,
                                                           paymentExternalKey,
                                                           transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(),
+                                                          Collections.emptyList(),
                                                           INVOICE_PAYMENT,
                                                           callContext);
 
-        final List<Payment> accountPayments2 = paymentApi.getAccountPayments(account.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final List<Payment> accountPayments2 = paymentApi.getAccountPayments(account.getId(), false, false, Collections.emptyList(), callContext);
         assertEquals(accountPayments2.size(), 1);
         final Payment payment2 = accountPayments2.get(0);
         assertEquals(payment2.getTransactions().size(), 2);
@@ -1130,7 +1128,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                               null,
                                                               paymentExternalKey,
                                                               transactionExternalKey,
-                                                              ImmutableList.<PluginProperty>of(),
+                                                              Collections.emptyList(),
                                                               INVOICE_PAYMENT,
                                                               callContext);
             Assert.fail("Unexpected success");
@@ -1172,12 +1170,12 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                           null,
                                                           paymentExternalKey,
                                                           transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(),
+                                                          Collections.emptyList(),
                                                           INVOICE_PAYMENT,
                                                           callContext);
-        final Payment payment = paymentApi.getPaymentByExternalKey(paymentExternalKey, false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment = paymentApi.getPaymentByExternalKey(paymentExternalKey, false, false, Collections.emptyList(), callContext);
 
-        final List<PluginProperty> refundProperties = ImmutableList.<PluginProperty>of();
+        final List<PluginProperty> refundProperties = Collections.emptyList();
         final Payment payment2 = paymentApi.createRefundWithPaymentControl(account, payment.getId(), requestedAmount, Currency.USD, null, transactionExternalKey2,
                                                                            refundProperties, INVOICE_PAYMENT, callContext);
 
@@ -1226,12 +1224,12 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                           null,
                                                           paymentExternalKey,
                                                           transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(),
+                                                          Collections.emptyList(),
                                                           INVOICE_PAYMENT,
                                                           callContext);
-        final Payment payment = paymentApi.getPaymentByExternalKey(paymentExternalKey, false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment = paymentApi.getPaymentByExternalKey(paymentExternalKey, false, false, Collections.emptyList(), callContext);
 
-        final List<PluginProperty> refundProperties = ImmutableList.<PluginProperty>of();
+        final List<PluginProperty> refundProperties = Collections.emptyList();
 
         try {
             paymentApi.createRefundWithPaymentControl(account, payment.getId(), BigDecimal.TEN, Currency.USD, null,transactionExternalKey2,
@@ -1275,10 +1273,10 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                           null,
                                                           paymentExternalKey,
                                                           transactionExternalKey,
-                                                          ImmutableList.<PluginProperty>of(),
+                                                          Collections.emptyList(),
                                                           INVOICE_PAYMENT,
                                                           callContext);
-        final Payment payment = paymentApi.getPaymentByExternalKey(paymentExternalKey, false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment = paymentApi.getPaymentByExternalKey(paymentExternalKey, false, false, Collections.emptyList(), callContext);
 
         final List<PluginProperty> refundProperties = new ArrayList<PluginProperty>();
         final HashMap<UUID, BigDecimal> uuidBigDecimalHashMap = new HashMap<UUID, BigDecimal>();
@@ -1286,7 +1284,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
         invoicePaymentApi.createRefundForInvoicePayment(true, uuidBigDecimalHashMap, account, payment.getId(), null, Currency.USD, null, transactionExternalKey2,
                                                         refundProperties, INVOICE_PAYMENT, callContext);
-        final Payment payment2 = paymentApi.getPayment(payment.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment payment2 = paymentApi.getPayment(payment.getId(), false, false, Collections.emptyList(), callContext);
 
         assertEquals(payment2.getTransactions().size(), 2);
         assertEquals(payment2.getExternalKey(), paymentExternalKey);
@@ -1306,7 +1304,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final String paymentExternalKey = UUID.randomUUID().toString();
         final String purchaseTransactionExternalKey = UUID.randomUUID().toString();
         final String chargebackTransactionExternalKey = UUID.randomUUID().toString();
-        final ImmutableList<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+        final List<PluginProperty> properties = Collections.emptyList();
 
         final Payment payment = paymentApi.createPurchase(account,
                                                           account.getPaymentMethodId(),
@@ -1549,7 +1547,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final String paymentExternalKey = UUID.randomUUID().toString();
         final String purchaseTransactionExternalKey = UUID.randomUUID().toString();
         final String chargebackTransactionExternalKey = UUID.randomUUID().toString();
-        final ImmutableList<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+        final List<PluginProperty> properties = Collections.emptyList();
 
         final Payment payment = paymentApi.createPurchase(account,
                                                           account.getPaymentMethodId(),
@@ -1597,7 +1595,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
             assertEquals(e.getCode(), ErrorCode.PAYMENT_NO_SUCH_SUCCESS_PAYMENT.getCode());
         }
 
-        assertEquals(paymentApi.getPayment(payment.getId(), false, false, ImmutableList.<PluginProperty>of(), callContext).getTransactions().size(), 1);
+        assertEquals(paymentApi.getPayment(payment.getId(), false, false, Collections.emptyList(), callContext).getTransactions().size(), 1);
 
         assertEquals(paymentDao.getPayment(payment.getId(), internalCallContext).getStateName(), "PURCHASE_SUCCESS");
         assertEquals(paymentDao.getPayment(payment.getId(), internalCallContext).getLastSuccessStateName(), "PURCHASE_SUCCESS");
@@ -1679,14 +1677,14 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final BigDecimal requestedAmount = new BigDecimal("80.0091");
 
         final Payment initialPayment = paymentApi.createAuthorization(account, account.getPaymentMethodId(), null, requestedAmount, account.getCurrency(), null,
-                                                                      UUID.randomUUID().toString(), UUID.randomUUID().toString(), ImmutableList.<PluginProperty>of(), callContext);
+                                                                      UUID.randomUUID().toString(), UUID.randomUUID().toString(), Collections.emptyList(), callContext);
         try {
-            paymentApi.createCapture(account, UUID.randomUUID(), requestedAmount, account.getCurrency(), null, UUID.randomUUID().toString(), ImmutableList.<PluginProperty>of(), callContext);
+            paymentApi.createCapture(account, UUID.randomUUID(), requestedAmount, account.getCurrency(), null, UUID.randomUUID().toString(), Collections.emptyList(), callContext);
             Assert.fail("Expected capture to fail...");
         } catch (final PaymentApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.PAYMENT_NO_SUCH_PAYMENT.getCode());
 
-            final Payment latestPayment = paymentApi.getPayment(initialPayment.getId(), true, false, ImmutableList.<PluginProperty>of(), callContext);
+            final Payment latestPayment = paymentApi.getPayment(initialPayment.getId(), true, false, Collections.emptyList(), callContext);
             assertEquals(latestPayment, initialPayment);
         }
     }
@@ -1696,15 +1694,15 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final BigDecimal requestedAmount = new BigDecimal("80.0091");
 
         final Payment initialPayment = paymentApi.createAuthorization(account, account.getPaymentMethodId(), null, requestedAmount, account.getCurrency(), null,
-                                                                      UUID.randomUUID().toString(), UUID.randomUUID().toString(), ImmutableList.<PluginProperty>of(), callContext);
+                                                                      UUID.randomUUID().toString(), UUID.randomUUID().toString(), Collections.emptyList(), callContext);
 
         try {
-            paymentApi.createCapture(account, initialPayment.getId(), requestedAmount, Currency.AMD, null, UUID.randomUUID().toString(), ImmutableList.<PluginProperty>of(), callContext);
+            paymentApi.createCapture(account, initialPayment.getId(), requestedAmount, Currency.AMD, null, UUID.randomUUID().toString(), Collections.emptyList(), callContext);
             Assert.fail("Expected capture to fail...");
         } catch (final PaymentApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.PAYMENT_INVALID_PARAMETER.getCode());
 
-            final Payment latestPayment = paymentApi.getPayment(initialPayment.getId(), true, false, ImmutableList.<PluginProperty>of(), callContext);
+            final Payment latestPayment = paymentApi.getPayment(initialPayment.getId(), true, false, Collections.emptyList(), callContext);
             assertEquals(latestPayment, initialPayment);
         }
     }
@@ -1718,7 +1716,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final String transactionExternalKey = "grenouye";
 
         final Payment payment = paymentApi.createAuthorization(account, account.getPaymentMethodId(), null, requestedAmount, Currency.EUR,  null,paymentExternalKey, transactionExternalKey,
-                                                               ImmutableList.<PluginProperty>of(), callContext);
+                                                               Collections.emptyList(), callContext);
 
         // Hack the Database to make it look like it was a failure
         paymentDao.updatePaymentAndTransactionOnCompletion(account.getId(), null, payment.getId(), TransactionType.AUTHORIZE, "AUTH_ERRORED", null,
@@ -1727,7 +1725,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         paymentSqlDao.updateLastSuccessPaymentStateName(payment.getId().toString(), "AUTH_ERRORED", null, internalCallContext);
 
         try {
-            paymentApi.createCapture(account, payment.getId(), requestedAmount, Currency.EUR, null, "tetard", ImmutableList.<PluginProperty>of(), callContext);
+            paymentApi.createCapture(account, payment.getId(), requestedAmount, Currency.EUR, null, "tetard", Collections.emptyList(), callContext);
             Assert.fail("Unexpected success");
         } catch (final PaymentApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.PAYMENT_INVALID_OPERATION.getCode());
@@ -1736,7 +1734,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow")
     public void testApiWithPendingPaymentTransaction() throws Exception {
-        for (final TransactionType transactionType : ImmutableList.<TransactionType>of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
+        for (final TransactionType transactionType : List.of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
             testApiWithPendingPaymentTransaction(transactionType, BigDecimal.TEN, BigDecimal.TEN);
             testApiWithPendingPaymentTransaction(transactionType, BigDecimal.TEN, BigDecimal.ONE);
             // See https://github.com/killbill/killbill/issues/372
@@ -1751,7 +1749,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final String refundTransactionExternalKey = UUID.randomUUID().toString();
         final BigDecimal requestedAmount = BigDecimal.TEN;
         final BigDecimal refundAmount = BigDecimal.ONE;
-        final Iterable<PluginProperty> pendingPluginProperties = ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, TransactionStatus.PENDING.toString(), false));
+        final Iterable<PluginProperty> pendingPluginProperties = List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, TransactionStatus.PENDING.toString(), false));
 
         final Payment payment = createPayment(TransactionType.PURCHASE, null, paymentExternalKey, paymentTransactionExternalKey, requestedAmount, PaymentPluginStatus.PROCESSED);
         assertNotNull(payment);
@@ -1809,7 +1807,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                                null,
                                                                null,
                                                                refundTransactionExternalKey,
-                                                               ImmutableList.<PluginProperty>of(),
+                                                               Collections.emptyList(),
                                                                callContext);
         verifyRefund(pendingRefund4, paymentExternalKey, paymentTransactionExternalKey, refundTransactionExternalKey, requestedAmount, requestedAmount, TransactionStatus.SUCCESS);
 
@@ -1920,7 +1918,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
             createPayment(TransactionType.CAPTURE, authorization.getId(), paymentExternalKey, paymentTransactionExternalKey, requestedAmount, PaymentPluginStatus.PROCESSED);
             Assert.fail();
         } catch (final PaymentApiException e) {
-            final Payment refreshedPayment = paymentApi.getPayment(pendingPayment.getId(), true, false, ImmutableList.<PluginProperty>of(), callContext);
+            final Payment refreshedPayment = paymentApi.getPayment(pendingPayment.getId(), true, false, Collections.emptyList(), callContext);
             Assert.assertEquals(refreshedPayment.getTransactions().size(), 2);
             Assert.assertEquals(refreshedPayment.getTransactions().get(0).getTransactionStatus(), TransactionStatus.SUCCESS);
             Assert.assertEquals(refreshedPayment.getTransactions().get(1).getTransactionStatus(), TransactionStatus.SUCCESS);
@@ -2026,7 +2024,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         mockPaymentProviderPlugin.makePluginWaitSomeMilliseconds((int) (paymentConfig.getPaymentPluginTimeout().getMillis() + 100));
         try {
             paymentApi.createPurchase(account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null,
-                                      paymentExternalKey, transactionExternalKey, ImmutableList.<PluginProperty>of(), callContext);
+                                      paymentExternalKey, transactionExternalKey, Collections.emptyList(), callContext);
             fail();
         } catch (PaymentApiException e) {
             assertEquals(e.getCode(), ErrorCode.PAYMENT_PLUGIN_TIMEOUT.getCode());
@@ -2043,7 +2041,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         try {
             paymentApi.createPurchaseWithPaymentControl(
                     account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null, paymentExternalKey,
-                    transactionExternalKey, ImmutableList.<PluginProperty>of(), CONTROL_PLUGIN_OPTIONS, callContext);
+                    transactionExternalKey, Collections.emptyList(), CONTROL_PLUGIN_OPTIONS, callContext);
             fail();
         } catch (PaymentApiException e) {
             assertEquals(e.getCode(), ErrorCode.PAYMENT_PLUGIN_TIMEOUT.getCode());
@@ -2077,7 +2075,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
     @Test(groups = "slow")
     public void testSuccessfulInitialTransactionToSameTransaction() throws Exception {
         final BigDecimal requestedAmount = BigDecimal.TEN;
-        for (final TransactionType transactionType : ImmutableList.<TransactionType>of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
+        for (final TransactionType transactionType : List.of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
             final String paymentExternalKey = UUID.randomUUID().toString();
             final String keyA = UUID.randomUUID().toString();
 
@@ -2109,7 +2107,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
     @Test(groups = "slow")
     public void testPendingInitialTransactionToSameTransaction() throws Exception {
         final BigDecimal requestedAmount = BigDecimal.TEN;
-        for (final TransactionType transactionType : ImmutableList.<TransactionType>of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
+        for (final TransactionType transactionType : List.of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
             final String paymentExternalKey = UUID.randomUUID().toString();
             final String keyA = UUID.randomUUID().toString();
 
@@ -2139,7 +2137,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
     @Test(groups = "slow")
     public void testFailedInitialTransactionToSameTransactionWithSameKey() throws Exception {
         final BigDecimal requestedAmount = BigDecimal.TEN;
-        for (final TransactionType transactionType : ImmutableList.<TransactionType>of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
+        for (final TransactionType transactionType : List.of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
             final String paymentExternalKey = UUID.randomUUID().toString();
             final String keyA = UUID.randomUUID().toString();
 
@@ -2159,7 +2157,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
     @Test(groups = "slow")
     public void testFailedInitialTransactionToSameTransactionWithDifferentKey() throws Exception {
         final BigDecimal requestedAmount = BigDecimal.TEN;
-        for (final TransactionType transactionType : ImmutableList.<TransactionType>of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
+        for (final TransactionType transactionType : List.of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
             final String paymentExternalKey = UUID.randomUUID().toString();
             final String keyA = UUID.randomUUID().toString();
 
@@ -2507,19 +2505,19 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
     public void testSearchPayments() throws Exception {
         // Add a second, non-default, payment method
         final PaymentMethodPlugin pm = new DefaultNoOpPaymentMethodPlugin(UUID.randomUUID().toString(), false, null);
-        final UUID secondPmId = testHelper.addTestPaymentMethod(MockPaymentProviderPlugin.PLUGIN_NAME + "2", account, pm, ImmutableList.<PluginProperty>of());
+        final UUID secondPmId = testHelper.addTestPaymentMethod(MockPaymentProviderPlugin.PLUGIN_NAME + "2", account, pm, Collections.emptyList());
 
-        Pagination<Payment> foundPayments = paymentApi.searchPayments("all", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        Pagination<Payment> foundPayments = paymentApi.searchPayments("all", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertFalse(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 0L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 0L);
 
-        foundPayments = paymentApi.searchPayments("A", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        foundPayments = paymentApi.searchPayments("A", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertFalse(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 0L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 0L);
 
-        foundPayments = paymentApi.searchPayments("B", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        foundPayments = paymentApi.searchPayments("B", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertFalse(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 0L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 0L);
@@ -2532,21 +2530,21 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                            clock.getUTCNow(),
                                                            UUID.randomUUID().toString(),
                                                            UUID.randomUUID().toString(),
-                                                           ImmutableList.<PluginProperty>of(new PluginProperty("group", "all", false), new PluginProperty("marker", "A", false)),
+                                                           List.of(new PluginProperty("group", "all", false), new PluginProperty("marker", "A", false)),
                                                            callContext);
 
-        foundPayments = paymentApi.searchPayments("all", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        foundPayments = paymentApi.searchPayments("all", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertTrue(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 1L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 1L);
 
-        foundPayments = paymentApi.searchPayments("A", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        foundPayments = paymentApi.searchPayments("A", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertTrue(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 1L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 1L);
         Assert.assertEquals(foundPayments.iterator().next().getId(), payment1.getId());
 
-        foundPayments = paymentApi.searchPayments("B", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        foundPayments = paymentApi.searchPayments("B", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertFalse(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 1L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 0L);
@@ -2559,21 +2557,21 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                                            clock.getUTCNow(),
                                                            UUID.randomUUID().toString(),
                                                            UUID.randomUUID().toString(),
-                                                           ImmutableList.<PluginProperty>of(new PluginProperty("group", "all", false), new PluginProperty("marker", "B", false)),
+                                                           List.of(new PluginProperty("group", "all", false), new PluginProperty("marker", "B", false)),
                                                            callContext);
 
-        foundPayments = paymentApi.searchPayments("all", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        foundPayments = paymentApi.searchPayments("all", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertTrue(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 2L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 2L);
 
-        foundPayments = paymentApi.searchPayments("A", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        foundPayments = paymentApi.searchPayments("A", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertTrue(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 2L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 1L);
         Assert.assertEquals(foundPayments.iterator().next().getId(), payment1.getId());
 
-        foundPayments = paymentApi.searchPayments("B", 0L, 10L, true, false, ImmutableList.<PluginProperty>of(), callContext);
+        foundPayments = paymentApi.searchPayments("B", 0L, 10L, true, false, Collections.emptyList(), callContext);
         Assert.assertTrue(foundPayments.iterator().hasNext());
         Assert.assertEquals(foundPayments.getMaxNbRecords(), (Long) 2L);
         Assert.assertEquals(foundPayments.getTotalNbRecords(), (Long) 1L);
@@ -2641,7 +2639,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
     private void verifyPaymentViaGetPath(final Payment payment) throws PaymentApiException {
         // We can't use Assert.assertEquals because the updateDate may have been updated by the Janitor
-        final Payment refreshedPayment = paymentApi.getPayment(payment.getId(), true, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Payment refreshedPayment = paymentApi.getPayment(payment.getId(), true, false, Collections.emptyList(), callContext);
 
         Assert.assertEquals(refreshedPayment.getAccountId(), payment.getAccountId());
 
@@ -2682,7 +2680,7 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
                                   @Nullable final String paymentTransactionExternalKey,
                                   @Nullable final BigDecimal amount,
                                   final PaymentPluginStatus paymentPluginStatus) throws PaymentApiException {
-        final Iterable<PluginProperty> pluginProperties = ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, paymentPluginStatus.toString(), false));
+        final Iterable<PluginProperty> pluginProperties = List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, paymentPluginStatus.toString(), false));
         switch (transactionType) {
             case AUTHORIZE:
                 return paymentApi.createAuthorization(account,
@@ -2743,42 +2741,42 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
 
     // Search by a key supported by the search in MockPaymentProviderPlugin
     private void checkPaymentMethodPagination(final UUID paymentMethodId, final Long maxNbRecords, final boolean deleted) throws PaymentApiException {
-        final Pagination<PaymentMethod> foundPaymentMethods = paymentApi.searchPaymentMethods(paymentMethodId.toString(), 0L, maxNbRecords + 1, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Pagination<PaymentMethod> foundPaymentMethods = paymentApi.searchPaymentMethods(paymentMethodId.toString(), 0L, maxNbRecords + 1, false, Collections.emptyList(), callContext);
         Assert.assertEquals(foundPaymentMethods.iterator().hasNext(), !deleted);
         Assert.assertEquals(foundPaymentMethods.getMaxNbRecords(), maxNbRecords);
         Assert.assertEquals(foundPaymentMethods.getTotalNbRecords(), (Long) (!deleted ? 1L : 0L));
 
-        final Pagination<PaymentMethod> foundPaymentMethodsWithPluginInfo = paymentApi.searchPaymentMethods(paymentMethodId.toString(), 0L, maxNbRecords + 1, true, ImmutableList.<PluginProperty>of(), callContext);
+        final Pagination<PaymentMethod> foundPaymentMethodsWithPluginInfo = paymentApi.searchPaymentMethods(paymentMethodId.toString(), 0L, maxNbRecords + 1, true, Collections.emptyList(), callContext);
         Assert.assertEquals(foundPaymentMethodsWithPluginInfo.iterator().hasNext(), !deleted);
         Assert.assertEquals(foundPaymentMethodsWithPluginInfo.getMaxNbRecords(), maxNbRecords);
         Assert.assertEquals(foundPaymentMethodsWithPluginInfo.getTotalNbRecords(), (Long) (!deleted ? 1L : 0L));
 
-        final Pagination<PaymentMethod> foundPaymentMethods2 = paymentApi.searchPaymentMethods(paymentMethodId.toString(), 0L, maxNbRecords + 1, MockPaymentProviderPlugin.PLUGIN_NAME, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Pagination<PaymentMethod> foundPaymentMethods2 = paymentApi.searchPaymentMethods(paymentMethodId.toString(), 0L, maxNbRecords + 1, MockPaymentProviderPlugin.PLUGIN_NAME, false, Collections.emptyList(), callContext);
         Assert.assertEquals(foundPaymentMethods2.iterator().hasNext(), !deleted);
         Assert.assertEquals(foundPaymentMethods2.getMaxNbRecords(), maxNbRecords);
         Assert.assertEquals(foundPaymentMethods2.getTotalNbRecords(), (Long) (!deleted ? 1L : 0L));
 
-        final Pagination<PaymentMethod> foundPaymentMethods2WithPluginInfo = paymentApi.searchPaymentMethods(paymentMethodId.toString(), 0L, maxNbRecords + 1, MockPaymentProviderPlugin.PLUGIN_NAME, true, ImmutableList.<PluginProperty>of(), callContext);
+        final Pagination<PaymentMethod> foundPaymentMethods2WithPluginInfo = paymentApi.searchPaymentMethods(paymentMethodId.toString(), 0L, maxNbRecords + 1, MockPaymentProviderPlugin.PLUGIN_NAME, true, Collections.emptyList(), callContext);
         Assert.assertEquals(foundPaymentMethods2WithPluginInfo.iterator().hasNext(), !deleted);
         Assert.assertEquals(foundPaymentMethods2WithPluginInfo.getMaxNbRecords(), maxNbRecords);
         Assert.assertEquals(foundPaymentMethods2WithPluginInfo.getTotalNbRecords(), (Long) (!deleted ? 1L : 0L));
 
-        final Pagination<PaymentMethod> gotPaymentMethods = paymentApi.getPaymentMethods(0L, maxNbRecords + 1L, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Pagination<PaymentMethod> gotPaymentMethods = paymentApi.getPaymentMethods(0L, maxNbRecords + 1L, false, Collections.emptyList(), callContext);
         Assert.assertEquals(gotPaymentMethods.iterator().hasNext(), maxNbRecords > 0);
         Assert.assertEquals(gotPaymentMethods.getMaxNbRecords(), maxNbRecords);
         Assert.assertEquals(gotPaymentMethods.getTotalNbRecords(), maxNbRecords);
 
-        final Pagination<PaymentMethod> gotPaymentMethodsWithPluginInfo = paymentApi.getPaymentMethods(0L, maxNbRecords + 1L, true, ImmutableList.<PluginProperty>of(), callContext);
+        final Pagination<PaymentMethod> gotPaymentMethodsWithPluginInfo = paymentApi.getPaymentMethods(0L, maxNbRecords + 1L, true, Collections.emptyList(), callContext);
         Assert.assertEquals(gotPaymentMethodsWithPluginInfo.iterator().hasNext(), maxNbRecords > 0);
         Assert.assertEquals(gotPaymentMethodsWithPluginInfo.getMaxNbRecords(), maxNbRecords);
         Assert.assertEquals(gotPaymentMethodsWithPluginInfo.getTotalNbRecords(), maxNbRecords);
 
-        final Pagination<PaymentMethod> gotPaymentMethods2 = paymentApi.getPaymentMethods(0L, maxNbRecords + 1L, MockPaymentProviderPlugin.PLUGIN_NAME, false, ImmutableList.<PluginProperty>of(), callContext);
+        final Pagination<PaymentMethod> gotPaymentMethods2 = paymentApi.getPaymentMethods(0L, maxNbRecords + 1L, MockPaymentProviderPlugin.PLUGIN_NAME, false, Collections.emptyList(), callContext);
         Assert.assertEquals(gotPaymentMethods2.iterator().hasNext(), maxNbRecords > 0);
         Assert.assertEquals(gotPaymentMethods2.getMaxNbRecords(), maxNbRecords);
         Assert.assertEquals(gotPaymentMethods2.getTotalNbRecords(), maxNbRecords);
 
-        final Pagination<PaymentMethod> gotPaymentMethods2WithPluginInfo = paymentApi.getPaymentMethods(0L, maxNbRecords + 1L, MockPaymentProviderPlugin.PLUGIN_NAME, true, ImmutableList.<PluginProperty>of(), callContext);
+        final Pagination<PaymentMethod> gotPaymentMethods2WithPluginInfo = paymentApi.getPaymentMethods(0L, maxNbRecords + 1L, MockPaymentProviderPlugin.PLUGIN_NAME, true, Collections.emptyList(), callContext);
         Assert.assertEquals(gotPaymentMethods2WithPluginInfo.iterator().hasNext(), maxNbRecords > 0);
         Assert.assertEquals(gotPaymentMethods2WithPluginInfo.getMaxNbRecords(), maxNbRecords);
         Assert.assertEquals(gotPaymentMethods2WithPluginInfo.getTotalNbRecords(), maxNbRecords);
@@ -2800,14 +2798,14 @@ public class TestPaymentApi extends PaymentTestSuiteWithEmbeddedDB {
         final String transactionExternalKey = "txn control external key";
         paymentApi.createPurchaseWithPaymentControl(
                 account, account.getPaymentMethodId(), null, requestedAmount, Currency.AED, null,
-                paymentExternalKey, transactionExternalKey, ImmutableList.<PluginProperty>of(), CONTROL_PLUGIN_OPTIONS, callContext);
+                paymentExternalKey, transactionExternalKey, Collections.emptyList(), CONTROL_PLUGIN_OPTIONS, callContext);
 
 
         final DateTime nextRetryDate2 = nextRetryDate.plusDays(1);
         mockPaymentControlProviderPlugin.setNextRetryDate(nextRetryDate2);
 
 
-        final List<Payment> payments = paymentApi.getAccountPayments(account.getId(), true, true, ImmutableList.of(), callContext);
+        final List<Payment> payments = paymentApi.getAccountPayments(account.getId(), true, true, Collections.emptyList(), callContext);
         assertEquals(payments.size(), 1);
 
         // The code return the attempt on disk and adds the scheduled retry in the notificationQ as an attempt

--- a/payment/src/test/java/org/killbill/billing/payment/api/TestPaymentGatewayApiWithPaymentControl.java
+++ b/payment/src/test/java/org/killbill/billing/payment/api/TestPaymentGatewayApiWithPaymentControl.java
@@ -18,8 +18,11 @@
 package org.killbill.billing.payment.api;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
 
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.account.api.Account;
@@ -35,14 +38,10 @@ import org.killbill.billing.payment.PaymentTestSuiteNoDB;
 import org.killbill.billing.payment.retry.DefaultFailureCallResult;
 import org.killbill.billing.payment.retry.DefaultOnSuccessPaymentControlResult;
 import org.killbill.billing.payment.retry.DefaultPriorPaymentControlResult;
+import org.killbill.billing.util.collect.Iterables;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.inject.Inject;
 
 public class TestPaymentGatewayApiWithPaymentControl extends PaymentTestSuiteNoDB {
 
@@ -73,7 +72,7 @@ public class TestPaymentGatewayApiWithPaymentControl extends PaymentTestSuiteNoD
 
             @Override
             public List<String> getPaymentControlPluginNames() {
-                return ImmutableList.of(TestPaymentGatewayApiControlPlugin.PLUGIN_NAME, TestPaymentGatewayApiValidationPlugin.VALIDATION_PLUGIN_NAME);
+                return List.of(TestPaymentGatewayApiControlPlugin.PLUGIN_NAME, TestPaymentGatewayApiValidationPlugin.VALIDATION_PLUGIN_NAME);
             }
         };
 
@@ -151,7 +150,7 @@ public class TestPaymentGatewayApiWithPaymentControl extends PaymentTestSuiteNoD
         validationPlugin.setExpectedProperties(expectedProperties);
 
         // Set a null paymentMethodId to verify the plugin will successfully override it
-        paymentGatewayApi.buildFormDescriptorWithPaymentControl(account, null, ImmutableList.<PluginProperty>of(), initialProperties, paymentOptions, callContext);
+        paymentGatewayApi.buildFormDescriptorWithPaymentControl(account, null, Collections.emptyList(), initialProperties, paymentOptions, callContext);
 
     }
 
@@ -161,7 +160,7 @@ public class TestPaymentGatewayApiWithPaymentControl extends PaymentTestSuiteNoD
 
         // Set a random UUID to verify the plugin will successfully override it
         try {
-            paymentGatewayApi.buildFormDescriptorWithPaymentControl(account, null, ImmutableList.<PluginProperty>of(), ImmutableList.<PluginProperty>of(), paymentOptions, callContext);
+            paymentGatewayApi.buildFormDescriptorWithPaymentControl(account, null, Collections.emptyList(), Collections.emptyList(), paymentOptions, callContext);
             Assert.fail();
         } catch (PaymentApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.PAYMENT_PLUGIN_API_ABORTED.getCode());
@@ -177,8 +176,8 @@ public class TestPaymentGatewayApiWithPaymentControl extends PaymentTestSuiteNoD
         private Iterable<PluginProperty> expectedProperties;
 
         public TestPaymentGatewayApiValidationPlugin() {
-            this.expectedPriorCallProperties = ImmutableList.of();
-            this.expectedProperties = ImmutableList.of();
+            this.expectedPriorCallProperties = Collections.emptyList();
+            this.expectedProperties = Collections.emptyList();
         }
 
         public void setExpectedProperties(final Iterable<PluginProperty> expectedProperties) {
@@ -211,13 +210,9 @@ public class TestPaymentGatewayApiWithPaymentControl extends PaymentTestSuiteNoD
             Assert.assertEquals(Iterables.size(properties), Iterables.size(expected), "Got " + Iterables.size(properties) + "properties" + ", expected " + Iterables.size(expected));
 
             for (final PluginProperty curExpected : expected) {
-                Assert.assertTrue(Iterables.any(properties, new Predicate<PluginProperty>() {
-                    @Override
-                    public boolean apply(final PluginProperty input) {
-                        return input.getKey().equals(curExpected.getKey()) && input.getValue().equals(curExpected.getValue());
-
-                    }
-                }), "Cannot find expected property" + curExpected.getKey());
+                final boolean isTestPassed = Iterables.toStream(properties)
+                        .anyMatch(input -> input.getKey().equals(curExpected.getKey()) && input.getValue().equals(curExpected.getValue()));
+                Assert.assertTrue(isTestPassed, "Cannot find expected property" + curExpected.getKey());
             }
         }
 
@@ -237,10 +232,10 @@ public class TestPaymentGatewayApiWithPaymentControl extends PaymentTestSuiteNoD
 
         public TestPaymentGatewayApiControlPlugin() {
             this.aborted = false;
-            this.newPriorCallProperties = ImmutableList.of();
-            this.removedPriorCallProperties = ImmutableList.of();
-            this.newOnResultProperties = ImmutableList.of();
-            this.removedOnResultProperties = ImmutableList.of();
+            this.newPriorCallProperties = Collections.emptyList();
+            this.removedPriorCallProperties = Collections.emptyList();
+            this.newOnResultProperties = Collections.emptyList();
+            this.removedOnResultProperties = Collections.emptyList();
         }
 
         public void setAborted(final boolean aborted) {
@@ -273,18 +268,13 @@ public class TestPaymentGatewayApiWithPaymentControl extends PaymentTestSuiteNoD
         }
 
         private Iterable<PluginProperty> getAdjustedProperties(final Iterable<PluginProperty> input, final Iterable<PluginProperty> newProperties, final Iterable<PluginProperty> removedProperties) {
-            final Iterable<PluginProperty> filtered = Iterables.filter(input, new Predicate<PluginProperty>() {
-                @Override
-                public boolean apply(final PluginProperty p) {
-                    final boolean toBeRemoved = Iterables.any(removedProperties, new Predicate<PluginProperty>() {
-                        @Override
-                        public boolean apply(final PluginProperty a) {
-                            return a.getKey().equals(p.getKey()) && a.getValue().equals(p.getValue());
-                        }
-                    });
-                    return !toBeRemoved;
-                }
-            });
+            final Iterable<PluginProperty> filtered = Iterables.toStream(input)
+                    .filter(p -> {
+                        final boolean toBeRemoved = Iterables.toStream(removedProperties)
+                                                             .anyMatch(a -> a.getKey().equals(p.getKey()) && a.getValue().equals(p.getValue()));
+                        return !toBeRemoved;
+                    })
+                    .collect(Collectors.toUnmodifiableList());
             return Iterables.concat(filtered, newProperties);
         }
     }

--- a/payment/src/test/java/org/killbill/billing/payment/core/TestPaymentMethodProcessorNoDB.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/TestPaymentMethodProcessorNoDB.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.payment.core;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,8 +32,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class TestPaymentMethodProcessorNoDB extends PaymentTestSuiteNoDB {
 
     @Test(groups = "fast")
@@ -43,7 +42,7 @@ public class TestPaymentMethodProcessorNoDB extends PaymentTestSuiteNoDB {
         Mockito.when(account.getExternalKey()).thenReturn(accountId.toString());
 
         final PaymentMethodPlugin paymentMethodPlugin = Mockito.mock(PaymentMethodPlugin.class);
-        final Iterable<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+        final Iterable<PluginProperty> properties = Collections.emptyList();
 
         // By default, the external payment plugin sets the external payment method id to "unknown"
         final UUID paymentMethodId2 = paymentMethodProcessor.addPaymentMethod(null, "__EXTERNAL_PAYMENT__", account, false, paymentMethodPlugin, properties, callContext, internalCallContext);
@@ -53,7 +52,7 @@ public class TestPaymentMethodProcessorNoDB extends PaymentTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testGetExternalPaymentProviderPlugin() throws Exception {
-        final Iterable<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+        final Iterable<PluginProperty> properties = Collections.emptyList();
         final UUID accountId = UUID.randomUUID();
         final Account account = Mockito.mock(Account.class);
         Mockito.when(account.getId()).thenReturn(accountId);

--- a/payment/src/test/java/org/killbill/billing/payment/core/TestPaymentMethodProcessorRefreshWithDB.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/TestPaymentMethodProcessorRefreshWithDB.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.payment.core;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,11 +34,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class TestPaymentMethodProcessorRefreshWithDB extends PaymentTestSuiteWithEmbeddedDB {
 
-    private static final ImmutableList<PluginProperty> PLUGIN_PROPERTIES = ImmutableList.<PluginProperty>of();
+    private static final List<PluginProperty> PLUGIN_PROPERTIES = Collections.emptyList();
 
     @BeforeMethod(groups = "slow")
     public void beforeMethod() throws Exception {
@@ -57,7 +56,7 @@ public class TestPaymentMethodProcessorRefreshWithDB extends PaymentTestSuiteWit
 
         // Add new payment in plugin directly
         final UUID newPmId = UUID.randomUUID();
-        getPluginApi().addPaymentMethod(account.getId(), newPmId, new DefaultNoOpPaymentMethodPlugin(UUID.randomUUID().toString(), false, ImmutableList.<PluginProperty>of()), false, PLUGIN_PROPERTIES, callContext);
+        getPluginApi().addPaymentMethod(account.getId(), newPmId, new DefaultNoOpPaymentMethodPlugin(UUID.randomUUID().toString(), false, Collections.emptyList()), false, PLUGIN_PROPERTIES, callContext);
 
         // Verify that the refresh does indeed show 2 PMs
         final List<PaymentMethod> methods = paymentMethodProcessor.refreshPaymentMethods(MockPaymentProviderPlugin.PLUGIN_NAME, account, PLUGIN_PROPERTIES, callContext, internalCallContext);

--- a/payment/src/test/java/org/killbill/billing/payment/core/TestPaymentMethodProcessorWithDB.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/TestPaymentMethodProcessorWithDB.java
@@ -17,30 +17,24 @@
 
 package org.killbill.billing.payment.core;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.payment.PaymentTestSuiteWithEmbeddedDB;
 import org.killbill.billing.payment.api.PaymentApiException;
-import org.killbill.billing.payment.api.PaymentMethod;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.payment.dao.PaymentMethodModelDao;
-import org.killbill.billing.payment.dao.PaymentMethodSqlDao;
-import org.killbill.billing.payment.dao.PaymentModelDao;
 import org.killbill.billing.util.api.AuditLevel;
 import org.killbill.billing.util.audit.AuditLogWithHistory;
 import org.killbill.billing.util.audit.ChangeType;
-import org.killbill.billing.util.dao.EntityHistoryModelDao;
-import org.killbill.billing.util.dao.TableName;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class TestPaymentMethodProcessorWithDB extends PaymentTestSuiteWithEmbeddedDB {
 
-    private static final ImmutableList<PluginProperty> PLUGIN_PROPERTIES = ImmutableList.<PluginProperty>of();
+    private static final List<PluginProperty> PLUGIN_PROPERTIES = Collections.emptyList();
 
     @Test(groups = "slow", expectedExceptions = PaymentApiException.class, expectedExceptionsMessageRegExp = ".*Payment method .* has a different account id")
     public void testSetDefaultPaymentMethodDifferentAccount() throws Exception {
@@ -83,7 +77,7 @@ public class TestPaymentMethodProcessorWithDB extends PaymentTestSuiteWithEmbedd
         Assert.assertEquals(history1.getExternalKey(), paymentMethodModelDao.getExternalKey());
         Assert.assertTrue(history1.isActive());
 
-        paymentMethodProcessor.deletedPaymentMethod(account, paymentMethodId, true, true, ImmutableList.<PluginProperty>of(), callContext, internalCallContext);
+        paymentMethodProcessor.deletedPaymentMethod(account, paymentMethodId, true, true, Collections.emptyList(), callContext, internalCallContext);
 
         auditLogsWithHistory = paymentDao.getPaymentMethodAuditLogsWithHistoryForId(paymentMethodModelDao.getId(), AuditLevel.FULL, internalCallContext);
         Assert.assertEquals(auditLogsWithHistory.size(), 2);

--- a/payment/src/test/java/org/killbill/billing/payment/core/TestPaymentProcessor.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/TestPaymentProcessor.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.core;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -45,7 +46,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
+// FIXME-1615 : eventbus - See https://github.com/killbill/killbill/issues/1615#issuecomment-1128229812
 import com.google.common.eventbus.Subscribe;
 import org.awaitility.Awaitility;
 
@@ -54,7 +55,7 @@ import static java.math.BigDecimal.ZERO;
 public class TestPaymentProcessor extends PaymentTestSuiteWithEmbeddedDB {
 
     private static final boolean SHOULD_LOCK_ACCOUNT = true;
-    private static final ImmutableList<PluginProperty> PLUGIN_PROPERTIES = ImmutableList.<PluginProperty>of();
+    private static final List<PluginProperty> PLUGIN_PROPERTIES = Collections.emptyList();
     private static final BigDecimal FIVE = new BigDecimal("5");
     private static final BigDecimal TEN = new BigDecimal("10");
     private static final Currency CURRENCY = Currency.BTC;
@@ -80,7 +81,7 @@ public class TestPaymentProcessor extends PaymentTestSuiteWithEmbeddedDB {
     public void testGetAccountPaymentsWithJanitor() throws Exception {
         final String paymentExternalKey = UUID.randomUUID().toString();
 
-        final Iterable<PluginProperty> pluginPropertiesToDriveTransationToUnknown = ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.UNDEFINED, false));
+        final Iterable<PluginProperty> pluginPropertiesToDriveTransationToUnknown = List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.UNDEFINED, false));
 
         final String authorizationKey = UUID.randomUUID().toString();
         final Payment authorization = paymentProcessor.createAuthorization(true, null, account, null, null, TEN, CURRENCY, null, paymentExternalKey, authorizationKey,
@@ -103,7 +104,7 @@ public class TestPaymentProcessor extends PaymentTestSuiteWithEmbeddedDB {
     public void testClassicFlow() throws Exception {
         final String paymentExternalKey = UUID.randomUUID().toString();
 
-        final Iterable<PluginProperty> pluginPropertiesToDriveTransationToPending = ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.PENDING, false));
+        final Iterable<PluginProperty> pluginPropertiesToDriveTransationToPending = List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.PENDING, false));
 
         // AUTH pre-3DS
         final String authorizationKey = UUID.randomUUID().toString();
@@ -207,7 +208,7 @@ public class TestPaymentProcessor extends PaymentTestSuiteWithEmbeddedDB {
     @Test(groups = "slow")
     public void testInvalidTransition() throws Exception {
         final String paymentExternalKey = UUID.randomUUID().toString();
-        final Iterable<PluginProperty> pluginPropertiesToDriveTransationToPending = ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.ERROR, false));
+        final Iterable<PluginProperty> pluginPropertiesToDriveTransationToPending = List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.ERROR, false));
 
         // AUTH
         final String authorizationKey = UUID.randomUUID().toString();
@@ -236,7 +237,7 @@ public class TestPaymentProcessor extends PaymentTestSuiteWithEmbeddedDB {
     @Test(groups = "slow")
     public void testNotifyPendingPaymentOfStateChanged() throws Exception {
         final String paymentExternalKey = UUID.randomUUID().toString();
-        final Iterable<PluginProperty> pluginPropertiesToDriveTransationToPending = ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.PENDING, false));
+        final Iterable<PluginProperty> pluginPropertiesToDriveTransationToPending = List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.PENDING, false));
 
         // Create Pending AUTH
         final String authorizationKey = UUID.randomUUID().toString();

--- a/payment/src/test/java/org/killbill/billing/payment/core/janitor/TestIncompletePaymentAttemptTaskWithDB.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/janitor/TestIncompletePaymentAttemptTaskWithDB.java
@@ -33,14 +33,11 @@ import org.killbill.clock.Clock;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class TestIncompletePaymentAttemptTaskWithDB extends PaymentTestSuiteWithEmbeddedDB {
 
     @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/757")
     public void testHandleRuntimeExceptions() throws PaymentApiException {
-        final List<PaymentAttemptModelDao> paymentAttemptModelDaos = ImmutableList.<PaymentAttemptModelDao>of(new PaymentAttemptModelDao(),
-                                                                                                              new PaymentAttemptModelDao());
+        final List<PaymentAttemptModelDao> paymentAttemptModelDaos = List.of(new PaymentAttemptModelDao(), new PaymentAttemptModelDao());
         final Iterator<PaymentAttemptModelDao> paymentAttemptModelDaoIterator = paymentAttemptModelDaos.iterator();
         final Iterable<PaymentAttemptModelDao> itemsForIteration = new Iterable<PaymentAttemptModelDao>() {
             @Override

--- a/payment/src/test/java/org/killbill/billing/payment/core/janitor/TestIncompletePaymentTransactionTaskWithDB.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/janitor/TestIncompletePaymentTransactionTaskWithDB.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.core.janitor;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 import org.killbill.billing.account.api.Account;
@@ -34,6 +35,7 @@ import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
 import org.killbill.billing.payment.provider.DefaultNoOpPaymentInfoPlugin;
 import org.killbill.billing.payment.provider.MockPaymentProviderPlugin;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.billing.util.globallocker.LockerType;
 import org.killbill.commons.locker.GlobalLock;
 import org.killbill.commons.locker.LockFailedException;
@@ -43,9 +45,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 public class TestIncompletePaymentTransactionTaskWithDB extends PaymentTestSuiteWithEmbeddedDB {
 
@@ -84,7 +83,7 @@ public class TestIncompletePaymentTransactionTaskWithDB extends PaymentTestSuite
                                                           null,
                                                           UUID.randomUUID().toString(),
                                                           UUID.randomUUID().toString(),
-                                                          ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.PENDING.toString(), false)),
+                                                          List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.PENDING.toString(), false)),
                                                           callContext);
 
         final UUID transactionId = payment.getTransactions().get(0).getId();
@@ -101,7 +100,7 @@ public class TestIncompletePaymentTransactionTaskWithDB extends PaymentTestSuite
 
             final Iterable<NotificationEventWithMetadata<NotificationEvent>> futureNotifications = incompletePaymentAttemptTask.janitorQueue.getFutureNotificationForSearchKeys(internalCallContext.getAccountRecordId(), internalCallContext.getTenantRecordId());
             Assert.assertFalse(Iterables.isEmpty(futureNotifications));
-            final NotificationEventWithMetadata<NotificationEvent> notificationEventWithMetadata = ImmutableList.<NotificationEventWithMetadata<NotificationEvent>>copyOf(futureNotifications).get(0);
+            final NotificationEventWithMetadata<NotificationEvent> notificationEventWithMetadata = Iterables.getFirst(futureNotifications, null);
             Assert.assertEquals(notificationEventWithMetadata.getUserToken(), userToken);
             Assert.assertEquals(notificationEventWithMetadata.getEvent().getClass(), JanitorNotificationKey.class);
             final JanitorNotificationKey event = (JanitorNotificationKey) notificationEventWithMetadata.getEvent();
@@ -129,7 +128,7 @@ public class TestIncompletePaymentTransactionTaskWithDB extends PaymentTestSuite
                                                           null,
                                                           UUID.randomUUID().toString(),
                                                           UUID.randomUUID().toString(),
-                                                          ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.UNDEFINED.toString(), false)),
+                                                          List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.UNDEFINED.toString(), false)),
                                                           callContext);
         final PaymentModelDao paymentModel = paymentDao.getPayment(payment.getId(), internalCallContext);
         final UUID transactionId = payment.getTransactions().get(0).getId();
@@ -160,7 +159,7 @@ public class TestIncompletePaymentTransactionTaskWithDB extends PaymentTestSuite
                                  Currency.EUR,
                                  null,
                                  UUID.randomUUID().toString(),
-                                 ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.PROCESSED.toString(), false)),
+                                 List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, PaymentPluginStatus.PROCESSED.toString(), false)),
                                  callContext);
 
         final PaymentModelDao paymentAfterCapture = paymentDao.getPayment(payment.getId(), internalCallContext);

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPaymentAutomatonDAOHelper.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPaymentAutomatonDAOHelper.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.core.sm;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -36,8 +37,6 @@ import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestPaymentAutomatonDAOHelper extends PaymentTestSuiteWithEmbeddedDB {
 
@@ -130,7 +129,7 @@ public class TestPaymentAutomatonDAOHelper extends PaymentTestSuiteWithEmbeddedD
                                                       null,
                                                       false,
                                                       null,
-                                                      ImmutableList.<PluginProperty>of(),
+                                                      Collections.emptyList(),
                                                       internalCallContext,
                                                       callContext);
 

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPaymentEnteringStateCallback.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPaymentEnteringStateCallback.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.core.sm;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.killbill.automaton.Operation.OperationCallback;
@@ -28,7 +29,6 @@ import org.killbill.billing.account.api.Account;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.payment.PaymentTestSuiteWithEmbeddedDB;
 import org.killbill.billing.payment.api.PaymentApiException;
-import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.payment.api.TransactionStatus;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.core.sm.payments.PaymentEnteringStateCallback;
@@ -39,8 +39,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestPaymentEnteringStateCallback extends PaymentTestSuiteWithEmbeddedDB {
 
@@ -67,7 +65,7 @@ public class TestPaymentEnteringStateCallback extends PaymentTestSuiteWithEmbedd
                                                       Currency.BRL,
                                                       null,
                                                       false,
-                                                      ImmutableList.<PluginProperty>of(),
+                                                      Collections.emptyList(),
                                                       internalCallContext,
                                                       callContext);
         daoHelper = new PaymentAutomatonDAOHelper(paymentStateContext, clock.getUTCNow(), paymentDao, paymentPluginServiceRegistration, internalCallContext, eventBus, paymentSMHelper);

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPaymentLeavingStateCallback.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPaymentLeavingStateCallback.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.core.sm;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,8 +38,6 @@ import org.killbill.billing.payment.dao.PaymentTransactionModelDao;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestPaymentLeavingStateCallback extends PaymentTestSuiteWithEmbeddedDB {
 
@@ -116,7 +115,8 @@ public class TestPaymentLeavingStateCallback extends PaymentTestSuiteWithEmbedde
                                                       null,
                                                       null,
                                                       false,
-                                                      null, ImmutableList.<PluginProperty>of(),
+                                                      null,
+                                                      Collections.emptyList(),
                                                       internalCallContext,
                                                       callContext);
 

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPaymentOperation.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPaymentOperation.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.core.sm;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -28,7 +29,6 @@ import org.killbill.billing.account.api.Account;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.payment.PaymentTestSuiteNoDB;
 import org.killbill.billing.payment.api.PaymentApiException;
-import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.core.PaymentPluginServiceRegistration;
 import org.killbill.billing.payment.core.sm.payments.PaymentOperation;
@@ -45,8 +45,6 @@ import org.killbill.commons.locker.memory.MemoryGlobalLocker;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestPaymentOperation extends PaymentTestSuiteNoDB {
 
@@ -120,7 +118,8 @@ public class TestPaymentOperation extends PaymentTestSuiteNoDB {
                                                       null,
                                                       null,
                                                       false,
-                                                      null, ImmutableList.<PluginProperty>of(),
+                                                      null,
+                                                      Collections.emptyList(),
                                                       internalCallContext,
                                                       callContext);
 

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPluginOperation.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/TestPluginOperation.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.payment.core.sm;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -54,8 +55,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestPluginOperation extends PaymentTestSuiteNoDB {
 
@@ -226,7 +225,7 @@ public class TestPluginOperation extends PaymentTestSuiteNoDB {
                                                                                 null,
                                                                                 shouldLockAccount,
                                                                                 null,
-                                                                                ImmutableList.<PluginProperty>of(),
+                                                                                Collections.emptyList(),
                                                                                 internalCallContext,
                                                                                 callContext);
 

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/control/TestControlPluginRunner.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/control/TestControlPluginRunner.java
@@ -18,6 +18,8 @@
 package org.killbill.billing.payment.core.sm.control;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import org.killbill.billing.account.api.Account;
@@ -33,8 +35,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class TestControlPluginRunner extends PaymentTestSuiteNoDB {
 
     @Test(groups = "fast")
@@ -47,8 +47,8 @@ public class TestControlPluginRunner extends PaymentTestSuiteNoDB {
         final String paymentTransactionExternalKey = UUIDs.randomUUID().toString();
         final BigDecimal amount = BigDecimal.ONE;
         final Currency currency = Currency.USD;
-        final ImmutableList<String> paymentControlPluginNames = ImmutableList.<String>of("not-registered");
-        final ImmutableList<PluginProperty> pluginProperties = ImmutableList.<PluginProperty>of();
+        final List<String> paymentControlPluginNames = List.of("not-registered");
+        final List<PluginProperty> pluginProperties = Collections.emptyList();
 
         final ControlPluginRunner controlPluginRunner = new ControlPluginRunner(new DefaultPaymentControlProviderPluginRegistry(), paymentConfig);
         final PriorPaymentControlResult paymentControlResult = controlPluginRunner.executePluginPriorCalls(account,
@@ -86,8 +86,8 @@ public class TestControlPluginRunner extends PaymentTestSuiteNoDB {
         final String paymentTransactionExternalKey = UUIDs.randomUUID().toString();
         final BigDecimal amount = BigDecimal.ONE;
         final Currency currency = Currency.USD;
-        final ImmutableList<String> paymentControlPluginNames = ImmutableList.<String>of("not-registered");
-        final ImmutableList<PluginProperty> pluginProperties = ImmutableList.<PluginProperty>of();
+        final List<String> paymentControlPluginNames = List.of("not-registered");
+        final List<PluginProperty> pluginProperties = Collections.emptyList();
 
         final ControlPluginRunner controlPluginRunner = new ControlPluginRunner(new DefaultPaymentControlProviderPluginRegistry(), paymentConfig);
         final PriorPaymentControlResult paymentControlResult = controlPluginRunner.executePluginPriorCalls(null,

--- a/payment/src/test/java/org/killbill/billing/payment/dao/MockPaymentDao.java
+++ b/payment/src/test/java/org/killbill/billing/payment/dao/MockPaymentDao.java
@@ -20,12 +20,14 @@ package org.killbill.billing.payment.dao;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -41,22 +43,19 @@ import org.killbill.billing.payment.api.TransactionStatus;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.util.api.AuditLevel;
 import org.killbill.billing.util.audit.AuditLogWithHistory;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.billing.util.entity.DefaultPagination;
 import org.killbill.billing.util.entity.Pagination;
 import org.killbill.billing.util.entity.dao.MockEntityDaoBase;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-
 public class MockPaymentDao extends MockEntityDaoBase<PaymentModelDao, Payment, PaymentApiException> implements PaymentDao {
 
-    private final Map<UUID, PaymentModelDao> payments = new HashMap<UUID, PaymentModelDao>();
-    private final Map<UUID, PaymentTransactionModelDao> transactions = new HashMap<UUID, PaymentTransactionModelDao>();
-    private final Map<UUID, PaymentAttemptModelDao> attempts = new HashMap<UUID, PaymentAttemptModelDao>();
+    private final Map<UUID, PaymentModelDao> payments = new HashMap<>();
+    private final Map<UUID, PaymentTransactionModelDao> transactions = new HashMap<>();
+    private final Map<UUID, PaymentAttemptModelDao> attempts = new HashMap<>();
 
     private final MockNonEntityDao mockNonEntityDao;
-    private final List<PaymentMethodModelDao> paymentMethods = new LinkedList<PaymentMethodModelDao>();
+    private final List<PaymentMethodModelDao> paymentMethods = new LinkedList<>();
 
     @Inject
     public MockPaymentDao(final MockNonEntityDao mockNonEntityDao) {
@@ -74,17 +73,10 @@ public class MockPaymentDao extends MockEntityDaoBase<PaymentModelDao, Payment, 
 
     @Override
     public Pagination<PaymentTransactionModelDao> getByTransactionStatusAcrossTenants(final Iterable<TransactionStatus> transactionStatuses, DateTime createdBeforeDate, DateTime createdAfterDate, Long offset, Long limit) {
-        final List<PaymentTransactionModelDao> result = ImmutableList.copyOf(Iterables.filter(transactions.values(), new Predicate<PaymentTransactionModelDao>() {
-            @Override
-            public boolean apply(final PaymentTransactionModelDao input) {
-                return Iterables.any(transactionStatuses, new Predicate<TransactionStatus>() {
-                    @Override
-                    public boolean apply(final TransactionStatus transactionStatus) {
-                        return input.getTransactionStatus() == transactionStatus;
-                    }
-                });
-            }
-        }));
+        final List<PaymentTransactionModelDao> result = transactions.values().stream()
+                .filter(input -> Iterables.toStream(transactionStatuses)
+                                          .anyMatch(transactionStatus -> input.getTransactionStatus() == transactionStatus))
+                .collect(Collectors.toUnmodifiableList());
         return new DefaultPagination<PaymentTransactionModelDao>(new Long(result.size()), result.iterator());
     }
 
@@ -135,7 +127,7 @@ public class MockPaymentDao extends MockEntityDaoBase<PaymentModelDao, Payment, 
     @Override
     public List<PaymentAttemptModelDao> getPaymentAttempts(final String paymentExternalKey, final InternalTenantContext context) {
         synchronized (this) {
-            final List<PaymentAttemptModelDao> result = new ArrayList<PaymentAttemptModelDao>();
+            final List<PaymentAttemptModelDao> result = new ArrayList<>();
             for (PaymentAttemptModelDao cur : attempts.values()) {
                 if (cur.getPaymentExternalKey().equals(paymentExternalKey)) {
                     result.add(cur);
@@ -148,7 +140,7 @@ public class MockPaymentDao extends MockEntityDaoBase<PaymentModelDao, Payment, 
     @Override
     public List<PaymentAttemptModelDao> getPaymentAttemptByTransactionExternalKey(final String transactionExternalKey, final InternalTenantContext context) {
         synchronized (this) {
-            final List<PaymentAttemptModelDao> result = new ArrayList<PaymentAttemptModelDao>();
+            final List<PaymentAttemptModelDao> result = new ArrayList<>();
             for (PaymentAttemptModelDao cur : attempts.values()) {
                 if (cur.getTransactionExternalKey().equals(transactionExternalKey)) {
                     result.add(cur);
@@ -160,9 +152,9 @@ public class MockPaymentDao extends MockEntityDaoBase<PaymentModelDao, Payment, 
 
     @Override
     public List<PaymentTransactionModelDao> getPaymentTransactionsByExternalKey(final String transactionExternalKey, final InternalTenantContext context) {
-        final List<PaymentTransactionModelDao> result = new ArrayList<PaymentTransactionModelDao>();
+        final List<PaymentTransactionModelDao> result = new ArrayList<>();
         synchronized (this) {
-            for (PaymentTransactionModelDao cur : transactions.values()) {
+            for (final PaymentTransactionModelDao cur : transactions.values()) {
                 if (cur.getTransactionExternalKey().equals(transactionExternalKey)) {
                     result.add(cur);
                 }
@@ -288,12 +280,9 @@ public class MockPaymentDao extends MockEntityDaoBase<PaymentModelDao, Payment, 
     @Override
     public List<PaymentModelDao> getPaymentsForAccount(final UUID accountId, final InternalTenantContext context) {
         synchronized (this) {
-            return ImmutableList.copyOf(Iterables.filter(payments.values(), new Predicate<PaymentModelDao>() {
-                @Override
-                public boolean apply(final PaymentModelDao input) {
-                    return input.getAccountId().equals(accountId);
-                }
-            }));
+            return payments.values().stream()
+                    .filter(input -> accountId.equals(input.getAccountId()))
+                    .collect(Collectors.toUnmodifiableList());
         }
     }
 
@@ -305,41 +294,34 @@ public class MockPaymentDao extends MockEntityDaoBase<PaymentModelDao, Payment, 
     @Override
     public List<PaymentTransactionModelDao> getTransactionsForAccount(final UUID accountId, final InternalTenantContext context) {
         synchronized (this) {
-            return ImmutableList.copyOf(Iterables.filter(transactions.values(), new Predicate<PaymentTransactionModelDao>() {
-                @Override
-                public boolean apply(final PaymentTransactionModelDao input) {
-                    final PaymentModelDao payment = payments.get(input.getPaymentId());
-                    if (payment != null) {
-                        return payment.getAccountId().equals(accountId);
-                    } else {
-                        return false;
-                    }
-                }
-            }));
+            return transactions.values().stream()
+                    .filter(input -> {
+                        final PaymentModelDao payment = payments.get(input.getPaymentId());
+                        if (payment != null) {
+                            return payment.getAccountId().equals(accountId);
+                        } else {
+                            return false;
+                        }
+                    })
+                    .collect(Collectors.toUnmodifiableList());
         }
     }
 
     @Override
     public List<PaymentTransactionModelDao> getTransactionsForPayment(final UUID paymentId, final InternalTenantContext context) {
         synchronized (this) {
-            return ImmutableList.copyOf(Iterables.filter(transactions.values(), new Predicate<PaymentTransactionModelDao>() {
-                @Override
-                public boolean apply(final PaymentTransactionModelDao input) {
-                    return input.getPaymentId().equals(paymentId);
-                }
-            }));
+            return transactions.values().stream()
+                    .filter(input -> paymentId.equals(input.getPaymentId()))
+                    .collect(Collectors.toUnmodifiableList());
         }
     }
 
     @Override
     public PaymentAttemptModelDao getPaymentAttempt(final UUID attemptId, final InternalTenantContext context) {
         synchronized (this) {
-            return Iterables.tryFind(attempts.values(), new Predicate<PaymentAttemptModelDao>() {
-                @Override
-                public boolean apply(final PaymentAttemptModelDao input) {
-                    return input.getId().equals(attemptId);
-                }
-            }).orNull();
+            return attempts.values().stream()
+                    .filter(input -> attemptId.equals(input.getId()))
+                    .findFirst().orElse(null);
         }
     }
 
@@ -421,7 +403,7 @@ public class MockPaymentDao extends MockEntityDaoBase<PaymentModelDao, Payment, 
 
     @Override
     public List<PaymentMethodModelDao> refreshPaymentMethods(final String pluginName, final List<PaymentMethodModelDao> paymentMethods, final InternalCallContext context) {
-        return ImmutableList.<PaymentMethodModelDao>of();
+        return Collections.emptyList();
     }
 
     @Override

--- a/payment/src/test/java/org/killbill/billing/payment/dao/TestPaymentDao.java
+++ b/payment/src/test/java/org/killbill/billing/payment/dao/TestPaymentDao.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.account.api.Account;
@@ -36,13 +37,10 @@ import org.killbill.billing.payment.dao.PluginPropertySerializer.PluginPropertyS
 import org.killbill.billing.util.api.AuditLevel;
 import org.killbill.billing.util.audit.AuditLogWithHistory;
 import org.killbill.billing.util.audit.ChangeType;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.billing.util.entity.Pagination;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -60,14 +58,14 @@ public class TestPaymentDao extends PaymentTestSuiteWithEmbeddedDB {
         final TransactionType transactionType = TransactionType.AUTHORIZE;
         final String pluginName = "superPlugin";
 
-        final List<PluginProperty> properties = new ArrayList<PluginProperty>();
+        final List<PluginProperty> properties = new ArrayList<>();
         properties.add(new PluginProperty("key1", "value1", false));
         properties.add(new PluginProperty("key2", "value2", false));
 
         final byte[] serialized = PluginPropertySerializer.serialize(properties);
         final PaymentAttemptModelDao attempt = new PaymentAttemptModelDao(UUID.randomUUID(), UUID.randomUUID(), clock.getUTCNow(), clock.getUTCNow(),
                                                                           paymentExternalKey, transactionId, transactionExternalKey, transactionType, stateName,
-                                                                          BigDecimal.ZERO, Currency.ALL, ImmutableList.<String>of(pluginName), serialized);
+                                                                          BigDecimal.ZERO, Currency.ALL, List.of(pluginName), serialized);
 
         PaymentAttemptModelDao savedAttempt = paymentDao.insertPaymentAttemptWithProperties(attempt, internalCallContext);
         assertEquals(savedAttempt.getTransactionExternalKey(), transactionExternalKey);
@@ -353,8 +351,8 @@ public class TestPaymentDao extends PaymentTestSuiteWithEmbeddedDB {
         final List<PaymentTransactionModelDao> result = getPendingTransactions(paymentModelDao.getId());
         Assert.assertEquals(result.size(), 3);
 
-        final Iterable<PaymentTransactionModelDao> transactions1 = paymentDao.getByTransactionStatusAcrossTenants(ImmutableList.of(TransactionStatus.PENDING), newTime, initialTime, 0L, 3L);
-        for (PaymentTransactionModelDao paymentTransaction : transactions1) {
+        final Iterable<PaymentTransactionModelDao> transactions1 = paymentDao.getByTransactionStatusAcrossTenants(List.of(TransactionStatus.PENDING), newTime, initialTime, 0L, 3L);
+        for (final PaymentTransactionModelDao paymentTransaction : transactions1) {
             final String newPaymentState = "XXX_FAILED";
             paymentDao.updatePaymentAndTransactionOnCompletion(payment.getAccountId(), paymentTransaction.getAttemptId(), payment.getId(), paymentTransaction.getTransactionType(), newPaymentState, payment.getLastSuccessStateName(),
                                                                paymentTransaction.getId(), TransactionStatus.PAYMENT_FAILURE, paymentTransaction.getProcessedAmount(), paymentTransaction.getProcessedCurrency(),
@@ -370,8 +368,8 @@ public class TestPaymentDao extends PaymentTestSuiteWithEmbeddedDB {
         } catch (final InterruptedException e) {
         }
 
-        final Iterable<PaymentTransactionModelDao> transactions2 = paymentDao.getByTransactionStatusAcrossTenants(ImmutableList.of(TransactionStatus.PENDING), clock.getUTCNow(), initialTime, 0L, 1L);
-        for (PaymentTransactionModelDao paymentTransaction : transactions2) {
+        final Iterable<PaymentTransactionModelDao> transactions2 = paymentDao.getByTransactionStatusAcrossTenants(List.of(TransactionStatus.PENDING), clock.getUTCNow(), initialTime, 0L, 1L);
+        for (final PaymentTransactionModelDao paymentTransaction : transactions2) {
             final String newPaymentState = "XXX_FAILED";
             paymentDao.updatePaymentAndTransactionOnCompletion(payment.getAccountId(), paymentTransaction.getAttemptId(), payment.getId(), paymentTransaction.getTransactionType(), newPaymentState, payment.getLastSuccessStateName(),
                                                                paymentTransaction.getId(), TransactionStatus.PAYMENT_FAILURE, paymentTransaction.getProcessedAmount(), paymentTransaction.getProcessedCurrency(),
@@ -498,7 +496,7 @@ public class TestPaymentDao extends PaymentTestSuiteWithEmbeddedDB {
 
         clock.setTime(createdDate1.plusHours(1));
 
-        final Pagination<PaymentTransactionModelDao> result = paymentDao.getByTransactionStatusAcrossTenants(ImmutableList.of(TransactionStatus.UNKNOWN), clock.getUTCNow(), createdDate1, 0L, (long) NB_ENTRIES);
+        final Pagination<PaymentTransactionModelDao> result = paymentDao.getByTransactionStatusAcrossTenants(List.of(TransactionStatus.UNKNOWN), clock.getUTCNow(), createdDate1, 0L, (long) NB_ENTRIES);
         Assert.assertEquals(result.getTotalNbRecords(), new Long(NB_ENTRIES));
 
         final Iterator<PaymentTransactionModelDao> iterator = result.iterator();
@@ -528,7 +526,7 @@ public class TestPaymentDao extends PaymentTestSuiteWithEmbeddedDB {
 
         final PaymentAttemptModelDao attempt1 = new PaymentAttemptModelDao(account.getId(), account.getPaymentMethodId(), createdAfterDate, createdAfterDate, externalKey1,
                                                                            UUID.randomUUID(), transactionExternalKey1, TransactionType.AUTHORIZE, stateName, BigDecimal.ONE, Currency.USD,
-                                                                           ImmutableList.<String>of(pluginName), null);
+                                                                           List.of(pluginName), null);
 
         paymentDao.insertPaymentAttemptWithProperties(attempt1, internalCallContext);
 
@@ -536,7 +534,7 @@ public class TestPaymentDao extends PaymentTestSuiteWithEmbeddedDB {
 
         final PaymentAttemptModelDao attempt2 = new PaymentAttemptModelDao(account.getId(), account.getPaymentMethodId(), createdAfterDate, createdAfterDate, externalKey2,
                                                                            UUID.randomUUID(), transactionExternalKey2, TransactionType.AUTHORIZE, stateName, BigDecimal.ONE, Currency.USD,
-                                                                           ImmutableList.<String>of(pluginName), null);
+                                                                           List.of(pluginName), null);
 
        paymentDao.insertPaymentAttemptWithProperties(attempt2, internalCallContext);
 
@@ -559,7 +557,7 @@ public class TestPaymentDao extends PaymentTestSuiteWithEmbeddedDB {
 
         final PaymentAttemptModelDao attempt = new PaymentAttemptModelDao(account.getId(), account.getPaymentMethodId(), createdAfterDate, createdAfterDate, externalKey1,
                                                                           UUID.randomUUID(), transactionExternalKey1, TransactionType.AUTHORIZE, stateName, BigDecimal.ONE, Currency.USD,
-                                                                          ImmutableList.<String>of(pluginName), null);
+                                                                          List.of(pluginName), null);
 
         final PaymentAttemptModelDao rehydratedAttempt = paymentDao.insertPaymentAttemptWithProperties(attempt, internalCallContext);
 
@@ -605,24 +603,18 @@ public class TestPaymentDao extends PaymentTestSuiteWithEmbeddedDB {
     }
 
     private void checkProperty(final Iterable<PluginProperty> properties, final PluginProperty expected) {
-        final PluginProperty found = Iterables.tryFind(properties, new Predicate<PluginProperty>() {
-            @Override
-            public boolean apply(final PluginProperty input) {
-                return input.getKey().equals(expected.getKey());
-            }
-        }).orNull();
+        final PluginProperty found = Iterables.toStream(properties)
+                .filter(input -> input.getKey().equals(expected.getKey()))
+                .findFirst().orElse(null);
         assertNotNull(found, "Did not find property key = " + expected.getKey());
         assertEquals(found.getValue(), expected.getValue());
     }
 
     private List<PaymentTransactionModelDao> getPendingTransactions(final UUID paymentId) {
         final List<PaymentTransactionModelDao> total = paymentDao.getTransactionsForPayment(paymentId, internalCallContext);
-        return ImmutableList.copyOf(Iterables.filter(total, new Predicate<PaymentTransactionModelDao>() {
-            @Override
-            public boolean apply(final PaymentTransactionModelDao input) {
-                return input.getTransactionStatus() == TransactionStatus.PENDING;
-            }
-        }));
+        return total.stream()
+                .filter(input -> input.getTransactionStatus() == TransactionStatus.PENDING)
+                .collect(Collectors.toUnmodifiableList());
     }
 }
 

--- a/payment/src/test/java/org/killbill/billing/payment/glue/TestPaymentModule.java
+++ b/payment/src/test/java/org/killbill/billing/payment/glue/TestPaymentModule.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.payment.glue;
 
+import java.util.Collections;
 import java.util.UUID;
 
 import org.killbill.billing.ObjectType;
@@ -36,13 +37,10 @@ import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
 import org.killbill.billing.util.glue.EventModule;
-import org.killbill.billing.util.tag.Tag;
 import org.killbill.clock.Clock;
 import org.killbill.commons.metrics.api.MetricRegistry;
 import org.killbill.commons.metrics.impl.NoOpMetricRegistry;
 import org.mockito.Mockito;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestPaymentModule extends PaymentModule {
 
@@ -63,7 +61,7 @@ public class TestPaymentModule extends PaymentModule {
     private void installExternalApis() {
         final TagInternalApi tagInternalApi = Mockito.mock(TagInternalApi.class);
         bind(TagInternalApi.class).toInstance(tagInternalApi);
-        Mockito.when(tagInternalApi.getTags(Mockito.<UUID>any(), Mockito.<ObjectType>any(), Mockito.<InternalTenantContext>any())).thenReturn(ImmutableList.<Tag>of());
+        Mockito.when(tagInternalApi.getTags(Mockito.<UUID>any(), Mockito.<ObjectType>any(), Mockito.<InternalTenantContext>any())).thenReturn(Collections.emptyList());
 
         final TagUserApi tagUserApi = Mockito.mock(TagUserApi.class);
         bind(TagUserApi.class).toInstance(tagUserApi);

--- a/payment/src/test/java/org/killbill/billing/payment/provider/MockPaymentProviderPlugin.java
+++ b/payment/src/test/java/org/killbill/billing/payment/provider/MockPaymentProviderPlugin.java
@@ -20,6 +20,8 @@ package org.killbill.billing.payment.provider;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,8 +31,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.payment.api.PaymentMethodPlugin;
@@ -44,19 +48,15 @@ import org.killbill.billing.payment.plugin.api.PaymentPluginApi;
 import org.killbill.billing.payment.plugin.api.PaymentPluginApiException;
 import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.collect.Iterables;
 import org.killbill.billing.util.entity.DefaultPagination;
 import org.killbill.billing.util.entity.Pagination;
 import org.killbill.billing.util.entity.dao.DBRouterUntyped;
 import org.killbill.billing.util.entity.dao.DBRouterUntyped.THREAD_STATE;
 import org.killbill.clock.Clock;
-
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.inject.Inject;
 
 /**
  * This MockPaymentProviderPlugin only works for a single accounts as we don't specify the accountId
@@ -324,27 +324,25 @@ public class MockPaymentProviderPlugin implements PaymentPluginApi {
     public List<PaymentTransactionInfoPlugin> getPaymentInfo(final UUID kbAccountId, final UUID kbPaymentId, final Iterable<PluginProperty> properties, final TenantContext context) throws PaymentPluginApiException {
         updateLastThreadState();
         final List<PaymentTransactionInfoPlugin> result = paymentTransactions.get(kbPaymentId.toString());
-        return result != null ? result : ImmutableList.<PaymentTransactionInfoPlugin>of();
+        return result != null ? result : Collections.emptyList();
     }
 
     @Override
     public Pagination<PaymentTransactionInfoPlugin> searchPayments(final String searchKey, final Long offset, final Long limit, final Iterable<PluginProperty> properties, final TenantContext tenantContext) throws PaymentPluginApiException {
         updateLastThreadState();
 
-        final ImmutableList<PaymentTransactionInfoPlugin> results = ImmutableList.<PaymentTransactionInfoPlugin>copyOf(Iterables.<PaymentTransactionInfoPlugin>filter(Iterables.<PaymentTransactionInfoPlugin>concat(paymentTransactions.values()), new Predicate<PaymentTransactionInfoPlugin>() {
-            @Override
-            public boolean apply(final PaymentTransactionInfoPlugin input) {
-                if (input.getProperties() !=  null) {
-                    for (final PluginProperty cur : input.getProperties()) {
-                        if (cur.getValue().equals(searchKey)) {
+        final List<PaymentTransactionInfoPlugin> results = paymentTransactions.values().stream()
+                .flatMap(Collection::stream)
+                .filter(input -> {
+                    if (input.getProperties() != null) {
+                        if (input.getProperties().stream().map(PluginProperty::getValue).anyMatch(searchKey::equals)) {
                             return true;
                         }
                     }
-                }
-                return (input.getKbPaymentId().toString().equals(searchKey));
-            }
-        }));
-        return DefaultPagination.<PaymentTransactionInfoPlugin>build(offset, limit, paymentTransactions.size(), results);
+                    return searchKey.equals(input.getKbPaymentId().toString());
+                })
+                .collect(Collectors.toUnmodifiableList());
+        return DefaultPagination.build(offset, limit, paymentTransactions.size(), results);
     }
 
     @Override
@@ -379,26 +377,25 @@ public class MockPaymentProviderPlugin implements PaymentPluginApi {
     @Override
     public List<PaymentMethodInfoPlugin> getPaymentMethods(final UUID kbAccountId, final boolean refreshFromGateway, final Iterable<PluginProperty> properties, final CallContext context) {
         updateLastThreadState();
-        return ImmutableList.<PaymentMethodInfoPlugin>copyOf(paymentMethodsInfo.values());
+        return List.copyOf(paymentMethodsInfo.values());
     }
 
     @Override
     public Pagination<PaymentMethodPlugin> searchPaymentMethods(final String searchKey, final Long offset, final Long limit, final Iterable<PluginProperty> properties, final TenantContext tenantContext) throws PaymentPluginApiException {
         updateLastThreadState();
-        final ImmutableList<PaymentMethodPlugin> results = ImmutableList.<PaymentMethodPlugin>copyOf(Iterables.<PaymentMethodPlugin>filter(paymentMethods.values(), new Predicate<PaymentMethodPlugin>() {
-            @Override
-            public boolean apply(final PaymentMethodPlugin input) {
-                if (input.getProperties() !=  null) {
-                    for (PluginProperty cur : input.getProperties()) {
-                        if (cur.getValue().equals(searchKey)) {
+
+        final List<PaymentMethodPlugin> results = paymentMethods.values().stream()
+                .filter(input -> {
+                    if (input.getProperties() != null) {
+                        if (input.getProperties().stream().map(PluginProperty::getValue).anyMatch(searchKey::equals)) {
                             return true;
                         }
                     }
-                }
-                return (input.getKbPaymentMethodId().toString().equals(searchKey));
-            }
-        }));
-        return DefaultPagination.<PaymentMethodPlugin>build(offset, limit, paymentMethods.size(), results);
+                    return searchKey.equals(input.getKbPaymentMethodId().toString());
+                })
+                .collect(Collectors.toUnmodifiableList());
+
+        return DefaultPagination.build(offset, limit, paymentMethods.size(), results);
     }
 
     @Override
@@ -451,7 +448,7 @@ public class MockPaymentProviderPlugin implements PaymentPluginApi {
         }
         Preconditions.checkNotNull(paymentTransactionInfoPlugin);
 
-        final Iterable<PluginProperty> pluginProperties = ImmutableList.<PluginProperty>of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, paymentPluginStatus.toString(), false));
+        final Iterable<PluginProperty> pluginProperties = List.of(new PluginProperty(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, paymentPluginStatus.toString(), false));
         getPaymentTransactionInfoPluginResult(kbPaymentId, kbTransactionId, TransactionType.AUTHORIZE, paymentTransactionInfoPlugin.getAmount(), paymentTransactionInfoPlugin.getCurrency(), pluginProperties);
     }
 
@@ -469,12 +466,9 @@ public class MockPaymentProviderPlugin implements PaymentPluginApi {
             throw new PaymentPluginApiException("", "test error");
         }
 
-        final PluginProperty paymentPluginStatusOverride = Iterables.tryFind(pluginProperties, new Predicate<PluginProperty>() {
-            @Override
-            public boolean apply(final PluginProperty input) {
-                return PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE.equals(input.getKey());
-            }
-        }).orNull();
+        final PluginProperty paymentPluginStatusOverride = Iterables.toStream(pluginProperties)
+                .filter(input -> PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE.equals(input.getKey()))
+                .findFirst().orElse(null);
 
         final PaymentPluginStatus status;
         if (paymentPluginStatusOverride != null && paymentPluginStatusOverride.getValue() != null) {
@@ -506,7 +500,7 @@ public class MockPaymentProviderPlugin implements PaymentPluginApi {
             processedCurrency = currency;
         }
 
-        final PaymentTransactionInfoPlugin result = new DefaultNoOpPaymentInfoPlugin(kbPaymentId, kbTransactionId, type, processedAmount, processedCurrency, clock.getUTCNow(), clock.getUTCNow(), status, errorCode, error, null, null, ImmutableList.<PluginProperty>copyOf(pluginProperties));
+        final PaymentTransactionInfoPlugin result = new DefaultNoOpPaymentInfoPlugin(kbPaymentId, kbTransactionId, type, processedAmount, processedCurrency, clock.getUTCNow(), clock.getUTCNow(), status, errorCode, error, null, null, Iterables.toUnmodifiableList(pluginProperties));
         List<PaymentTransactionInfoPlugin> existingTransactions = paymentTransactions.get(kbPaymentId.toString());
         if (existingTransactions == null) {
             existingTransactions = new ArrayList<PaymentTransactionInfoPlugin>();

--- a/payment/src/test/java/org/killbill/billing/payment/provider/TestDefaultNoOpPaymentMethodPlugin.java
+++ b/payment/src/test/java/org/killbill/billing/payment/provider/TestDefaultNoOpPaymentMethodPlugin.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.payment.provider;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,15 +27,13 @@ import org.killbill.billing.payment.api.PluginProperty;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class TestDefaultNoOpPaymentMethodPlugin extends PaymentTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testEquals() throws Exception {
         final String externalId = UUID.randomUUID().toString();
         final boolean isDefault = false;
-        final List<PluginProperty> props = ImmutableList.<PluginProperty>of(new PluginProperty(UUID.randomUUID().toString(), UUID.randomUUID().toString(), false));
+        final List<PluginProperty> props = List.of(new PluginProperty(UUID.randomUUID().toString(), UUID.randomUUID().toString(), false));
 
         final DefaultNoOpPaymentMethodPlugin paymentMethod = new DefaultNoOpPaymentMethodPlugin(externalId, isDefault, props);
         Assert.assertEquals(paymentMethod, paymentMethod);
@@ -42,7 +41,7 @@ public class TestDefaultNoOpPaymentMethodPlugin extends PaymentTestSuiteNoDB {
         final DefaultNoOpPaymentMethodPlugin samePaymentMethod = new DefaultNoOpPaymentMethodPlugin(externalId, isDefault, props);
         Assert.assertEquals(samePaymentMethod, paymentMethod);
 
-        final DefaultNoOpPaymentMethodPlugin otherPaymentMethod = new DefaultNoOpPaymentMethodPlugin(externalId, isDefault, ImmutableList.<PluginProperty>of());
+        final DefaultNoOpPaymentMethodPlugin otherPaymentMethod = new DefaultNoOpPaymentMethodPlugin(externalId, isDefault, Collections.emptyList());
         Assert.assertNotEquals(otherPaymentMethod, paymentMethod);
     }
 

--- a/payment/src/test/java/org/killbill/billing/payment/provider/TestExternalPaymentProviderPlugin.java
+++ b/payment/src/test/java/org/killbill/billing/payment/provider/TestExternalPaymentProviderPlugin.java
@@ -19,22 +19,18 @@
 package org.killbill.billing.payment.provider;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.payment.PaymentTestSuiteNoDB;
 import org.killbill.billing.payment.api.PluginProperty;
-import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
 import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
-import org.killbill.clock.Clock;
-import org.killbill.clock.ClockMock;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestExternalPaymentProviderPlugin extends PaymentTestSuiteNoDB {
 
@@ -52,7 +48,7 @@ public class TestExternalPaymentProviderPlugin extends PaymentTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testProcessPayment() throws Exception {
-        final List<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+        final List<PluginProperty> properties = Collections.emptyList();
         final UUID accountId = UUID.randomUUID();
         final UUID paymentId = UUID.randomUUID();
         final UUID kbTransactionId = UUID.randomUUID();


### PR DESCRIPTION
Replace Guava and Guice usage with stream API and JSR-330 in kb-payment. This is 4th part and last PR for `killbill-payment` work for issue 1615.