### PR TITLE
1615 profiles killbill part 2

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/filters/ResponseCorsFilter.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/filters/ResponseCorsFilter.java
@@ -53,7 +53,8 @@ public class ResponseCorsFilter implements Filter {
                                              JaxrsResource.HDR_PAGINATION_MAX_NB_RECORDS,
                                              JaxrsResource.HDR_PAGINATION_NEXT_OFFSET,
                                              JaxrsResource.HDR_PAGINATION_NEXT_PAGE_URI,
-                                             JaxrsResource.HDR_PAGINATION_TOTAL_NB_RECORDS, JaxrsResource.HDR_REASON)
+                                             JaxrsResource.HDR_PAGINATION_TOTAL_NB_RECORDS,
+                                             JaxrsResource.HDR_REASON)
                                     );
     }
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceItem.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceItem.java
@@ -18,7 +18,6 @@
 package org.killbill.billing.jaxrs;
 
 import java.util.List;
-import java.util.UUID;
 
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.client.RequestOptions;
@@ -35,8 +34,8 @@ import org.killbill.billing.util.api.AuditLevel;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+// FIXME-1615 : killbill-client-java : RequestOptions using MultiMap
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 
 public class TestInvoiceItem extends TestJaxrsBase {
@@ -54,7 +53,7 @@ public class TestInvoiceItem extends TestJaxrsBase {
         Assert.assertNotNull(invoiceItems);
 
         // Create tag definition
-        final TagDefinition input = new TagDefinition(null, false, "tagtest", "invoice item tag test", ImmutableList.<ObjectType>of(ObjectType.INVOICE_ITEM), null);
+        final TagDefinition input = new TagDefinition(null, false, "tagtest", "invoice item tag test", List.of(ObjectType.INVOICE_ITEM), null);
 
         final TagDefinition objFromJson = tagDefinitionApi.createTagDefinition(input, requestOptions);
         Assert.assertNotNull(objFromJson);
@@ -65,7 +64,7 @@ public class TestInvoiceItem extends TestJaxrsBase {
         final Multimap<String, String> followQueryParams = HashMultimap.create();
         followQueryParams.put(JaxrsResource.QUERY_ACCOUNT_ID, accountJson.getAccountId().toString());
         final RequestOptions followRequestOptions = requestOptions.extend().withQueryParamsForFollow(followQueryParams).build();
-        invoiceItemApi.createInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), ImmutableList.<UUID>of(objFromJson.getId()), followRequestOptions);
+        invoiceItemApi.createInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), List.of(objFromJson.getId()), followRequestOptions);
 
         // Retrieves all tags
         final List<Tag> tags1 = invoiceItemApi.getInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), accountJson.getAccountId(), null, AuditLevel.FULL, requestOptions);
@@ -73,7 +72,7 @@ public class TestInvoiceItem extends TestJaxrsBase {
         Assert.assertEquals(tags1.get(0).getTagDefinitionId(), objFromJson.getId());
 
         // Verify adding the same tag a second time doesn't do anything
-        invoiceItemApi.createInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), ImmutableList.<UUID>of(objFromJson.getId()), followRequestOptions);
+        invoiceItemApi.createInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), List.of(objFromJson.getId()), followRequestOptions);
 
         // Retrieves all tags again
         final List<Tag> tags2 = invoiceItemApi.getInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), accountJson.getAccountId(), null, AuditLevel.FULL, requestOptions);
@@ -90,15 +89,15 @@ public class TestInvoiceItem extends TestJaxrsBase {
         Assert.assertNotNull(auditLogJson.getUserToken());
 
         // remove it
-        invoiceItemApi.deleteInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), ImmutableList.<UUID>of(objFromJson.getId()), requestOptions);
+        invoiceItemApi.deleteInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), List.of(objFromJson.getId()), requestOptions);
         final List<Tag> tags3 = invoiceItemApi.getInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), accountJson.getAccountId(), null, AuditLevel.FULL, requestOptions);
         Assert.assertEquals(tags3.size(), 0);
 
         tagDefinitionApi.deleteTagDefinition(objFromJson.getId(), requestOptions);
-        List<TagDefinition> objsFromJson = tagDefinitionApi.getTagDefinitions(requestOptions);
+        final List<TagDefinition> objsFromJson = tagDefinitionApi.getTagDefinitions(requestOptions);
         Assert.assertNotNull(objsFromJson);
