### PR TITLE
Invoice translation custom properties

### DIFF
--- a/invoice/src/test/java/org/killbill/billing/invoice/TestHtmlInvoiceGenerator.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestHtmlInvoiceGenerator.java
@@ -66,6 +66,7 @@ public class TestHtmlInvoiceGenerator extends InvoiceTestSuiteNoDB {
         final HtmlInvoice output = g.generateInvoice(createAccount(), createInvoice(), false, internalCallContext);
         Assert.assertNotNull(output);
         Assert.assertNotNull(output.getBody());
+        Assert.assertTrue(output.getBody().contains("<!-- Test customKey value -->"));
         Assert.assertEquals(output.getSubject(), "Your invoice");
     }
 

--- a/invoice/src/test/resources/org/killbill/billing/util/template/translation/InvoiceTranslation_en_US.properties
+++ b/invoice/src/test/resources/org/killbill/billing/util/template/translation/InvoiceTranslation_en_US.properties
@@ -38,3 +38,5 @@ invoiceItemAmount=Amount
 
 processedPaymentCurrency=(*) The payment was processed in
 processedPaymentRate=The rate applied was
+
+customKey=Test customKey value

--- a/util/src/main/java/org/killbill/billing/util/template/translation/DefaultTranslatorBase.java
+++ b/util/src/main/java/org/killbill/billing/util/template/translation/DefaultTranslatorBase.java
@@ -16,8 +16,6 @@
 
 package org.killbill.billing.util.template.translation;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.annotation.Nullable;
