### PR TITLE
invoice: Introduce a greedy way to charge for in-arrear subscriptions

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1366,6 +1366,16 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
             return getItemResultBehaviorMode();
         }
 
+        @Override
+        public InArrearMode getInArrearMode() {
+            return InArrearMode.DEFAULT;
+        }
+
+        @Override
+        public InArrearMode getInArrearMode(final InternalTenantContext tenantContext) {
+            return InArrearMode.DEFAULT;
+        }
+
         public void setItemResultBehaviorMode(final UsageDetailMode detailMode) {
             this.detailMode = detailMode;
         }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1058,7 +1058,6 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         usageUserApi.recordRolledUpUsage(record, context);
     }
 
-
     protected void recordUsageData(final SubscriptionUsageRecord usageRecord, final CallContext context) throws UsageApiException {
         usageUserApi.recordRolledUpUsage(usageRecord, context);
     }
@@ -1073,7 +1072,6 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
             }
         });
     }
-
 
     protected boolean areAllNotificationsProcessed(final Long tenantRecordId) {
         int nbNotifications = 0;
@@ -1108,8 +1106,6 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
             }
         });
     }
-
-
 
     protected static class TestDryRunArguments implements DryRunArguments {
 
@@ -1220,6 +1216,7 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         private boolean shouldParkAccountsWithUnknownUsage;
         private boolean isZeroAmountUsageDisabled;
         private UsageDetailMode detailMode;
+        private InArrearMode inArrearMode;
         private Period maxInvoiceLimit;
         private int maxRawUsagePreviousPeriod;
 
@@ -1368,12 +1365,16 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
         @Override
         public InArrearMode getInArrearMode() {
-            return InArrearMode.DEFAULT;
+            return inArrearMode;
         }
 
         @Override
         public InArrearMode getInArrearMode(final InternalTenantContext tenantContext) {
-            return InArrearMode.DEFAULT;
+            return getInArrearMode();
+        }
+
+        public void setInArrearMode(final InArrearMode inArrearMode) {
+            this.inArrearMode = inArrearMode;
         }
 
         public void setItemResultBehaviorMode(final UsageDetailMode detailMode) {
@@ -1417,6 +1418,7 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
             shouldParkAccountsWithUnknownUsage = defaultInvoiceConfig.shouldParkAccountsWithUnknownUsage();
             isZeroAmountUsageDisabled = defaultInvoiceConfig.isUsageZeroAmountDisabled();
             detailMode = defaultInvoiceConfig.getItemResultBehaviorMode();
+            inArrearMode = defaultInvoiceConfig.getInArrearMode();
             maxInvoiceLimit = defaultInvoiceConfig.getMaxInvoiceLimit();
             maxRawUsagePreviousPeriod = defaultInvoiceConfig.getMaxRawUsagePreviousPeriod();
         }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInArrearGreedySubscriptions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInArrearGreedySubscriptions.java
@@ -115,7 +115,7 @@ public class TestWithInArrearGreedySubscriptions extends TestIntegrationBase {
         entitlement.cancelEntitlementWithPolicyOverrideBillingPolicy(EntitlementActionPolicy.IMMEDIATE, BillingActionPolicy.IMMEDIATE, ImmutableList.of(), callContext);
         assertListenerStatus();
 
-        // Cancel 2022-03-13
+        // 2022-04-13
         busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE);
         clock.addMonths(1);
         assertListenerStatus();

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInArrearGreedySubscriptions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInArrearGreedySubscriptions.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Entitlement;
+import org.killbill.billing.entitlement.api.Entitlement.EntitlementActionPolicy;
+import org.killbill.billing.entitlement.api.Entitlement.EntitlementState;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.billing.util.config.definition.InvoiceConfig.InArrearMode;
+import org.killbill.billing.util.config.definition.InvoiceConfig.UsageDetailMode;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestWithInArrearGreedySubscriptions extends TestIntegrationBase {
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        // Reuse catalog from testWithInArrearSubscriptions as we are doind in-arrear (just a different behavior)
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testWithInArrearSubscriptions");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    @BeforeMethod(groups = "slow")
+    public void beforeMethod() throws Exception {
+        if (hasFailed()) {
+            return;
+        }
+        super.beforeMethod();
+        invoiceConfig.setInArrearMode(InArrearMode.GREEDY);
+
+    }
+    @Test(groups = "slow")
+    public void testWithBillRun_A() throws Exception {
+        final DateTime initialCreationDate = new DateTime(2022, 1, 13, 0, 0, 0, 0, testTimeZone);
+        clock.setTime(initialCreationDate);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-support-monthly-notrial", null);
+
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BCD_CHANGE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, 13, null, null), "bundleExternalKey", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
+        assertListenerStatus();
+        final Entitlement entitlement = entitlementApi.getEntitlementForId(entitlementId, callContext);
+
+        // 2022-02-01
+        clock.addDays(19);
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        invoiceUserApi.triggerInvoiceGeneration(account.getId(), clock.getUTCToday(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2022, 1, 13), new LocalDate(2022, 2, 13), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
+
+
+        // 2022-02-13
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE);
+        clock.addDays(12);
+        assertListenerStatus();
+
+        // 2022-03-01
+        clock.addDays(16);
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        invoiceUserApi.triggerInvoiceGeneration(account.getId(), clock.getUTCToday(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2022, 2, 13), new LocalDate(2022, 3, 13), InvoiceItemType.RECURRING, new BigDecimal("100.00")));
+
+        // 2022-03-13
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE);
+        clock.addDays(12);
+        assertListenerStatus();
+
+        // Cancel 2022-03-13
+        busHandler.pushExpectedEvents(NextEvent.CANCEL, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
+        entitlement.cancelEntitlementWithPolicyOverrideBillingPolicy(EntitlementActionPolicy.IMMEDIATE, BillingActionPolicy.IMMEDIATE, ImmutableList.of(), callContext);
+        assertListenerStatus();
+
+
+        for (int i = 0; i < 3; i++) {
+            clock.addMonths(1);
+            assertListenerStatus();
+        }
+
+        checkNoMoreInvoiceToGenerate(account);
+    }
+}

