### PR TITLE
1615 blocking state dao

### DIFF
--- a/entitlement/pom.xml
+++ b/entitlement/pom.xml
@@ -39,10 +39,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>provided</scope>

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultEntitlementInternalApi.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultEntitlementInternalApi.java
@@ -149,10 +149,9 @@ public class DefaultEntitlementInternalApi extends DefaultEntitlementApiBase imp
 
         pluginExecution.executeWithPlugin(preCallbacksCallback, callbacks, pluginContexts);
 
-        // FIXME-1615 : Cross module. Needed so `blockingStates` could use Java 8 Optional.
-        final Map<BlockingState, com.google.common.base.Optional<UUID>> states = new HashMap<>();
-        for (Entry<BlockingState, Optional<UUID>> entry : blockingStates.entrySet()) {
-            states.put(entry.getKey(), com.google.common.base.Optional.of(entry.getValue().get()));
+        final Map<BlockingState, Optional<UUID>> states = new HashMap<>();
+        for (final Entry<BlockingState, Optional<UUID>> entry : blockingStates.entrySet()) {
+            states.put(entry.getKey(), Optional.of(entry.getValue().get()));
         }
         // Record the new states first, then insert the notifications to avoid race conditions
         blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(states, internalCallContext);

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/BlockingStateDao.java
@@ -20,6 +20,7 @@ package org.killbill.billing.entitlement.dao;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -35,9 +36,6 @@ import org.killbill.billing.entitlement.api.EntitlementApiException;
 import org.killbill.billing.util.api.AuditLevel;
 import org.killbill.billing.util.audit.AuditLogWithHistory;
 import org.killbill.billing.util.entity.dao.EntityDao;
-
-// FIXME-1615 : Cross module (affected org.killbill.billing.junction.plumbing.billing.TestBillingApi)
-import com.google.common.base.Optional;
 
 public interface BlockingStateDao extends EntityDao<BlockingStateModelDao, BlockingState, EntitlementApiException> {
 

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -74,9 +75,6 @@ import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-// FIXME-1615 : Cross module (affected org.killbill.billing.junction.plumbing.billing.TestBillingApi, TestBlockingCalculator)
-import com.google.common.base.Optional;
 
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 
@@ -182,7 +180,7 @@ public class DefaultBlockingStateDao extends EntityDaoBase<BlockingStateModelDao
     @Override
     public List<BlockingState> getBlockingActiveForAccount(final VersionedCatalog catalog, @Nullable final LocalDate cutoffDt, final InternalTenantContext context) {
         return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
-            List<BlockingStateModelDao> states = entitySqlDaoWrapperFactory
+            final List<BlockingStateModelDao> states = entitySqlDaoWrapperFactory
                     .become(BlockingStateSqlDao.class)
                     .getBlockingActiveForAccount(context);
             return states.stream()
@@ -192,9 +190,9 @@ public class DefaultBlockingStateDao extends EntityDaoBase<BlockingStateModelDao
     }
 
     @Override
-    public List<BlockingState> getByBlockingIds(Iterable<UUID> blockableIds, final InternalTenantContext context) {
+    public List<BlockingState> getByBlockingIds(final Iterable<UUID> blockableIds, final InternalTenantContext context) {
         return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
-            List<BlockingStateModelDao> states = entitySqlDaoWrapperFactory
+            final List<BlockingStateModelDao> states = entitySqlDaoWrapperFactory
                     .become(BlockingStateSqlDao.class)
                     .getByBlockingIds(blockableIds, context);
             return states.stream()
@@ -213,7 +211,7 @@ public class DefaultBlockingStateDao extends EntityDaoBase<BlockingStateModelDao
             int seqId = 0;
             for (final BlockingState state : states.keySet()) {
                 final DateTime upToDate = state.getEffectiveDate();
-                final UUID bundleId = states.get(state).orNull();
+                final UUID bundleId = states.get(state).orElse(null);
 
                 final boolean isBusEvent = state.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0;
                 final boolean shouldRecordNotification = (!isBusEvent || !groupBusEvents || seqId == 0);

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -65,9 +66,6 @@ import org.killbill.notificationq.api.NotificationQueueService;
 import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-// FIXME-1615 : Inherited from BlockingStateDao
-import com.google.common.base.Optional;
 
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/engine/core/EntitlementUtils.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/engine/core/EntitlementUtils.java
@@ -20,6 +20,7 @@ package org.killbill.billing.entitlement.engine.core;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
 
@@ -37,9 +38,6 @@ import org.killbill.billing.subscription.api.SubscriptionBaseInternalApi;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
 import org.killbill.billing.util.collect.Iterables;
 import org.killbill.notificationq.api.NotificationQueueService;
-
-// FIXME-1615 : have BlockingStateDao instance
-import com.google.common.base.Optional;
 
 public class EntitlementUtils {
 
@@ -59,7 +57,7 @@ public class EntitlementUtils {
 
     public void setBlockingStatesAndPostBlockingTransitionEvent(final Iterable<BlockingState> blockingStates, @Nullable final UUID bundleId, final InternalCallContext internalCallContext) {
         final Map<BlockingState, Optional<UUID>> states = new HashMap<>();
-        final Optional<UUID> bundleIdOptional = Optional.fromNullable(bundleId);
+        final Optional<UUID> bundleIdOptional = Optional.ofNullable(bundleId);
         for (final BlockingState blockingState : blockingStates) {
             states.put(blockingState, bundleIdOptional);
         }
@@ -69,7 +67,7 @@ public class EntitlementUtils {
     public void setBlockingStateAndPostBlockingTransitionEvent(final Map<BlockingState, UUID> blockingStates, final InternalCallContext internalCallContext) {
         final Map<BlockingState, Optional<UUID>> states = new HashMap<>();
         for (final BlockingState blockingState : blockingStates.keySet()) {
-            states.put(blockingState, Optional.fromNullable(blockingStates.get(blockingState)));
+            states.put(blockingState, Optional.ofNullable(blockingStates.get(blockingState)));
         }
         dao.setBlockingStatesAndPostBlockingTransitionEvent(states, internalCallContext);
     }
@@ -84,7 +82,7 @@ public class EntitlementUtils {
                 throw new RuntimeException(e);
             }
         }
-        dao.setBlockingStatesAndPostBlockingTransitionEvent(Map.<BlockingState, Optional<UUID>>of(state, Optional.fromNullable(bundleId)), context);
+        dao.setBlockingStatesAndPostBlockingTransitionEvent(Map.<BlockingState, Optional<UUID>>of(state, Optional.ofNullable(bundleId)), context);
     }
 
     /**

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/block/TestBlockingChecker.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/block/TestBlockingChecker.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.entitlement.block;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.killbill.billing.account.api.Account;
@@ -36,9 +37,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-// FIXME-1615 : some test deal with BlockingStateDao
-import com.google.common.base.Optional;
 
 public class TestBlockingChecker extends EntitlementTestSuiteNoDB {
 
@@ -81,12 +79,12 @@ public class TestBlockingChecker extends EntitlementTestSuiteNoDB {
 
     private void setStateBundle(final boolean bC, final boolean bE, final boolean bB) {
         final BlockingState bundleState = new DefaultBlockingState(bundle.getId(), BlockingStateType.SUBSCRIPTION_BUNDLE, "state", "test-service", bC, bE, bB, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(bundleState, Optional.<UUID>absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(bundleState, Optional.<UUID>empty()), internalCallContext);
     }
 
     private void setStateAccount(final boolean bC, final boolean bE, final boolean bB) {
         final BlockingState accountState = new DefaultBlockingState(account.getId(), BlockingStateType.ACCOUNT, "state", "test-service", bC, bE, bB, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(accountState, Optional.<UUID>absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(accountState, Optional.<UUID>empty()), internalCallContext);
     }
 
     private void setStateSubscription(final boolean bC, final boolean bE, final boolean bB) {

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/dao/MockBlockingStateDao.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/dao/MockBlockingStateDao.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -43,12 +44,8 @@ import org.killbill.billing.util.collect.MultiValueHashMap;
 import org.killbill.billing.util.collect.MultiValueMap;
 import org.killbill.billing.util.entity.dao.MockEntityDaoBase;
 
-// FIXME-1615 : this class implements BlockingStateDao
-import com.google.common.base.Optional;
-
 public class MockBlockingStateDao extends MockEntityDaoBase<BlockingStateModelDao, BlockingState, EntitlementApiException> implements BlockingStateDao {
 
-    // FIXME-1615 : Beware new MultiValueMap usage
     private final MultiValueMap<UUID, BlockingState> blockingStates = new MultiValueHashMap<>();
     private final MultiValueMap<Long, BlockingState> blockingStatesPerAccountRecordId = new MultiValueHashMap<>();
 

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/dao/TestBlockingDao.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/dao/TestBlockingDao.java
@@ -20,6 +20,7 @@ package org.killbill.billing.entitlement.dao;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.joda.time.LocalDate;
@@ -34,9 +35,6 @@ import org.killbill.billing.util.audit.AuditLogWithHistory;
 import org.killbill.billing.util.audit.ChangeType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-// FIXME-1615 : Invoking BlockingStateDao method(s)
-import com.google.common.base.Optional;
 
 public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
 
@@ -54,7 +52,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
 
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState state1 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, overdueStateName, service, blockChange, blockEntitlement, blockBilling, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state1, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state1, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         clock.addDays(1);
@@ -62,7 +60,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final String overdueStateName2 = "NoReallyThisCantGoOn";
         final BlockingState state2 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, overdueStateName2, service, blockChange, blockEntitlement, blockBilling, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state2, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state2, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         Assert.assertEquals(blockingStateDao.getBlockingStateForService(accountId, BlockingStateType.ACCOUNT, service, internalCallContext).getStateName(), state2.getStateName());
@@ -92,7 +90,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
 
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState state1 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, overdueStateName, service, blockChange, blockEntitlement, blockBilling, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state1, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state1, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         clock.addDays(1);
@@ -101,7 +99,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final String overdueStateName2 = "NoReallyThisCantGoOn";
         final BlockingState state2 = new DefaultBlockingState(bundleId, BlockingStateType.SUBSCRIPTION_BUNDLE, overdueStateName2, service, blockChange, blockEntitlement, blockBilling, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state2, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state2, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         clock.addDays(1);
@@ -110,7 +108,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final String overdueStateName3 = "OhBoy!";
         final BlockingState state3 = new DefaultBlockingState(subscriptionId, BlockingStateType.SUBSCRIPTION, overdueStateName3, service, blockChange, blockEntitlement, blockBilling, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state3, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state3, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         clock.addDays(1);
@@ -118,7 +116,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
         final UUID subscriptionId2 = UUID.randomUUID();
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState state4 = new DefaultBlockingState(subscriptionId2, BlockingStateType.SUBSCRIPTION, overdueStateName3, service, blockChange, blockEntitlement, blockBilling, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state4, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state4, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
 
@@ -146,32 +144,32 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
 
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState stateA1 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, "warning", service, false, false, false, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateA1, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateA1, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         clock.addDays(1);
 
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState stateA2 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, "warning+", service, false, false, false, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateA2, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateA2, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         final UUID bundleId = UUID.randomUUID();
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState stateB1 = new DefaultBlockingState(bundleId, BlockingStateType.SUBSCRIPTION_BUNDLE, "block", service, true, true, true, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateB1, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateB1, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         clock.addDays(1);
 
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState stateA3 = new DefaultBlockingState(accountId, BlockingStateType.ACCOUNT, "warning++", service, false, false, false, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateA3, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateA3, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState stateB2 = new DefaultBlockingState(bundleId, BlockingStateType.SUBSCRIPTION_BUNDLE, "unblock", service, false, false, false, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateB2, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(stateB2, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         List<BlockingState> states = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
@@ -200,7 +198,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
 
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState state1 = new DefaultBlockingState(uuid, BlockingStateType.ACCOUNT, overdueStateName, service1, blockChange, blockEntitlement, blockBilling, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state1, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state1, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         clock.setDeltaFromReality(1000 * 3600 * 24);
@@ -210,7 +208,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final String overdueStateName2 = "NoReallyThisCantGoOn";
         final BlockingState state2 = new DefaultBlockingState(uuid, BlockingStateType.ACCOUNT, overdueStateName2, service2, blockChange, blockEntitlement, blockBilling, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state2, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(state2, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
         final List<BlockingState> history2 = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
@@ -228,7 +226,7 @@ public class TestBlockingDao extends EntitlementTestSuiteWithEmbeddedDB {
 
         testListener.pushExpectedEvent(NextEvent.BLOCK);
         final BlockingState blockingState = new DefaultBlockingState(uuid, BlockingStateType.ACCOUNT, overdueStateName, service, false, true, false, clock.getUTCNow());
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState, Optional.empty()), internalCallContext);
         assertListenerStatus();
 
 

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/dao/TestDefaultBlockingStateDao.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/dao/TestDefaultBlockingStateDao.java
@@ -21,6 +21,7 @@ package org.killbill.billing.entitlement.dao;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -40,8 +41,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-// FIXME-1615 : Invoking BlockingStateDao method(s)
-import com.google.common.base.Optional;
 
 public class TestDefaultBlockingStateDao extends EntitlementTestSuiteWithEmbeddedDB {
 
@@ -76,7 +75,7 @@ public class TestDefaultBlockingStateDao extends EntitlementTestSuiteWithEmbedde
         // Set a state in the future so no event
         final DateTime stateDateTime = new DateTime(2013, 5, 6, 10, 11, 12, DateTimeZone.UTC);
         final BlockingState blockingState = new DefaultBlockingState(entitlement.getId(), type, state, service, false, false, false, stateDateTime);
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState, Optional.<UUID>of(entitlement.getBundleId())), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState, Optional.of(entitlement.getBundleId())), internalCallContext);
         assertListenerStatus();
 
         Assert.assertEquals(blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext).size(), 2);
@@ -100,7 +99,7 @@ public class TestDefaultBlockingStateDao extends EntitlementTestSuiteWithEmbedde
         // Set a state for service A
         final DateTime stateDateTime = new DateTime(2013, 5, 6, 10, 11, 12, DateTimeZone.UTC);
         final BlockingState blockingState1 = new DefaultBlockingState(blockableId, type, state, serviceA, false, false, false, stateDateTime);
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState1, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState1, Optional.empty()), internalCallContext);
         final List<BlockingState> blockingStates1 = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
         Assert.assertEquals(blockingStates1.size(), 1);
         Assert.assertEquals(blockingStates1.get(0).getBlockedId(), blockableId);
@@ -109,7 +108,7 @@ public class TestDefaultBlockingStateDao extends EntitlementTestSuiteWithEmbedde
         Assert.assertEquals(blockingStates1.get(0).getEffectiveDate(), stateDateTime);
 
         // Set the same state again - no change
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState1, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState1, Optional.empty()), internalCallContext);
         final List<BlockingState> blockingStates2 = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
         Assert.assertEquals(blockingStates2.size(), 1);
         Assert.assertEquals(blockingStates2.get(0).getBlockedId(), blockableId);
@@ -119,7 +118,7 @@ public class TestDefaultBlockingStateDao extends EntitlementTestSuiteWithEmbedde
 
         // Set the state for service B
         final BlockingState blockingState2 = new DefaultBlockingState(blockableId, type, state, serviceB, false, false, false, stateDateTime);
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState2, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState2, Optional.empty()), internalCallContext);
         final List<BlockingState> blockingStates3 = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
         Assert.assertEquals(blockingStates3.size(), 2);
         Assert.assertEquals(blockingStates3.get(0).getBlockedId(), blockableId);
@@ -134,7 +133,7 @@ public class TestDefaultBlockingStateDao extends EntitlementTestSuiteWithEmbedde
         // Set the state for service A in the future - there should be no change (already effective)
         final DateTime stateDateTime2 = new DateTime(2013, 6, 6, 10, 11, 12, DateTimeZone.UTC);
         final BlockingState blockingState3 = new DefaultBlockingState(blockableId, type, state, serviceA, false, false, false, stateDateTime2);
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState3, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState3, Optional.empty()), internalCallContext);
         final List<BlockingState> blockingStates4 = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
         Assert.assertEquals(blockingStates4.size(), 2);
         Assert.assertEquals(blockingStates4.get(0).getBlockedId(), blockableId);
@@ -149,7 +148,7 @@ public class TestDefaultBlockingStateDao extends EntitlementTestSuiteWithEmbedde
         // Set the state for service A in the past - the new effective date should be respected
         final DateTime stateDateTime3 = new DateTime(2013, 2, 6, 10, 11, 12, DateTimeZone.UTC);
         final BlockingState blockingState4 = new DefaultBlockingState(blockableId, type, state, serviceA, false, false, false, stateDateTime3);
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState4, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState4, Optional.empty()), internalCallContext);
         final List<BlockingState> blockingStates5 = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
         Assert.assertEquals(blockingStates5.size(), 2);
         Assert.assertEquals(blockingStates5.get(0).getBlockedId(), blockableId);
@@ -164,7 +163,7 @@ public class TestDefaultBlockingStateDao extends EntitlementTestSuiteWithEmbedde
         // Set a new state for service A
         final DateTime state2DateTime = new DateTime(2013, 12, 6, 10, 11, 12, DateTimeZone.UTC);
         final BlockingState blockingState5 = new DefaultBlockingState(blockableId, type, state2, serviceA, false, false, false, state2DateTime);
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState5, Optional.absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState5, Optional.empty()), internalCallContext);
         final List<BlockingState> blockingStates6 = blockingStateDao.getBlockingAllForAccountRecordId(catalog, internalCallContext);
         Assert.assertEquals(blockingStates6.size(), 3);
         Assert.assertEquals(blockingStates6.get(0).getBlockedId(), blockableId);

--- a/junction/src/test/java/org/killbill/billing/junction/plumbing/billing/TestBillingApi.java
+++ b/junction/src/test/java/org/killbill/billing/junction/plumbing/billing/TestBillingApi.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedSet;
 import java.util.UUID;
 
@@ -67,9 +68,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-// FIXME-1615 : BlockingStateDao
-import com.google.common.base.Optional;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -205,7 +203,7 @@ public class TestBillingApi extends JunctionTestSuiteNoDB {
 
         final BlockingState blockingState1 = new DefaultBlockingState(bunId, BlockingStateType.SUBSCRIPTION_BUNDLE, DISABLED_BUNDLE, "test", true, true, true, now.plusDays(1));
         final BlockingState blockingState2 = new DefaultBlockingState(bunId, BlockingStateType.SUBSCRIPTION_BUNDLE, CLEAR_BUNDLE, "test", false, false, false, now.plusDays(2));
-        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState1, Optional.<UUID>absent(), blockingState2, Optional.<UUID>absent()), internalCallContext);
+        blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(Map.of(blockingState1, Optional.empty(), blockingState2, Optional.empty()), internalCallContext);
 
         final SortedSet<BillingEvent> events = billingInternalApi.getBillingEventsForAccountAndUpdateAccountBCD(account.getId(), null, null, internalCallContext);
 

--- a/junction/src/test/java/org/killbill/billing/junction/plumbing/billing/TestBlockingCalculator.java
+++ b/junction/src/test/java/org/killbill/billing/junction/plumbing/billing/TestBlockingCalculator.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -59,9 +60,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-// FIXME-1615 : BlockingStateDao
-import com.google.common.base.Optional;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -149,7 +147,7 @@ public class TestBlockingCalculator extends JunctionTestSuiteNoDB {
         final BlockingState blockingState1 = new DefaultBlockingState(bundleId1, BlockingStateType.SUBSCRIPTION_BUNDLE, DISABLED_BUNDLE, "test", true, true, true, now);
         final BlockingState blockingState2 = new DefaultBlockingState(bundleId1, BlockingStateType.SUBSCRIPTION_BUNDLE, CLEAR_BUNDLE, "test", false, false, false, now.plusDays(2));
 
-        final Map<BlockingState, Optional<UUID>> mapParams = Map.of(blockingState1, Optional.absent(), blockingState2, Optional.absent());
+        final Map<BlockingState, Optional<UUID>> mapParams = Map.of(blockingState1, Optional.empty(), blockingState2, Optional.empty());
         blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(mapParams, internalCallContext);
 
         blockingCalculator.insertBlockingEvents(billingEvents, new HashSet<UUID>(), subscriptionsForAccount, catalog, null, internalCallContext);
@@ -824,10 +822,10 @@ public class TestBlockingCalculator extends JunctionTestSuiteNoDB {
         final BlockingState blockingState3 = new DefaultBlockingState(bundleId1, BlockingStateType.SUBSCRIPTION_BUNDLE, DISABLED_BUNDLE, "test", true, true, true, new LocalDate(2012, 7, 24).toDateTimeAtStartOfDay(DateTimeZone.UTC));
         final BlockingState blockingState4 = new DefaultBlockingState(bundleId1, BlockingStateType.SUBSCRIPTION_BUNDLE, CLEAR_BUNDLE, "test", false, false, false, new LocalDate(2012, 7, 25).toDateTimeAtStartOfDay(DateTimeZone.UTC));
 
-        final Map<BlockingState, Optional<UUID>> mapParams = Map.of(blockingState1, Optional.absent(),
-                                                                    blockingState2, Optional.absent(),
-                                                                    blockingState3, Optional.absent(),
-                                                                    blockingState4, Optional.absent());
+        final Map<BlockingState, Optional<UUID>> mapParams = Map.of(blockingState1, Optional.empty(),
+                                                                    blockingState2, Optional.empty(),
+                                                                    blockingState3, Optional.empty(),
+                                                                    blockingState4, Optional.empty());
         blockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent(mapParams, internalCallContext);
 
         blockingCalculator.insertBlockingEvents(billingEvents, new HashSet<UUID>(), subscriptionsForAccount, catalog, null, internalCallContext);


### PR DESCRIPTION
`BlockingStateDao.setBlockingStatesAndPostBlockingTransitionEvent()` use Guava's Optional instead of Java 8 Optional. This commit changes that, also fix affected classes. As result, Guava dependency in entitlement's `pom.xml` get removed.