-        Boolean isFound = false;
-        for (TagDefinition tagDefinition : objsFromJson) {
+        boolean isFound = false;
+        for (final TagDefinition tagDefinition : objsFromJson) {
             isFound |= tagDefinition.getId().equals(objFromJson.getId());
         }
         Assert.assertFalse(isFound);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoicePayment.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoicePayment.java
@@ -20,8 +20,11 @@ package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.catalog.api.BillingPeriod;
@@ -50,9 +53,6 @@ import org.killbill.billing.util.tag.ControlTagType;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.inject.Inject;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -206,7 +206,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
         final InvoiceItem adjustment = new InvoiceItem();
         adjustment.setInvoiceItemId(itemToAdjust.getInvoiceItemId());
         //null amount means full adjustment for that item
-        refund.setAdjustments(ImmutableList.<InvoiceItem>of(adjustment));
+        refund.setAdjustments(List.of(adjustment));
 
         invoicePaymentApi.createRefundWithAdjustments(paymentJson.getPaymentId(), refund, paymentJson.getPaymentMethodId(), NULL_PLUGIN_PROPERTIES, requestOptions);
         final Payment paymentAfterRefundJson = paymentApi.getPayment(paymentJson.getPaymentId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -235,7 +235,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
         final InvoiceItem adjustment = new InvoiceItem();
         adjustment.setInvoiceItemId(itemToAdjust.getInvoiceItemId());
         adjustment.setAmount(refundAmount);
-        refund.setAdjustments(ImmutableList.<InvoiceItem>of(adjustment));
+        refund.setAdjustments(List.of(adjustment));
 
         invoicePaymentApi.createRefundWithAdjustments(paymentJson.getPaymentId(), refund, paymentJson.getPaymentMethodId(), NULL_PLUGIN_PROPERTIES, requestOptions);
         final Payment paymentAfterRefundJson = paymentApi.getPayment(paymentJson.getPaymentId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -266,7 +266,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
         adjustment.setInvoiceItemId(itemToAdjust.getInvoiceItemId());
         // Ask for an adjustment for the full amount (bigger than the refund amount)
         adjustment.setAmount(itemToAdjust.getAmount());
-        refund.setAdjustments(ImmutableList.<InvoiceItem>of(adjustment));
+        refund.setAdjustments(List.of(adjustment));
 
         invoicePaymentApi.createRefundWithAdjustments(paymentJson.getPaymentId(), refund, paymentJson.getPaymentMethodId(), NULL_PLUGIN_PROPERTIES, requestOptions);
         final Payment paymentAfterRefundJson = paymentApi.getPayment(paymentJson.getPaymentId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -293,7 +293,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
             invoicePayment.setPurchasedAmount(lastPayment.getPurchasedAmount());
             invoicePayment.setAccountId(lastPayment.getAccountId());
             invoicePayment.setTargetInvoiceId(lastPayment.getTargetInvoiceId());
-            final InvoicePayment payment = invoiceApi.createInstantPayment(lastPayment.getTargetInvoiceId(), invoicePayment, ImmutableList.of(), NULL_PLUGIN_PROPERTIES, requestOptions);
+            final InvoicePayment payment = invoiceApi.createInstantPayment(lastPayment.getTargetInvoiceId(), invoicePayment, Collections.emptyList(), NULL_PLUGIN_PROPERTIES, requestOptions);
             lastPayment = payment;
         }
 
@@ -357,7 +357,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
 
         // Disable automatic payments
         callbackServlet.pushExpectedEvent(ExtBusEventType.TAG_CREATION);
-        accountApi.createAccountTags(accountJson.getAccountId(), ImmutableList.<UUID>of(ControlTagType.AUTO_PAY_OFF.getId()), requestOptions);
+        accountApi.createAccountTags(accountJson.getAccountId(), List.of(ControlTagType.AUTO_PAY_OFF.getId()), requestOptions);
         callbackServlet.assertListenerStatus();
 
         // Add a bundle, subscription and move the clock to get the first invoice
@@ -380,7 +380,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
 
         // Pay too too much => 400
         try {
-            invoiceApi.createInstantPayment(invoicePayment1.getTargetInvoiceId(), invoicePayment1, ImmutableList.of(), NULL_PLUGIN_PROPERTIES, requestOptions);
+            invoiceApi.createInstantPayment(invoicePayment1.getTargetInvoiceId(), invoicePayment1, Collections.emptyList(), NULL_PLUGIN_PROPERTIES, requestOptions);
             Assert.fail("InvoicePayment call should fail with 400");
         } catch (final KillBillClientException e) {
             assertTrue(true);
@@ -392,12 +392,12 @@ public class TestInvoicePayment extends TestJaxrsBase {
         invoicePayment2.setTargetInvoiceId(invoices.get(1).getInvoiceId());
 
         // Just right, Yah! => 201
-        final InvoicePayment result2 = invoiceApi.createInstantPayment(invoicePayment2.getTargetInvoiceId(), invoicePayment2, ImmutableList.of(), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final InvoicePayment result2 = invoiceApi.createInstantPayment(invoicePayment2.getTargetInvoiceId(), invoicePayment2, Collections.emptyList(), NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(result2.getTransactions().size(), 1);
         assertTrue(result2.getTransactions().get(0).getAmount().compareTo(invoices.get(1).getBalance()) == 0);
 
         // Already paid -> 204
-        final InvoicePayment result3 = invoiceApi.createInstantPayment(invoicePayment2.getTargetInvoiceId(), invoicePayment2, ImmutableList.of(), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final InvoicePayment result3 = invoiceApi.createInstantPayment(invoicePayment2.getTargetInvoiceId(), invoicePayment2, Collections.emptyList(), NULL_PLUGIN_PROPERTIES, requestOptions);
         assertNull(result3);
     }
 
@@ -427,7 +427,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
 
     private void verifyRefund(final InvoicePayment paymentJson, final Payment paymentAfterRefund, final BigDecimal refundAmount) throws KillBillClientException {
 
-        final List<PaymentTransaction> transactions = getPaymentTransactions(ImmutableList.of(paymentAfterRefund), TransactionType.REFUND);
+        final List<PaymentTransaction> transactions = getPaymentTransactions(List.of(paymentAfterRefund), TransactionType.REFUND);
         Assert.assertEquals(transactions.size(), 1);
 
         final PaymentTransaction refund = transactions.get(0);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceVoid.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceVoid.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -40,8 +41,6 @@ import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.util.api.AuditLevel;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -257,7 +256,7 @@ public class TestInvoiceVoid extends TestJaxrsBase {
         invoicePayment.setTargetInvoiceId(invoice.getInvoiceId());
 
         callbackServlet.pushExpectedEvents(ExtBusEventType.PAYMENT_SUCCESS, ExtBusEventType.INVOICE_PAYMENT_SUCCESS);
-        final InvoicePayment result = invoiceApi.createInstantPayment(invoice.getInvoiceId(), invoicePayment, true, ImmutableList.of(), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final InvoicePayment result = invoiceApi.createInstantPayment(invoice.getInvoiceId(), invoicePayment, true, Collections.emptyList(), NULL_PLUGIN_PROPERTIES, requestOptions);
         callbackServlet.assertListenerStatus();
         assertEquals(result.getTransactions().size(), 1);
         assertTrue(result.getTransactions().get(0).getAmount().compareTo(payAmount) == 0);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJetty.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJetty.java
@@ -29,8 +29,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-
-import com.google.common.io.CharStreams;
+import org.killbill.billing.util.io.IOUtils;
 
 public class TestJetty {
 
@@ -59,7 +58,7 @@ public class TestJetty {
 
         @Override
         protected void doPost(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
-            final String body = CharStreams.toString(new InputStreamReader(request.getInputStream(), "UTF-8"));
+            final String body = IOUtils.toString(new InputStreamReader(request.getInputStream(), "UTF-8"));
             System.out.print("Got " + body);
 
             response.setContentType("application/json");

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestOverdue.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestOverdue.java
@@ -19,9 +19,10 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.killbill.billing.client.model.Invoices;
 import org.killbill.billing.client.model.Tags;
@@ -32,9 +33,6 @@ import org.killbill.billing.notification.plugin.api.ExtBusEventType;
 import org.killbill.billing.util.tag.ControlTagType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Ordering;
 
 import static org.testng.Assert.assertEquals;
 
@@ -80,12 +78,9 @@ public class TestOverdue extends TestJaxrsBase {
         // a refresh overdue notification kicks in after the first payment, which makes the account goes CLEAR and
         // triggers an AUTO_INVOICE_OFF tag removal (hence adjustment of the other invoices balance).
         final Invoices invoicesForAccount = accountApi.getInvoicesForAccount(accountJson.getAccountId(), null, null, null, requestOptions);
-        final List<Invoice> mostRecentInvoiceFirst = Ordering.<Invoice>from(new Comparator<Invoice>() {
-            @Override
-            public int compare(final Invoice invoice1, final Invoice invoice2) {
-                return invoice1.getInvoiceDate().compareTo(invoice2.getInvoiceDate());
-            }
-        }).reverse().sortedCopy(invoicesForAccount);
+        final List<Invoice> mostRecentInvoiceFirst = invoicesForAccount.stream()
+                .sorted(Comparator.comparing(Invoice::getInvoiceDate).reversed())
+                .collect(Collectors.toUnmodifiableList());
         for (final Invoice invoice : mostRecentInvoiceFirst) {
             if (invoice.getBalance().compareTo(BigDecimal.ZERO) > 0) {
                 final InvoicePayment invoicePayment = new InvoicePayment();
@@ -93,7 +88,7 @@ public class TestOverdue extends TestJaxrsBase {
                 invoicePayment.setAccountId(accountJson.getAccountId());
                 invoicePayment.setTargetInvoiceId(invoice.getInvoiceId());
                 callbackServlet.pushExpectedEvents(ExtBusEventType.INVOICE_PAYMENT_SUCCESS, ExtBusEventType.PAYMENT_SUCCESS);
-                invoiceApi.createInstantPayment(invoice.getInvoiceId(), invoicePayment, true, ImmutableList.of(), NULL_PLUGIN_PROPERTIES, requestOptions);
+                invoiceApi.createInstantPayment(invoice.getInvoiceId(), invoicePayment, true, Collections.emptyList(), NULL_PLUGIN_PROPERTIES, requestOptions);
                 callbackServlet.assertListenerStatus();
             }
         }
@@ -113,7 +108,7 @@ public class TestOverdue extends TestJaxrsBase {
         // Create an account without a payment method and assign a TEST tag
         final Account accountJson = createAccountNoPMBundleAndSubscription();
         callbackServlet.pushExpectedEvent(ExtBusEventType.TAG_CREATION);
-        final Tags accountTag = accountApi.createAccountTags(accountJson.getAccountId(), ImmutableList.<UUID>of(ControlTagType.TEST.getId()), requestOptions);
+        final Tags accountTag = accountApi.createAccountTags(accountJson.getAccountId(), List.of(ControlTagType.TEST.getId()), requestOptions);
         callbackServlet.assertListenerStatus();
         assertEquals(accountTag.get(0).getTagDefinitionId(), ControlTagType.TEST.getId());
 
@@ -160,7 +155,7 @@ public class TestOverdue extends TestJaxrsBase {
         // Create an account without a payment method and assign a TEST tag
         final Account accountJson = createAccountNoPMBundleAndSubscription();
         callbackServlet.pushExpectedEvent(ExtBusEventType.TAG_CREATION);
-        final Tags accountTag = accountApi.createAccountTags(accountJson.getAccountId(), ImmutableList.<UUID>of(ControlTagType.TEST.getId()), requestOptions);
+        final Tags accountTag = accountApi.createAccountTags(accountJson.getAccountId(), List.of(ControlTagType.TEST.getId()), requestOptions);
         callbackServlet.assertListenerStatus();
         assertEquals(accountTag.get(0).getTagDefinitionId(), ControlTagType.TEST.getId());
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPayment.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPayment.java
@@ -20,13 +20,15 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.killbill.billing.ObjectType;
@@ -44,7 +46,6 @@ import org.killbill.billing.client.model.gen.Payment;
 import org.killbill.billing.client.model.gen.PaymentMethod;
 import org.killbill.billing.client.model.gen.PaymentMethodPluginDetail;
 import org.killbill.billing.client.model.gen.PaymentTransaction;
-import org.killbill.billing.client.model.gen.PluginProperty;
 import org.killbill.billing.client.model.gen.TagDefinition;
 import org.killbill.billing.control.plugin.api.PaymentControlPluginApi;
 import org.killbill.billing.osgi.api.OSGIServiceDescriptor;
@@ -62,11 +63,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.base.MoreObjects;
+// FIXME-1615 : killbill-client-java : RequestOptions using MultiMap
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.inject.Inject;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -216,7 +214,7 @@ public class TestPayment extends TestJaxrsBase {
             accountApi.processPayment(account.getAccountId(), authTransaction, account.getPaymentMethodId(),
                                       NULL_PLUGIN_NAMES, NULL_PLUGIN_PROPERTIES, requestOptions);
             fail();
-        } catch (KillBillClientException e) {
+        } catch (final KillBillClientException e) {
             assertEquals(504, e.getResponse().statusCode());
         }
     }
@@ -229,7 +227,7 @@ public class TestPayment extends TestJaxrsBase {
         final Invoice failedInvoice = accountApi.getInvoicesForAccount(account.getAccountId(), null, null, null, RequestOptions.empty()).get(1);
 
         // Verify initial state
-        final Payments initialPayments = accountApi.getPaymentsForAccount(account.getAccountId(), true, false, ImmutableMap.<String, String>of(), AuditLevel.NONE, requestOptions);
+        final Payments initialPayments = accountApi.getPaymentsForAccount(account.getAccountId(), true, false, Collections.emptyMap(), AuditLevel.NONE, requestOptions);
         Assert.assertEquals(initialPayments.size(), 1);
         Assert.assertEquals(initialPayments.get(0).getTransactions().size(), 1);
         Assert.assertEquals(initialPayments.get(0).getTransactions().get(0).getStatus(), TransactionStatus.PAYMENT_FAILURE);
@@ -243,7 +241,7 @@ public class TestPayment extends TestJaxrsBase {
         // Trigger manually an invoice payment but make the control plugin abort it
         mockPaymentControlProviderPlugin.setAborted(true);
         final HashMultimap<String, String> queryParams = HashMultimap.create();
-        queryParams.putAll("controlPluginName", Arrays.<String>asList(MockPaymentControlProviderPlugin.PLUGIN_NAME));
+        queryParams.putAll("controlPluginName", List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME));
         final RequestOptions inputOptions = RequestOptions.builder()
                                                           .withCreatedBy(createdBy)
                                                           .withReason(reason)
@@ -253,11 +251,11 @@ public class TestPayment extends TestJaxrsBase {
         invoicePayment.setPurchasedAmount(failedInvoice.getBalance());
         invoicePayment.setAccountId(failedInvoice.getAccountId());
         invoicePayment.setTargetInvoiceId(failedInvoice.getInvoiceId());
-        final InvoicePayment invoicePaymentNull = invoiceApi.createInstantPayment(failedInvoice.getInvoiceId(), invoicePayment, ImmutableList.of(), null, inputOptions);
+        final InvoicePayment invoicePaymentNull = invoiceApi.createInstantPayment(failedInvoice.getInvoiceId(), invoicePayment, Collections.emptyList(), null, inputOptions);
         Assert.assertNull(invoicePaymentNull);
 
         // Verify new state
-        final Payments updatedPayments = accountApi.getPaymentsForAccount(account.getAccountId(), true, false, ImmutableMap.<String, String>of(), AuditLevel.NONE, requestOptions);
+        final Payments updatedPayments = accountApi.getPaymentsForAccount(account.getAccountId(), true, false, Collections.emptyMap(), AuditLevel.NONE, requestOptions);
         Assert.assertEquals(updatedPayments.size(), 1);
         Assert.assertEquals(updatedPayments.get(0).getPaymentId(), initialPayments.get(0).getPaymentId());
         final InvoicePayments updatedInvoicePayments = invoiceApi.getPaymentsForInvoice(failedInvoice.getInvoiceId(), requestOptions);
@@ -270,15 +268,15 @@ public class TestPayment extends TestJaxrsBase {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
         final Account account = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
         // Getting Invoice #2 (first after Trial period)
-        UUID failedInvoiceId = accountApi.getInvoicesForAccount(account.getAccountId(), null, null, null, RequestOptions.empty()).get(1).getInvoiceId();
+        final UUID failedInvoiceId = accountApi.getInvoicesForAccount(account.getAccountId(), null, null, null, RequestOptions.empty()).get(1).getInvoiceId();
 
-        HashMultimap<String, String> queryParams = HashMultimap.create();
+        final HashMultimap<String, String> queryParams = HashMultimap.create();
         queryParams.put("withAttempts", "true");
-        RequestOptions inputOptions = RequestOptions.builder()
-                                                    .withCreatedBy(createdBy)
-                                                    .withReason(reason)
-                                                    .withComment(comment)
-                                                    .withQueryParams(queryParams).build();
+        final RequestOptions inputOptions = RequestOptions.builder()
+                                                          .withCreatedBy(createdBy)
+                                                          .withReason(reason)
+                                                          .withComment(comment)
+                                                          .withQueryParams(queryParams).build();
 
         InvoicePayments invoicePayments = invoiceApi.getPaymentsForInvoice(failedInvoiceId, inputOptions);
 
@@ -300,15 +298,15 @@ public class TestPayment extends TestJaxrsBase {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
         final Account account = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 
-        HashMultimap<String, String> queryParams = HashMultimap.create();
+        final HashMultimap<String, String> queryParams = HashMultimap.create();
         queryParams.put("withAttempts", "true");
-        RequestOptions inputOptions = RequestOptions.builder()
-                                                    .withCreatedBy(createdBy)
-                                                    .withReason(reason)
-                                                    .withComment(comment)
-                                                    .withQueryParams(queryParams).build();
+        final RequestOptions inputOptions = RequestOptions.builder()
+                                                          .withCreatedBy(createdBy)
+                                                          .withReason(reason)
+                                                          .withComment(comment)
+                                                          .withQueryParams(queryParams).build();
 
-        Payments payments = accountApi.getPaymentsForAccount(account.getAccountId(), NULL_PLUGIN_PROPERTIES, inputOptions);
+        final Payments payments = accountApi.getPaymentsForAccount(account.getAccountId(), NULL_PLUGIN_PROPERTIES, inputOptions);
 
         Assert.assertNotNull(payments.get(0).getPaymentAttempts());
         Assert.assertEquals(payments.get(0).getPaymentAttempts().get(0).getStateName(), "RETRIED");
@@ -320,15 +318,15 @@ public class TestPayment extends TestJaxrsBase {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
         createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 
-        HashMultimap<String, String> queryParams = HashMultimap.create();
+        final HashMultimap<String, String> queryParams = HashMultimap.create();
         queryParams.put("withAttempts", "true");
-        RequestOptions inputOptions = RequestOptions.builder()
-                                                    .withCreatedBy(createdBy)
-                                                    .withReason(reason)
-                                                    .withComment(comment)
-                                                    .withQueryParams(queryParams).build();
+        final RequestOptions inputOptions = RequestOptions.builder()
+                                                          .withCreatedBy(createdBy)
+                                                          .withReason(reason)
+                                                          .withComment(comment)
+                                                          .withQueryParams(queryParams).build();
 
-        Payments payments = paymentApi.getPayments(0L, 100L, null, false, true, NULL_PLUGIN_PROPERTIES, AuditLevel.NONE, inputOptions);
+        final Payments payments = paymentApi.getPayments(0L, 100L, null, false, true, NULL_PLUGIN_PROPERTIES, AuditLevel.NONE, inputOptions);
 
         Assert.assertNotNull(payments.get(0).getPaymentAttempts());
         Assert.assertEquals(payments.get(0).getPaymentAttempts().get(0).getStateName(), "RETRIED");
@@ -340,15 +338,15 @@ public class TestPayment extends TestJaxrsBase {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
         createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 
-        HashMultimap<String, String> queryParams = HashMultimap.create();
+        final HashMultimap<String, String> queryParams = HashMultimap.create();
         queryParams.put("withAttempts", "true");
-        RequestOptions inputOptions = RequestOptions.builder()
-                                                    .withCreatedBy(createdBy)
-                                                    .withReason(reason)
-                                                    .withComment(comment)
-                                                    .withQueryParams(queryParams).build();
+        final RequestOptions inputOptions = RequestOptions.builder()
+                                                          .withCreatedBy(createdBy)
+                                                          .withReason(reason)
+                                                          .withComment(comment)
+                                                          .withQueryParams(queryParams).build();
 
-        Payments payments = paymentApi.searchPayments("", 0L, 100L, false, true, null, NULL_PLUGIN_PROPERTIES, AuditLevel.NONE, inputOptions);
+        final Payments payments = paymentApi.searchPayments("", 0L, 100L, false, true, null, NULL_PLUGIN_PROPERTIES, AuditLevel.NONE, inputOptions);
 
         Assert.assertNotNull(payments.get(0).getPaymentAttempts());
         Assert.assertEquals(payments.get(0).getPaymentAttempts().get(0).getStateName(), "RETRIED");
@@ -360,9 +358,9 @@ public class TestPayment extends TestJaxrsBase {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
         createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 
-        Payments payments = paymentApi.searchPayments("", 0L, 100L, false, true, null, NULL_PLUGIN_PROPERTIES, AuditLevel.NONE, requestOptions);
+        final Payments payments = paymentApi.searchPayments("", 0L, 100L, false, true, null, NULL_PLUGIN_PROPERTIES, AuditLevel.NONE, requestOptions);
         Assert.assertNotNull(payments.get(0));
-        Payment payment = paymentApi.getPayment(payments.get(0).getPaymentId(), false, true, NULL_PLUGIN_PROPERTIES, AuditLevel.NONE, requestOptions);
+        final Payment payment = paymentApi.getPayment(payments.get(0).getPaymentId(), false, true, NULL_PLUGIN_PROPERTIES, AuditLevel.NONE, requestOptions);
 
         Assert.assertNotNull(payment.getPaymentAttempts());
         Assert.assertEquals(payment.getPaymentAttempts().get(0).getStateName(), "RETRIED");
@@ -374,14 +372,14 @@ public class TestPayment extends TestJaxrsBase {
         final Account account = createAccountWithDefaultPaymentMethod();
         final UUID paymentMethodId = account.getPaymentMethodId();
 
-        RequestOptions inputOptions = RequestOptions.builder()
-                                                    .withCreatedBy(createdBy)
-                                                    .withReason(reason)
-                                                    .withComment(comment).build();
+        final RequestOptions inputOptions = RequestOptions.builder()
+                                                          .withCreatedBy(createdBy)
+                                                          .withReason(reason)
+                                                          .withComment(comment).build();
 
         paymentMethodApi.deletePaymentMethod(paymentMethodId, true, false, NULL_PLUGIN_PROPERTIES, inputOptions);
 
-        Tags accountTags = accountApi.getAccountTags(account.getAccountId(), inputOptions);
+        final Tags accountTags = accountApi.getAccountTags(account.getAccountId(), inputOptions);
 
         Assert.assertNotNull(accountTags);
         Assert.assertEquals(accountTags.get(0).getTagDefinitionName(), "AUTO_PAY_OFF");
@@ -408,10 +406,10 @@ public class TestPayment extends TestJaxrsBase {
         final BigDecimal amount = BigDecimal.TEN;
 
         final String pending = PaymentPluginStatus.PENDING.toString();
-        final ImmutableMap<String, String> pluginProperties = ImmutableMap.<String, String>of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
+        final Map<String, String> pluginProperties = Map.of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
 
         int paymentNb = 0;
-        for (final TransactionType transactionType : ImmutableList.<TransactionType>of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
+        for (final TransactionType transactionType : List.of(TransactionType.AUTHORIZE, TransactionType.PURCHASE, TransactionType.CREDIT)) {
             final BigDecimal authAmount = BigDecimal.ZERO;
             final String paymentExternalKey = UUID.randomUUID().toString();
             final String authTransactionExternalKey = UUID.randomUUID().toString();
@@ -459,11 +457,11 @@ public class TestPayment extends TestJaxrsBase {
         final BigDecimal amount = BigDecimal.TEN;
 
         final String pending = PaymentPluginStatus.PENDING.toString();
-        final ImmutableMap<String, String> pendingPluginProperties = ImmutableMap.<String, String>of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
+        final Map<String, String> pendingPluginProperties = Map.of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
 
-        final ImmutableMap<String, String> pluginProperties = ImmutableMap.of();
+        final Map<String, String> pluginProperties = Collections.emptyMap();
 
-        TransactionType transactionType = TransactionType.AUTHORIZE;
+        final TransactionType transactionType = TransactionType.AUTHORIZE;
         final String paymentExternalKey = UUID.randomUUID().toString();
         final String authTransactionExternalKey = UUID.randomUUID().toString();
 
@@ -484,11 +482,11 @@ public class TestPayment extends TestJaxrsBase {
         final BigDecimal amount = BigDecimal.TEN;
 
         final String pending = PaymentPluginStatus.PENDING.toString();
-        final ImmutableMap<String, String> pendingPluginProperties = ImmutableMap.<String, String>of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
+        final Map<String, String> pendingPluginProperties = Map.of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
 
-        final ImmutableMap<String, String> pluginProperties = ImmutableMap.of();
+        final Map<String, String> pluginProperties = Collections.emptyMap();
 
-        TransactionType transactionType = TransactionType.AUTHORIZE;
+        final TransactionType transactionType = TransactionType.AUTHORIZE;
         final String paymentExternalKey = UUID.randomUUID().toString();
         final String authTransactionExternalKey = UUID.randomUUID().toString();
 
@@ -518,11 +516,11 @@ public class TestPayment extends TestJaxrsBase {
         final BigDecimal amount = BigDecimal.TEN;
 
         final String pending = PaymentPluginStatus.PENDING.toString();
-        final ImmutableMap<String, String> pendingPluginProperties = ImmutableMap.<String, String>of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
+        final Map<String, String> pendingPluginProperties = Map.of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
 
-        final ImmutableMap<String, String> pluginProperties = ImmutableMap.of();
+        final Map<String, String> pluginProperties = Collections.emptyMap();
 
-        TransactionType transactionType = TransactionType.AUTHORIZE;
+        final TransactionType transactionType = TransactionType.AUTHORIZE;
         final String paymentExternalKey = UUID.randomUUID().toString();
         final String authTransactionExternalKey = UUID.randomUUID().toString();
 
@@ -552,11 +550,11 @@ public class TestPayment extends TestJaxrsBase {
         final BigDecimal amount = BigDecimal.TEN;
 
         final String pending = PaymentPluginStatus.PENDING.toString();
-        final ImmutableMap<String, String> pendingPluginProperties = ImmutableMap.<String, String>of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
+        final Map<String, String> pendingPluginProperties = Map.of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
 
-        final ImmutableMap<String, String> pluginProperties = ImmutableMap.of();
+        final Map<String, String> pluginProperties = Collections.emptyMap();
 
-        TransactionType transactionType = TransactionType.AUTHORIZE;
+        final TransactionType transactionType = TransactionType.AUTHORIZE;
         final String paymentExternalKey = UUID.randomUUID().toString();
         final String authTransactionExternalKey = UUID.randomUUID().toString();
 
@@ -587,11 +585,11 @@ public class TestPayment extends TestJaxrsBase {
         final BigDecimal amount = BigDecimal.TEN;
 
         final String pending = PaymentPluginStatus.PENDING.toString();
-        final ImmutableMap<String, String> pendingPluginProperties = ImmutableMap.<String, String>of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
+        final Map<String, String> pendingPluginProperties = Map.of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
 
-        final ImmutableMap<String, String> pluginProperties = ImmutableMap.of();
+        final Map<String, String> pluginProperties = Collections.emptyMap();
 
-        TransactionType transactionType = TransactionType.AUTHORIZE;
+        final TransactionType transactionType = TransactionType.AUTHORIZE;
         final String paymentExternalKey = UUID.randomUUID().toString();
         final String authTransactionExternalKey = UUID.randomUUID().toString();
 
@@ -611,9 +609,9 @@ public class TestPayment extends TestJaxrsBase {
         final UUID paymentMethodId = account.getPaymentMethodId();
         final BigDecimal amount = BigDecimal.TEN;
 
-        final ImmutableMap<String, String> pluginProperties = ImmutableMap.of();
+        final Map<String, String> pluginProperties = Collections.emptyMap();
 
-        TransactionType transactionType = TransactionType.AUTHORIZE;
+        final TransactionType transactionType = TransactionType.AUTHORIZE;
         final String paymentExternalKey = UUID.randomUUID().toString();
         final String authTransactionExternalKey = UUID.randomUUID().toString();
 
@@ -635,10 +633,10 @@ public class TestPayment extends TestJaxrsBase {
 
         // Create a successful purchase
         final Payment authPayment = createVerifyTransaction(account, paymentMethodId, paymentExternalKey, purchaseTransactionExternalKey, TransactionType.PURCHASE,
-                                                            TransactionStatus.SUCCESS, purchaseAmount, BigDecimal.ZERO, ImmutableMap.<String, String>of(), 1);
+                                                            TransactionStatus.SUCCESS, purchaseAmount, BigDecimal.ZERO, Collections.emptyMap(), 1);
 
         final String pending = PaymentPluginStatus.PENDING.toString();
-        final ImmutableMap<String, String> pluginProperties = ImmutableMap.<String, String>of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
+        final Map<String, String> pluginProperties = Map.of(MockPaymentProviderPlugin.PLUGIN_PROPERTY_PAYMENT_PLUGIN_STATUS_OVERRIDE, pending);
 
         // Trigger a pending refund
         final String refundTransactionExternalKey = UUID.randomUUID().toString();
@@ -679,7 +677,7 @@ public class TestPayment extends TestJaxrsBase {
 
         // Void payment using externalKey
         final String voidTransactionExternalKey = UUID.randomUUID().toString();
-        PaymentTransaction voidTransaction = new PaymentTransaction();
+        final PaymentTransaction voidTransaction = new PaymentTransaction();
         voidTransaction.setTransactionExternalKey(voidTransactionExternalKey);
         voidTransaction.setPaymentExternalKey(paymentExternalKey);
         paymentApi.voidPaymentByExternalKey(voidTransaction, NULL_PLUGIN_NAMES, NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -697,9 +695,9 @@ public class TestPayment extends TestJaxrsBase {
 
         mockPaymentControlProviderPlugin.setAborted(true);
         try {
-            paymentApi.createComboPayment(comboPaymentTransaction, Arrays.asList(MockPaymentControlProviderPlugin.PLUGIN_NAME), requestOptions);
+            paymentApi.createComboPayment(comboPaymentTransaction, List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME), requestOptions);
             fail();
-        } catch (KillBillClientException e) {
+        } catch (final KillBillClientException e) {
             assertEquals(e.getResponse().statusCode(), 422);
         }
         assertFalse(mockPaymentControlProviderPlugin.isOnFailureCallExecuted());
@@ -726,10 +724,10 @@ public class TestPayment extends TestJaxrsBase {
         comboPaymentTransaction.setTransaction(authTransactionJson);
         comboPaymentTransaction.setTransaction(authTransactionJson);
 
-        final Payment payment = paymentApi.createComboPayment(comboPaymentTransaction, ImmutableList.<String>of(MockPaymentControlProviderPlugin.PLUGIN_NAME), requestOptions);
+        final Payment payment = paymentApi.createComboPayment(comboPaymentTransaction, List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME), requestOptions);
         verifyComboPayment(payment, paymentExternalKey, BigDecimal.TEN, BigDecimal.ZERO, BigDecimal.ZERO, 1, 1);
 
-        assertEquals(paymentApi.getPayment(payment.getPaymentId(), false, true, ImmutableMap.<String, String>of(), AuditLevel.NONE, requestOptions).getPaymentAttempts().size(), 1);
+        assertEquals(paymentApi.getPayment(payment.getPaymentId(), false, true, Collections.emptyMap(), AuditLevel.NONE, requestOptions).getPaymentAttempts().size(), 1);
     }
 
     @Test(groups = "slow")
@@ -741,9 +739,9 @@ public class TestPayment extends TestJaxrsBase {
 
         mockPaymentControlProviderPlugin.throwsException(new IllegalStateException());
         try {
-            paymentApi.createComboPayment(comboPaymentTransaction, Arrays.asList(MockPaymentControlProviderPlugin.PLUGIN_NAME), requestOptions);
+            paymentApi.createComboPayment(comboPaymentTransaction, List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME), requestOptions);
             fail();
-        } catch (KillBillClientException e) {
+        } catch (final KillBillClientException e) {
             assertEquals(e.getResponse().statusCode(), 500);
         }
     }
@@ -766,7 +764,7 @@ public class TestPayment extends TestJaxrsBase {
         authTransactionJson.setTransactionExternalKey(authTransactionExternalKey);
         authTransactionJson.setTransactionType(TransactionType.AUTHORIZE);
 
-        return new ComboPaymentTransaction(accountJson, paymentMethodJson, authTransactionJson, ImmutableList.<PluginProperty>of(), ImmutableList.<PluginProperty>of(), null);
+        return new ComboPaymentTransaction(accountJson, paymentMethodJson, authTransactionJson, Collections.emptyList(), Collections.emptyList(), null);
     }
 
     @Test(groups = "slow")
@@ -784,7 +782,7 @@ public class TestPayment extends TestJaxrsBase {
         paymentMethodJson.setIsDefault(true);
         paymentMethodJson.setPaymentMethodId(paymentMethodId);
 
-        final ComboPaymentTransaction comboPaymentTransaction = new ComboPaymentTransaction(accountJson, paymentMethodJson, new PaymentTransaction(), ImmutableList.<PluginProperty>of(), ImmutableList.<PluginProperty>of(), null);
+        final ComboPaymentTransaction comboPaymentTransaction = new ComboPaymentTransaction(accountJson, paymentMethodJson, new PaymentTransaction(), Collections.emptyList(), Collections.emptyList(), null);
 
         final Payment payment = paymentApi.createComboPayment(comboPaymentTransaction, NULL_PLUGIN_NAMES, requestOptions);
         // Client returns null in case of a 404
@@ -793,9 +791,9 @@ public class TestPayment extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testGetTagsForPaymentTransaction() throws Exception {
-        UUID tagDefinitionId = UUID.randomUUID();
-        String tagDefinitionName = "payment-transaction";
-        TagDefinition tagDefinition = new TagDefinition(tagDefinitionId, false, tagDefinitionName, "description", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null);
+        final UUID tagDefinitionId = UUID.randomUUID();
+        final String tagDefinitionName = "payment-transaction";
+        final TagDefinition tagDefinition = new TagDefinition(tagDefinitionId, false, tagDefinitionName, "description", List.of(ObjectType.TRANSACTION), null);
         final TagDefinition createdTagDefinition = tagDefinitionApi.createTagDefinition(tagDefinition, requestOptions);
 
         final Account account = createAccountWithDefaultPaymentMethod();
@@ -805,8 +803,8 @@ public class TestPayment extends TestJaxrsBase {
         final Payment payment = paymentApi.getPaymentByExternalKey(externalPaymentKey, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(payment.getPaymentId(), paymentId);
 
-        UUID paymentTransactionId = payment.getTransactions().get(0).getTransactionId();
-        paymentTransactionApi.createTransactionTags(paymentTransactionId, ImmutableList.<UUID>of(createdTagDefinition.getId()), requestOptions);
+        final UUID paymentTransactionId = payment.getTransactions().get(0).getTransactionId();
+        paymentTransactionApi.createTransactionTags(paymentTransactionId, List.of(createdTagDefinition.getId()), requestOptions);
 
         final Tags paymentTransactionTags = paymentTransactionApi.getTransactionTags(paymentTransactionId, requestOptions);
 
@@ -816,9 +814,9 @@ public class TestPayment extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateTagForPaymentTransaction() throws Exception {
-        UUID tagDefinitionId = UUID.randomUUID();
-        String tagDefinitionName = "payment-transaction";
-        TagDefinition tagDefinition = new TagDefinition(tagDefinitionId, false, tagDefinitionName, "description", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null);
+        final UUID tagDefinitionId = UUID.randomUUID();
+        final String tagDefinitionName = "payment-transaction";
+        final TagDefinition tagDefinition = new TagDefinition(tagDefinitionId, false, tagDefinitionName, "description", List.of(ObjectType.TRANSACTION), null);
         final TagDefinition createdTagDefinition = tagDefinitionApi.createTagDefinition(tagDefinition, requestOptions);
 
         final Account account = createAccountWithDefaultPaymentMethod();
@@ -828,8 +826,8 @@ public class TestPayment extends TestJaxrsBase {
         final Payment payment = paymentApi.getPaymentByExternalKey(externalPaymentKey, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(payment.getPaymentId(), paymentId);
 
-        UUID paymentTransactionId = payment.getTransactions().get(0).getTransactionId();
-        final Tags paymentTransactionTag = paymentTransactionApi.createTransactionTags(paymentTransactionId, ImmutableList.<UUID>of(createdTagDefinition.getId()), requestOptions);
+        final UUID paymentTransactionId = payment.getTransactions().get(0).getTransactionId();
+        final Tags paymentTransactionTag = paymentTransactionApi.createTransactionTags(paymentTransactionId, List.of(createdTagDefinition.getId()), requestOptions);
 
         Assert.assertNotNull(paymentTransactionTag);
         Assert.assertEquals(paymentTransactionTag.get(0).getTagDefinitionName(), tagDefinitionName);
@@ -881,7 +879,7 @@ public class TestPayment extends TestJaxrsBase {
         // Authorization
         final String authTransactionExternalKey = UUID.randomUUID().toString();
         final Payment authPayment = createVerifyTransaction(account, paymentMethodId, paymentExternalKey, authTransactionExternalKey, TransactionType.AUTHORIZE,
-                                                            TransactionStatus.SUCCESS, BigDecimal.TEN, BigDecimal.TEN, ImmutableMap.<String, String>of(), paymentNb);
+                                                            TransactionStatus.SUCCESS, BigDecimal.TEN, BigDecimal.TEN, Collections.emptyMap(), paymentNb);
 
         // Capture 1
         final String capture1TransactionExternalKey = UUID.randomUUID().toString();
@@ -995,7 +993,7 @@ public class TestPayment extends TestJaxrsBase {
                                             final int nbTransactions,
                                             final int paymentNb) throws KillBillClientException {
         assertEquals(payment.getAccountId(), account.getAccountId());
-        assertEquals(payment.getPaymentMethodId(), MoreObjects.firstNonNull(paymentMethodId, account.getPaymentMethodId()));
+        assertEquals(payment.getPaymentMethodId(), Objects.requireNonNullElse(paymentMethodId, account.getPaymentMethodId()));
         Assert.assertNotNull(payment.getPaymentId());
         Assert.assertNotNull(payment.getPaymentNumber());
         assertEquals(payment.getPaymentExternalKey(), paymentExternalKey);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPaymentGateway.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPaymentGateway.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.jaxrs;
 
+import java.util.Collections;
 import java.util.UUID;
 
 import org.killbill.billing.client.model.gen.Account;
@@ -25,11 +26,8 @@ import org.killbill.billing.client.model.gen.HostedPaymentPageFields;
 import org.killbill.billing.client.model.gen.HostedPaymentPageFormDescriptor;
 import org.killbill.billing.client.model.gen.PaymentMethod;
 import org.killbill.billing.client.model.gen.PaymentMethodPluginDetail;
-import org.killbill.billing.client.model.gen.PluginProperty;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestPaymentGateway extends TestJaxrsBase {
 
@@ -53,7 +51,7 @@ public class TestPaymentGateway extends TestJaxrsBase {
 
         final HostedPaymentPageFields hppFields = new HostedPaymentPageFields();
 
-        final ComboHostedPaymentPage comboHostedPaymentPage = new ComboHostedPaymentPage(account, paymentMethod, hppFields, ImmutableList.<PluginProperty>of(), null);
+        final ComboHostedPaymentPage comboHostedPaymentPage = new ComboHostedPaymentPage(account, paymentMethod, hppFields, Collections.emptyList(), null);
 
         final HostedPaymentPageFormDescriptor hostedPaymentPageFormDescriptor = paymentGatewayApi.buildComboFormDescriptor(comboHostedPaymentPage, NULL_PLUGIN_NAMES, NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertNotNull(hostedPaymentPageFormDescriptor.getKbAccountId());

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestSecurity.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestSecurity.java
@@ -19,11 +19,12 @@
 
 package org.killbill.billing.jaxrs;
 
-import java.io.File;
-import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -34,13 +35,9 @@ import org.killbill.billing.client.RequestOptions;
 import org.killbill.billing.client.model.gen.RoleDefinition;
 import org.killbill.billing.client.model.gen.UserRoles;
 import org.killbill.billing.security.Permission;
+import org.killbill.billing.util.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
-import com.google.common.io.Resources;
 
 public class TestSecurity extends TestJaxrsBase {
 
@@ -59,31 +56,31 @@ public class TestSecurity extends TestJaxrsBase {
 
         final List<String> pierresPermissions = getPermissions("pierre", "password");
         Assert.assertEquals(pierresPermissions.size(), 2);
-        Assert.assertEquals(new HashSet<String>(pierresPermissions), ImmutableSet.<String>of(Permission.INVOICE_CAN_CREDIT.toString(), Permission.INVOICE_CAN_ITEM_ADJUST.toString()));
+        Assert.assertEquals(new HashSet<String>(pierresPermissions), Set.of(Permission.INVOICE_CAN_CREDIT.toString(), Permission.INVOICE_CAN_ITEM_ADJUST.toString()));
 
         final List<String> stephanesPermissions = getPermissions("stephane", "password");
         Assert.assertEquals(stephanesPermissions.size(), 1);
-        Assert.assertEquals(new HashSet<String>(stephanesPermissions), ImmutableSet.<String>of(Permission.PAYMENT_CAN_REFUND.toString()));
+        Assert.assertEquals(new HashSet<String>(stephanesPermissions), Set.of(Permission.PAYMENT_CAN_REFUND.toString()));
     }
 
     @Test(groups = "slow")
     public void testDynamicUserRolesAllPermissions() throws Exception {
-        testDynamicUserRolesInternal("wqeqwe", "jdsh763s", "all", ImmutableList.of("*"), true);
+        testDynamicUserRolesInternal("wqeqwe", "jdsh763s", "all", List.of("*"), true);
     }
 
     @Test(groups = "slow")
     public void testDynamicUserRolesAllCatalogPermissions() throws Exception {
-        testDynamicUserRolesInternal("wqeqsdswe", "jsddsh763s", "allcatalog", ImmutableList.of("catalog:*", "tenant_kvs:add"), true);
+        testDynamicUserRolesInternal("wqeqsdswe", "jsddsh763s", "allcatalog", List.of("catalog:*", "tenant_kvs:add"), true);
     }
 
     @Test(groups = "slow")
     public void testDynamicUserRolesCorrectCatalogPermissions() throws Exception {
-        testDynamicUserRolesInternal("wqeq23f6we", "jds5gh763s", "correctcatalog", ImmutableList.of("catalog:config_upload", "tenant_kvs:add"), true);
+        testDynamicUserRolesInternal("wqeq23f6we", "jds5gh763s", "correctcatalog", List.of("catalog:config_upload", "tenant_kvs:add"), true);
     }
 
     @Test(groups = "slow")
     public void testDynamicUserRolesIncorrectPermissions() throws Exception {
-        testDynamicUserRolesInternal("wqsdeqwe", "jd23fsh63s", "incorrect", ImmutableList.of("account:*"), false);
+        testDynamicUserRolesInternal("wqsdeqwe", "jd23fsh63s", "incorrect", List.of("account:*"), false);
     }
 
     @Test(groups = "slow")
@@ -91,7 +88,7 @@ public class TestSecurity extends TestJaxrsBase {
         final String username = UUID.randomUUID().toString();
         final String password = UUID.randomUUID().toString();
         final String role = UUID.randomUUID().toString();
-        testDynamicUserRolesInternal(username, password, role, ImmutableList.of(""), false);
+        testDynamicUserRolesInternal(username, password, role, List.of(""), false);
 
         final List<String> permissions = securityApi.getCurrentUserPermissions(RequestOptions.builder().withUser(username).withPassword(password).build());
         Assert.assertEquals(permissions.size(), 0);
@@ -103,7 +100,7 @@ public class TestSecurity extends TestJaxrsBase {
         final String roleDefinition = "notEnoughToAddUserAndRoles";
 
         final List<String> permissions = new ArrayList<String>();
-        for (Permission cur : Permission.values()) {
+        for (final Permission cur : Permission.values()) {
             if (!cur.getGroup().equals("user")) {
                 permissions.add(cur.toString());
             }
@@ -112,7 +109,7 @@ public class TestSecurity extends TestJaxrsBase {
 
         final String username = "candy";
         final String password = "lolipop";
-        securityApi.addUserRoles(new UserRoles(username, password, ImmutableList.of(roleDefinition)), requestOptions);
+        securityApi.addUserRoles(new UserRoles(username, password, List.of(roleDefinition)), requestOptions);
 
         // Now 'login' as new user (along with roles to make an API call requiring permissions), and check behavior
         logout();
@@ -120,7 +117,7 @@ public class TestSecurity extends TestJaxrsBase {
 
         boolean success = false;
         try {
-            securityApi.addRoleDefinition(new RoleDefinition("dsfdsfds", ImmutableList.of("*")), requestOptions);
+            securityApi.addRoleDefinition(new RoleDefinition("dsfdsfds", List.of("*")), requestOptions);
             success = true;
         } catch (final Exception e) {
         } finally {
@@ -129,7 +126,7 @@ public class TestSecurity extends TestJaxrsBase {
 
         success = false;
         try {
-            securityApi.addUserRoles(new UserRoles("sdsd", "sdsdsd", ImmutableList.of(roleDefinition)), requestOptions);
+            securityApi.addUserRoles(new UserRoles("sdsd", "sdsdsd", List.of(roleDefinition)), requestOptions);
             success = true;
         } catch (final Exception e) {
         } finally {
@@ -146,14 +143,14 @@ public class TestSecurity extends TestJaxrsBase {
         final String username = "GuanYu";
         final String password = "IamAGreatWarrior";
 
-        securityApi.addRoleDefinition(new RoleDefinition(roleDefinition, ImmutableList.of(allPermissions)), requestOptions);
+        securityApi.addRoleDefinition(new RoleDefinition(roleDefinition, List.of(allPermissions)), requestOptions);
 
-        securityApi.addUserRoles(new UserRoles(username, password, ImmutableList.of(roleDefinition)), requestOptions);
+        securityApi.addUserRoles(new UserRoles(username, password, List.of(roleDefinition)), requestOptions);
 
         logout();
         login(username, password);
         List<String> permissions = securityApi.getCurrentUserPermissions(requestOptions);
-        Assert.assertEquals(permissions, ImmutableList.<String>of("*"));
+        Assert.assertEquals(permissions, List.of("*"));
 
         final String newPassword = "IamTheBestWarrior";
         securityApi.updateUserPassword(username, new UserRoles(username, newPassword, null), requestOptions);
@@ -161,18 +158,18 @@ public class TestSecurity extends TestJaxrsBase {
         logout();
         login(username, newPassword);
         permissions = securityApi.getCurrentUserPermissions(requestOptions);
-        Assert.assertEquals(permissions, ImmutableList.<String>of("*"));
+        Assert.assertEquals(permissions, List.of("*"));
 
         final String newRoleDefinition = "somethingLessNice";
         // Only enough permissions to invalidate itself in the last step...
         final String littlePermissions = "user";
 
-        securityApi.addRoleDefinition(new RoleDefinition(newRoleDefinition, ImmutableList.of(littlePermissions)), requestOptions);
+        securityApi.addRoleDefinition(new RoleDefinition(newRoleDefinition, List.of(littlePermissions)), requestOptions);
 
-        securityApi.updateUserRoles(username, new UserRoles(username, null, ImmutableList.of(newRoleDefinition)), requestOptions);
+        securityApi.updateUserRoles(username, new UserRoles(username, null, List.of(newRoleDefinition)), requestOptions);
         permissions = securityApi.getCurrentUserPermissions(requestOptions);
         // This will only work if correct shiro cache invalidation was performed... requires lots of sweat to get it to work ;-)
-        Assert.assertEquals(permissions, ImmutableList.<String>of("user:*"));
+        Assert.assertEquals(permissions, List.of("user:*"));
 
         securityApi.invalidateUser(username, requestOptions);
         try {
@@ -188,7 +185,7 @@ public class TestSecurity extends TestJaxrsBase {
 
         securityApi.addRoleDefinition(new RoleDefinition(roleDefinition, permissions), requestOptions);
 
-        securityApi.addUserRoles(new UserRoles(username, password, ImmutableList.of(roleDefinition)), requestOptions);
+        securityApi.addUserRoles(new UserRoles(username, password, List.of(roleDefinition)), requestOptions);
 
         // Now 'login' as new user (along with roles to make an API call requiring permissions), and check behavior
         logout();
@@ -196,9 +193,8 @@ public class TestSecurity extends TestJaxrsBase {
 
         boolean success = false;
         try {
-            final String catalogPath = Resources.getResource("org/killbill/billing/server/SpyCarBasic.xml").getPath();
-            final File catalogFile = new File(catalogPath);
-            final String body = Files.toString(catalogFile, Charset.forName("UTF-8"));
+            final String catalogPath = IOUtils.getResourceAsURL("org/killbill/billing/server/SpyCarBasic.xml").getPath();
+            final String body = Files.readString(Path.of(catalogPath));
             catalogApi.uploadCatalogXml(body, requestOptions);
             success = true;
         } catch (final Exception e) {

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
@@ -44,10 +44,6 @@ import org.killbill.billing.util.tag.dao.SystemTags;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
@@ -56,9 +52,9 @@ public class TestTag extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Cannot add badly formatted TagDefinition")
     public void testTagErrorHandling() throws Exception {
-        final TagDefinition[] tagDefinitions = {new TagDefinition(null, false, null, null, ImmutableList.<ObjectType>of(ObjectType.ACCOUNT), null),
-                                                new TagDefinition(null, false, "something", null, ImmutableList.<ObjectType>of(ObjectType.INVOICE), null),
-                                                new TagDefinition(null, false, null, "something", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null)};
+        final TagDefinition[] tagDefinitions = {new TagDefinition(null, false, null, null, List.of(ObjectType.ACCOUNT), null),
+                                                new TagDefinition(null, false, "something", null, List.of(ObjectType.INVOICE), null),
+                                                new TagDefinition(null, false, null, "something", List.of(ObjectType.TRANSACTION), null)};
 
         for (final TagDefinition tagDefinition : tagDefinitions) {
             try {
@@ -71,7 +67,7 @@ public class TestTag extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create a TagDefinition")
     public void testTagDefinitionOk() throws Exception {
-        final TagDefinition input = new TagDefinition(null, false, "blue", "relaxing color", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null);
+        final TagDefinition input = new TagDefinition(null, false, "blue", "relaxing color", List.of(ObjectType.TRANSACTION), null);
 
         final TagDefinition objFromJson = tagDefinitionApi.createTagDefinition(input, requestOptions);
         assertNotNull(objFromJson);
@@ -84,16 +80,16 @@ public class TestTag extends TestJaxrsBase {
         List<TagDefinition> objFromJson = tagDefinitionApi.getTagDefinitions(requestOptions);
         final int sizeSystemTag = objFromJson.isEmpty() ? 0 : objFromJson.size();
 
-        final TagDefinition inputBlue = new TagDefinition(null, false, "blue", "relaxing color", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null);
+        final TagDefinition inputBlue = new TagDefinition(null, false, "blue", "relaxing color", List.of(ObjectType.TRANSACTION), null);
         tagDefinitionApi.createTagDefinition(inputBlue, requestOptions);
 
-        final TagDefinition inputRed = new TagDefinition(null, false, "red", "hot color", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null);
+        final TagDefinition inputRed = new TagDefinition(null, false, "red", "hot color", List.of(ObjectType.TRANSACTION), null);
         tagDefinitionApi.createTagDefinition(inputRed, requestOptions);
 
-        final TagDefinition inputYellow = new TagDefinition(null, false, "yellow", "vibrant color", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null);
+        final TagDefinition inputYellow = new TagDefinition(null, false, "yellow", "vibrant color", List.of(ObjectType.TRANSACTION), null);
         tagDefinitionApi.createTagDefinition(inputYellow, requestOptions);
 
-        final TagDefinition inputGreen = new TagDefinition(null, false, "green", "super relaxing color", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null);
+        final TagDefinition inputGreen = new TagDefinition(null, false, "green", "super relaxing color", List.of(ObjectType.TRANSACTION), null);
         tagDefinitionApi.createTagDefinition(inputGreen, requestOptions);
 
         objFromJson = tagDefinitionApi.getTagDefinitions(requestOptions);
@@ -121,15 +117,15 @@ public class TestTag extends TestJaxrsBase {
         int nbAllowedControlTagType = 0;
         for (final ControlTagType controlTagType : ControlTagType.values()) {
             if (controlTagType.getApplicableObjectTypes().contains(ObjectType.ACCOUNT)) {
-                accountApi.createAccountTags(account.getAccountId(), ImmutableList.<UUID>of(controlTagType.getId()), requestOptions);
+                accountApi.createAccountTags(account.getAccountId(), List.of(controlTagType.getId()), requestOptions);
                 nbAllowedControlTagType++;
             }
         }
 
-        final TagDefinition bundleTagDefInput = new TagDefinition(null, false, "bundletagdef", "nothing special", ImmutableList.<ObjectType>of(ObjectType.TRANSACTION), null);
+        final TagDefinition bundleTagDefInput = new TagDefinition(null, false, "bundletagdef", "nothing special", List.of(ObjectType.TRANSACTION), null);
         final TagDefinition bundleTagDef = tagDefinitionApi.createTagDefinition(bundleTagDefInput, requestOptions);
 
-        bundleApi.createBundleTags(subscriptionJson.getBundleId(), ImmutableList.<UUID>of(bundleTagDef.getId()), requestOptions);
+        bundleApi.createBundleTags(subscriptionJson.getBundleId(), List.of(bundleTagDef.getId()), requestOptions);
 
         final Tags allBundleTags = bundleApi.getBundleTags(subscriptionJson.getBundleId(), requestOptions);
         Assert.assertEquals(allBundleTags.size(), 1);
@@ -148,7 +144,7 @@ public class TestTag extends TestJaxrsBase {
         int nbAllowedControlTagType = 0;
         for (final ControlTagType controlTagType : ControlTagType.values()) {
             if (controlTagType.getApplicableObjectTypes().contains(ObjectType.ACCOUNT)) {
-                accountApi.createAccountTags(account.getAccountId(), ImmutableList.<UUID>of(controlTagType.getId()), requestOptions);
+                accountApi.createAccountTags(account.getAccountId(), List.of(controlTagType.getId()), requestOptions);
                 nbAllowedControlTagType++;
             }
         }
@@ -171,7 +167,7 @@ public class TestTag extends TestJaxrsBase {
         final Account account = createAccount();
 
         try {
-            accountApi.createAccountTags(account.getAccountId(), ImmutableList.<UUID>of(SystemTags.PARK_TAG_DEFINITION_ID), requestOptions);
+            accountApi.createAccountTags(account.getAccountId(), List.of(SystemTags.PARK_TAG_DEFINITION_ID), requestOptions);
             Assert.fail("Creating a tag associated with a system tag should fail");
         } catch (final Exception e) {
             Assert.assertTrue(true);
@@ -183,7 +179,7 @@ public class TestTag extends TestJaxrsBase {
 
         final Account account = createAccount();
         try {
-            accountApi.createAccountTags(account.getAccountId(), ImmutableList.<UUID>of(ControlTagType.WRITTEN_OFF.getId()), requestOptions);
+            accountApi.createAccountTags(account.getAccountId(), List.of(ControlTagType.WRITTEN_OFF.getId()), requestOptions);
             Assert.fail("Creating a (control) tag against a wrong object type should fail");
         } catch (final Exception e) {
             Assert.assertTrue(true);
@@ -199,10 +195,10 @@ public class TestTag extends TestJaxrsBase {
         final TagDefinition accountTagDefInput = new TagDefinition()
                 .setName("tag_name")
                 .setDescription("nothing special")
-                .setApplicableObjectTypes(ImmutableList.<ObjectType>of(ObjectType.ACCOUNT));
+                .setApplicableObjectTypes(List.of(ObjectType.ACCOUNT));
 
         final TagDefinition accountTagDef = tagDefinitionApi.createTagDefinition(accountTagDefInput, requestOptions);
-        accountApi.createAccountTags(accountJson.getAccountId(), ImmutableList.<UUID>of(accountTagDef.getId()), requestOptions);
+        accountApi.createAccountTags(accountJson.getAccountId(), List.of(accountTagDef.getId()), requestOptions);
 
         // get all audit for the account
         final List<AuditLog> auditLogsJson = accountApi.getAccountAuditLogs(accountJson.getAccountId(), requestOptions);
@@ -232,9 +228,9 @@ public class TestTag extends TestJaxrsBase {
     public void testTagsPagination() throws Exception {
         final Account account = createAccount();
         for (int i = 0; i < 5; i++) {
-            final TagDefinition tagDefinition = new TagDefinition(null, false, "td-" + i, UUID.randomUUID().toString(), ImmutableList.<ObjectType>of(ObjectType.ACCOUNT), null);
+            final TagDefinition tagDefinition = new TagDefinition(null, false, "td-" + i, UUID.randomUUID().toString(), List.of(ObjectType.ACCOUNT), null);
             final UUID tagDefinitionId = tagDefinitionApi.createTagDefinition(tagDefinition, requestOptions).getId();
-            accountApi.createAccountTags(account.getAccountId(), ImmutableList.<UUID>of(tagDefinitionId), requestOptions);
+            accountApi.createAccountTags(account.getAccountId(), List.of(tagDefinitionId), requestOptions);
         }
 
         final Tags allTags = accountApi.getAccountTags(account.getAccountId(), requestOptions);
@@ -245,12 +241,9 @@ public class TestTag extends TestJaxrsBase {
             Assert.assertNotNull(page);
             Assert.assertEquals(page.size(), 1);
             final Tag targetTag = page.get(0);
-            Assert.assertTrue(Iterables.any(allTags, new Predicate<Tag>() {
-                @Override
-                public boolean apply(@Nullable final Tag input) {
-                    return input.equals(targetTag);
-                }
-            }));
+
+            Assert.assertTrue(allTags.stream().anyMatch(targetTag::equals));
+
             page = page.getNext();
         }
         Assert.assertNull(page);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTenantKV.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTenantKV.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -35,7 +36,6 @@ import org.killbill.billing.client.model.gen.Payment;
 import org.killbill.billing.client.model.gen.PaymentMethod;
 import org.killbill.billing.client.model.gen.PaymentMethodPluginDetail;
 import org.killbill.billing.client.model.gen.PaymentTransaction;
-import org.killbill.billing.client.model.gen.PluginProperty;
 import org.killbill.billing.client.model.gen.TenantKeyValue;
 import org.killbill.billing.notification.plugin.api.ExtBusEventType;
 import org.killbill.billing.payment.api.TransactionStatus;
@@ -43,8 +43,6 @@ import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.tenant.api.TenantKV;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 
 import static org.testng.Assert.assertEquals;
 
@@ -191,7 +189,7 @@ public class TestTenantKV extends TestJaxrsBase {
         authTransactionJson.setTransactionType(TransactionType.AUTHORIZE);
 
         callbackServlet.pushExpectedEvents(ExtBusEventType.ACCOUNT_CREATION, ExtBusEventType.ACCOUNT_CHANGE, ExtBusEventType.PAYMENT_SUCCESS);
-        final ComboPaymentTransaction comboAuthorization = new ComboPaymentTransaction(accountJson, paymentMethodJson, authTransactionJson, ImmutableList.<PluginProperty>of(), ImmutableList.<PluginProperty>of(), null);
+        final ComboPaymentTransaction comboAuthorization = new ComboPaymentTransaction(accountJson, paymentMethodJson, authTransactionJson, Collections.emptyList(), Collections.emptyList(), null);
         final Payment payment = paymentApi.createComboPayment(comboAuthorization, NULL_PLUGIN_NAMES, requestOptions);
         callbackServlet.assertListenerStatus();
         assertEquals(payment.getTransactions().get(0).getStatus(), TransactionStatus.SUCCESS);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jetty/HttpServer.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jetty/HttpServer.java
@@ -51,10 +51,9 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.xml.XmlConfiguration;
+import org.killbill.billing.util.Preconditions;
 import org.killbill.commons.skeleton.listeners.JULServletContextListener;
 
-import com.google.common.base.Preconditions;
-import com.google.common.io.Resources;
 import com.google.inject.servlet.GuiceFilter;
 
 /**

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestObfuscator.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestObfuscator.java
@@ -17,6 +17,7 @@
 
 package org.killbill.billing.server.log.obfuscators;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.killbill.billing.server.log.ServerTestSuiteNoDB;
@@ -25,7 +26,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.google.common.collect.ImmutableList;
 
 public class TestObfuscator extends ServerTestSuiteNoDB {
 
@@ -39,7 +39,7 @@ public class TestObfuscator extends ServerTestSuiteNoDB {
     @Test(groups = "fast")
     public void testObfuscateWithOnePattern() throws Exception {
         final Pattern pattern = Pattern.compile("number=([^;]+)");
-        final ImmutableList<Pattern> patterns = ImmutableList.<Pattern>of(pattern);
+        final List<Pattern> patterns = List.of(pattern);
         Assert.assertEquals(obfuscator.obfuscate("number=1234;number=12345;number=123456;number=1234567;number=12345678;number=123456789", patterns, Mockito.mock(ILoggingEvent.class)),
                             "number=****;number=*****;number=******;number=*******;number=********;number=*********");
 
@@ -49,7 +49,7 @@ public class TestObfuscator extends ServerTestSuiteNoDB {
     public void testObfuscateWithMultiplePatterns() throws Exception {
         final Pattern pattern1 = Pattern.compile("number=([^;]+)");
         final Pattern pattern2 = Pattern.compile("numberB=([^;]+)");
-        final ImmutableList<Pattern> patterns = ImmutableList.<Pattern>of(pattern1, pattern2);
+        final List<Pattern> patterns = List.of(pattern1, pattern2);
         Assert.assertEquals(obfuscator.obfuscate("number=1234;numberB=12345;number=123456;numberB=1234567;number=12345678;numberB=123456789", patterns, Mockito.mock(ILoggingEvent.class)),
                             "number=****;numberB=*****;number=******;numberB=*******;number=********;numberB=*********");
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestObfuscatorConverter.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestObfuscatorConverter.java
@@ -25,7 +25,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.google.common.collect.ImmutableList;
 
 public class TestObfuscatorConverter extends ServerTestSuiteNoDB {
 
@@ -108,7 +107,7 @@ public class TestObfuscatorConverter extends ServerTestSuiteNoDB {
 
         @Override
         public List<String> getOptionList() {
-            return ImmutableList.of("address1");
+            return List.of("address1");
         }
     }
 }

--- a/profiles/killpay/pom.xml
+++ b/profiles/killpay/pom.xml
@@ -31,11 +31,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>compile</scope>

--- a/profiles/killpay/src/main/java/org/killbill/billing/server/listeners/KillpayGuiceListener.java
+++ b/profiles/killpay/src/main/java/org/killbill/billing/server/listeners/KillpayGuiceListener.java
@@ -19,14 +19,13 @@ package org.killbill.billing.server.listeners;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 import javax.servlet.ServletContext;
 
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.platform.config.DefaultKillbillConfigSource;
 import org.killbill.billing.server.modules.KillpayServerModule;
-
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
 
 public class KillpayGuiceListener extends KillbillGuiceListener {
@@ -38,8 +37,8 @@ public class KillpayGuiceListener extends KillbillGuiceListener {
 
     @Override
     protected KillbillConfigSource getConfigSource() throws IOException, URISyntaxException {
-        final ImmutableMap<String, String> defaultProperties = ImmutableMap.<String, String>of("org.killbill.server.updateCheck.url",
-                                                                                               "https://raw.github.com/killbill/killbill/master/profiles/killpay/src/main/resources/update-checker/killbill-server-update-list.properties");
+        final Map<String, String> defaultProperties = Map.of("org.killbill.server.updateCheck.url",
+                                                             "https://raw.github.com/killbill/killbill/master/profiles/killpay/src/main/resources/update-checker/killbill-server-update-list.properties");
         return new DefaultKillbillConfigSource(defaultProperties);
     }
 }


### PR DESCRIPTION
This is last PR for `killbill-profiles-killbill`. Changes to `killbill-profiles-killpay` also included in this changes, because it only affected to 1 file (`KillpayGuiceListener`). 

Notes:
- `TestJaxrsBase.filterTransaction()` get removed as filter function merged into caller's stream processing, thus no longer needed.
- `ShiroWebModuleWith435` Guava's table usage removed and replaced by plain `Map<Key<? extends PathMatchingFilter>, Map<String, String>>`
