### PR TITLE
cancel subscription with NO_BILLING_PERIOD. fix endless cycle

### DIFF
--- a/catalog/src/test/resources/org/killbill/billing/catalog/catalogTest.xml
+++ b/catalog/src/test/resources/org/killbill/billing/catalog/catalogTest.xml
@@ -778,6 +778,35 @@
                 </recurring>
             </finalPhase>
         </plan>
+        <plan name="shotgun-free" prettyName="Shotgun NoBillingPeriod">
+            <product>Shotgun</product>
+            <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+            <initialPhases/>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                    <number>-1</number>
+                </duration>
+                <fixed type="ONE_TIME">
+                    <fixedPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>0</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>0</value>
+                        </price>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>0</value>
+                        </price>
+                    </fixedPrice>
+                </fixed>
+                <usages/>
+            </finalPhase>
+            <plansAllowedInBundle>-1</plansAllowedInBundle>
+        </plan>
         <plan name="assault-rifle-monthly">
             <product>Assault-Rifle</product>
             <initialPhases>
@@ -1777,6 +1806,7 @@
                 <plan>blowdart-monthly</plan>
                 <plan>pistol-monthly</plan>
                 <plan>shotgun-monthly</plan>
+                <plan>shotgun-free</plan>
                 <plan>assault-rifle-monthly</plan>
                 <plan>pistol-annual</plan>
                 <plan>pistol-quarterly</plan>

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
+import org.joda.time.Period;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.BillingAlignment;
@@ -813,8 +814,12 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
 
                     final BillingPeriod billingPeriod = getLastActivePlan().getRecurringBillingPeriod();
                     DateTime proposedDate = chargedThroughDate;
-                    while (proposedDate.isAfter(clock.getUTCNow())) {
-                        proposedDate = proposedDate.minus(billingPeriod.getPeriod());
+                    if (billingPeriod.getPeriod().equals(Period.ZERO)) {
+                        proposedDate = clock.getUTCNow();
+                    } else {
+                        while (proposedDate.isAfter(clock.getUTCNow())) {
+                            proposedDate = proposedDate.minus(billingPeriod.getPeriod());
+                        }
                     }
 
                     final LocalDate resultingLocalDate = BillCycleDayCalculator.alignProposedBillCycleDate(proposedDate, bcd, billingPeriod, context);


### PR DESCRIPTION
if the CTD is later than the current date and the plan has a billing period of NO_BILLING_PERIOD then this will cause an infinite loop