### PR TITLE
sql: work around race condition in stringtemplate

### DIFF
--- a/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
+++ b/entitlement/src/main/resources/org/killbill/billing/entitlement/dao/BlockingStateSqlDao.sql.stg
@@ -150,7 +150,7 @@ and service = :service
 ;
 >>
 
-getByBlockingIds() ::= <<
+getByBlockingIds(ids) ::= <<
 select
 <allTableFields("")>
 from
@@ -162,7 +162,7 @@ where blockable_id in (<ids>)
 ;
 >>
 
-getByBlockingIdsIncludingDeleted() ::= <<
+getByBlockingIdsIncludingDeleted(ids) ::= <<
 select
 <allTableFields("")>
 from

--- a/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.sql.stg
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.sql.stg
@@ -53,7 +53,7 @@ tableValues() ::= <<
 , :createdDate
 >>
 
-getInvoiceItemsForInvoices() ::= <<
+getInvoiceItemsForInvoices(invoiceIds) ::= <<
   SELECT <allTableFields("")>
   FROM <tableName()>
   WHERE invoice_id in (<invoiceIds>)

--- a/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoicePaymentSqlDao.sql.stg
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoicePaymentSqlDao.sql.stg
@@ -82,7 +82,7 @@ getInvoicePayments() ::= <<
     ;
 >>
 
-getPaymentsForInvoices() ::= <<
+getPaymentsForInvoices(invoiceIds) ::= <<
     SELECT <allTableFields("")>
     FROM <tableName()>
     WHERE invoice_id in (<invoiceIds>)

--- a/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceTrackingSqlDao.sql.stg
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceTrackingSqlDao.sql.stg
@@ -29,7 +29,7 @@ tableValues() ::= <<
 , :updatedDate
 >>
 
-deactivateByIds() ::= <<
+deactivateByIds(ids) ::= <<
 update <tableName()>
 set
   is_active = FALSE

--- a/subscription/src/main/resources/org/killbill/billing/subscription/engine/dao/BundleSqlDao.sql.stg
+++ b/subscription/src/main/resources/org/killbill/billing/subscription/engine/dao/BundleSqlDao.sql.stg
@@ -37,7 +37,7 @@ where id = :id
 >>
 
 
-renameBundleExternalKey(prefix)  ::= <<
+renameBundleExternalKey(prefix, ids)  ::= <<
 update bundles
 set external_key = concat('kb', '<prefix>', '-', record_id, ':', external_key)
 where <idField("")> in (<ids>)

--- a/subscription/src/main/resources/org/killbill/billing/subscription/engine/dao/SubscriptionSqlDao.sql.stg
+++ b/subscription/src/main/resources/org/killbill/billing/subscription/engine/dao/SubscriptionSqlDao.sql.stg
@@ -76,7 +76,7 @@ where id = :id
 ;
 >>
 
-updateChargedThroughDates() ::= <<
+updateChargedThroughDates(ids) ::= <<
 update <tableName()>
 set
 charged_through_date = :chargedThroughDate


### PR DESCRIPTION
The implementation for the StringTemplate (`st.impl`) is cached: https://github.com/killbill/killbill-commons/blob/07940775e6c51f26b05e9e136c4ff1e43f113cc6/jdbi/src/main/java/org/skife/jdbi/v2/sqlobject/stringtemplate/ST4StatementLocator.java#L302

It's a `CompiledST` that comes from `STGroupFileWithThreadSafeLoading` (`lookupTemplateInternal` method) and stored in the `STGroup.templates` map.

The following code from `ST` (`add` method) is not thread safe (the method is synchronized but `ST` is a local variable):

```
if ( impl.formalArguments!=null ) {
    arg = impl.formalArguments.get(name);
}
if ( arg==null ) { // not defined
    arg = new FormalArgument(name);
    impl.addArg(arg);
```

This can lead to bugs like this:

```
Caused by: java.lang.IllegalArgumentException: Formal argument ids already exists.
    at org.stringtemplate.v4.compiler.CompiledST.addArg(CompiledST.java:208)
    at org.stringtemplate.v4.ST.add(ST.java:245)
    at org.skife.jdbi.v2.sqlobject.stringtemplate.ST4StatementLocator.locateAndRender(ST4StatementLocator.java:308)
    at org.skife.jdbi.v2.sqlobject.stringtemplate.ST4StatementLocator.locateFromCache(ST4StatementLocator.java:282)
    at org.skife.jdbi.v2.sqlobject.stringtemplate.ST4StatementLocator.locate(ST4StatementLocator.java:250)
    at org.skife.jdbi.v2.SQLStatement.wrapLookup(SQLStatement.java:1292)
    at org.skife.jdbi.v2.SQLStatement.internalExecute(SQLStatement.java:1301)
    at org.skife.jdbi.v2.Update.execute(Update.java:60)
    at org.skife.jdbi.v2.sqlobject.UpdateHandler$3.value(UpdateHandler.java:77)
    at org.skife.jdbi.v2.sqlobject.UpdateHandler.invoke(UpdateHandler.java:90)
    at org.skife.jdbi.v2.sqlobject.SqlObject.invoke(SqlObject.java:184)
    at org.skife.jdbi.v2.sqlobject.SqlObject$2.intercept(SqlObject.java:97)
    at org.skife.jdbi.v2.sqlobject.CloseInternalDoNotUseThisClass$$EnhancerByCGLIB$$81876da2.updateChargedThroughDates(<generated>)
```

As a workaround, we change the `Stringtemplate` to define the argument in the template directly, so that it's parsed as a formal argument when the file (aka `STGroup`) is loaded and compiled, instead of defining these formal arguments on the fly at runtime (see `SqlStatementCustomizer` in `BindIn` annotation).

For future debugging, you can experience the above by running the test `TestST4StatementLocator` in killbill-commons twice, with and without `(ids)` in the template `Jun.sql.stg` and set breakpoints in the methods mentioned above.

I did a pass at updating all queries with an IN clause (this was already done in the majority of cases).