### PR TITLE
subscription: Fix billing event logic for catalog transition with multi-phase plans

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMultiPhasePlan.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMultiPhasePlan.java
@@ -18,17 +18,20 @@
 package org.killbill.billing.beatrix.integration;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
-import org.killbill.billing.catalog.api.BillingPeriod;
-import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.catalog.api.VersionedCatalog;
-import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Entitlement;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.platform.api.KillbillConfigSource;
@@ -49,7 +52,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMul
     }
 
     @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1862")
-    public void testSubscriptionWithMultiPhasePlan() throws Exception {
+    public void testMultiPhasePlanWithTrialPhase() throws Exception {
 
         final LocalDate today = new LocalDate(2023, 3, 18);
         clock.setDay(today);
@@ -57,27 +60,72 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMul
         final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
 
         //
-        // We have 2 catalog versions, V2 is effective on 2023-05-18 but there is an effectiveDateForExistingSubscriptions=2023-05-18 for the Liability Plan.
-        // The plan has a 14-day DISCOUNT phase followed by an EVERGREEN phase
-        // The invoices are generated correctly up until 2023-05-01
-        // On moving the clock to 2023-06-01 (v2 effective), invoices are generated for $0
+        // liability-monthly-trial has a a 14-day TRIAL phase followed by an EVERGREEN phase
         //
 
-
         final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(18));
-        final DefaultEntitlement bpEntitlement1 =
-                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey1", "Liability",
-                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
-                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
-
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-trial"), null, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, Collections.emptyList(), callContext);
+        final Entitlement bpEntitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
         assertListenerStatus();
         assertNotNull(bpEntitlement1);
-        //invoice corresponding to discount phase
+
+        //invoice corresponding to trial phase
         Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
-                                                                      new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 18), new LocalDate(2023, 4, 1), InvoiceItemType.RECURRING, BigDecimal.ZERO)); //TODO - This is of type recurring since the catalog defines a recurring price - maybe this should be changed to fixed?
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 18), new LocalDate(2023, 4, 1), InvoiceItemType.RECURRING, BigDecimal.ZERO));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
 
-        //move clock to 2023-04-01 (end of discount phase) - invoice generated for evergreen phase
+        //move clock to 2023-04-01 (end of trial phase) - invoice corresponding to evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 4, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 1), new LocalDate(2023, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("4")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-05-01 - invoice corresponding to evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 1), new LocalDate(2023, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("4")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-06-01 (v2 effective) - invoice corresponding to evergreen phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 6, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 1), new LocalDate(2023, 7, 1), InvoiceItemType.RECURRING, new BigDecimal("8.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+    }
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1862")
+    public void testMultiPhasePlanWithDiscountPhaseSubAlignedWithChange() throws Exception { //This test is exactly the same as the scenario reported in https://github.com/killbill/killbill/issues/1862
+
+        final LocalDate today = new LocalDate(2023, 3, 18);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        //
+        // liability-monthly-discount has a a 14-day DISCOUNT phase followed by an EVERGREEN phase
+        //
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(18));
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-discount"), null, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, Collections.emptyList(), callContext);
+        final Entitlement bpEntitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        assertListenerStatus();
+        assertNotNull(bpEntitlement1);
+
+        //invoice corresponding to discount phase
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 18), new LocalDate(2023, 4, 1), InvoiceItemType.RECURRING, BigDecimal.ZERO));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-04-01 (end of discount phase) - invoice corresponding to evergreen phase as per v1
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
         clock.setDay(new LocalDate(2023, 4, 1));
         assertListenerStatus();
