### PR TITLE
overdue: Avoid computing billing state when account is tagged with OV…

### DIFF
--- a/overdue/src/main/java/org/killbill/billing/overdue/applicator/OverdueStateApplicator.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/applicator/OverdueStateApplicator.java
@@ -107,11 +107,6 @@ public class OverdueStateApplicator {
     public void apply(final DateTime effectiveDate, final OverdueStateSet overdueStateSet, final BillingState billingState,
                       final ImmutableAccountData account, final OverdueState previousOverdueState,
                       final OverdueState nextOverdueState, final InternalCallContext context) throws OverdueException, OverdueApiException {
-        if (isAccountTaggedWith_OVERDUE_ENFORCEMENT_OFF(context)) {
-            log.debug("OverdueStateApplicator: apply returns because account (recordId={}) is set with OVERDUE_ENFORCEMENT_OFF", context.getAccountRecordId());
-            return;
-        }
-
         log.debug("OverdueStateApplicator: time={}, previousState={}, nextState={}, billingState={}", effectiveDate, previousOverdueState, nextOverdueState, billingState);
 
         final OverdueState firstOverdueState = overdueStateSet.getFirstState();
@@ -338,7 +333,7 @@ public class OverdueStateApplicator {
     //
     // Uses callcontext information to retrieve account matching the Overduable object and check whether we should do any overdue processing
     //
-    private boolean isAccountTaggedWith_OVERDUE_ENFORCEMENT_OFF(final InternalCallContext context) throws OverdueException {
+    public boolean isAccountTaggedWith_OVERDUE_ENFORCEMENT_OFF(final InternalCallContext context) throws OverdueException {
 
         try {
             final UUID accountId = accountApi.getByRecordId(context.getAccountRecordId(), context);

--- a/overdue/src/main/java/org/killbill/billing/overdue/wrapper/OverdueWrapper.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/wrapper/OverdueWrapper.java
@@ -100,6 +100,11 @@ public class OverdueWrapper {
     }
 
     private OverdueState refreshWithLock(final DateTime effectiveDate, final InternalCallContext context) throws OverdueException, OverdueApiException {
+        if (overdueStateApplicator.isAccountTaggedWith_OVERDUE_ENFORCEMENT_OFF(context)) {
+            log.debug("OverdueStateApplicator: apply returns because account (recordId={}) is set with OVERDUE_ENFORCEMENT_OFF", context.getAccountRecordId());
+            return null;
+        }
+
         final BillingState billingState = billingState(context);
         final BlockingState blockingStateForService = api.getBlockingStateForService(overdueable.getId(), BlockingStateType.ACCOUNT, OverdueService.OVERDUE_SERVICE_NAME, context);
         final String previousOverdueStateName = blockingStateForService != null ? blockingStateForService.getStateName() : OverdueWrapper.CLEAR_STATE_NAME;

--- a/overdue/src/test/java/org/killbill/billing/overdue/wrapper/TestOverdueWrapper.java
+++ b/overdue/src/test/java/org/killbill/billing/overdue/wrapper/TestOverdueWrapper.java
@@ -26,6 +26,7 @@ import org.killbill.billing.overdue.OverdueTestSuiteWithEmbeddedDB;
 import org.killbill.billing.overdue.api.OverdueState;
 import org.killbill.billing.overdue.caching.MockOverdueConfigCache;
 import org.killbill.billing.overdue.config.DefaultOverdueConfig;
+import org.killbill.billing.overdue.config.api.BillingState;
 import org.killbill.xmlloader.XMLLoader;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -84,8 +85,11 @@ public class TestOverdueWrapper extends OverdueTestSuiteWithEmbeddedDB {
         state = config.getOverdueStatesAccount().findState(OverdueWrapper.CLEAR_STATE_NAME);
         account = testOverdueHelper.createAccount(clock.getUTCToday().minusDays(31));
         wrapper = overdueWrapperFactory.createOverdueWrapperFor(account, internalCallContext);
-        final OverdueState result = wrapper.refresh(clock.getUTCNow(), internalCallContext);
+        wrapper.refresh(clock.getUTCNow(), internalCallContext);
 
+
+        final BillingState billingState = calculatorBundle.calculateBillingState(account, internalCallContext);
+        final OverdueState result = wrapper.getNextOverdueState(billingState, internalCallContext);
         Assert.assertEquals(result.getName(), state.getName());
         Assert.assertEquals(result.isBlockChanges(), state.isBlockChanges());
         Assert.assertEquals(result.isDisableEntitlementAndChangesBlocked(), state.isDisableEntitlementAndChangesBlocked());


### PR DESCRIPTION
…ERDUE_ENFORCEMENT_OFF

The logic to check the OVERDUE_ENFORCEMENT_OFF is now moved earlier to avoid first computing the state (which can be costly for large accounts).