--- a/beatrix/src/test/resources/catalogs/testWithInArrearGreedySubscriptions/InArrearCatalog.xml
+++ b/beatrix/src/test/resources/catalogs/testWithInArrearGreedySubscriptions/InArrearCatalog.xml
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2014-2018 Groupon, Inc
+  ~ Copyright 2014-2018 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2019-01-01T00:00:00+00:00</effectiveDate>
+    <catalogName>Services</catalogName>
+
+    <recurringBillingMode>IN_ARREAR</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+        <currency>EUR</currency>
+        <currency>GBP</currency>
+    </currencies>
+
+    <units>
+        <unit name="hours"/>
+    </units>
+
+    <products>
+        <product name="BasicSupport">
+            <category>BASE</category>
+        </product>
+        <product name="PremiumSupport">
+            <category>BASE</category>
+ 			<available>
+                <addonProduct>PremiumSupportAddOn</addonProduct>
+            </available>            
+        </product>
+        <product name="PremiumSupportAddOn">
+            <category>ADD_ON</category>
+        </product>        
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <phaseType>TRIAL</phaseType>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+            <changePolicyCase>
+                <fromBillingPeriod>MONTHLY</fromBillingPeriod>
+                <toBillingPeriod>ANNUAL</toBillingPeriod>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+            <changePolicyCase>
+                <fromBillingPeriod>ANNUAL</fromBillingPeriod>
+                <toBillingPeriod>MONTHLY</toBillingPeriod>
+                <policy>END_OF_TERM</policy>
+            </changePolicyCase>
+            <changePolicyCase>
+                <policy>END_OF_TERM</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_SUBSCRIPTION</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <phaseType>TRIAL</phaseType>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+            <cancelPolicyCase>
+                <policy>END_OF_TERM</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <productCategory>ADD_ON</productCategory>
+                <alignment>BUNDLE</alignment>
+            </billingAlignmentCase>
+            <billingAlignmentCase>
+                <billingPeriod>ANNUAL</billingPeriod>
+                <alignment>SUBSCRIPTION</alignment>
+            </billingAlignmentCase>
+            <billingAlignmentCase>
+                <alignment>ACCOUNT</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="basic-support-monthly-notrial">
+            <product>BasicSupport</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>100.00</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>100.00</value>
+                        </price>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>100.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        <plan name="basic-support-annual-notrial">
+            <product>BasicSupport</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>700.00</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>700.00</value>
+                        </price>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>700.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+
+        <plan name="premium-support-monthly-notrial">
+            <product>PremiumSupport</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>1000.00</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>1000.00</value>
+                        </price>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>1000.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+       <plan name="premium-support-addon-monthly-notrial">
+            <product>PremiumSupportAddOn</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>900.00</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>900.00</value>
+                        </price>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>900.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>        
+        <plan name="premium-support-annual-notrial">
+            <product>PremiumSupport</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>7000.00</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>7000.00</value>
+                        </price>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>7000.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        <plan name="basic-support-monthly-overrage-notrial" prettyName="Basic support">
+            <product>BasicSupport</product>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>10.00</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>10.00</value>
+                        </price>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>10.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+                <usages>
+                    <usage name="basic-support-monthly-overrage-notrial-usage" prettyName="Basic support usage" billingMode="IN_ARREAR" usageType="CONSUMABLE">
+                        <billingPeriod>MONTHLY</billingPeriod>
+                        <tiers>
+                            <tier>
+                                <blocks>
+                                    <tieredBlock>
+                                        <unit>hours</unit>
+                                        <size>1</size>
+                                        <prices>
+                                            <price>
+                                                <currency>USD</currency>
+                                                <value>0.00</value>
+                                            </price>
+                                            <price>
+                                                <currency>EUR</currency>
+                                                <value>0.00</value>
+                                            </price>
+                                            <price>
+                                                <currency>GBP</currency>
+                                                <value>0.00</value>
+                                            </price>
+                                        </prices>
+                                        <max>10</max>
+                                    </tieredBlock>
+                                </blocks>
+                            </tier>
+                            <tier>
+                                <blocks>
+                                    <tieredBlock>
+                                        <unit>hours</unit>
+                                        <size>1</size>
+                                        <prices>
+                                            <price>
+                                                <currency>USD</currency>
+                                                <value>5.00</value>
+                                            </price>
+                                            <price>
+                                                <currency>EUR</currency>
+                                                <value>5.00</value>
+                                            </price>
+                                            <price>
+                                                <currency>GBP</currency>
+                                                <value>5.00</value>
+                                            </price>
+                                        </prices>
+                                        <max>-1</max>
+                                    </tieredBlock>
+                                </blocks>
+                            </tier>
+                        </tiers>
+                    </usage>
+                </usages>
+            </finalPhase>
+        </plan>
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>basic-support-monthly-notrial</plan>
+                <plan>basic-support-annual-notrial</plan>
+                <plan>premium-support-monthly-notrial</plan>
+                <plan>premium-support-annual-notrial</plan>
+                <plan>premium-support-addon-monthly-notrial</plan>
+                <plan>basic-support-monthly-overrage-notrial</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+
+</catalog>

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -212,7 +212,6 @@ public class MultiTenantInvoiceConfig extends MultiTenantConfigBase implements I
         if (mode == UsageDetailMode.AGGREGATE || mode == UsageDetailMode.DETAIL) {
             return mode;
         }
-
         return UsageDetailMode.AGGREGATE;
     }
 
@@ -229,6 +228,24 @@ public class MultiTenantInvoiceConfig extends MultiTenantConfigBase implements I
         }
 
         return UsageDetailMode.AGGREGATE;
