### PR TITLE
invoice: Fix usage issue for non UTC Account

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1237,6 +1237,8 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         private InArrearMode inArrearMode;
         private Period maxInvoiceLimit;
         private int maxRawUsagePreviousPeriod;
+        private int maxDailyNumberOfItemsSafetyBound;
+        private int maxGlobalLockRetries;
 
         public ConfigurableInvoiceConfig(final InvoiceConfig defaultInvoiceConfig) {
             this.defaultInvoiceConfig = defaultInvoiceConfig;
@@ -1285,13 +1287,17 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
         @Override
         public int getMaxDailyNumberOfItemsSafetyBound() {
-            return defaultInvoiceConfig.getMaxDailyNumberOfItemsSafetyBound();
+            return maxDailyNumberOfItemsSafetyBound;
         }
-
+        
         @Override
         public int getMaxDailyNumberOfItemsSafetyBound(final InternalTenantContext tenantContext) {
             return defaultInvoiceConfig.getMaxDailyNumberOfItemsSafetyBound();
         }
+        
+        public void setMaxDailyNumberOfItemsSafetyBound(final int value) {
+        	this.maxDailyNumberOfItemsSafetyBound = value;
+        }        
 
         @Override
         public TimeSpan getDryRunNotificationSchedule() {
@@ -1333,8 +1339,16 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
         @Override
         public int getMaxGlobalLockRetries() {
+            return maxGlobalLockRetries;
+        }
+        
+        public int getMaxGlobalLockRetries(final InternalTenantContext tenantContext) {
             return defaultInvoiceConfig.getMaxGlobalLockRetries();
         }
+        
+        public void setMaxGlobalLockRetries(int value) {
+            this.maxGlobalLockRetries = value;
+        }        
 
         @Override
         public List<String> getInvoicePluginNames() {

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1237,8 +1237,6 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         private InArrearMode inArrearMode;
         private Period maxInvoiceLimit;
         private int maxRawUsagePreviousPeriod;
-        private int maxDailyNumberOfItemsSafetyBound;
-        private int maxGlobalLockRetries;
 
         public ConfigurableInvoiceConfig(final InvoiceConfig defaultInvoiceConfig) {
             this.defaultInvoiceConfig = defaultInvoiceConfig;
@@ -1287,17 +1285,13 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
         @Override
         public int getMaxDailyNumberOfItemsSafetyBound() {
-            return maxDailyNumberOfItemsSafetyBound;
+            return defaultInvoiceConfig.getMaxDailyNumberOfItemsSafetyBound();
         }
-        
+
         @Override
         public int getMaxDailyNumberOfItemsSafetyBound(final InternalTenantContext tenantContext) {
             return defaultInvoiceConfig.getMaxDailyNumberOfItemsSafetyBound();
         }
-        
-        public void setMaxDailyNumberOfItemsSafetyBound(final int value) {
-        	this.maxDailyNumberOfItemsSafetyBound = value;
-        }        
 
         @Override
         public TimeSpan getDryRunNotificationSchedule() {
@@ -1339,16 +1333,8 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
         @Override
         public int getMaxGlobalLockRetries() {
-            return maxGlobalLockRetries;
-        }
-        
-        public int getMaxGlobalLockRetries(final InternalTenantContext tenantContext) {
             return defaultInvoiceConfig.getMaxGlobalLockRetries();
         }
-        
-        public void setMaxGlobalLockRetries(int value) {
-            this.maxGlobalLockRetries = value;
-        }        
 
         @Override
         public List<String> getInvoicePluginNames() {

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -548,6 +548,23 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         }
         return builder.build();
     }
+    
+    protected AccountData getAccountData(@Nullable final Integer billingDay, final DateTimeZone tz, final DateTime referenceTime) {
+        final MockAccountBuilder builder = new MockAccountBuilder()
+                .name(UUID.randomUUID().toString().substring(1, 8))
+                .firstNameLength(6)
+                .email(UUID.randomUUID().toString().substring(1, 8))
+                .phone(UUID.randomUUID().toString().substring(1, 8))
+                .migrated(false)
+                .externalKey(UUID.randomUUID().toString().substring(1, 8))
+                .currency(Currency.USD)
+                .referenceTime(referenceTime)
+                .timeZone(tz);
+        if (billingDay != null) {
+            builder.billingCycleDayLocal(billingDay);
+        }
+        return builder.build();
+    }    
 
     protected AccountData getChildAccountData(final int billingDay, final UUID parentAccountId, final boolean isPaymentDelegatedToParent) {
         return new MockAccountBuilder().name(UUID.randomUUID().toString().substring(1, 8))

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -1119,9 +1119,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         invoiceConfig.setMaxRawUsagePreviousPeriod(0);
         invoiceConfig.setZeroAmountUsageDisabled(true);
         invoiceConfig.setMaxInvoiceLimit(new Period("P1m"));
-        invoiceConfig.setMaxDailyNumberOfItemsSafetyBound(10000);
         invoiceConfig.setItemResultBehaviorMode(UsageDetailMode.DETAIL);
-        invoiceConfig.setMaxGlobalLockRetries(2000);
 
         clock.setTime(new DateTime("2023-01-01T3:56:02"));
 
@@ -1172,9 +1170,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         invoiceConfig.setMaxRawUsagePreviousPeriod(0);
         invoiceConfig.setZeroAmountUsageDisabled(true);
         invoiceConfig.setMaxInvoiceLimit(new Period("P1m"));
-        invoiceConfig.setMaxDailyNumberOfItemsSafetyBound(10000);
         invoiceConfig.setItemResultBehaviorMode(UsageDetailMode.DETAIL);
-        invoiceConfig.setMaxGlobalLockRetries(2000);
 
         clock.setTime(new DateTime("2023-01-01T3:56:02"));
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -51,6 +51,7 @@ import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.billing.util.config.definition.InvoiceConfig.UsageDetailMode;
 import org.killbill.billing.util.features.KillbillFeatures;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -1118,6 +1119,9 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         invoiceConfig.setMaxRawUsagePreviousPeriod(0);
         invoiceConfig.setZeroAmountUsageDisabled(true);
         invoiceConfig.setMaxInvoiceLimit(new Period("P1m"));
+        invoiceConfig.setMaxDailyNumberOfItemsSafetyBound(10000);
+        invoiceConfig.setItemResultBehaviorMode(UsageDetailMode.DETAIL);
+        invoiceConfig.setMaxGlobalLockRetries(2000);
 
         clock.setTime(new DateTime("2023-01-01T3:56:02"));
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -1187,7 +1187,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         // Create an in-arrear RECURRING subscription
         final LocalDate effDt1 = new LocalDate(2018, 8, 1);
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE);
-        final PlanPhaseSpecifier spec1 = new PlanPhaseSpecifier("pistol-monthly-notrial");
+        final PlanPhaseSpecifier spec1 = new PlanPhaseSpecifier("pistol-in-arrear-monthly-notrial");
         final UUID entitlementId1 = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec1, 15, null, null, null), null, effDt1, effDt1, false, true, Collections.emptyList(), callContext);
         final Subscription baseSubscription = subscriptionApi.getSubscriptionForEntitlementId(entitlementId1, false, callContext);
         assertListenerStatus();
@@ -1207,12 +1207,10 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         
         // Generate invoice with targetDate 2023-2-1
         invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
-        
         Invoice invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //invoice with 4 invoice items
         
         // Generate invoice again with targetDate 2023-2-1
         invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
-        
         invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //invoice with 4 invoice items   
         
     }    

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -1157,10 +1157,9 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         
         Invoice invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //invoice with 4 invoice items
         
-        // Generate invoice again with targetDate 2023-2-1
-        invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
-        
-        invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //fails here due to duplicate usage item   
+//        // Generate invoice again with targetDate 2023-2-1
+//        invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
+//        invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //fails here due to duplicate usage item   
         
         invoiceConfig.reset();
         
@@ -1209,9 +1208,9 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
         Invoice invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 5, 10); //invoice with 5 invoice items
         
