### PR TITLE
Fix for #1842

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig.java
@@ -202,7 +202,15 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
         assertListenerStatus();
 
         curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
-                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 5, 5), new LocalDate(2022, 6, 5), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 5, 5), new LocalDate(2022, 6, 5), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2022-06-05
+        assertListenerStatus();
+
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2022, 6, 5), new LocalDate(2022, 7, 5), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
 
     }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2.java
@@ -18,7 +18,6 @@
 package org.killbill.billing.beatrix.integration;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,11 +26,9 @@ import org.killbill.billing.account.api.Account;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
 import org.killbill.billing.catalog.api.BillingPeriod;
-import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.entitlement.api.DefaultEntitlement;
-import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.platform.api.KillbillConfigSource;
@@ -51,18 +48,23 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2 e
         return super.getConfigSource(null, allExtraProperties);
     }
 
-    @Test(groups = "slow", description="https://github.com/killbill/killbill/issues/1842")
-    public void testSubscriptionWithBothAccounts() throws Exception {  //test for the complete scenario described in #1842
-    	
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1842")
+    public void testSubscriptionWithBothAccounts() throws Exception {
+
         final LocalDate today = new LocalDate(2023, 3, 28);
         clock.setDay(today);
 
         final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
 
+        //
+        // We have 2 catalog versions, V2 is effective on 2023-04-07 but there is an effectiveDateForExistingSubscriptions=2023-04-20 for the Liability Plan.
+        // - Account1 has a BCD set after the 20, so it worked as expected
+        // - Account2 has a BCD set before the 20, and it did not work as expected as per #1842
+        //
         final boolean isAccount1 = true;
         final boolean isAccount2 = true;
 
-        final Account account1 = createAccountWithNonOsgiPaymentMethod(getAccountData(28)); //TODO remove bcd?
+        final Account account1 = createAccountWithNonOsgiPaymentMethod(getAccountData(28));
         Invoice curInvoice1;
         if (isAccount1) {
             final DefaultEntitlement bpEntitlement1 =
@@ -72,14 +74,13 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2 e
 
             assertNotNull(bpEntitlement1);
             curInvoice1 = invoiceChecker.checkInvoice(account1.getId(), 1, callContext,
-                                                              new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 28), new LocalDate(2023, 4, 28), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+                                                      new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 28), new LocalDate(2023, 4, 28), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
             Assert.assertEquals(curInvoice1.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
         }
 
-
         clock.setDay(new LocalDate(2023, 4, 6));
-        
-        final Account account2 = createAccountWithNonOsgiPaymentMethod(getAccountData(6)); //TODO remove bcd?
+
+        final Account account2 = createAccountWithNonOsgiPaymentMethod(getAccountData(6));
         Invoice curInvoice2;
         if (isAccount2) {
             final DefaultEntitlement bpEntitlement2 =
@@ -89,7 +90,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2 e
 
             assertNotNull(bpEntitlement2);
             curInvoice2 = invoiceChecker.checkInvoice(account2.getId(), 1, callContext,
-                                                              new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 6), new LocalDate(2023, 5, 6), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+                                                      new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 6), new LocalDate(2023, 5, 6), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
             Assert.assertEquals(curInvoice2.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
         }
 
@@ -103,17 +104,15 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2 e
         assertListenerStatus();
 
         if (isAccount1) {
-            curInvoice1 = invoiceChecker.checkInvoice(account1.getId(), 2, callContext,
-                                                      new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 28), new LocalDate(2023, 5, 28), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+            invoiceChecker.checkInvoice(account1.getId(), 2, callContext,
+                                        new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 28), new LocalDate(2023, 5, 28), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
         }
 
         if (isAccount2) {
-            curInvoice2 = invoiceChecker.checkInvoice(account2.getId(), 2, callContext,
-                                                      new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 6), new LocalDate(2023, 6, 6), InvoiceItemType.RECURRING, new BigDecimal("59.95"))); //FAILS here, invoice created for 49.95 as per v1
+            invoiceChecker.checkInvoice(account2.getId(), 2, callContext,
+                                        new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 6), new LocalDate(2023, 6, 6), InvoiceItemType.RECURRING, new BigDecimal("59.95"))); //FAILS here, invoice created for 49.95 as per v1
         }
-
         assertListenerStatus();
     }