+    }
+
+    @Override
+    public InArrearMode getInArrearMode() {
+        final InArrearMode mode = staticConfig.getInArrearMode();
+        if (mode == InArrearMode.DEFAULT || mode == InArrearMode.GREEDY) {
+            return mode;
+        }
+        return InArrearMode.DEFAULT;
+    }
+
+    @Override
+    public InArrearMode getInArrearMode(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("getInArrearMode", tenantContext);
+        if (result != null){
+            return InArrearMode.valueOf(result);
+        }
+        return getInArrearMode();
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/BillingIntervalDetail.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/BillingIntervalDetail.java
@@ -22,6 +22,7 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.BillingMode;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.util.bcd.BillCycleDayCalculator;
+import org.killbill.billing.util.config.definition.InvoiceConfig.InArrearMode;
 
 public class BillingIntervalDetail {
 
@@ -49,7 +50,7 @@ public class BillingIntervalDetail {
                                  final int billingCycleDay,
                                  final BillingPeriod billingPeriod,
                                  final BillingMode billingMode,
-                                 final boolean inArrearGreedy) {
+                                 final InArrearMode inArrearMode) {
         this.startDate = startDate;
         this.endDate = endDate;
         this.targetDate = targetDate;
@@ -60,7 +61,7 @@ public class BillingIntervalDetail {
         }
         this.billingPeriod = billingPeriod;
         this.billingMode = billingMode;
-        this.inArrearGreedy = inArrearGreedy;
+        this.inArrearGreedy = inArrearMode == InArrearMode.GREEDY;
         computeAll();
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/BillingIntervalDetail.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/BillingIntervalDetail.java
@@ -94,6 +94,11 @@ public class BillingIntervalDetail {
                (endDate == null || endDate.isAfter(startDate)); /* When there is an endDate, it should be > startDate since we don't bill for less than a day */
     }
 
+    public boolean isInArrearGreedy() {
+        return inArrearGreedy;
+    }
+
+
     private void computeAll() {
         calculateFirstBillingCycleDate();
         calculateEffectiveEndDate();

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -330,7 +330,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
 
         final List<RecurringInvoiceItemData> results = new ArrayList<RecurringInvoiceItemData>();
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, billingMode);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, billingMode, false);
 
         // We are not billing for less than a day
         if (!billingIntervalDetail.hasSomethingToBill()) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -239,7 +239,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
 
                 final RecurringInvoiceItemDataWithNextBillingCycleDate itemDataWithNextBillingCycleDate;
                 try {
-                    itemDataWithNextBillingCycleDate = generateInvoiceItemData(startDate, endDate, targetDate, billCycleDayLocal, billingPeriod, recurringBillingMode, null);
+                    itemDataWithNextBillingCycleDate = generateInvoiceItemData(startDate, endDate, targetDate, billCycleDayLocal, billingPeriod, recurringBillingMode, internalCallContext);
                 } catch (final InvalidDateSequenceException e) {
                     throw new InvoiceApiException(ErrorCode.INVOICE_INVALID_DATE_SEQUENCE, startDate, endDate, targetDate);
                 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -239,7 +239,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
 
                 final RecurringInvoiceItemDataWithNextBillingCycleDate itemDataWithNextBillingCycleDate;
                 try {
-                    itemDataWithNextBillingCycleDate = generateInvoiceItemData(startDate, endDate, targetDate, billCycleDayLocal, billingPeriod, recurringBillingMode);
+                    itemDataWithNextBillingCycleDate = generateInvoiceItemData(startDate, endDate, targetDate, billCycleDayLocal, billingPeriod, recurringBillingMode, null);
                 } catch (final InvalidDateSequenceException e) {
                     throw new InvoiceApiException(ErrorCode.INVOICE_INVALID_DATE_SEQUENCE, startDate, endDate, targetDate);
                 }
@@ -316,11 +316,13 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         }
     }
 
-    public RecurringInvoiceItemDataWithNextBillingCycleDate generateInvoiceItemData(final LocalDate startDate, @Nullable final LocalDate endDate,
+    public RecurringInvoiceItemDataWithNextBillingCycleDate generateInvoiceItemData(final LocalDate startDate,
+                                                                                    @Nullable final LocalDate endDate,
                                                                                     final LocalDate targetDate,
                                                                                     final int billingCycleDayLocal,
                                                                                     final BillingPeriod billingPeriod,
-                                                                                    final BillingMode billingMode) throws InvalidDateSequenceException {
+                                                                                    final BillingMode billingMode,
+                                                                                    final InternalCallContext internalCallContext) throws InvalidDateSequenceException {
         if (endDate != null && endDate.isBefore(startDate)) {
             throw new InvalidDateSequenceException();
         }
@@ -330,7 +332,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
 
         final List<RecurringInvoiceItemData> results = new ArrayList<RecurringInvoiceItemData>();
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, billingMode, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, billingMode, config.getInArrearMode(internalCallContext));
 
         // We are not billing for less than a day
         if (!billingIntervalDetail.hasSomethingToBill()) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
@@ -55,6 +55,7 @@ import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.usage.api.RawUsageRecord;
 import org.killbill.billing.usage.api.RolledUpUnit;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
+import org.killbill.billing.util.config.definition.InvoiceConfig.InArrearMode;
 import org.killbill.billing.util.config.definition.InvoiceConfig.UsageDetailMode;
 import org.killbill.billing.util.currency.KillBillMoney;
 import org.killbill.billing.util.jackson.ObjectMapper;
@@ -237,7 +238,7 @@ public abstract class ContiguousIntervalUsageInArrear {
     }
 
     private void addTransitionTimesForBillingEvent(final BillingEvent event, final LocalDate startDate, final LocalDate endDate, final int bcd, final boolean lastEvent) {
-        final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, bcd, usage.getBillingPeriod(), usage.getBillingMode(), false);
+        final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, bcd, usage.getBillingPeriod(), usage.getBillingMode(), InArrearMode.DEFAULT);
 
 
         int numberOfPeriod = 0;
@@ -385,13 +386,13 @@ public abstract class ContiguousIntervalUsageInArrear {
             final LocalDate startDate = internalTenantContext.toLocalDate(thisEvent.getEffectiveDate());
             final LocalDate endDate = internalTenantContext.toLocalDate(nextEvent.getEffectiveDate());
 
-            final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, thisEvent.getBillCycleDayLocal(), usage.getBillingPeriod(), BillingMode.IN_ARREAR, false);
+            final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, thisEvent.getBillCycleDayLocal(), usage.getBillingPeriod(), BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
             final LocalDate nextBillingCycleDate = bid.getNextBillingCycleDate();
             result = (result == null || result.compareTo(nextBillingCycleDate) < 0) ? nextBillingCycleDate : result;
         }
 
         final LocalDate startDate = internalTenantContext.toLocalDate(nextEvent.getEffectiveDate());
