### PR TITLE
catalog: add validation endpoint

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/api/user/DefaultCatalogUserApi.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/api/user/DefaultCatalogUserApi.java
@@ -1,7 +1,10 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -19,6 +22,7 @@ package org.killbill.billing.catalog.api.user;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -133,6 +137,20 @@ public class DefaultCatalogUserApi implements CatalogUserApi {
             throw new IllegalStateException(e);
         } catch (final SAXException e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void validateCatalog(final String catalogXML, final CallContext context) throws CatalogApiException {
+        final InternalTenantContext internalTenantContext = createInternalTenantContext(context);
+        try {
+            XMLLoader.getObjectFromStream(new ByteArrayInputStream(catalogXML.getBytes(StandardCharsets.UTF_8)), StandaloneCatalog.class);
+        } catch (final ValidationException e) {
+            throw new CatalogApiException(e, ErrorCode.CAT_INVALID_FOR_TENANT, internalTenantContext.getTenantRecordId());
+        } catch (final JAXBException e) {
+            throw new CatalogApiException(e, ErrorCode.CAT_INVALID_FOR_TENANT, internalTenantContext.getTenantRecordId());
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/catalog/src/test/java/org/killbill/billing/catalog/api/user/TestDefaultCatalogUserApi.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/api/user/TestDefaultCatalogUserApi.java
@@ -28,7 +28,6 @@ import org.killbill.billing.catalog.CatalogTestSuiteNoDB;
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.catalog.api.CatalogService;
 import org.killbill.billing.catalog.api.CatalogUserApi;
-import org.killbill.billing.tenant.api.TenantInternalApi;
 import org.killbill.billing.tenant.api.TenantUserApi;
 import org.killbill.billing.util.io.IOUtils;
 import org.killbill.xmlloader.UriAccessor;
@@ -37,8 +36,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
 
 public class TestDefaultCatalogUserApi extends CatalogTestSuiteNoDB {
 

--- a/catalog/src/test/java/org/killbill/billing/catalog/api/user/TestDefaultCatalogUserApi.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/api/user/TestDefaultCatalogUserApi.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.user;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+
+import org.killbill.billing.catalog.CatalogTestSuiteNoDB;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.CatalogService;
+import org.killbill.billing.catalog.api.CatalogUserApi;
+import org.killbill.billing.tenant.api.TenantInternalApi;
+import org.killbill.billing.tenant.api.TenantUserApi;
+import org.killbill.billing.util.io.IOUtils;
+import org.killbill.xmlloader.UriAccessor;
+import org.killbill.xmlloader.ValidationException;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class TestDefaultCatalogUserApi extends CatalogTestSuiteNoDB {
+
+    private CatalogUserApi catalogUserApi;
+
+    @BeforeMethod(groups = "fast")
+    protected void beforeMethod() throws Exception {
+        if (hasFailed()) {
+            return;
+        }
+
+        catalogUserApi = new DefaultCatalogUserApi(Mockito.mock(CatalogService.class),
+                                                   Mockito.mock(TenantUserApi.class),
+                                                   catalogCache,
+                                                   clock,
+                                                   internalCallContextFactory);
+    }
+
+    @Test(groups = "fast")
+    public void testValidateValidCatalog() throws Exception {
+        catalogUserApi.validateCatalog(getXMLCatalog("SpyCarAdvanced.xml"), callContext);
+    }
+
+    @Test(groups = "fast")
+    public void testValidateInvalidCatalog() throws Exception {
+        try {
+            catalogUserApi.validateCatalog(getXMLCatalog("CatalogWithValidationErrors.xml"), callContext);
+        } catch (final CatalogApiException e) {
+            Assert.assertTrue(e.getCause() instanceof ValidationException);
+            Assert.assertEquals(((ValidationException) e.getCause()).getErrors().size(), 17);
+        }
+    }
+
+    private String getXMLCatalog(final String name) throws URISyntaxException, IOException {
+        final InputStream tenantInputCatalog = UriAccessor.accessUri(new URI(IOUtils.getResourceAsURL("org/killbill/billing/catalog/" + name).toExternalForm()));
+        return IOUtils.toString(new InputStreamReader(tenantInputCatalog, StandardCharsets.UTF_8));
+    }
+}

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/CatalogResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/CatalogResource.java
@@ -1,7 +1,8 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
  * Copyright 2014-2020 Groupon, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -229,6 +230,24 @@ public class CatalogResource extends JaxRsResourceBase {
                                      @javax.ws.rs.core.Context final HttpServletRequest request,
                                      @javax.ws.rs.core.Context final UriInfo uriInfo) throws Exception {
         return uploadCatalogXmlOriginal(catalogXML, createdBy, reason, comment, request, uriInfo);
+    }
+
+    @TimedResource
+    @POST
+    @Path("/xml/validate")
+    @Consumes(TEXT_XML)
+    @ApiOperation(value = "Validate a XML catalog", response = String.class)
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Valid XML catalog"),
+                           @ApiResponse(code = 400, message = "Invalid XML catalog")})
+    public Response validateCatalogXml(final String catalogXML,
+                                       @HeaderParam(HDR_CREATED_BY) final String createdBy,
+                                       @HeaderParam(HDR_REASON) final String reason,
+                                       @HeaderParam(HDR_COMMENT) final String comment,
+                                       @javax.ws.rs.core.Context final HttpServletRequest request,
+                                       @javax.ws.rs.core.Context final UriInfo uriInfo) throws Exception {
+        final CallContext callContext = context.createCallContextNoAccountId(createdBy, reason, comment, request);
+        catalogUserApi.validateCatalog(catalogXML, callContext);
+        return Response.status(Status.OK).build();
     }
 
     @TimedResource

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     </issueManagement>
     <properties>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
-        <killbill-api.version>0.54.0-28a0594-SNAPSHOT</killbill-api.version>
+        <killbill-api.version>0.54.0-eeee2bd-SNAPSHOT</killbill-api.version>
         <killbill-client.version>1.3.0-3be7b14-SNAPSHOT</killbill-client.version>
         <killbill-commons.version>0.25.1-02e249b-SNAPSHOT</killbill-commons.version>
         <killbill-plugin-api.version>0.27.0-af603fc-SNAPSHOT</killbill-plugin-api.version>


### PR DESCRIPTION
Error reporting isn't great client-side. This is tracked by https://github.com/killbill/killbill/issues/1674.

```
curl -v \
    -X POST \
    -u admin:password \
    -H "X-Killbill-ApiKey: bob" \
    -H "X-Killbill-ApiSecret: lazar" \
    -H "Content-Type: text/xml" \
    -H "Accept: application/json" \
    -H "X-Killbill-CreatedBy: demo" \
    -H "X-Killbill-Reason: demo" \
    -H "X-Killbill-Comment: demo" \
    -d @CatalogWithValidationErrors.xml \
    "http://127.0.0.1:8080/1.0/kb/catalog/xml/validate"
{"className":"org.killbill.billing.catalog.api.CatalogApiException","code":2080,"message":"Invalid catalog for tenant : 1","causeClassName":"org.killbill.xmlloader.ValidationException","causeMessage":null,"stackTrace":[]}
```