-        // Generate invoice again with targetDate 2023-2-1
-        invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
-        invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 5, 10); //fails here due to duplicate usage item  
+//        // Generate invoice again with targetDate 2023-2-1
+//        invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
+//        invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 5, 10); //fails here due to duplicate usage item  
         
         invoiceConfig.reset();
         

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -1137,7 +1137,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         final LocalDate effDt1 = new LocalDate(2018, 8, 1);
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE);
         final PlanPhaseSpecifier spec1 = new PlanPhaseSpecifier("blowdart-in-arrear-monthly-notrial");
-        final UUID entitlementId1 = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec1, 15, null, null, null), null, effDt1, effDt1, false, true, Collections.emptyList(), callContext);
+        final UUID entitlementId1 = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec1, 1, null, null, null), null, effDt1, effDt1, false, true, Collections.emptyList(), callContext);
         subscriptionApi.getSubscriptionForEntitlementId(entitlementId1, false, callContext);
         assertListenerStatus();
 
@@ -1155,12 +1155,14 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         // Generate invoice with targetDate 2023-2-1
         invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
         
-        Invoice invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 3, 10); //invoice with 3 invoice items
+        Invoice invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //invoice with 3 invoice items
         
         // Generate invoice again with targetDate 2023-2-1
         invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
         