-        final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, null, targetDate, nextEvent.getBillCycleDayLocal(), usage.getBillingPeriod(), BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, null, targetDate, nextEvent.getBillCycleDayLocal(), usage.getBillingPeriod(), BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
         final LocalDate nextBillingCycleDate = bid.getNextBillingCycleDate();
         result = (result == null || result.compareTo(nextBillingCycleDate) < 0) ? nextBillingCycleDate : result;
         return result;

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
@@ -240,7 +240,6 @@ public abstract class ContiguousIntervalUsageInArrear {
     private void addTransitionTimesForBillingEvent(final BillingEvent event, final LocalDate startDate, final LocalDate endDate, final int bcd, final boolean lastEvent) {
         final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, bcd, usage.getBillingPeriod(), usage.getBillingMode(), InArrearMode.DEFAULT);
 
-
         int numberOfPeriod = 0;
         // First billingCycleDate prior startDate
         LocalDate nextBillCycleDate = bid.getFutureBillingDateFor(numberOfPeriod);

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/ContiguousIntervalUsageInArrear.java
@@ -237,7 +237,7 @@ public abstract class ContiguousIntervalUsageInArrear {
     }
 
     private void addTransitionTimesForBillingEvent(final BillingEvent event, final LocalDate startDate, final LocalDate endDate, final int bcd, final boolean lastEvent) {
-        final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, bcd, usage.getBillingPeriod(), usage.getBillingMode());
+        final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, bcd, usage.getBillingPeriod(), usage.getBillingMode(), false);
 
 
         int numberOfPeriod = 0;
@@ -385,13 +385,13 @@ public abstract class ContiguousIntervalUsageInArrear {
             final LocalDate startDate = internalTenantContext.toLocalDate(thisEvent.getEffectiveDate());
             final LocalDate endDate = internalTenantContext.toLocalDate(nextEvent.getEffectiveDate());
 
-            final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, thisEvent.getBillCycleDayLocal(), usage.getBillingPeriod(), BillingMode.IN_ARREAR);
+            final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, endDate, targetDate, thisEvent.getBillCycleDayLocal(), usage.getBillingPeriod(), BillingMode.IN_ARREAR, false);
             final LocalDate nextBillingCycleDate = bid.getNextBillingCycleDate();
             result = (result == null || result.compareTo(nextBillingCycleDate) < 0) ? nextBillingCycleDate : result;
         }
 
         final LocalDate startDate = internalTenantContext.toLocalDate(nextEvent.getEffectiveDate());
-        final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, null, targetDate, nextEvent.getBillCycleDayLocal(), usage.getBillingPeriod(), BillingMode.IN_ARREAR);
+        final BillingIntervalDetail bid = new BillingIntervalDetail(startDate, null, targetDate, nextEvent.getBillCycleDayLocal(), usage.getBillingPeriod(), BillingMode.IN_ARREAR, false);
         final LocalDate nextBillingCycleDate = bid.getNextBillingCycleDate();
         result = (result == null || result.compareTo(nextBillingCycleDate) < 0) ? nextBillingCycleDate : result;
         return result;

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInAdvanceBillingIntervalDetail.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInAdvanceBillingIntervalDetail.java
@@ -22,6 +22,7 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.BillingMode;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.killbill.billing.util.config.definition.InvoiceConfig.InArrearMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -42,13 +43,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 17;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-17"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-17"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-16"));
     }
 
@@ -65,13 +66,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 30;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-16"));
     }
 
@@ -90,13 +91,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 30;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2013-01-30"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-31"));
     }
 
@@ -113,20 +114,20 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 14;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2013-02-14"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-03-14"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-16"));
     }
 
     @Test(groups = "fast")
     public void testNextBCDShouldNotBeInThePast() throws Exception {
         final LocalDate from = new LocalDate("2012-07-16");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 15, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 15, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-08-15"));
     }
@@ -134,7 +135,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testBeforeBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-02");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-03-03"));
     }
@@ -142,7 +143,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testEqualBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-03");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-03-03"));
     }
@@ -150,7 +151,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testAfterBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-04");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-04-03"));
     }
@@ -161,7 +162,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate(2012, 8, 16);
         final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(firstBCD, null, targetDate, 16, billingPeriod, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(firstBCD, null, targetDate, 16, billingPeriod, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         final LocalDate effectiveEndDate = billingIntervalDetail.getEffectiveEndDate();
         Assert.assertEquals(effectiveEndDate, new LocalDate(2012, 9, 16));
     }
@@ -172,7 +173,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate endDate = new LocalDate(2012, 9, 15); // so we get effectiveEndDate on 9/15
         final LocalDate targetDate = new LocalDate(2012, 8, 16);
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, endDate, targetDate, 16, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, endDate, targetDate, 16, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         final LocalDate lastBCD = billingIntervalDetail.getLastBillingCycleDate();
         Assert.assertEquals(lastBCD, new LocalDate(2012, 8, 16));
     }
@@ -182,7 +183,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-07-16");
         final int bcdLocal = 15;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, start, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, start, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         final LocalDate lastBCD = billingIntervalDetail.getLastBillingCycleDate();
         Assert.assertEquals(lastBCD, new LocalDate("2012-08-15"));
     }
@@ -194,7 +195,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = null;
         final int bcdLocal = 31;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
         final LocalDate effectiveEndDate = billingIntervalDetail.getEffectiveEndDate();
         Assert.assertEquals(effectiveEndDate, new LocalDate("2012-05-31"));
     }
