### PR TITLE
pom.xml: pin test-jar dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,29 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Temporary until 0.24.x is released -->
+            <dependency>
+                <groupId>org.kill-bill.commons</groupId>
+                <artifactId>killbill-clock</artifactId>
+                <version>0.25.1-775465f-SNAPSHOT</version>
+                <type>test-jar</type>
+            </dependency>
+            <!-- Temporary until 0.24.x is released -->
+            <dependency>
+                <groupId>org.kill-bill.commons</groupId>
+                <artifactId>killbill-embeddeddb-mysql</artifactId>
+                <version>0.25.1-775465f-SNAPSHOT</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+            <!-- Temporary until 0.24.x is released -->
+            <dependency>
+                <groupId>org.kill-bill.commons</groupId>
+                <artifactId>killbill-embeddeddb-postgresql</artifactId>
+                <version>0.25.1-775465f-SNAPSHOT</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>


### PR DESCRIPTION
Work around incorrect maven-dependency-versions-check-plugin errors with SNAPSHOT dependencies.