-        invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 3, 10); //invoice with 3 invoice items   
+        invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //invoice with 3 invoice items   
+        
+        invoiceConfig.reset();
         
     }
     
@@ -1188,7 +1190,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         final LocalDate effDt1 = new LocalDate(2018, 8, 1);
         busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE);
         final PlanPhaseSpecifier spec1 = new PlanPhaseSpecifier("pistol-in-arrear-monthly-notrial");
-        final UUID entitlementId1 = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec1, 15, null, null, null), null, effDt1, effDt1, false, true, Collections.emptyList(), callContext);
+        final UUID entitlementId1 = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec1, 1, null, null, null), null, effDt1, effDt1, false, true, Collections.emptyList(), callContext);
         final Subscription baseSubscription = subscriptionApi.getSubscriptionForEntitlementId(entitlementId1, false, callContext);
         assertListenerStatus();
 
@@ -1207,11 +1209,13 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
         
         // Generate invoice with targetDate 2023-2-1
         invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
-        Invoice invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //invoice with 4 invoice items
+        Invoice invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 5, 10); //invoice with 4 invoice items
         
         // Generate invoice again with targetDate 2023-2-1
         invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 2, 1), Collections.emptyList(), callContext);
-        invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 4, 10); //invoice with 4 invoice items   
+        invoice = getCurrentDraftInvoice(account.getId(), input -> input.getInvoiceItems().size() == 5, 10); //invoice with 4 invoice items   
+        
+        invoiceConfig.reset();
         
     }    
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoiceOptimization.java
@@ -1125,7 +1125,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
 
         clock.setTime(new DateTime("2023-01-01T3:56:02"));
 
-        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
         assertNotNull(account);
 
         // Set AUTO_INVOICING_OFF, AUTO_INVOICING_DRAFT and AUTO_INVOICING_REUSE_DRAFT tags.
@@ -1176,7 +1176,7 @@ public class TestWithInvoiceOptimization extends TestIntegrationBase {
 
         clock.setTime(new DateTime("2023-01-01T3:56:02"));
 
-        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
         assertNotNull(account);
 
         // Set AUTO_INVOICING_OFF, AUTO_INVOICING_DRAFT and AUTO_INVOICING_REUSE_DRAFT tags.

--- a/beatrix/src/test/resources/catalogs/default/catalogTest.xml
+++ b/beatrix/src/test/resources/catalogs/default/catalogTest.xml
@@ -285,6 +285,32 @@
                 </recurring>
             </finalPhase>
         </plan>
+      <plan name="pistol-in-arrear-monthly-notrial">
+            <product>Pistol</product>
+            <recurringBillingMode>IN_ARREAR</recurringBillingMode>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>100.00</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>100.00</value>
+                        </price>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>100.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>        
         <plan name="blowdart-quarterly-notrial">
             <product>Blowdart</product>
             <finalPhase type="EVERGREEN">
@@ -1614,6 +1640,7 @@
         <childPriceList name="inArrearNotrial">
             <plans>
                 <plan>blowdart-in-arrear-monthly-notrial</plan>
+                <plan>pistol-in-arrear-monthly-notrial</plan>
             </plans>
         </childPriceList>
         <childPriceList name="trial">


### PR DESCRIPTION
The computation of the `ContiguousIntervalUsageInArrear#toEndOfDay` was not correctly taking into account
the Account#TZ. As a result, we end up creating endOfDay `transition` which are not the end of day as seen from
the customer Account.
    
When later in the method `ContiguousIntervalUsageInArrear#computeMissingItemsAndNextNotificationDate` we compute a LocalDate based on this endOfDay `transition`, we do not end up with the correct transition; during the next invoice run, the method `ContiguousIntervalUsageInArrear#getBilledItems` which should return the existing USAGE invoice item(s) for a given period does not find an existing item leading to a double billing of the period.

Fix is implemented in https://github.com/killbill/killbill/pull/1856/commits/96c876e53b6f84388a85529938f51311965f86fa