@@ -206,7 +207,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate endDate = null;
         final LocalDate targetDate = new LocalDate("2017-03-31");
         int BCD = 31;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, BCD, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, BCD, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, InArrearMode.DEFAULT);
 
         final LocalDate firstBillingCycleDate = billingIntervalDetail.getFirstBillingCycleDate();
         final LocalDate lastBillingCycleDate = billingIntervalDetail.getLastBillingCycleDate();

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInAdvanceBillingIntervalDetail.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInAdvanceBillingIntervalDetail.java
@@ -42,13 +42,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 17;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-17"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-17"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-16"));
     }
 
@@ -65,13 +65,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 30;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-16"));
     }
 
@@ -90,13 +90,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 30;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2013-01-30"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-31"));
     }
 
@@ -113,20 +113,20 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 14;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2013-02-14"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-03-14"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, false);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-16"));
     }
 
     @Test(groups = "fast")
     public void testNextBCDShouldNotBeInThePast() throws Exception {
         final LocalDate from = new LocalDate("2012-07-16");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 15, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 15, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-08-15"));
     }
@@ -134,7 +134,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testBeforeBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-02");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-03-03"));
     }
@@ -142,7 +142,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testEqualBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-03");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-03-03"));
     }
@@ -150,7 +150,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testAfterBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-04");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-04-03"));
     }
@@ -161,7 +161,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate(2012, 8, 16);
         final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(firstBCD, null, targetDate, 16, billingPeriod, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(firstBCD, null, targetDate, 16, billingPeriod, BillingMode.IN_ADVANCE, false);
         final LocalDate effectiveEndDate = billingIntervalDetail.getEffectiveEndDate();
         Assert.assertEquals(effectiveEndDate, new LocalDate(2012, 9, 16));
     }
@@ -172,7 +172,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate endDate = new LocalDate(2012, 9, 15); // so we get effectiveEndDate on 9/15
         final LocalDate targetDate = new LocalDate(2012, 8, 16);
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, endDate, targetDate, 16, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, endDate, targetDate, 16, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         final LocalDate lastBCD = billingIntervalDetail.getLastBillingCycleDate();
         Assert.assertEquals(lastBCD, new LocalDate(2012, 8, 16));
     }
@@ -182,7 +182,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-07-16");
         final int bcdLocal = 15;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, start, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, start, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         final LocalDate lastBCD = billingIntervalDetail.getLastBillingCycleDate();
         Assert.assertEquals(lastBCD, new LocalDate("2012-08-15"));
     }
@@ -194,7 +194,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = null;
         final int bcdLocal = 31;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
         final LocalDate effectiveEndDate = billingIntervalDetail.getEffectiveEndDate();
         Assert.assertEquals(effectiveEndDate, new LocalDate("2012-05-31"));
     }
@@ -206,7 +206,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate endDate = null;
         final LocalDate targetDate = new LocalDate("2017-03-31");
         int BCD = 31;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, BCD, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, BCD, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
 
         final LocalDate firstBillingCycleDate = billingIntervalDetail.getFirstBillingCycleDate();
         final LocalDate lastBillingCycleDate = billingIntervalDetail.getLastBillingCycleDate();

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInAdvanceBillingIntervalDetail.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInAdvanceBillingIntervalDetail.java
@@ -42,13 +42,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 17;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-17"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-17"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-16"));
     }
 
@@ -65,13 +65,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 30;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-16"));
     }
 
@@ -90,13 +90,13 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 30;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2013-01-30"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-29"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-31"));
     }
 
@@ -113,20 +113,20 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate();
         final int bcd = 14;
 
-        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail annualBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.ANNUAL, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(annualBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2013-02-14"));
 
-        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail monthlyBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(monthlyBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-03-14"));
 
-        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail thirtyDaysBillingIntervalDetail = new BillingIntervalDetail(from, to, targetDate, bcd, BillingPeriod.THIRTY_DAYS, BillingMode.IN_ADVANCE, null);
         Assert.assertEquals(thirtyDaysBillingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-16"));
     }
 
     @Test(groups = "fast")
     public void testNextBCDShouldNotBeInThePast() throws Exception {
         final LocalDate from = new LocalDate("2012-07-16");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 15, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 15, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-08-15"));
     }
@@ -134,7 +134,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testBeforeBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-02");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-03-03"));
     }
@@ -142,7 +142,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testEqualBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-03");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-03-03"));
     }
@@ -150,7 +150,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
     @Test(groups = "fast")
     public void testAfterBCDWithOnOrAfter() throws Exception {
         final LocalDate from = new LocalDate("2012-03-04");
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(from, null, new LocalDate(), 3, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         final LocalDate to = billingIntervalDetail.getFirstBillingCycleDate();
         Assert.assertEquals(to, new LocalDate("2012-04-03"));
     }
@@ -161,7 +161,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate targetDate = new LocalDate(2012, 8, 16);
         final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(firstBCD, null, targetDate, 16, billingPeriod, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(firstBCD, null, targetDate, 16, billingPeriod, BillingMode.IN_ADVANCE, null);
         final LocalDate effectiveEndDate = billingIntervalDetail.getEffectiveEndDate();
         Assert.assertEquals(effectiveEndDate, new LocalDate(2012, 9, 16));
     }
@@ -172,7 +172,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate endDate = new LocalDate(2012, 9, 15); // so we get effectiveEndDate on 9/15
         final LocalDate targetDate = new LocalDate(2012, 8, 16);
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, endDate, targetDate, 16, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, endDate, targetDate, 16, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         final LocalDate lastBCD = billingIntervalDetail.getLastBillingCycleDate();
         Assert.assertEquals(lastBCD, new LocalDate(2012, 8, 16));
     }
@@ -182,7 +182,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-07-16");
         final int bcdLocal = 15;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, start, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, start, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         final LocalDate lastBCD = billingIntervalDetail.getLastBillingCycleDate();
         Assert.assertEquals(lastBCD, new LocalDate("2012-08-15"));
     }
