### PR TITLE
Beatrix test for 1375

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java
@@ -572,7 +572,7 @@ public class TestSubscription extends TestIntegrationBase {
     @Test(groups = "slow")
     public void testCreateChangeCancelSubscriptionWithDateTime() throws Exception {
         
-    	final DateTime initialDateTime = new DateTime(2012, 5, 1, 10, 30);
+    	final DateTime initialDateTime = new DateTime(2012, 5, 1, 10, 0);
         clock.setTime(initialDateTime);
         final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
         

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <properties>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <killbill-api.version>0.54.0-05dc842-SNAPSHOT</killbill-api.version>
-        <killbill-client.version>1.3.0-5cb82e7-SNAPSHOT</killbill-client.version>
+        <killbill-client.version>1.3.0-46ee408-SNAPSHOT</killbill-client.version>
         <killbill-plugin-api.version>0.27.0-a4410f3-SNAPSHOT</killbill-plugin-api.version>
         <killbill.version>${project.version}</killbill.version>
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
- Added beatrix test for create subscription/change plan/cancel subscription with datetime
- Added integration test in `killbill-profiles-killbill` for `blockSubscription` with Date and DateTime (I had missed adding this earlier)