### PR TITLE
1615 use non guava killbill java client

### DIFF
--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -341,9 +341,5 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.weakref</groupId>
-            <artifactId>jmxutils</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/overdue/TestOverdueChildParentRelationship.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/overdue/TestOverdueChildParentRelationship.java
@@ -41,7 +41,7 @@ import org.weakref.jmx.internal.guava.collect.Iterables;
 
 import static org.testng.Assert.assertEquals;
 
-// For all the tests, we set the the property org.killbill.payment.retry.days=8,8,8,8,8,8,8,8 so that Payment retry logic does not end with an ABORTED state
+// For all the tests, we set the property org.killbill.payment.retry.days=8,8,8,8,8,8,8,8 so that Payment retry logic does not end with an ABORTED state
 // preventing final instant payment to succeed.
 //
 // The tests are difficult to follow because there are actually two tracks of retry in logic:
@@ -294,7 +294,7 @@ public class TestOverdueChildParentRelationship extends TestOverdueBase {
                 if (remainingUnpaidInvoices > 0) {
                     createPaymentAndCheckForCompletion(account, invoice, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
                 } else {
-                    createPaymentAndCheckForCompletion(account, invoice, Iterables.toArray(nextEventList, NextEvent.class));
+                    createPaymentAndCheckForCompletion(account, invoice, nextEventList.toArray(new NextEvent[0]));
                 }
             }
         }

--- a/currency/pom.xml
+++ b/currency/pom.xml
@@ -36,11 +36,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>provided</scope>

--- a/junction/pom.xml
+++ b/junction/pom.xml
@@ -36,14 +36,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <!-- We don't really need Guava - we need jsr305. Guava uses the com.google.code.findbugs
-            implementation, so let's use the same one. But since we don't explicitly depend on it elsewhere
-            (this should be fixed), let's depend on it transitively for now -->
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
     </issueManagement>
     <properties>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
-        <killbill-api.version>0.54.0-28a0594-SNAPSHOT</killbill-api.version>
-        <killbill-client.version>1.3.0-3be7b14-SNAPSHOT</killbill-client.version>
+        <killbill-api.version>0.54.0-e467c04-SNAPSHOT</killbill-api.version>
+        <killbill-client.version>1.3.0-4d44774-SNAPSHOT</killbill-client.version>
         <killbill-commons.version>0.25.1-02e249b-SNAPSHOT</killbill-commons.version>
         <killbill-plugin-api.version>0.27.0-af603fc-SNAPSHOT</killbill-plugin-api.version>
         <killbill.version>${project.version}</killbill.version>
@@ -162,4 +162,15 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,20 @@
             </dependency>
             <!-- Temporary until 0.24.x is released -->
             <dependency>
+                <groupId>org.kill-bill.billing</groupId>
+                <artifactId>killbill-platform-server</artifactId>
+                <version>0.41.0-8593f21-SNAPSHOT</version>
+                <classifier>classes</classifier>
+            </dependency>
+            <!-- Temporary until 0.24.x is released -->
+            <dependency>
+                <groupId>org.kill-bill.billing</groupId>
+                <artifactId>killbill-platform-test</artifactId>
+                <version>0.41.0-8593f21-SNAPSHOT</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- Temporary until 0.24.x is released -->
+            <dependency>
                 <groupId>org.kill-bill.commons</groupId>
                 <artifactId>killbill-clock</artifactId>
                 <version>0.25.1-775465f-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,15 +162,5 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
-    </repositories>
 
 </project>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -67,14 +67,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccount.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccount.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -54,9 +55,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-// FIXME-1615 : killbill-client-java : RequestOptions using MultiMap