@@ -85,7 +133,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMul
                                                  new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 1), new LocalDate(2023, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
 
-        //move clock to 2023-05-01 - invoice generated for evergreen phase
+        //move clock to 2023-05-01 - invoice corresponding to evergreen phase as per v1
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.setDay(new LocalDate(2023, 5, 1));
         assertListenerStatus();
@@ -93,7 +141,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMul
                                                  new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 1), new LocalDate(2023, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
 
-        //move clock to 2023-06-01 (v2 effective) - Test fails here as invoice for $0 is generated
+        //move clock to 2023-06-01 (v2 effective) - invoice corresponding to evergreen phase as per v2
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         clock.setDay(new LocalDate(2023, 6, 1));
         assertListenerStatus();
@@ -102,4 +150,355 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMul
         Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
 
     }
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1862")
+    public void testMultiPhasePlanWithDiscountPhaseSubNotAlignedWithChange() throws Exception {
+
+        final LocalDate today = new LocalDate(2023, 4, 1);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        //
+        // liability-monthly-discount has a a 14-day DISCOUNT phase followed by an EVERGREEN phase
+        //
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(18));
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-discount"), null, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, Collections.emptyList(), callContext);
+        final Entitlement bpEntitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        assertListenerStatus();
+        assertNotNull(bpEntitlement1);
+
+        //invoice corresponding to discount phase
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 1), new LocalDate(2023, 4, 15), InvoiceItemType.RECURRING, BigDecimal.ZERO));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-04-15 (end of discount phase) - invoice corresponding to evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 4, 15));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 15), new LocalDate(2023, 5, 15), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-05-15 - invoice corresponding to evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 15));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 15), new LocalDate(2023, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-06-15 (v2 effective) - invoice corresponding to evergreen phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 6, 15));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 15), new LocalDate(2023, 7, 15), InvoiceItemType.RECURRING, new BigDecimal("10.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+    }
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1862")
+    public void testMultiPhasePlanWithDiscountPhaseAndThreeCatalogVersions() throws Exception {
+
+        final LocalDate today = new LocalDate(2023, 3, 18);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        //
+        // liability-monthly-discount has a a 14-day DISCOUNT phase followed by an EVERGREEN phase
+        //
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(18));
+
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-discount"), null, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, Collections.emptyList(), callContext);
+        final Entitlement bpEntitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        assertListenerStatus();
+        assertNotNull(bpEntitlement1);
+
+        //invoice corresponding to discount phase
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 18), new LocalDate(2023, 4, 1), InvoiceItemType.RECURRING, BigDecimal.ZERO));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-04-01 (end of discount phase) - invoice corresponding to evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 4, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 1), new LocalDate(2023, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-05-01 - invoice corresponding to evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 1), new LocalDate(2023, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-06-01 (v2 effective) - invoice corresponding to evergreen phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 6, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 1), new LocalDate(2023, 7, 1), InvoiceItemType.RECURRING, new BigDecimal("10.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+        //move clock to 2023-07-01 (v2 effective) - invoice corresponding to evergreen phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 7, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 5, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 7, 1), new LocalDate(2023, 8, 1), InvoiceItemType.RECURRING, new BigDecimal("10.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+        //move clock to 2023-08-01 (v3 effective) - invoice corresponding to evergreen phase as per v3
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 8, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 6, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 1), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("15.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(2).getEffectiveDate()), 0);
+
+    }
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1862")
+    public void testMultiPhasePlanPriceChangeInDiscountPhaseSubAlignedWithChange() throws Exception {
+
+        final LocalDate today = new LocalDate(2023, 3, 18);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        //
+        // liability-monthly-discount3 has a 4-MONTH DISCOUNT phase followed by an EVERGREEN phase
+        //
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(18));
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-discount3"), null, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, Collections.emptyList(), callContext);
+        final Entitlement bpEntitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        assertListenerStatus();
+        assertNotNull(bpEntitlement1);
+
+        //invoice corresponding to discount phase as per v1
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 18), new LocalDate(2023, 4, 18), InvoiceItemType.RECURRING, new BigDecimal("5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-04-18 invoice generated for discount phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 4, 18));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 18), new LocalDate(2023, 5, 18), InvoiceItemType.RECURRING, new BigDecimal("5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-05-18 - invoice generated for discount phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 18));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 18), new LocalDate(2023, 6, 18), InvoiceItemType.RECURRING, new BigDecimal("7")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+        //move clock to 2023-06-18 - invoice generated for discount phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 6, 18));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 18), new LocalDate(2023, 7, 18), InvoiceItemType.RECURRING, new BigDecimal("7")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+        //move clock to 2023-07-18 - invoice generated for evergreen phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 7, 18));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 5, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 7, 18), new LocalDate(2023, 8, 18), InvoiceItemType.RECURRING, new BigDecimal("10.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+    }
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1862")
+    public void testMultiPhasePlanPriceChangeInDiscountPhaseSubNotAlignedWithChange() throws Exception {
+
+        final LocalDate today = new LocalDate(2023, 3, 1);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        //
+        // liability-monthly-discount3 has a 4-MONTH DISCOUNT phase followed by an EVERGREEN phase
+        //
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(18));
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-discount3"), null, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, Collections.emptyList(), callContext);
+        final Entitlement bpEntitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        assertListenerStatus();
+        assertNotNull(bpEntitlement1);
+
+        //invoice corresponding to discount phase as per v1
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 1), new LocalDate(2023, 4, 1), InvoiceItemType.RECURRING, new BigDecimal("5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-04-1 invoice generated for discount phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 4, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 1), new LocalDate(2023, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-05-1 - invoice generated for discount phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 1), new LocalDate(2023, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-06-1 - invoice generated for discount phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 6, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 1), new LocalDate(2023, 7, 1), InvoiceItemType.RECURRING, new BigDecimal("7")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+
+        //move clock to 2023-07-1 - invoice generated for evergreen phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 7, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 5, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 7, 1), new LocalDate(2023, 8, 1), InvoiceItemType.RECURRING, new BigDecimal("10.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+    }
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1862")
+    public void testMultiPhasePlanWithoutEffectiveDateForExistingSubs() throws Exception {
+
+        final LocalDate today = new LocalDate(2023, 3, 18);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        //
+        // liability-monthly-discount2 has a a 14-day DISCOUNT phase followed by an EVERGREEN phase and no effectiveDateForExistingSubscriptions
+        //
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(18));
+
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-discount2"), null, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, Collections.emptyList(), callContext);
+        final Entitlement bpEntitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        assertListenerStatus();
+        assertNotNull(bpEntitlement1);
+
+        //invoice corresponding to discount phase
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 18), new LocalDate(2023, 4, 1), InvoiceItemType.RECURRING, BigDecimal.ZERO));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-04-01 (end of discount phase) - invoice generated for evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 4, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 1), new LocalDate(2023, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-05-01 - invoice generated for evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 1), new LocalDate(2023, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-06-01 (v2 effective) - Invoice generated as per v1 since effectiveDateForExistingSubscriptions is not specified
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 6, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 1), new LocalDate(2023, 7, 1), InvoiceItemType.RECURRING, new BigDecimal("6.99")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+    }
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1862")
+    public void testMultiPhasePlanChangePlanFromTrialToDiscount() throws Exception {
+
+        final LocalDate today = new LocalDate(2023, 3, 18);
+        clock.setDay(today);
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("foo", callContext);
+
+        //
+        // liability-monthly-trial has a 14-day TRIAL phase followed by an EVERGREEN phase
+        // liability-monthly-discount has a 14-day DISCOUNT phase followed by an EVERGREEN phase
+        //
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(18));
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-trial"), null, null, UUID.randomUUID().toString(), null), "something", null, null, false, true, Collections.emptyList(), callContext);
+        final Entitlement bpEntitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        assertListenerStatus();
+        assertNotNull(bpEntitlement1);
+
+        //invoice corresponding to trial phase
+        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                                         new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 18), new LocalDate(2023, 4, 1), InvoiceItemType.RECURRING, BigDecimal.ZERO));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-04-01 (end of trial phase) - invoice corresponding to evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 4, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 1), new LocalDate(2023, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("4")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-05-01 - invoice corresponding to evergreen phase as per v1
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 1), new LocalDate(2023, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("4")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(0).getEffectiveDate()), 0);
+
+        //move clock to 2023-06-01 (v2 effective) - invoice corresponding to evergreen phase as per v2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 6, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 4, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 1), new LocalDate(2023, 7, 1), InvoiceItemType.RECURRING, new BigDecimal("8.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+        
+        //change to liability-monthly-discount with END_OF_TERM policy
+        bpEntitlement1.changePlanOverrideBillingPolicy(new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("liability-monthly-discount"), null, null, UUID.randomUUID().toString(), null), null, BillingActionPolicy.END_OF_TERM, Collections.emptyList(), callContext);
+        
+        //move clock to 2023-07-01 (switched to liability-monthly-discount)  - invoice corresponding to evergreen phase of liability-monthly-discount as per v2 (since START_OF_SUBSCRIPTION change alignment is used, change is aligned with EVERGREEN phase)
+        busHandler.pushExpectedEvents(NextEvent.CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 7, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 5, callContext,
+                                             	new ExpectedInvoiceItemCheck(new LocalDate(2023, 7, 1), new LocalDate(2023, 8, 1), InvoiceItemType.RECURRING, new BigDecimal("10.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(1).getEffectiveDate()), 0);
+        
+        //move clock to 2023-08-01 (v3 effective) - invoice corresponding to evergreen phase of liability-monthly-discount as per v3
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 8, 1));
+        assertListenerStatus();
+        curInvoice = invoiceChecker.checkInvoice(account.getId(), 6, callContext,
+                                                 new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 1), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("15.5")));
+        Assert.assertEquals(curInvoice.getInvoiceItems().get(0).getCatalogEffectiveDate().toDate().compareTo(catalog.getVersions().get(2).getEffectiveDate()), 0);
+    }
+
 }

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMultiPhasePlan/Insurance-v2.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMultiPhasePlan/Insurance-v2.xml
@@ -43,7 +43,7 @@
         </changePolicy>
         <changeAlignment>
             <changeAlignmentCase>
