### PR TITLE
1615 replace guava cache with utils cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-e8112a5-SNAPSHOT</version>
+        <version>0.145.3-15e1fee-SNAPSHOT</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.23.0-SNAPSHOT</version>
@@ -62,6 +62,7 @@
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <killbill-api.version>0.54.0-05dc842-SNAPSHOT</killbill-api.version>
         <killbill-client.version>1.3.0-5cb82e7-SNAPSHOT</killbill-client.version>
+        <killbill-commons.version>0.25.1-862fbb9-SNAPSHOT</killbill-commons.version>
         <killbill-plugin-api.version>0.27.0-a4410f3-SNAPSHOT</killbill-plugin-api.version>
         <killbill.version>${project.version}</killbill.version>
         <main.basedir>${project.basedir}</main.basedir>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-15e1fee-SNAPSHOT</version>
+        <version>0.145.3-bb9d252-SNAPSHOT</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.23.0-SNAPSHOT</version>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -288,6 +288,10 @@
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-xmlloader</artifactId>
         </dependency>
         <dependency>

--- a/util/src/main/java/org/killbill/billing/util/security/shiro/dao/JDBCSessionDao.java
+++ b/util/src/main/java/org/killbill/billing/util/security/shiro/dao/JDBCSessionDao.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -33,23 +32,26 @@ import org.apache.shiro.session.Session;
 import org.apache.shiro.session.mgt.eis.CachingSessionDAO;
 import org.killbill.billing.util.UUIDs;
 import org.killbill.billing.util.entity.dao.DBRouter;
+import org.killbill.commons.utils.annotation.VisibleForTesting;
+import org.killbill.commons.utils.cache.Cache;
+import org.killbill.commons.utils.cache.DefaultCache;
 import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-// FIXME-1615 : Cache: should discuss this.
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 import static org.killbill.billing.util.glue.IDBISetup.MAIN_RO_IDBI_NAMED;
 
 public class JDBCSessionDao extends CachingSessionDAO {
 
+    private static final int CACHE_MAX_SIZE = 20;
+    private static final int CACHE_TIMEOUT_IN_SECONDS = 5;
+
     private static final Logger log = LoggerFactory.getLogger(JDBCSessionDao.class);
 
     private final DBRouter<JDBCSessionSqlDao> dbRouter;
 
-    private final Cache<Serializable, Boolean> noUpdateSessionsCache = CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.SECONDS).build();
+    @VisibleForTesting
+    final Cache<Serializable, Boolean> noUpdateSessionsCache = new DefaultCache<>(CACHE_MAX_SIZE, CACHE_TIMEOUT_IN_SECONDS, DefaultCache.noCacheLoader());
 
     @Inject
     public JDBCSessionDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi) {
@@ -119,8 +121,9 @@ public class JDBCSessionDao extends CachingSessionDAO {
         doUpdate(session);
     }
 
-    private boolean shouldUpdateSession(final Session session) {
-        return noUpdateSessionsCache.getIfPresent(session.getId()) == Boolean.TRUE ? Boolean.FALSE : Boolean.TRUE;
+    @VisibleForTesting
+    boolean shouldUpdateSession(final Session session) {
+        return noUpdateSessionsCache.get(session.getId()) == Boolean.TRUE ? Boolean.FALSE : Boolean.TRUE;
     }
 
     private Session toSession(final SessionModelDao sessionModelDao) {

--- a/util/src/test/java/org/killbill/billing/util/security/shiro/dao/TestJDBCSessionDaoUnit.java
+++ b/util/src/test/java/org/killbill/billing/util/security/shiro/dao/TestJDBCSessionDaoUnit.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.security.shiro.dao;
+
+
+import java.io.Serializable;
+
+import org.apache.shiro.session.Session;
+import org.killbill.billing.util.UtilTestSuiteNoDB;
+import org.mockito.Mockito;
+import org.skife.jdbi.v2.IDBI;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestJDBCSessionDaoUnit extends UtilTestSuiteNoDB {
+
+    private JDBCSessionDao createJdbcSessionDao() {
+        final IDBI idbi = Mockito.mock(IDBI.class);
+        final JDBCSessionDao toSpy = new JDBCSessionDao(idbi, idbi);
+        return Mockito.spy(toSpy);
+    }
+
+    private Session createSession(final Serializable id) {
+        final Session session = Mockito.mock(Session.class);
+        Mockito.when(session.getId()).thenReturn(id);
+        return session;
+    }
+
+    @Test(groups = "fast")
+    public void testShouldUpdateSession() {
+        final JDBCSessionDao jdbcSessionDao = createJdbcSessionDao();
+
+        final Session a = createSession("A");
+        final Session b = createSession("B");
+        final Session c = createSession("C");
+
+        jdbcSessionDao.noUpdateSessionsCache.put(a.getId(), true);
+        jdbcSessionDao.noUpdateSessionsCache.put(b.getId(), false);
+        jdbcSessionDao.noUpdateSessionsCache.put(c.getId(), true);
+
+        Assert.assertFalse(jdbcSessionDao.shouldUpdateSession(a));
+        Assert.assertTrue(jdbcSessionDao.shouldUpdateSession(b));
+        Assert.assertFalse(jdbcSessionDao.shouldUpdateSession(c));
+    }
+}


### PR DESCRIPTION
Affected classes: `JDBCSessionDao` and `KillBillAuth0Realm` in `killbill-util` modules.