### PR TITLE
beatrix: Harden usage tests

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestInArrearWithCatalogVersions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestInArrearWithCatalogVersions.java
@@ -67,7 +67,7 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
         assertListenerStatus();
 
-        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 1), BigDecimal.valueOf(143L), callContext);
+        recordUsageData(entitlementId, "t1", "kilowatt-hour", clock.getUTCNow(), BigDecimal.valueOf(143L), callContext);
         recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 18), BigDecimal.valueOf(57L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -112,7 +112,7 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec1), null, null, null, false, true, Collections.emptyList(), callContext);
         assertListenerStatus();
 
-        recordUsageData(entitlementId, "t1", "kilowatt-hour", new LocalDate(2016, 4, 1), BigDecimal.valueOf(143L), callContext);
+        recordUsageData(entitlementId, "t1", "kilowatt-hour", clock.getUTCNow(), BigDecimal.valueOf(143L), callContext);
         recordUsageData(entitlementId, "t2", "kilowatt-hour", new LocalDate(2016, 4, 18), BigDecimal.valueOf(57L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -182,7 +182,7 @@ public class TestInArrearWithCatalogVersions extends TestIntegrationBase {
                                                          new ExpectedInvoiceItemCheck(new LocalDate(2016, 4, 1), new LocalDate(2016, 5, 1), InvoiceItemType.USAGE, new BigDecimal("150.00")));
         invoiceChecker.checkTrackingIds(curInvoice, Set.of("t1", "t2"), internalCallContext);
 
-        recordUsageData(entitlementId, "t3", "kilowatt-hour", new LocalDate(2016, 5, 1), BigDecimal.valueOf(100L), callContext);
+        recordUsageData(entitlementId, "t3", "kilowatt-hour", clock.getUTCNow(), BigDecimal.valueOf(100L), callContext);
         recordUsageData(entitlementId, "t4", "kilowatt-hour", new LocalDate(2016, 5, 2), BigDecimal.valueOf(900L), callContext);
         recordUsageData(entitlementId, "t5", "kilowatt-hour", new LocalDate(2016, 5, 3), BigDecimal.valueOf(200L), callContext); // Move to tier 2.
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUnknownUsageUnits.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUnknownUsageUnits.java
@@ -66,7 +66,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         subscriptionChecker.checkSubscriptionCreated(bpSubscription.getId(), internalCallContext);
 
         // Record known usage for April
-        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -85,7 +85,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceConfig.setShouldParkAccountsWithUnknownUsage(true);
 
         // Record known consumable usage but unknown capacity usage for May
-        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-1", new LocalDate(2012, 5, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-1", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-4", "bandwidth-type-2", new LocalDate(2012, 5, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.TAG);
@@ -116,7 +116,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-3", "tracking-4"), internalCallContext);
 
         // Record known capacity usage but unknown consumable usage for June
-        recordUsageData(bpSubscription.getId(), "tracking-5", "server-hourly-type-2", new LocalDate(2012, 6, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-5", "server-hourly-type-2", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-6", "bandwidth-type-1", new LocalDate(2012, 6, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.TAG);
@@ -177,7 +177,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         assertListenerStatus();
 
         // Record unknown usage for August (the unit has been retired)
-        recordUsageData(bpSubscription.getId(), "tracking-9", "server-hourly-type-1", new LocalDate(2012, 8, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-9", "server-hourly-type-1", new LocalDate(2012, 8, 2), BigDecimal.valueOf(99L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.TAG);
         clock.addMonths(1);
@@ -237,7 +237,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         subscriptionChecker.checkSubscriptionCreated(bpSubscription.getId(), internalCallContext);
 
         // Record known usage for April
-        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -251,7 +251,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-1", "tracking-2"), internalCallContext);
 
         // Record known usage for May
-        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-1", new LocalDate(2012, 5, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-1", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-4", "bandwidth-type-1", new LocalDate(2012, 5, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -265,7 +265,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-3", "tracking-4"), internalCallContext);
 
         // Record known usage for June
-        recordUsageData(bpSubscription.getId(), "tracking-5", "server-hourly-type-1", new LocalDate(2012, 6, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-5", "server-hourly-type-1", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-6", "bandwidth-type-1", new LocalDate(2012, 6, 15), BigDecimal.valueOf(100L), callContext);
 
         // Trigger a future change plan on the same plan, to force the new catalog version at the next billing cycle (Catalog-v4.xml)
@@ -284,7 +284,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-5", "tracking-6"), internalCallContext);
 
         // Record known and unknown usage for July (server-hourly-type-1 doesn't exist anymore)
-        recordUsageData(bpSubscription.getId(), "tracking-7", "server-hourly-type-1", new LocalDate(2012, 7, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-7", "server-hourly-type-1", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-8", "bandwidth-type-1", new LocalDate(2012, 7, 15), BigDecimal.valueOf(100L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.TAG);
@@ -311,7 +311,7 @@ public class TestUnknownUsageUnits extends TestIntegrationBase {
         subscriptionChecker.checkSubscriptionCreated(bpSubscription.getId(), internalCallContext);
 
         // Record known and unknown usage for April
-        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(bpSubscription.getId(), "tracking-1", "server-hourly-type-1", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-2", "bandwidth-type-1", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
         recordUsageData(bpSubscription.getId(), "tracking-3", "server-hourly-type-2", new LocalDate(2012, 4, 20), BigDecimal.valueOf(100L), callContext);
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
@@ -229,7 +229,7 @@ public class TestUsageInArrear extends TestIntegrationBase {
         //
         final DefaultEntitlement aoSubscription = addAOEntitlementAndCheckForCompletion(bpSubscription.getBundleId(), "Bullets", ProductCategory.ADD_ON, BillingPeriod.NO_BILLING_PERIOD, NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // 2012-05-01
@@ -243,7 +243,7 @@ public class TestUsageInArrear extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-1", "tracking-2"), internalCallContext);
 
         // Billed on 2012-06-01
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", clock.getUTCNow(), BigDecimal.valueOf(50L), callContext);
         // Billed on 2012-07-01
         recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 1), BigDecimal.valueOf(300L), callContext);
 
@@ -322,7 +322,7 @@ public class TestUsageInArrear extends TestIntegrationBase {
                                                  new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2012, 6, 1), InvoiceItemType.USAGE, BigDecimal.ZERO));
         invoiceChecker.checkTrackingIds(curInvoice, Collections.emptySet(), internalCallContext);
 
-        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", new LocalDate(2012, 6, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-3", "bullets", clock.getUTCNow(), BigDecimal.valueOf(50L), callContext);
         recordUsageData(aoSubscription.getId(), "tracking-4", "bullets", new LocalDate(2012, 6, 16), BigDecimal.valueOf(300L), callContext);
 
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
@@ -340,7 +340,7 @@ public class TestUsageInArrear extends TestIntegrationBase {
         recordUsageData(aoSubscription.getId(), "tracking-6", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(199L), callContext);
 
         // New usage for this past period
-        recordUsageData(aoSubscription.getId(), "tracking-7", "bullets", new LocalDate(2012, 7, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-7", "bullets", clock.getUTCNow(), BigDecimal.valueOf(50L), callContext);
         recordUsageData(aoSubscription.getId(), "tracking-8", "bullets", new LocalDate(2012, 7, 16), BigDecimal.valueOf(300L), callContext);
 
         // Remove old data, should be ignored by the system because readMaxRawUsagePreviousPeriod = 2, so:
@@ -405,7 +405,7 @@ public class TestUsageInArrear extends TestIntegrationBase {
                                                                                         new LocalDate(2012, 4, 1),
                                                                                         NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
 
-        recordUsageData(aoSubscription.getId(), "t1", "bullets", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "t1", "bullets", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(aoSubscription.getId(), "t2", "bullets", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // Trigger future invoice
@@ -438,7 +438,7 @@ public class TestUsageInArrear extends TestIntegrationBase {
         invoiceChecker.checkTrackingIds(thirdInvoice, Collections.emptySet(), internalCallContext);
 
         // Add usage data
-        recordUsageData(aoSubscription.getId(), "u1", "slugs", new LocalDate(2012, 4, 1), BigDecimal.valueOf(99L), callContext);
+        recordUsageData(aoSubscription.getId(), "u1", "slugs", clock.getUTCNow(), BigDecimal.valueOf(99L), callContext);
         recordUsageData(aoSubscription.getId(), "u2", "slugs", new LocalDate(2012, 4, 15), BigDecimal.valueOf(100L), callContext);
 
         // Trigger future invoice

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestWithoutZeroUsageItems.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestWithoutZeroUsageItems.java
@@ -207,7 +207,7 @@ public class TestWithoutZeroUsageItems extends TestIntegrationBase {
         recordUsageData(aoSubscription.getId(), "tracking-6", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(199L), callContext);
 
         // New usage for this past period
-        recordUsageData(aoSubscription.getId(), "tracking-7", "bullets", new LocalDate(2012, 7, 1), BigDecimal.valueOf(50L), callContext);
+        recordUsageData(aoSubscription.getId(), "tracking-7", "bullets", clock.getUTCNow(), BigDecimal.valueOf(50L), callContext);
         recordUsageData(aoSubscription.getId(), "tracking-8", "bullets", new LocalDate(2012, 7, 16), BigDecimal.valueOf(300L), callContext);
 
         // Remove old data, should be ignored by the system because readMaxRawUsagePreviousPeriod = 2, so:


### PR DESCRIPTION
With the changes introduced in 08f9b913b886b8e497b6edde02d51f4166137e69, we need to be more cautious when we record usage on the first day, to make sure the timestamp is not too early and usage data points is indeed taken into consideration.

For such test scenario we can use the test api `recordUsageData` which uses a DateTime and aligns with the clock value.

I did a pass on all usage tests, but this may be part of an incremental effort to fully stabilize this.