-import com.google.common.collect.ImmutableMultimap;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -101,7 +99,7 @@ public class TestAccount extends TestJaxrsBase {
                                                             .withComment(Base64.getEncoder().encodeToString(comment.getBytes(StandardCharsets.UTF_8)))
                                                             .withHeader("X-Killbill-Encoding", "base64")
                                                             .withFollowLocation(true)
-                                                            .withQueryParamsForFollow(ImmutableMultimap.of(JaxrsResource.QUERY_AUDIT, AuditLevel.MINIMAL.name()))
+                                                            .withQueryParamsForFollow(Map.of(JaxrsResource.QUERY_AUDIT, List.of(AuditLevel.MINIMAL.name())))
                                                             .build();
         final Account emptyAccount = new Account();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAdmin.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAdmin.java
@@ -50,9 +50,6 @@ import org.testng.annotations.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-// FIXME-1615 : killbill-client-java : RequestOptions using MultiMap
-import com.google.common.collect.ImmutableMultimap;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -195,7 +192,7 @@ public class TestAdmin extends TestJaxrsBase {
         final String uri = "/1.0/kb/admin/invoices";
 
         final RequestOptions requestOptions = RequestOptions.builder()
-                                                            .withQueryParams(ImmutableMultimap.<String, String>of(JaxrsResource.QUERY_SEARCH_LIMIT, String.valueOf(limit)))
+                                                            .withQueryParams(Map.of(JaxrsResource.QUERY_SEARCH_LIMIT, List.of(String.valueOf(limit))))
                                                             .withCreatedBy(createdBy)
                                                             .withReason(reason)
                                                             .withComment(comment).build();

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceItem.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceItem.java
@@ -17,7 +17,10 @@
 
 package org.killbill.billing.jaxrs;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.client.RequestOptions;
@@ -33,10 +36,6 @@ import org.killbill.billing.jaxrs.resources.JaxrsResource;
 import org.killbill.billing.util.api.AuditLevel;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-// FIXME-1615 : killbill-client-java : RequestOptions using MultiMap
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 
 public class TestInvoiceItem extends TestJaxrsBase {
 
@@ -61,8 +60,9 @@ public class TestInvoiceItem extends TestJaxrsBase {
         Assert.assertEquals(objFromJson.getDescription(), input.getDescription());
 
         // Add a tag
-        final Multimap<String, String> followQueryParams = HashMultimap.create();
-        followQueryParams.put(JaxrsResource.QUERY_ACCOUNT_ID, accountJson.getAccountId().toString());
+        // FIXME-1615 : Not using MultiValueMap because of line 66 (killbill-client-java still not support it)
+        final Map<String, Collection<String>> followQueryParams = new LinkedHashMap<>();
+        followQueryParams.put(JaxrsResource.QUERY_ACCOUNT_ID, List.of(accountJson.getAccountId().toString()));
         final RequestOptions followRequestOptions = requestOptions.extend().withQueryParamsForFollow(followQueryParams).build();
         invoiceItemApi.createInvoiceItemTags(invoiceItems.get(0).getInvoiceItemId(), List.of(objFromJson.getId()), followRequestOptions);
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPayment.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPayment.java
@@ -20,6 +20,7 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -62,9 +63,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-// FIXME-1615 : killbill-client-java : RequestOptions using MultiMap
-import com.google.common.collect.HashMultimap;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -240,8 +238,9 @@ public class TestPayment extends TestJaxrsBase {
 
         // Trigger manually an invoice payment but make the control plugin abort it
         mockPaymentControlProviderPlugin.setAborted(true);
-        final HashMultimap<String, String> queryParams = HashMultimap.create();
-        queryParams.putAll("controlPluginName", List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME));
+        // FIXME-1615 : Not using MultiValueMap because killbill-client-java still not support it
+        final Map<String, Collection<String>> queryParams = new LinkedHashMap<>();
+        queryParams.put("controlPluginName", List.of(MockPaymentControlProviderPlugin.PLUGIN_NAME));
         final RequestOptions inputOptions = RequestOptions.builder()
                                                           .withCreatedBy(createdBy)
                                                           .withReason(reason)
@@ -270,8 +269,9 @@ public class TestPayment extends TestJaxrsBase {
         // Getting Invoice #2 (first after Trial period)
         final UUID failedInvoiceId = accountApi.getInvoicesForAccount(account.getAccountId(), null, null, null, RequestOptions.empty()).get(1).getInvoiceId();
 
-        final HashMultimap<String, String> queryParams = HashMultimap.create();
-        queryParams.put("withAttempts", "true");
+        // FIXME-1615 : Not using MultiValueMap because killbill-client-java still not support it
+        final Map<String, Collection<String>> queryParams = new LinkedHashMap<>();
+        queryParams.put("withAttempts", List.of("true"));
         final RequestOptions inputOptions = RequestOptions.builder()
                                                           .withCreatedBy(createdBy)
                                                           .withReason(reason)
@@ -298,8 +298,9 @@ public class TestPayment extends TestJaxrsBase {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
         final Account account = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 
-        final HashMultimap<String, String> queryParams = HashMultimap.create();
-        queryParams.put("withAttempts", "true");
+        // FIXME-1615 : Not using MultiValueMap because killbill-client-java still not support it
+        final Map<String, Collection<String>> queryParams = new LinkedHashMap<>();
+        queryParams.put("withAttempts", List.of("true"));
         final RequestOptions inputOptions = RequestOptions.builder()
                                                           .withCreatedBy(createdBy)
                                                           .withReason(reason)
@@ -318,8 +319,9 @@ public class TestPayment extends TestJaxrsBase {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
         createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 
-        final HashMultimap<String, String> queryParams = HashMultimap.create();
-        queryParams.put("withAttempts", "true");
+        // FIXME-1615 : Not using MultiValueMap because killbill-client-java still not support it
+        final Map<String, Collection<String>> queryParams = new LinkedHashMap<>();
+        queryParams.put("withAttempts", List.of("true"));
         final RequestOptions inputOptions = RequestOptions.builder()
                                                           .withCreatedBy(createdBy)
                                                           .withReason(reason)
@@ -338,8 +340,9 @@ public class TestPayment extends TestJaxrsBase {
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
         createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 
-        final HashMultimap<String, String> queryParams = HashMultimap.create();
-        queryParams.put("withAttempts", "true");
+        // FIXME-1615 : Not using MultiValueMap because killbill-client-java still not support it
+        final Map<String, Collection<String>> queryParams = new LinkedHashMap<>();
+        queryParams.put("withAttempts", List.of("true"));
         final RequestOptions inputOptions = RequestOptions.builder()
                                                           .withCreatedBy(createdBy)
                                                           .withReason(reason)

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPaymentPluginProperties.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPaymentPluginProperties.java
@@ -19,8 +19,10 @@ package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -53,10 +55,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-// FIXME-1615 : killbill-client-java : RequestOptions using MultiMap
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
 
 public class TestPaymentPluginProperties extends TestJaxrsBase {
 
@@ -231,9 +229,9 @@ public class TestPaymentPluginProperties extends TestJaxrsBase {
         completeTransactionByPaymentId.setProperties(bodyProperties);
 
         final RequestOptions basicRequestOptions = requestOptions;
-        // FIXME-1615 : killbill-client-java : RequestOptions using MultiMap
-        final Multimap<String, String> params = LinkedListMultimap.create(basicRequestOptions.getQueryParams());
-        params.putAll(KillBillHttpClient.CONTROL_PLUGIN_NAME, List.of(PluginPropertiesVerificator.PLUGIN_NAME));
+        // FIXME-1615 : Not using MultiValueMap because killbill-client-java still not support it
+        final Map<String, Collection<String>> params = new LinkedHashMap<>(basicRequestOptions.getQueryParamsForFollowAsMap());
+        params.put(KillBillHttpClient.CONTROL_PLUGIN_NAME, List.of(PluginPropertiesVerificator.PLUGIN_NAME));
 
         final RequestOptions requestOptionsWithParams = basicRequestOptions.extend()
                                                                            .withQueryParams(params).build();


### PR DESCRIPTION
replace all `HashMultimap`, `ImmutableMultimap`, and `Multimap` with plain `Map`. This is now possible because [this commit in killbill-client-java](https://github.com/killbill/killbill-client-java/commit/4d447749d9dd4442e3c53f5c98a0d40c7ee4a70f). this PR remove all guava classes from this repository.

Note about failed build `TestUsageInArrear#testWithUsageAtCancellationDayWithUncancel()`: I was wondering why `TestUsageInArrear` behave differently. Single test lead to failed test most of the time, but when I ran test suite, the test passed:
- Failed: `mvn -Dgroups=slow -Dtest=TestUsageInArrear#testWithUsageAtCancellationDayWithUncancel test`
- Passed: `mvn -Dgroups=slow -Dtest=TestUsageInArrear test`

But then I tried pick changes in `TestUsageInArrear` [in this PR](https://github.com/killbill/killbill/pull/1750), and seems like that PR fix the problem completely. So can I pretend that this is Ok, and wait until [PR 1750](https://github.com/killbill/killbill/pull/1750) merged?