### PR TITLE
Test and potential fix for 1631

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java
@@ -575,4 +575,42 @@ public class TestSubscription extends TestIntegrationBase {
 
     }
 
+    @Test(groups = "slow",description="https://github.com/killbill/killbill/issues/1631")
+    public void testChangePlanWithStartDate() throws Exception {
+    	
+        final LocalDate initialDate = new LocalDate(2015, 8, 1);
+        clock.setDay(initialDate);
+
+        Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(0));
+        
+        //MOVE CLOCK BY A FEW MINUTES SO THAT SUBSCRIPTION START DATETIME IS A LITTLE AFTER INITIAL DATE TIME
+        clock.setTime(clock.getUTCNow().plusMinutes(2));
+
+        //CREATE PLAN
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT,
+                NextEvent.PAYMENT);
+
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial", null);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        assertNotNull(entitlementId);
+        Entitlement entitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
+        assertEquals(entitlement.getState(), EntitlementState.ACTIVE);
+        assertEquals(entitlement.getLastActiveProduct().getName(), "Pistol");
+        assertListenerStatus();
+        
+        clock.addDays(10);
+        
+        //CHANGE PLAN WITH START DATE
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier newPlanSpec = new PlanPhaseSpecifier("blowdart-monthly-notrial", null);
+        entitlement.changePlanWithDate(new DefaultEntitlementSpecifier(newPlanSpec), initialDate, ImmutableList.<PluginProperty>of(), callContext);
+        entitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
+        
+        //PLAN CHANGED SUCCESSFULLY
+        assertEquals(entitlement.getState(), EntitlementState.ACTIVE);
+        assertEquals(entitlement.getLastActiveProduct().getName(), "Blowdart");        
+        assertEquals(entitlement.getEffectiveStartDate(), initialDate);   
+        assertListenerStatus();
+    }            
+    
 }

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlementApi.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlementApi.java
@@ -677,15 +677,7 @@ public class TestDefaultEntitlementApi extends EntitlementTestSuiteWithEmbeddedD
         assertListenerStatus();
 
 
-        // effectiveDate = entitlementDate prior billingDate
         final PlanPhaseSpecifier spec2 = new PlanPhaseSpecifier("Pistol",  BillingPeriod.MONTHLY, PriceListSet.DEFAULT_PRICELIST_NAME, null);
-        try {
-            entitlement.changePlanWithDate(new DefaultEntitlementSpecifier(spec2), entitlementDate, ImmutableList.<PluginProperty>of(), callContext);
-            Assert.fail("Change plan prior billingStartDate should fail");
-        } catch (EntitlementApiException e) {
-            Assert.assertEquals(e.getCode(), ErrorCode.SUB_INVALID_REQUESTED_DATE.getCode());
-        }
-
         // effectiveDate is null (same as first case above), but **did**  reach the billing startDate (and entitlement startDate) so will succeed
         clock.addDeltaFromReality(1000); // Add one sec to make sure CHANGE event does not coincide with CREATE (realistic scenario), and therefore we do expect a CHANGE event
         testListener.pushExpectedEvents(NextEvent.CHANGE);

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiChangePlan.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiChangePlan.java
@@ -531,7 +531,7 @@ public class TestUserApiChangePlan extends SubscriptionTestSuiteWithEmbeddedDB {
             subscription.changePlanWithDate(spec, subscription.getStartDate().minusDays(1), callContext);
             fail("Change plan should have failed : subscription PENDING");
         } catch (final SubscriptionBaseApiException e) {
-            assertEquals(e.getCode(), ErrorCode.SUB_INVALID_REQUESTED_DATE.getCode());
+            assertEquals(e.getCode(), ErrorCode.SUB_CHANGE_NON_ACTIVE.getCode());
         }
 
         // Third try with date equals to startDate  Call should succeed, but no event because action in future


### PR DESCRIPTION
- Includes code changes and potential fix for #1631 
- Code changes caused `TestUserApiChangePlan.testChangePlanOnPendingSubscription` to fail, so had to change it [here](https://github.com/reshmabidikar/killbill/blob/7ec2a02332667f83bee1005e6deee076896f68a9/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestUserApiChangePlan.java#L534).
- Code changes caused `TestDefaultEntitlementApi.testCreateBaseWithDifferentStartDate` to fail so had to change it [here](https://github.com/reshmabidikar/killbill/blob/7ec2a02332667f83bee1005e6deee076896f68a9/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultEntitlementApi.java#L679).