### PR TITLE
Fix for avatax plugin

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -342,10 +342,11 @@ public class InvoicePluginDispatcher {
             final AdditionalItemsResult res = invoicePlugin.getAdditionalInvoiceItems(clonedInvoice, isDryRun, inputPluginProperties, invoiceContext);
 
             if (res != null) {
-                if (res.getAdditionalItems() != null &&
-                    !res.getAdditionalItems().isEmpty()) {
+            	final List<InvoiceItem> itemsFromPlugin = res.getAdditionalItems();
+                if (itemsFromPlugin != null &&
+                    !itemsFromPlugin.isEmpty()) {
                     final Collection<InvoiceItem> additionalInvoiceItems = new LinkedList<InvoiceItem>();
-                    for (final InvoiceItem additionalInvoiceItem : res.getAdditionalItems()) {
+                    for (final InvoiceItem additionalInvoiceItem : itemsFromPlugin) {
                         final InvoiceItem sanitizedInvoiceItem = validateAndSanitizeInvoiceItemFromPlugin(originalInvoice.getId(),
                                                                                                           invoiceItemsByItemId,
                                                                                                           additionalInvoiceItem,


### PR DESCRIPTION
The `res.getAdditionalItems()`  returns the additional invoice items only the first time it is invoked in the case of the `Avatax` plugin. On subsequent calls, it returns an empty list which prevents the tax items from being created. With this fix in place, the tax items are created.