@@ -194,7 +194,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = null;
         final int bcdLocal = 31;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcdLocal, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
         final LocalDate effectiveEndDate = billingIntervalDetail.getEffectiveEndDate();
         Assert.assertEquals(effectiveEndDate, new LocalDate("2012-05-31"));
     }
@@ -206,7 +206,7 @@ public class TestInAdvanceBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate endDate = null;
         final LocalDate targetDate = new LocalDate("2017-03-31");
         int BCD = 31;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, BCD, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(startDate, endDate, targetDate, BCD, BillingPeriod.MONTHLY, BillingMode.IN_ADVANCE, null);
 
         final LocalDate firstBillingCycleDate = billingIntervalDetail.getFirstBillingCycleDate();
         final LocalDate lastBillingCycleDate = billingIntervalDetail.getLastBillingCycleDate();

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInArrearBillingIntervalDetail.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInArrearBillingIntervalDetail.java
@@ -38,7 +38,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-16");
         final int bcd = 13;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertFalse(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-13"));
@@ -57,7 +57,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-02-13");
         final int bcd = 13;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-13"));
@@ -77,7 +77,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-19");
         final int bcd = 16;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-16"));
@@ -97,7 +97,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-19");
         final int bcd = 25;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertFalse(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-25"));
@@ -118,7 +118,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = new LocalDate("2012-01-19");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 25;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-25"));
@@ -139,7 +139,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 25;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-25"));
@@ -160,7 +160,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = new LocalDate("2012-01-20");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));
@@ -179,7 +179,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));
@@ -199,7 +199,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = new LocalDate("2012-01-28");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));
@@ -218,7 +218,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-02-18");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));
@@ -238,7 +238,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = new LocalDate("2012-02-16");
         final LocalDate targetDate = new LocalDate("2012-02-18");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInArrearBillingIntervalDetail.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInArrearBillingIntervalDetail.java
@@ -21,6 +21,7 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.BillingMode;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.killbill.billing.util.config.definition.InvoiceConfig.InArrearMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -38,7 +39,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-16");
         final int bcd = 13;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertFalse(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-13"));
@@ -57,7 +58,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-02-13");
         final int bcd = 13;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-02-13"));
@@ -77,7 +78,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-19");
         final int bcd = 16;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-16"));
@@ -97,7 +98,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-19");
         final int bcd = 25;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertFalse(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-25"));
@@ -118,7 +119,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = new LocalDate("2012-01-19");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 25;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-25"));
@@ -139,7 +140,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 25;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-25"));
@@ -160,7 +161,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = new LocalDate("2012-01-20");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));
@@ -179,7 +180,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));
@@ -199,7 +200,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = new LocalDate("2012-01-28");
         final LocalDate targetDate = new LocalDate("2012-01-25");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));
@@ -218,7 +219,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate start = new LocalDate("2012-01-16");
         final LocalDate targetDate = new LocalDate("2012-02-18");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));
@@ -238,7 +239,7 @@ public class TestInArrearBillingIntervalDetail extends InvoiceTestSuiteNoDB {
         final LocalDate end = new LocalDate("2012-02-16");
         final LocalDate targetDate = new LocalDate("2012-02-18");
         final int bcd = 18;
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, false);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.DEFAULT);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2012-01-18"));

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInArrearGreedyBillingIntervalDetail.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInArrearGreedyBillingIntervalDetail.java
@@ -21,6 +21,7 @@ import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.BillingMode;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.killbill.billing.util.config.definition.InvoiceConfig.InArrearMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -36,7 +37,7 @@ public class TestInArrearGreedyBillingIntervalDetail extends InvoiceTestSuiteNoD
         final LocalDate start = new LocalDate("2022-11-07");
         final int bcd = 7;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.GREEDY);
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-07"));
         Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-12-07"));
@@ -53,7 +54,7 @@ public class TestInArrearGreedyBillingIntervalDetail extends InvoiceTestSuiteNoD
         final LocalDate start = new LocalDate("2022-09-07");
         final int bcd = 7;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.GREEDY);
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-09-07"));
         Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-12-07"));
@@ -71,7 +72,7 @@ public class TestInArrearGreedyBillingIntervalDetail extends InvoiceTestSuiteNoD
         final LocalDate start = new LocalDate("2022-11-01");
         final int bcd = 1;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.GREEDY);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-01"));
@@ -88,7 +89,7 @@ public class TestInArrearGreedyBillingIntervalDetail extends InvoiceTestSuiteNoD
         final LocalDate start = new LocalDate("2022-09-01");
         final int bcd = 1;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.GREEDY);
 
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-09-01"));
@@ -108,7 +109,7 @@ public class TestInArrearGreedyBillingIntervalDetail extends InvoiceTestSuiteNoD
         final LocalDate end = new LocalDate("2022-11-15");
         final int bcd = 7;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.GREEDY);
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-07"));
         Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-11-15"));
@@ -126,7 +127,7 @@ public class TestInArrearGreedyBillingIntervalDetail extends InvoiceTestSuiteNoD
         final LocalDate end = new LocalDate("2022-12-02");
         final int bcd = 7;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.GREEDY);
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-07"));
         Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-12-02"));
@@ -144,7 +145,7 @@ public class TestInArrearGreedyBillingIntervalDetail extends InvoiceTestSuiteNoD
         final LocalDate end = new LocalDate("2022-12-08");
         final int bcd = 7;
 