-                <alignment>CHANGE_OF_PLAN</alignment>
+                <alignment>START_OF_SUBSCRIPTION</alignment>
             </changeAlignmentCase>
         </changeAlignment>
         <cancelPolicy>
@@ -69,7 +69,44 @@
     </rules>
 
     <plans>
-        <plan name="liability-monthly-no-trial">
+        <plan name="liability-monthly-trial">
+            <effectiveDateForExistingSubscriptions>2023-05-18T00:00:00+00:00</effectiveDateForExistingSubscriptions>
+            <product>Liability</product>
+            <initialPhases>
+                <phase type="TRIAL">
+                    <duration>
+                        <unit>DAYS</unit>
+                        <number>14</number>
+                    </duration>
+                    <recurring>
+                        <billingPeriod>MONTHLY</billingPeriod>
+                        <recurringPrice>
+                            <price>
+                                <currency>USD</currency>
+                                <value>0.0</value>
+                            </price>
+                        </recurringPrice>
+                    </recurring>
+                    <usages/>
+                </phase>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>8.5</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+    
+        <plan name="liability-monthly-discount">
             <effectiveDateForExistingSubscriptions>2023-05-18T00:00:00+00:00</effectiveDateForExistingSubscriptions>
             <product>Liability</product>
             <initialPhases>
