### PR TITLE
jaxrs: fix PluginResource encoding

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/PluginResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/PluginResource.java
@@ -221,7 +221,7 @@ public class PluginResource extends JaxRsResourceBase {
         }
 
         return Response.status(response.getStatus())
-                       .entity(new String(byteArrayOutputStream.toByteArray(), "UTF-8"))
+                       .entity(byteArrayOutputStream.toByteArray())
                        .build();
     }
 


### PR DESCRIPTION
This was breaking plugins returning binary data (e.g. zip files).