-        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, InArrearMode.GREEDY);
         Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
         Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-07"));
         Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-12-07"));

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInArrearGreedyBillingIntervalDetail.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInArrearGreedyBillingIntervalDetail.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.generator;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingMode;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestInArrearGreedyBillingIntervalDetail extends InvoiceTestSuiteNoDB {
+
+
+    @Test(groups = "fast")
+    public void testScenarioBillRun_A() {
+
+        // Simulate a bill-run on the first and verify we bill the current period
+        // start date aligns with BCD
+        final LocalDate targetDate = new LocalDate("2022-12-01");
+        final LocalDate start = new LocalDate("2022-11-07");
+        final int bcd = 7;
+
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
+        Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-07"));
+        Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-12-07"));
+        Assert.assertEquals(billingIntervalDetail.getNextBillingCycleDate(), new LocalDate("2023-01-07"));
+    }
+
+
+    @Test(groups = "fast")
+    public void testScenarioBillRun_B() {
+
+        // Simulate a bill-run on the first and verify we bill the current period and the past periods
+        // start date aligns with BCD
+        final LocalDate targetDate = new LocalDate("2022-12-01");
+        final LocalDate start = new LocalDate("2022-09-07");
+        final int bcd = 7;
+
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
+        Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-09-07"));
+        Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-12-07"));
+        Assert.assertEquals(billingIntervalDetail.getNextBillingCycleDate(), new LocalDate("2023-01-07"));
+    }
+
+
+
+    @Test(groups = "fast")
+    public void testScenarioBillRun_C() {
+
+        // Simulate a bill-run on the startDate and verify we **don't bill** the upcoming period (we don't bill in-advance)
+        // start date aligns with BCD
+        final LocalDate targetDate = new LocalDate("2022-11-01");
+        final LocalDate start = new LocalDate("2022-11-01");
+        final int bcd = 1;
+
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+
+        Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
+        Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-01"));
+        Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-11-01"));
+        Assert.assertEquals(billingIntervalDetail.getNextBillingCycleDate(), new LocalDate("2022-12-01"));
+    }
+
+    @Test(groups = "fast")
+    public void testScenarioBillRun_D() {
+
+        // Simulate a bill-run on the startDate and verify we **don't bill** the upcoming period (we don't bill in-advance)
+        // start date aligns with BCD
+        final LocalDate targetDate = new LocalDate("2022-11-01");
+        final LocalDate start = new LocalDate("2022-09-01");
+        final int bcd = 1;
+
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, null, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+
+        Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
+        Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-09-01"));
+        Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-11-01"));
+        Assert.assertEquals(billingIntervalDetail.getNextBillingCycleDate(), new LocalDate("2022-12-01"));
+    }
+
+
+    @Test(groups = "fast")
+    public void testScenarioBillRun_E() {
+
+        // Simulate a bill-run on the first and verify we bill the current period
+        // start date aligns with BCD
+        // endDate prior targetDate
+        final LocalDate targetDate = new LocalDate("2022-12-01");
+        final LocalDate start = new LocalDate("2022-11-07");
+        final LocalDate end = new LocalDate("2022-11-15");
+        final int bcd = 7;
+
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
+        Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-07"));
+        Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-11-15"));
+        Assert.assertEquals(billingIntervalDetail.getNextBillingCycleDate(), new LocalDate("2022-12-07"));
+    }
+
+    @Test(groups = "fast")
+    public void testScenarioBillRun_F() {
+
+        // Simulate a bill-run on the first and verify we bill the current period
+        // start date aligns with BCD
+        // endDate after targetDate (but prior nextBCD)
+        final LocalDate targetDate = new LocalDate("2022-12-01");
+        final LocalDate start = new LocalDate("2022-11-07");
+        final LocalDate end = new LocalDate("2022-12-02");
+        final int bcd = 7;
+
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
+        Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-07"));
+        Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-12-02"));
+        Assert.assertEquals(billingIntervalDetail.getNextBillingCycleDate(), new LocalDate("2022-12-07"));
+    }
+
+    @Test(groups = "fast")
+    public void testScenarioBillRun_G() {
+
+        // Simulate a bill-run on the first and verify we bill the current period
+        // start date aligns with BCD
+        // endDate after targetDate and nextBCD
+        final LocalDate targetDate = new LocalDate("2022-12-01");
+        final LocalDate start = new LocalDate("2022-11-07");
+        final LocalDate end = new LocalDate("2022-12-08");
+        final int bcd = 7;
+
+        final BillingIntervalDetail billingIntervalDetail = new BillingIntervalDetail(start, end, targetDate, bcd, BillingPeriod.MONTHLY, BillingMode.IN_ARREAR, true);
+        Assert.assertTrue(billingIntervalDetail.hasSomethingToBill());
+        Assert.assertEquals(billingIntervalDetail.getFirstBillingCycleDate(), new LocalDate("2022-11-07"));
+        Assert.assertEquals(billingIntervalDetail.getEffectiveEndDate(), new LocalDate("2022-12-07"));
+        Assert.assertEquals(billingIntervalDetail.getNextBillingCycleDate(), new LocalDate("2023-01-07"));
+    }
+
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/model/TestRecurringInAdvance.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/model/TestRecurringInAdvance.java
@@ -150,7 +150,7 @@ public class TestRecurringInAdvance extends InvoiceTestSuiteNoDB {
                                     final int billingCycleDayLocal, final BillingPeriod billingPeriod,
                                     final LinkedHashMap<LocalDate, LocalDate> expectedDates) throws InvalidDateSequenceException {
 
-        final RecurringInvoiceItemDataWithNextBillingCycleDate invoiceItemsWithDates = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, BillingMode.IN_ADVANCE, null);
+        final RecurringInvoiceItemDataWithNextBillingCycleDate invoiceItemsWithDates = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, BillingMode.IN_ADVANCE, internalCallContext);
         final List<RecurringInvoiceItemData> invoiceItems = invoiceItemsWithDates.getItemData();
         int i = 0;
         for (final LocalDate periodStartDate : expectedDates.keySet()) {

--- a/invoice/src/test/java/org/killbill/billing/invoice/model/TestRecurringInAdvance.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/model/TestRecurringInAdvance.java
@@ -150,7 +150,7 @@ public class TestRecurringInAdvance extends InvoiceTestSuiteNoDB {
                                     final int billingCycleDayLocal, final BillingPeriod billingPeriod,
                                     final LinkedHashMap<LocalDate, LocalDate> expectedDates) throws InvalidDateSequenceException {
 
-        final RecurringInvoiceItemDataWithNextBillingCycleDate invoiceItemsWithDates = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, BillingMode.IN_ADVANCE);
+        final RecurringInvoiceItemDataWithNextBillingCycleDate invoiceItemsWithDates = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, BillingMode.IN_ADVANCE, null);
         final List<RecurringInvoiceItemData> invoiceItems = invoiceItemsWithDates.getItemData();
         int i = 0;
         for (final LocalDate periodStartDate : expectedDates.keySet()) {

--- a/invoice/src/test/java/org/killbill/billing/invoice/model/TestRecurringInArrear.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/model/TestRecurringInArrear.java
@@ -152,7 +152,7 @@ public class TestRecurringInArrear extends InvoiceTestSuiteNoDB {
                                     final int billingCycleDayLocal, final BillingPeriod billingPeriod,
                                     final LinkedHashMap<LocalDate, LocalDate> expectedDates) throws InvalidDateSequenceException {
 
-        final RecurringInvoiceItemDataWithNextBillingCycleDate invoiceItemsWithDates = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, BillingMode.IN_ARREAR);
+        final RecurringInvoiceItemDataWithNextBillingCycleDate invoiceItemsWithDates = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, endDate, targetDate, billingCycleDayLocal, billingPeriod, BillingMode.IN_ARREAR, null);
         final List<RecurringInvoiceItemData> invoiceItems = invoiceItemsWithDates.getItemData();
 
         int i = 0;

