### PR TITLE
update various version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-bb9d252-SNAPSHOT</version>
+        <version>0.145.3-8ec8d1f-SNAPSHOT</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.23.0-SNAPSHOT</version>
@@ -62,7 +62,8 @@
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <killbill-api.version>0.54.0-eeee2bd-SNAPSHOT</killbill-api.version>
         <killbill-client.version>1.3.0-4d44774-SNAPSHOT</killbill-client.version>
-        <killbill-commons.version>0.25.1-02e249b-SNAPSHOT</killbill-commons.version>
+        <killbill-commons.version>0.25.1-2361a7d-SNAPSHOT</killbill-commons.version>
+        <killbill-platform.version>0.41.0-642a42b-SNAPSHOT</killbill-platform.version>
         <killbill-plugin-api.version>0.27.0-af603fc-SNAPSHOT</killbill-plugin-api.version>
         <killbill.version>${project.version}</killbill.version>
         <main.basedir>${project.basedir}</main.basedir>
@@ -105,43 +106,6 @@
                         <artifactId>jakarta.inject</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <!-- Temporary until 0.24.x is released -->
-            <dependency>
-                <groupId>org.kill-bill.billing</groupId>
-                <artifactId>killbill-platform-server</artifactId>
-                <version>0.41.0-8593f21-SNAPSHOT</version>
-                <classifier>classes</classifier>
-            </dependency>
-            <!-- Temporary until 0.24.x is released -->
-            <dependency>
-                <groupId>org.kill-bill.billing</groupId>
-                <artifactId>killbill-platform-test</artifactId>
-                <version>0.41.0-8593f21-SNAPSHOT</version>
-                <scope>test</scope>
-            </dependency>
-            <!-- Temporary until 0.24.x is released -->
-            <dependency>
-                <groupId>org.kill-bill.commons</groupId>
-                <artifactId>killbill-clock</artifactId>
-                <version>0.25.1-775465f-SNAPSHOT</version>
-                <type>test-jar</type>
-            </dependency>
-            <!-- Temporary until 0.24.x is released -->
-            <dependency>
-                <groupId>org.kill-bill.commons</groupId>
-                <artifactId>killbill-embeddeddb-mysql</artifactId>
-                <version>0.25.1-775465f-SNAPSHOT</version>
-                <type>test-jar</type>
-                <scope>test</scope>
-            </dependency>
-            <!-- Temporary until 0.24.x is released -->
-            <dependency>
-                <groupId>org.kill-bill.commons</groupId>
-                <artifactId>killbill-embeddeddb-postgresql</artifactId>
-                <version>0.25.1-775465f-SNAPSHOT</version>
-                <type>test-jar</type>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>


### PR DESCRIPTION
update various version, and remove declared killbill-platform dependencies

- killbill parent to 0.145.3-8ec8d1f-SNAPSHOT
- killbill-commons to 0.25.1-2361a7d-SNAPSHOT
- killbill-platform to 0.41.0-642a42b-SNAPSHOT

Draft, since I'm wondering whether removing various killbill-platform artifact affecting the `slow` test or not.

Update: Build failed at beatrix because of Guice.TDLR: We need to find out exact replacement of `@com.google.guice.Inject(optional = true)`, because `@javax.inject.Inject` + `@Nullable` is not direct replacement and behave differently.