@@ -105,12 +142,86 @@
                 </recurring>
             </finalPhase>
         </plan>
-
+        <plan name="liability-monthly-discount2">
+            <product>Liability</product>
+            <initialPhases>
+                <phase type="DISCOUNT">
+                    <duration>
+                        <unit>DAYS</unit>
+                        <number>14</number>
+                    </duration>
+                    <recurring>
+                        <billingPeriod>MONTHLY</billingPeriod>
+                        <recurringPrice>
+                            <price>
+                                <currency>USD</currency>
+                                <value>0.0</value>
+                            </price>
+                        </recurringPrice>
+                    </recurring>
+                    <usages/>
+                </phase>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>10.5</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        <plan name="liability-monthly-discount3">
+        	<effectiveDateForExistingSubscriptions>2023-05-18T00:00:00+00:00</effectiveDateForExistingSubscriptions>
+            <product>Liability</product>
+            <initialPhases>
+                <phase type="DISCOUNT">
+                    <duration>
+                        <unit>MONTHS</unit>
+                        <number>4</number>
+                    </duration>
+                    <recurring>
+                        <billingPeriod>MONTHLY</billingPeriod>
+                        <recurringPrice>
+                            <price>
+                                <currency>USD</currency>
+                                <value>7</value>
+                            </price>
+                        </recurringPrice>
+                    </recurring>
+                    <usages/>
+                </phase>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>10.5</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
+        
     </plans>
     <priceLists>
         <defaultPriceList name="DEFAULT">
             <plans>
-                <plan>liability-monthly-no-trial</plan>
+            	<plan>liability-monthly-trial</plan>
+                <plan>liability-monthly-discount</plan>
+                <plan>liability-monthly-discount2</plan>
+                <plan>liability-monthly-discount3</plan>
             </plans>
         </defaultPriceList>
     </priceLists>

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMultiPhasePlan/Insurance-v3.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMultiPhasePlan/Insurance-v3.xml
@@ -17,7 +17,7 @@
 
 <catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
 
-    <effectiveDate>2022-05-18T00:00:00+00:00</effectiveDate>
+    <effectiveDate>2023-07-25T00:00:00+00:00</effectiveDate>
     <catalogName>Insurance</catalogName>
 
     <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
@@ -69,43 +69,8 @@
     </rules>
 
     <plans>