--- a/invoice/src/test/java/org/killbill/billing/invoice/proRations/ProRationTestBase.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/proRations/ProRationTestBase.java
@@ -66,7 +66,7 @@ public abstract class ProRationTestBase extends InvoiceTestSuiteNoDB {
     }
 
     protected BigDecimal calculateNumberOfBillingCycles(final LocalDate startDate, final LocalDate endDate, final LocalDate targetDate, final int billingCycleDay) throws InvalidDateSequenceException {
-        final RecurringInvoiceItemDataWithNextBillingCycleDate items = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, endDate, targetDate, billingCycleDay, getBillingPeriod(), getBillingMode());
+        final RecurringInvoiceItemDataWithNextBillingCycleDate items = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, endDate, targetDate, billingCycleDay, getBillingPeriod(), getBillingMode(), null);
 
         BigDecimal numberOfBillingCycles = ZERO;
         for (final RecurringInvoiceItemData item : items.getItemData()) {
@@ -77,7 +77,7 @@ public abstract class ProRationTestBase extends InvoiceTestSuiteNoDB {
     }
 
     protected BigDecimal calculateNumberOfBillingCycles(final LocalDate startDate, final LocalDate targetDate, final int billingCycleDay) throws InvalidDateSequenceException {
-        final RecurringInvoiceItemDataWithNextBillingCycleDate items = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, null, targetDate, billingCycleDay, getBillingPeriod(), getBillingMode());
+        final RecurringInvoiceItemDataWithNextBillingCycleDate items = fixedAndRecurringInvoiceItemGenerator.generateInvoiceItemData(startDate, null, targetDate, billingCycleDay, getBillingPeriod(), getBillingMode(), null);
 
         BigDecimal numberOfBillingCycles = ZERO;
         for (final RecurringInvoiceItemData item : items.getItemData()) {

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -41,6 +41,11 @@ public interface InvoiceConfig extends KillbillConfig {
         DETAIL,
     }
 
+    public enum InArrearMode {
+        DEFAULT,
+        GREEDY
+    }
+
     @Config("org.killbill.invoice.maxNumberOfMonthsInFuture")
     @Default("36")
     @Description("Maximum target date to consider when generating an invoice")
@@ -161,6 +166,16 @@ public interface InvoiceConfig extends KillbillConfig {
     @Default("AGGREGATE")
     @Description("How the result for an item will be reported (aggregate mode or detail mode). ")
     UsageDetailMode getItemResultBehaviorMode(@Param("dummy") final InternalTenantContext tenantContext);
+
+    @Config("org.killbill.invoice.in-arrear.mode")
+    @Default("DEFAULT")
+    @Description("Determine how the system should behave for in-arrear plans")
+    InArrearMode getInArrearMode();
+
+    @Config("org.killbill.invoice.in-arrear.mode")
+    @Default("DEFAULT")
+    @Description("Determine how the system should behave for in-arrear plans")
+    InArrearMode getInArrearMode(@Param("dummy") final InternalTenantContext tenantContext);
 
     @Config("org.killbill.invoice.parkAccountsWithUnknownUsage")
     @Default("false")

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -167,12 +167,12 @@ public interface InvoiceConfig extends KillbillConfig {
     @Description("How the result for an item will be reported (aggregate mode or detail mode). ")
     UsageDetailMode getItemResultBehaviorMode(@Param("dummy") final InternalTenantContext tenantContext);
 
-    @Config("org.killbill.invoice.in-arrear.mode")
+    @Config("org.killbill.invoice.inArrear.mode")
     @Default("DEFAULT")
     @Description("Determine how the system should behave for in-arrear plans")
     InArrearMode getInArrearMode();
 
-    @Config("org.killbill.invoice.in-arrear.mode")
+    @Config("org.killbill.invoice.inArrear.mode")
     @Default("DEFAULT")
     @Description("Determine how the system should behave for in-arrear plans")
     InArrearMode getInArrearMode(@Param("dummy") final InternalTenantContext tenantContext);


### PR DESCRIPTION
In scenarios where we want to align RECURRING subscriptions on the day they start, and yet perform a 'bill run' later (i.e. generate all the invoices for the current month on the 1st), none of the `IN_ARREAR` nor `IN_ADVANCE` modes work very well. 

We are introducing a variation for the  `IN_ARREAR` mode which behaves just like the default use case we have, except that **when configured we allow to generate the invoice prior we reach the end of the period**. The configuration can be made at the tenant level using a new property `org.killbill.invoice.in-arrear.mode=GREEDY`.

The behavior has only been plugged for RECURRING subscriptions and not USAGE based.

Note: The PR is against our `0.22.x` `maint` branch.
