### PR TITLE
.github: don't trigger snapshot on push

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,7 +1,6 @@
 name: snapshot
 
 on:
-  push:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We don't always need SNAPSHOT builds of Kill Bill core.