### PR TITLE
subscription: Rework billing events computation. See #1862

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig.java
@@ -124,6 +124,8 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig ex
         // Catalog v2 is 2022-04-01, but Liability effDt is 2022-05-01
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         clock.addMonths(1); // 2022-05-15
+
+        //Thread.sleep(1000 * 3600);
         assertListenerStatus();
 
         // We expect to see no pro-ration because of property 'align.effectiveDateForExistingSubscriptions' and new price

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -35,7 +35,6 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.Period;
-import org.killbill.billing.ErrorCode;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.BillingAlignment;
@@ -470,7 +469,6 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
         return getPrevValue(false);
     }
 
-
     private Integer getPrevValue(final boolean bcd) {
 
         final SubscriptionBaseTransitionDataIterator it = new SubscriptionBaseTransitionDataIterator(
@@ -480,7 +478,7 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
             final SubscriptionBaseTransition cur = it.next();
             if (bcd && cur.getTransitionType() == SubscriptionBaseTransitionType.BCD_CHANGE) {
                 return cur.getNextBillingCycleDayLocal();
-            } else if (!bcd &&  cur.getTransitionType() == SubscriptionBaseTransitionType.QUANTITY_CHANGE) {
+            } else if (!bcd && cur.getTransitionType() == SubscriptionBaseTransitionType.QUANTITY_CHANGE) {
                 return cur.getNextQuantity();
             }
         }
@@ -630,10 +628,10 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
 
             // Recomputed for each event from the active Plan -- if Plan is null (cancellation this is not set)
             StaticCatalog lastActiveCatalog = null;
-            final PriorityQueue<SubscriptionBillingEvent> candidatesCatalogChangeEvents = new PriorityQueue<SubscriptionBillingEvent>();
+            final PriorityQueue<SubscriptionBillingEvent> candidatesCatalogChangeEvents = new PriorityQueue<>();
             boolean foundInitialEvent = false;
 
-            SubscriptionBaseTransitionData lastPhaseTransition = null;
+            SubscriptionBaseTransitionData lastPlanTransition = null;
             while (it.hasNext()) {
 
                 final SubscriptionBaseTransitionData cur = (SubscriptionBaseTransitionData) it.next();
@@ -650,9 +648,9 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
                 // Remove anything prior to first CREATE
                 if (foundInitialEvent) {
 
-                    // Track the last transition that may modify the phase -- either from a new Plan or new PlanPhase of the same Plan
-                    if (isCreateOrTransfer || isChangeEvent || isPhaseEvent) {
-                        lastPhaseTransition = cur;
+                    // Track the last transition where we changed Plan
+                    if (isCreateOrTransfer || isChangeEvent) {
+                        lastPlanTransition = cur;
                     }
 
                     // Look for any catalog change transition whose date is less the cur event
@@ -663,8 +661,7 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
                         prevCandidateForCatalogChangeEvents = candidatesCatalogChangeEvents.poll();
                     }
 
-                    // If we see a change or a cancellation and we still have catalog change transitions, we discard them
-                    if (isChangeEvent || isCancelEvent) {
+                    if (isChangeEvent || isCancelEvent || isPhaseEvent) {
                         candidatesCatalogChangeEvents.clear();
                     } else if (prevCandidateForCatalogChangeEvents != null) {
                         candidatesCatalogChangeEvents.add(prevCandidateForCatalogChangeEvents);
@@ -686,26 +683,18 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
 
                     if (isCreateOrTransfer || isChangeEvent || isPhaseEvent) {
 
-                        // We are moving to a new Plan, we use the latest active catalog version at the time this operation took place.
-                        final StaticCatalog catalogVersion = catalog.versionForDate(billingTransition.getEffectiveDate());
+                        // If we are moving to a new Plan, we use the latest active catalog version at the time this operation took place.
+                        final DateTime billingTransitionEffectiveDate = isPhaseEvent ? lastPlanTransition.getEffectiveTransitionTime() : billingTransition.getEffectiveDate();
+                        final StaticCatalog catalogVersion = catalog.versionForDate(billingTransitionEffectiveDate);
 
-                        final Plan currentPlan;
-                        try {
-                            currentPlan = catalogVersion.findPlan(billingTransition.getPlan().getName());
-                        } catch (final CatalogApiException e) {
-                            if (e.getCode() == ErrorCode.CAT_NO_SUCH_PLAN.getCode()) {
-                                // Retired plan
-                                continue;
-                            } else {
-                                throw e;
-                            }
-                        }
-
+                        final Plan currentPlan = catalogVersion.findPlan(billingTransition.getPlan().getName());
                         final Integer bcdLocal = cur.getNextBillingCycleDayLocal();
                         // Iterate through all more recent version of the catalog to find possible effectiveDateForExistingSubscriptions transition for this Plan
                         Plan nextPlan = catalog.getNextPlanVersion(currentPlan);
+
                         while (nextPlan != null) {
                             if (nextPlan.getEffectiveDateForExistingSubscriptions() != null) {
+
                                 DateTime nextEffectiveDate = new DateTime(nextPlan.getEffectiveDateForExistingSubscriptions()).toDateTime(DateTimeZone.UTC);
                                 final PlanPhase nextPlanPhase = nextPlan.findPhase(planPhase.getName());
 
@@ -716,7 +705,6 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
                                 final SubscriptionBillingEvent newBillingTransition = new DefaultSubscriptionBillingEvent(SubscriptionBaseTransitionType.CHANGE, nextPlan, nextPlanPhase, nextEffectiveDate,
                                                                                                                           cur.getTotalOrdering(), bcdLocal, cur.getNextQuantity(), catalogEffectiveDateForNextPlan);
 
-                                candidatesCatalogChangeEvents.removeIf(subscriptionBillingEvent -> subscriptionBillingEvent.getEffectiveDate().compareTo(newBillingTransition.getEffectiveDate()) == 0);
                                 candidatesCatalogChangeEvents.add(newBillingTransition);
                             }
                             // TODO not so optimized as we keep parsing catalogs from the start...
@@ -996,7 +984,6 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
                 case QUANTITY_UPDATE:
                     // Skip, taken into account from NextBillingCycleDayLocal
                     break;
-
 
                 case API_USER:
                     final ApiEvent userEV = (ApiEvent) cur;

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestSubscriptionBillingEvents.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestSubscriptionBillingEvents.java
@@ -195,7 +195,7 @@ public class TestSubscriptionBillingEvents extends SubscriptionTestSuiteNoDB {
 
         final List<SubscriptionBillingEvent> result = subscriptionBase.getSubscriptionBillingEvents(catalog.getCatalog(), internalCallContext);
 
-        Assert.assertEquals(result.size(), 4);
+        Assert.assertEquals(result.size(), 5);
         Assert.assertEquals(result.get(0).getType(), SubscriptionBaseTransitionType.CREATE);
         Assert.assertEquals(result.get(0).getEffectiveDate().compareTo(createDate), 0);
         Assert.assertEquals(result.get(0).getPlan().getName().compareTo("gold-monthly"), 0);
@@ -206,16 +206,22 @@ public class TestSubscriptionBillingEvents extends SubscriptionTestSuiteNoDB {
         Assert.assertEquals(result.get(1).getPlan().getName().compareTo("gold-monthly"), 0);
         Assert.assertEquals(toDateTime(result.get(1).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V1), 0);
 
-        // Catalog change event for EFF_SUB_DT_V3
+        // Catalog change event for EFF_SUB_DT_V2
         Assert.assertEquals(result.get(2).getType(), SubscriptionBaseTransitionType.CHANGE);
-        Assert.assertEquals(result.get(2).getEffectiveDate().toLocalDate().compareTo(EFF_SUB_DT_V3.toLocalDate()), 0);
+        Assert.assertEquals(result.get(2).getEffectiveDate().toLocalDate().compareTo(EFF_SUB_DT_V2.toLocalDate()), 0);
         Assert.assertEquals(result.get(2).getPlan().getName().compareTo("gold-monthly"), 0);
-        Assert.assertEquals(toDateTime(result.get(2).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V3), 0);
+        Assert.assertEquals(toDateTime(result.get(2).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V2), 0);
+
+        // Catalog change event for EFF_SUB_DT_V3
+        Assert.assertEquals(result.get(3).getType(), SubscriptionBaseTransitionType.CHANGE);
+        Assert.assertEquals(result.get(3).getEffectiveDate().toLocalDate().compareTo(EFF_SUB_DT_V3.toLocalDate()), 0);
+        Assert.assertEquals(result.get(3).getPlan().getName().compareTo("gold-monthly"), 0);
+        Assert.assertEquals(toDateTime(result.get(3).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V3), 0);
 
         // Cancel event
-        Assert.assertEquals(result.get(3).getType(), SubscriptionBaseTransitionType.CANCEL);
-        Assert.assertEquals(result.get(3).getEffectiveDate().compareTo(cancelDate), 0);
-        Assert.assertNull(result.get(3).getPlan());
+        Assert.assertEquals(result.get(4).getType(), SubscriptionBaseTransitionType.CANCEL);
+        Assert.assertEquals(result.get(4).getEffectiveDate().compareTo(cancelDate), 0);
+        Assert.assertNull(result.get(4).getPlan());
 
         // Nothing after cancel -> we correctly discarded subsequent catalog update events after the cancel
     }
@@ -339,7 +345,7 @@ public class TestSubscriptionBillingEvents extends SubscriptionTestSuiteNoDB {
 
         final List<SubscriptionBillingEvent> result = subscriptionBase.getSubscriptionBillingEvents(catalog.getCatalog(), internalCallContext);
 
-        Assert.assertEquals(result.size(), 4);
+        Assert.assertEquals(result.size(), 5);
         Assert.assertEquals(result.get(0).getType(), SubscriptionBaseTransitionType.CREATE);
         Assert.assertEquals(result.get(0).getEffectiveDate().compareTo(createDate), 0);
         Assert.assertEquals(result.get(0).getPlan().getName().compareTo("gold-monthly"), 0);
@@ -350,17 +356,23 @@ public class TestSubscriptionBillingEvents extends SubscriptionTestSuiteNoDB {
         Assert.assertEquals(result.get(1).getPlan().getName().compareTo("gold-monthly"), 0);
         Assert.assertEquals(toDateTime(result.get(1).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V1), 0);
 
-        // Catalog change event for EFF_SUB_DT_V3
+        // Catalog change event for EFF_SUB_DT_V2
         Assert.assertEquals(result.get(2).getType(), SubscriptionBaseTransitionType.CHANGE);
-        Assert.assertEquals(result.get(2).getEffectiveDate().toLocalDate().compareTo(EFF_SUB_DT_V3.toLocalDate()), 0);
+        Assert.assertEquals(result.get(2).getEffectiveDate().toLocalDate().compareTo(EFF_SUB_DT_V2.toLocalDate()), 0);
         Assert.assertEquals(result.get(2).getPlan().getName().compareTo("gold-monthly"), 0);
-        Assert.assertEquals(toDateTime(result.get(2).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V3), 0);
+        Assert.assertEquals(toDateTime(result.get(2).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V2), 0);
+
+        // Catalog change event for EFF_SUB_DT_V3
+        Assert.assertEquals(result.get(3).getType(), SubscriptionBaseTransitionType.CHANGE);
+        Assert.assertEquals(result.get(3).getEffectiveDate().toLocalDate().compareTo(EFF_SUB_DT_V3.toLocalDate()), 0);
+        Assert.assertEquals(result.get(3).getPlan().getName().compareTo("gold-monthly"), 0);
+        Assert.assertEquals(toDateTime(result.get(3).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V3), 0);
 
         // User CHANGE event
-        Assert.assertEquals(result.get(3).getType(), SubscriptionBaseTransitionType.CHANGE);
-        Assert.assertEquals(result.get(3).getEffectiveDate().compareTo(changeDate), 0);
-        Assert.assertEquals(result.get(3).getPlan().getName().compareTo("silver-monthly"), 0);
-        Assert.assertEquals(toDateTime(result.get(3).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V3), 0);
+        Assert.assertEquals(result.get(4).getType(), SubscriptionBaseTransitionType.CHANGE);
+        Assert.assertEquals(result.get(4).getEffectiveDate().compareTo(changeDate), 0);
+        Assert.assertEquals(result.get(4).getPlan().getName().compareTo("silver-monthly"), 0);
+        Assert.assertEquals(toDateTime(result.get(4).getPlan().getCatalog().getEffectiveDate()).compareTo(EFF_V3), 0);
 
         // We should not see any more catalog CHANGE events
     }


### PR DESCRIPTION
This undo the fix introduced in 42e9b205900d.

Also note that the diff in the test `TestSubscriptionBillingEvents.java` just reverts it exactly to what it currently is in `master`, so the code introduces no known behavior change aside from fixing the issue #1862