-
 
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2014-2019 Groupon, Inc
+ * Copyright 2014-2019 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2 extends TestIntegrationBase {
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2");
+        // Custom subscription config to test the alignment for the catalog effectiveDateForExistingSubscriptions
+        allExtraProperties.put("org.killbill.subscription.align.effectiveDateForExistingSubscriptions", "true");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    @Test(groups = "slow", description="https://github.com/killbill/killbill/issues/1842")
+    public void testSubscriptionWithBothAccounts() throws Exception {  //test for the complete scenario described in #1842
+    	
+        final LocalDate today = new LocalDate(2023, 3, 28);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        final Account account1 = createAccountWithNonOsgiPaymentMethod(getAccountData(28)); //TODO remove bcd?
+
+        final DefaultEntitlement bpEntitlement1 =
+                createBaseEntitlementAndCheckForCompletion(account1.getId(), "externalKey1", "Liability",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+
+        assertNotNull(bpEntitlement1);
+        Invoice curInvoice1 = invoiceChecker.checkInvoice(account1.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 28), new LocalDate(2023, 4, 28), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice1.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+        
+        clock.setDay(new LocalDate(2023, 4, 6));
+        
+        final Account account2 = createAccountWithNonOsgiPaymentMethod(getAccountData(6)); //TODO remove bcd?
+
+        final DefaultEntitlement bpEntitlement2 =
+                createBaseEntitlementAndCheckForCompletion(account2.getId(), "externalKey2", "Liability",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+
+        assertNotNull(bpEntitlement2);
+        Invoice curInvoice2 = invoiceChecker.checkInvoice(account2.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 6), new LocalDate(2023, 5, 6), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice2.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+        
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 6));
+        assertListenerStatus();
+        
+        curInvoice1 = invoiceChecker.checkInvoice(account1.getId(), 2, callContext,
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 28), new LocalDate(2023, 5, 28), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+        
+//        curInvoice2 = invoiceChecker.checkInvoice(account2.getId(), 2, callContext,
+//                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 6), new LocalDate(2023, 6, 6), InvoiceItemType.RECURRING, new BigDecimal("59.95"))); //FAILS here, invoice created for 49.95 as per v1
+        
+    }
+    
+    @Test(groups = "slow", description="https://github.com/killbill/killbill/issues/1842")
+    public void testSubscriptionWithAccountNotWorking() throws Exception { //test for the account a2 described in #1842
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+        clock.setDay(new LocalDate(2023, 4, 6));
+        
+        final Account account2 = createAccountWithNonOsgiPaymentMethod(getAccountData(6)); //TODO remove bcd?
+
+        final DefaultEntitlement bpEntitlement2 =
+                createBaseEntitlementAndCheckForCompletion(account2.getId(), "externalKey2", "Liability",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+
+        assertNotNull(bpEntitlement2);
+        Invoice curInvoice2 = invoiceChecker.checkInvoice(account2.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 6), new LocalDate(2023, 5, 6), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice2.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+        
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 6));
+        assertListenerStatus();
+        
+//        curInvoice2 = invoiceChecker.checkInvoice(account2.getId(), 2, callContext,
+//                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 6), new LocalDate(2023, 6, 6), InvoiceItemType.RECURRING, new BigDecimal("59.95"))); //FAILS here, invoice created for 49.95 as per v1
+        
+    }  
+    
+    @Test(groups = "slow", description="https://github.com/killbill/killbill/issues/1842")
+    public void testSubscriptionWithAccountWorking() throws Exception { //test for the account a1 described in #1842
+
+        final LocalDate today = new LocalDate(2023, 3, 28);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        final Account account1 = createAccountWithNonOsgiPaymentMethod(getAccountData(28)); //TODO remove bcd?
+
+        final DefaultEntitlement bpEntitlement1 =
+                createBaseEntitlementAndCheckForCompletion(account1.getId(), "externalKey1", "Liability",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+
+        assertNotNull(bpEntitlement1);
+        Invoice curInvoice1 = invoiceChecker.checkInvoice(account1.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 28), new LocalDate(2023, 4, 28), InvoiceItemType.RECURRING, new BigDecimal("49.95")));
+        Assert.assertEquals(curInvoice1.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+        
+        clock.setDay(new LocalDate(2023, 4, 6));
+        
+        
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 6));
+        assertListenerStatus();
+        
+        curInvoice1 = invoiceChecker.checkInvoice(account1.getId(), 2, callContext,
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 28), new LocalDate(2023, 5, 28), InvoiceItemType.RECURRING, new BigDecimal("59.95")));
+        
+    }    
+
+}

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2/Insurance-v1.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2/Insurance-v1.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2014 The Billing Project, Inc.
+  ~
+  ~ Ning licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2023-03-01T00:00:00+00:00</effectiveDate>
+    <catalogName>Insurance</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <units>
+    </units>
+
+    <products>
+        <product name="Liability">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>CHANGE_OF_PLAN</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>SUBSCRIPTION</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="liability-monthly-no-trial">
+            <product>Liability</product>
+            <initialPhases>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>49.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>liability-monthly-no-trial</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2/Insurance-v2.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig2/Insurance-v2.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2014 The Billing Project, Inc.
+  ~
+  ~ Ning licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2023-04-07T00:00:00+00:00</effectiveDate>
+    <catalogName>Insurance</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <units>
+    </units>
+
+    <products>
+        <product name="Liability">
+            <category>BASE</category>
+        </product>
+    </products>
+
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>CHANGE_OF_PLAN</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>SUBSCRIPTION</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="liability-monthly-no-trial">
+            <effectiveDateForExistingSubscriptions>2023-04-20T00:00:00+00:00</effectiveDateForExistingSubscriptions>
+            <product>Liability</product>
+            <initialPhases>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>59.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+
+
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>liability-monthly-no-trial</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -736,7 +736,7 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
         }
 
         final BillingPeriod billingPeriod = curPlanPhase.getRecurring() != null ? curPlanPhase.getRecurring().getBillingPeriod() : BillingPeriod.NO_BILLING_PERIOD;