@@ -25,35 +23,26 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.samskivert.mustache.Mustache.Lambda;
+
 public abstract class DefaultTranslatorBase implements Translator {
 
     protected final Logger log = LoggerFactory.getLogger(DefaultTranslatorBase.class);
 
     private final ResourceBundle bundle;
     private final ResourceBundle defaultBundle;
-    private final Map<String, String> properties;
 
     public DefaultTranslatorBase(@Nullable final ResourceBundle bundle,
                                  @Nullable final ResourceBundle defaultBundle) {
         this.bundle = bundle;
         this.defaultBundle = defaultBundle;
-        this.properties = new HashMap<>();
-
-        if (this.bundle != null) {
-            for (String key : bundle.keySet()) {
-                this.properties.put(key, getTranslation(key));
-            }
-        }
-
-        if (this.defaultBundle != null) {
-            for (String key : defaultBundle.keySet()) {
-                this.properties.put(key, getTranslation(key));
-            }
-        }
     }
 
-    public Map<String, String> getProperties() {
-        return this.properties;
+    public Lambda properties() {
+        return (frag, out) -> {
+            String template = frag.execute();
+            out.write(this.getTranslation(template));
+        };
     }
 
     @Override

--- a/util/src/main/java/org/killbill/billing/util/template/translation/DefaultTranslatorBase.java
+++ b/util/src/main/java/org/killbill/billing/util/template/translation/DefaultTranslatorBase.java
@@ -16,6 +16,9 @@
 
 package org.killbill.billing.util.template.translation;
 
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.annotation.Nullable;
@@ -29,11 +32,31 @@ public abstract class DefaultTranslatorBase implements Translator {
 
     private final ResourceBundle bundle;
     private final ResourceBundle defaultBundle;
+    private final Map<String, String> properties;
 
     public DefaultTranslatorBase(@Nullable final ResourceBundle bundle,
                                  @Nullable final ResourceBundle defaultBundle) {
         this.bundle = bundle;
         this.defaultBundle = defaultBundle;
+        this.properties = new HashMap<>();
+
+        if (this.bundle != null) {
+            for (Enumeration<String> e = bundle.getKeys(); e.hasMoreElements();) {
+                String key = e.nextElement();
+                this.properties.put(key, getTranslation(key));
+            }
+        }
+
+        if (this.defaultBundle != null) {
+            for (Enumeration<String> e = defaultBundle.getKeys(); e.hasMoreElements();) {
+                String key = e.nextElement();
+                this.properties.put(key, getTranslation(key));
+            }
+        }
+    }
+
+    public Map<String, String> getProperties() {
+        return this.properties;
     }
 
     @Override

--- a/util/src/main/java/org/killbill/billing/util/template/translation/DefaultTranslatorBase.java
+++ b/util/src/main/java/org/killbill/billing/util/template/translation/DefaultTranslatorBase.java
@@ -16,7 +16,6 @@
 
 package org.killbill.billing.util.template.translation;
 
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -41,15 +40,13 @@ public abstract class DefaultTranslatorBase implements Translator {
         this.properties = new HashMap<>();
 
         if (this.bundle != null) {
-            for (Enumeration<String> e = bundle.getKeys(); e.hasMoreElements();) {
-                String key = e.nextElement();
+            for (String key : bundle.keySet()) {
                 this.properties.put(key, getTranslation(key));
             }
         }
 
         if (this.defaultBundle != null) {
-            for (Enumeration<String> e = defaultBundle.getKeys(); e.hasMoreElements();) {
-                String key = e.nextElement();
+            for (String key : defaultBundle.keySet()) {
                 this.properties.put(key, getTranslation(key));
             }
         }

--- a/util/src/main/resources/org/killbill/billing/util/invoice/templates/HtmlInvoiceTemplate.mustache
+++ b/util/src/main/resources/org/killbill/billing/util/invoice/templates/HtmlInvoiceTemplate.mustache
@@ -13,6 +13,7 @@
 </head>
 <body>
 <div class="invoice-box">
+    <!-- {{text.properties.customKey}} -->
     <table cellpadding="0" cellspacing="0">
         <tr class="top">
             <td colspan="3">

--- a/util/src/main/resources/org/killbill/billing/util/invoice/templates/HtmlInvoiceTemplate.mustache
+++ b/util/src/main/resources/org/killbill/billing/util/invoice/templates/HtmlInvoiceTemplate.mustache
@@ -13,7 +13,7 @@
 </head>
 <body>
 <div class="invoice-box">
-    <!-- {{text.properties.customKey}} -->
+    <!-- {{#text.properties}}customKey{{/text.properties}} -->
     <table cellpadding="0" cellspacing="0">
         <tr class="top">
             <td colspan="3">

--- a/util/src/main/resources/org/killbill/billing/util/invoice/translation/InvoiceTranslation_en_US.properties
+++ b/util/src/main/resources/org/killbill/billing/util/invoice/translation/InvoiceTranslation_en_US.properties
@@ -30,3 +30,5 @@ companyCountry=USA
 invoiceItemDescription=Plan
 invoiceItemServicePeriod=Service Period
 invoiceItemAmount=Amount
+
+customKey=Test customKey value

--- a/util/src/test/java/org/killbill/billing/util/template/translation/TestDefaultTranslatorBase.java
+++ b/util/src/test/java/org/killbill/billing/util/template/translation/TestDefaultTranslatorBase.java
@@ -16,6 +16,9 @@
 
 package org.killbill.billing.util.template.translation;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.UUID;
 
@@ -39,6 +42,18 @@ public class TestDefaultTranslatorBase extends UtilTestSuiteNoDB {
     public void testResourceDoesNotExist() throws Exception {
         final TestTranslatorBase translator = new TestTranslatorBase(Mockito.mock(TranslatorConfig.class), Mockito.mock(ResourceBundle.class));
         final String originalText = UUID.randomUUID().toString();
+        Assert.assertEquals(translator.getTranslation(originalText), originalText);
+    }
+
+    @Test(groups = "fast")
+    public void testPropertyResourceBundle() throws Exception {
+        String propStr = "invoiceDate=Date\ncustomKey=Anything";
+	    InputStream propStrStream = new ByteArrayInputStream(propStr.getBytes());
+        final TestTranslatorBase translator = new TestTranslatorBase(Mockito.mock(TranslatorConfig.class), new PropertyResourceBundle(propStrStream));
+        final String originalText = UUID.randomUUID().toString();
+        Assert.assertEquals(translator.getProperties().size(), 2);
+        Assert.assertEquals(translator.getProperties().get("invoiceDate"), "Date");
+        Assert.assertEquals(translator.getProperties().get("customKey"), "Anything");
         Assert.assertEquals(translator.getTranslation(originalText), originalText);
     }
 }

--- a/util/src/test/java/org/killbill/billing/util/template/translation/TestDefaultTranslatorBase.java
+++ b/util/src/test/java/org/killbill/billing/util/template/translation/TestDefaultTranslatorBase.java
@@ -18,15 +18,18 @@ package org.killbill.billing.util.template.translation;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.UUID;
 
+import org.killbill.billing.util.UtilTestSuiteNoDB;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import org.killbill.billing.util.UtilTestSuiteNoDB;
+import com.samskivert.mustache.Mustache;
 
 public class TestDefaultTranslatorBase extends UtilTestSuiteNoDB {
 
@@ -50,10 +53,28 @@ public class TestDefaultTranslatorBase extends UtilTestSuiteNoDB {
         String propStr = "invoiceDate=Date\ncustomKey=Anything";
 	    InputStream propStrStream = new ByteArrayInputStream(propStr.getBytes());
         final TestTranslatorBase translator = new TestTranslatorBase(Mockito.mock(TranslatorConfig.class), new PropertyResourceBundle(propStrStream));
+        Map<String, Object> ctx = new HashMap<String, Object>();
+        ctx.put("translator", translator);
         final String originalText = UUID.randomUUID().toString();
-        Assert.assertEquals(translator.getProperties().size(), 2);
-        Assert.assertEquals(translator.getProperties().get("invoiceDate"), "Date");
-        Assert.assertEquals(translator.getProperties().get("customKey"), "Anything");
+        
+        test("Date", "{{#translator.properties}}invoiceDate{{/translator.properties}}", ctx);
+        test("Anything", "{{#translator.properties}}customKey{{/translator.properties}}", ctx);
         Assert.assertEquals(translator.getTranslation(originalText), originalText);
+    }
+
+    protected void test (String expected, String template, Object ctx) {
+        test(Mustache.compiler(), expected, template, ctx);
+    }
+
+    protected void test (Mustache.Compiler compiler, String expected, String template, Object ctx) {
+        check(expected, compiler.compile(template).execute(ctx));
+    }
+
+    protected void check (String expected, String output) {
+        Assert.assertEquals(uncrlf(expected), uncrlf(output));
+    }
+
+    protected static String uncrlf (String text) {
+        return text == null ? null : text.replace("\r", "\\r").replace("\n", "\\n");
     }
 }


### PR DESCRIPTION
This code wants to fix an issue encountered while working to create an invoice template and the relative translations.

In my template I added something like 

```
<div><strong>{{text.payTo}}</strong></div>
```

Even if I added the ```payTo``` property in the translation file for both the default locale (en_US) and the account locale (fr_FR) I get the error from mustache

```
"stack_trace":"org.glassfish.jersey.server.internal.process.MappableException: com.samskivert.mustache.MustacheException$Context: No method or field with name 'text.payTo' on line 46
...
```

The code wants to fix this allowing to use a new field to access any property name even when there is no a named method

In the template we will be able to use the following:

```
<div><strong>{{text.properties.payTo}}</strong></div>
```

Properties will be a Map and should return the translated value for any custom key

Let me know if you see any problem to add this fix
Cheers,
Enrico