-        <plan name="liability-monthly-trial">
-            <product>Liability</product>
-            <initialPhases>
-                <phase type="TRIAL">
-                    <duration>
-                        <unit>DAYS</unit>
-                        <number>14</number>
-                    </duration>
-                    <recurring>
-                        <billingPeriod>MONTHLY</billingPeriod>
-                        <recurringPrice>
-                            <price>
-                                <currency>USD</currency>
-                                <value>0.0</value>
-                            </price>
-                        </recurringPrice>
-                    </recurring>
-                    <usages/>
-                </phase>
-            </initialPhases>
-            <finalPhase type="EVERGREEN">
-                <duration>
-                    <unit>UNLIMITED</unit>
-                </duration>
-                <recurring>
-                    <billingPeriod>MONTHLY</billingPeriod>
-                    <recurringPrice>
-                        <price>
-                            <currency>USD</currency>
-                            <value>4</value>
-                        </price>
-                    </recurringPrice>
-                </recurring>
-            </finalPhase>
-        </plan>
-    
         <plan name="liability-monthly-discount">
+            <effectiveDateForExistingSubscriptions>2023-07-25T00:00:00+00:00</effectiveDateForExistingSubscriptions>
             <product>Liability</product>
             <initialPhases>
                 <phase type="DISCOUNT">
@@ -134,7 +99,7 @@
                     <recurringPrice>
                         <price>
                             <currency>USD</currency>
-                            <value>6.99</value>
+                            <value>15.5</value>
                         </price>
                     </recurringPrice>
                 </recurring>
@@ -169,56 +134,18 @@
                     <recurringPrice>
                         <price>
                             <currency>USD</currency>
-                            <value>6.99</value>
+                            <value>10.5</value>
                         </price>
                     </recurringPrice>
                 </recurring>
             </finalPhase>
         </plan>
-        <plan name="liability-monthly-discount3">
-            <product>Liability</product>
-            <initialPhases>
-                <phase type="DISCOUNT">
-                    <duration>
-                        <unit>MONTHS</unit>
-                        <number>4</number>
-                    </duration>
-                    <recurring>
-                        <billingPeriod>MONTHLY</billingPeriod>
-                        <recurringPrice>
-                            <price>
-                                <currency>USD</currency>
-                                <value>5</value>
-                            </price>
-                        </recurringPrice>
-                    </recurring>
-                    <usages/>
-                </phase>
-            </initialPhases>
-            <finalPhase type="EVERGREEN">
-                <duration>
-                    <unit>UNLIMITED</unit>
-                </duration>
-                <recurring>
-                    <billingPeriod>MONTHLY</billingPeriod>
-                    <recurringPrice>
-                        <price>
-                            <currency>USD</currency>
-                            <value>6.99</value>
-                        </price>
-                    </recurringPrice>
-                </recurring>
-            </finalPhase>
-        </plan>
-        
     </plans>
     <priceLists>
         <defaultPriceList name="DEFAULT">
             <plans>
-            	<plan>liability-monthly-trial</plan>
                 <plan>liability-monthly-discount</plan>
                 <plan>liability-monthly-discount2</plan>
-                <plan>liability-monthly-discount3</plan>
             </plans>
         </defaultPriceList>
     </priceLists>

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -715,7 +715,10 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
             }
             SubscriptionBillingEvent prevCandidateForCatalogChangeEvents = candidatesCatalogChangeEvents.poll();
             while (prevCandidateForCatalogChangeEvents != null) {
-                result.add(prevCandidateForCatalogChangeEvents);
+            	final DateTime effectiveDateTime = prevCandidateForCatalogChangeEvents.getEffectiveDate();
+            	if (!result.stream().anyMatch(subBillingEvent -> subBillingEvent.getEffectiveDate().compareTo(effectiveDateTime) == 0)) {
+            		result.add(prevCandidateForCatalogChangeEvents);
+            	}
                 prevCandidateForCatalogChangeEvents = candidatesCatalogChangeEvents.poll();
             }
 


### PR DESCRIPTION
The tests `TestCatalogWithEffectiveDateForExistingSubscriptionsCustomConfigMultiPhasePlan`
showed a duplicate transition was being added in our billing events for plans with multiple phases
and where we have multiple catalog versions with `Plan#effectiveDateForExistingSubscriptions`.

The fix in place is to check that if the catalog transition was already added as part of a previous plan transition, we don't add it again. This undo the fix introduced in https://github.com/killbill/killbill/commit/f58cba4edc31ff5d407a425c268c802f2de0d63f which was removing additional transition at the end. I think it's better/cleaner to not include wrong transition in the first place.