-        final LocalDate resultingLocalDate = BillCycleDayCalculator.alignProposedBillCycleDate(originalTransitionDate, bcd, billingPeriod, context);
+        final LocalDate resultingLocalDate = BillCycleDayCalculator.alignProposedNextBillCycleDate(originalTransitionDate, bcd, billingPeriod, context);
         final DateTime candidateResult = context.toUTCDateTime(resultingLocalDate);
         return candidateResult;
     }

--- a/util/src/main/java/org/killbill/billing/util/bcd/BillCycleDayCalculator.java
+++ b/util/src/main/java/org/killbill/billing/util/bcd/BillCycleDayCalculator.java
@@ -75,6 +75,26 @@ public abstract class BillCycleDayCalculator {
         return resultingLocalDate;
     }
 
+
+    public static LocalDate alignProposedNextBillCycleDate(final LocalDate proposedDate, final int billingCycleDay, final BillingPeriod billingPeriod) {
+        // billingCycleDay alignment only makes sense for month based BillingPeriod (MONTHLY, QUARTERLY, BIANNUAL, ANNUAL)
+        final boolean isMonthBased = (billingPeriod.getPeriod().getMonths() | billingPeriod.getPeriod().getYears()) > 0;
+        if (!isMonthBased) {
+            return proposedDate;
+        }
+       if (proposedDate.getDayOfMonth() > billingCycleDay) {
+           return alignProposedBillCycleDate(proposedDate.plusMonths(1), billingCycleDay, billingPeriod);
+       } else {
+           return alignProposedBillCycleDate(proposedDate, billingCycleDay, billingPeriod);
+       }
+    }
+
+    public static LocalDate alignProposedNextBillCycleDate(final DateTime proposedDate, final int billingCycleDay, final BillingPeriod billingPeriod, final InternalTenantContext internalTenantContext) {
+        final LocalDate proposedLocalDate = internalTenantContext.toLocalDate(proposedDate);
+        final LocalDate resultingLocalDate = alignProposedNextBillCycleDate(proposedLocalDate, billingCycleDay, billingPeriod);
+        return resultingLocalDate;
+    }
+
     private static int calculateOrRetrieveBcdFromSubscription(@Nullable final Map<UUID, Integer> bcdCache, final SubscriptionBase subscription, final InternalTenantContext internalTenantContext) {
         Integer result = bcdCache != null ? bcdCache.get(subscription.getId()) : null;
         if (result == null) {

--- a/util/src/test/java/org/killbill/billing/util/bcd/TestBillCycleDayCalculator.java
+++ b/util/src/test/java/org/killbill/billing/util/bcd/TestBillCycleDayCalculator.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 
 public class TestBillCycleDayCalculator extends UtilTestSuiteNoDB {
 
+
     @Test(groups = "fast")
     public void testCalculateBCDForAOWithBPCancelledBundleAligned() throws Exception {
         final DateTimeZone accountTimeZone = DateTimeZone.UTC;
@@ -135,6 +136,7 @@ public class TestBillCycleDayCalculator extends UtilTestSuiteNoDB {
     public void testAlignProposedBillCycleDate1() {
         final DateTime proposedDate = new DateTime(2022, 7, 19, 17, 28, 0, DateTimeZone.UTC);
         final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
+        // BCD > proposed day of the month
         final int bcd = 23;
 
         final LocalDate result = BillCycleDayCalculator.alignProposedBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
@@ -145,11 +147,60 @@ public class TestBillCycleDayCalculator extends UtilTestSuiteNoDB {
     public void testAlignProposedBillCycleDate2() {
         final DateTime proposedDate = new DateTime(2022, 7, 19, 17, 28, 0, DateTimeZone.UTC);
         final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
+        // BCD < proposed day of the month
         final int bcd = 17;
 
         final LocalDate result = BillCycleDayCalculator.alignProposedBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
         Assert.assertEquals(result, new LocalDate(2022, 7, 17));
     }
+
+    @Test(groups = "fast")
+    public void testAlignProposedBillCycleDate3() {
+        final DateTime proposedDate = new DateTime(2022, 2, 19, 17, 28, 0, DateTimeZone.UTC);
+        final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
+        // BCD > last day of the month
+        final int bcd = 31;
+
+        final LocalDate result = BillCycleDayCalculator.alignProposedBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
+        Assert.assertEquals(result, new LocalDate(2022, 2, 28));
+    }
+
+    @Test(groups = "fast")
+    public void testAlignProposedNextBillCycleDate1() {
+        final DateTime proposedDate = new DateTime(2022, 7, 19, 17, 28, 0, DateTimeZone.UTC);
+        final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
+        // BCD > proposed day of the month
+        final int bcd = 23;
+
+        final LocalDate result = BillCycleDayCalculator.alignProposedNextBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
+        Assert.assertEquals(result, new LocalDate(2022, 7, 23));
+    }
+
+    @Test(groups = "fast")
+    public void testAlignProposedNextBillCycleDate2() {
+        final DateTime proposedDate = new DateTime(2022, 7, 19, 17, 28, 0, DateTimeZone.UTC);
+        final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
+        // BCD < proposed day of the month
+        final int bcd = 17;
+
+        final LocalDate result = BillCycleDayCalculator.alignProposedNextBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
+        Assert.assertEquals(result, new LocalDate(2022, 8, 17));
+    }
+
+    @Test(groups = "fast")
+    public void testAlignProposedNextBillCycleDate3() {
+        final DateTime proposedDate = new DateTime(2022, 2, 19, 17, 28, 0, DateTimeZone.UTC);
+        final BillingPeriod billingPeriod = BillingPeriod.MONTHLY;
+        // BCD > last day of the month
+        final int bcd = 31;
+
+        final LocalDate result = BillCycleDayCalculator.alignProposedNextBillCycleDate(proposedDate, bcd, billingPeriod, internalCallContext);
+        Assert.assertEquals(result, new LocalDate(2022, 2, 28));
+    }
+
+
+
+
 
     private void verifyBCDCalculation(final DateTimeZone accountTimeZone, final DateTime startDateUTC, final int bcdLocal) throws AccountApiException, CatalogApiException {
         final SubscriptionBase subscription = Mockito.mock(SubscriptionBase.class);


### PR DESCRIPTION
* https://github.com/killbill/killbill/pull/1846/commits/b9309e058be85922c76a98336afb061f27e767e3 https://github.com/killbill/killbill/pull/1846/commits/2fba9e04b5bbabe500605c078251f44fc7389289: Add utility method and implement the fix
* https://github.com/killbill/killbill/pull/1846/commits/6be7adb414bbefd730456203bb9c62cf332d8f00: **Behavior change** as explained below; given the following scenario:

Two catalog versions, V1 effDt=`2022-01-01` and V2 effDt=`2022-04-01`. Plan 'P' has an `effectiveDateForExistingSubscriptions`=`2022-05-15`

0. Set the `org.killbill.subscription.align.effectiveDateForExistingSubscriptions=true` to align changes on subscription BCD
1. Start subscription on `2022-03-05`
2. Invoice up to `2022-05-05` using V1 price

The previous behavior was such that starting from period [2022-05-05 - 2022-06-05], we would invoice with V2 price. However, with this change, the period [2022-05-05 - 2022-06-05] is still invoiced at V1 price, and only starting [2022-06-05 - 2022-07-05] we invoice at V2 price.

This semantics is very debatable but new behavior seems more logical as the `effectiveDateForExistingSubscriptions` is set at `2022-05-15`, so we don't end up invoicing with the price from catalog V2 until we have a period starting strictly after the `effectiveDateForExistingSubscriptions`.

See test `TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig#testSubscriptionNotAlignedWithVersionChange4` to reproduce the scenario.


