### PR TITLE
subscription: Add missing clause to query 

### DIFF
--- a/subscription/src/main/resources/org/killbill/billing/subscription/engine/dao/SubscriptionEventSqlDao.sql.stg
+++ b/subscription/src/main/resources/org/killbill/billing/subscription/engine/dao/SubscriptionEventSqlDao.sql.stg
@@ -108,7 +108,8 @@ join (select
       where
       se1.user_type in ('CREATE','TRANSFER') and se1.is_active
       and (se2.id IS NULL or se2.effective_date \> :cutoffDt)
-      and <accountRecordIdField("se1.")> = :accountRecordId)  tmp on tmp.subscription_id = se.subscription_id
+      and <accountRecordIdField("se1.")> = :accountRecordId
+      <AND_CHECK_TENANT("se1.")>)  tmp on tmp.subscription_id = se.subscription_id
 where
 se.is_active
 and <accountRecordIdField("se.")> = :accountRecordId


### PR DESCRIPTION
We have a composite index on `{tenant_record_id, account_record_id}` and so adding the clause on `tenant_record_id` is required to make this index active.
