### PR TITLE
Fix ts 103

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/PatternObfuscator.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/PatternObfuscator.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.server.log.obfuscators;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -28,30 +29,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class PatternObfuscator extends Obfuscator {
 
+    private static final String KILLBILL_KEYWORDS_TO_OBFUSCATE_PROPERTY = "killbill.server.log.keywordstoobfuscate";
     // Hide by default sensitive bank, PCI and PII data. For PANs, see LuhnMaskingObfuscator
-    private static final Collection<String> DEFAULT_SENSITIVE_KEYS = List.of(
-            "accountnumber",
-            "authenticationdata",
-            "bankaccountnumber",
-            "banknumber",
-            "bic",
-            "cardvalidationnum",
-            "cavv",
-            "ccFirstName",
-            "ccLastName",
-            "ccNumber",
-            "ccTrackData",
-            "ccVerificationValue",
-            "ccvv",
-            "cvNumber",
-            "cvc",
-            "cvv",
-            "email",
-            "iban",
-            "name",
-            "number",
-            "password",
-            "xid");
+    private static final Collection<String> DEFAULT_SENSITIVE_KEYS = loadKeywordsToObfuscate();
+
 
     private final Collection<Pattern> patterns = new LinkedList<>();
 
@@ -99,11 +80,41 @@ public class PatternObfuscator extends Obfuscator {
 
     // Splunk-type logging
     private Pattern buildKeyValuePattern1(final String key) {
-        return Pattern.compile(key + "\\s*=\\s*'([^\']+)'", DEFAULT_PATTERN_FLAGS);
+        return Pattern.compile(key + "\\s*=\\s*'([^']+)'", DEFAULT_PATTERN_FLAGS);
     }
 
     // Splunk-type logging
     private Pattern buildKeyValuePattern2(final String key) {
         return Pattern.compile(key + "\\s*=\\s*\"([^\"]+)\"", DEFAULT_PATTERN_FLAGS);
+    }
+
+    private static Collection<String> loadKeywordsToObfuscate() {
+        if (System.getProperty(KILLBILL_KEYWORDS_TO_OBFUSCATE_PROPERTY) != null && !System.getProperty(KILLBILL_KEYWORDS_TO_OBFUSCATE_PROPERTY).isEmpty()) {
+            return Arrays.asList(System.getProperty(KILLBILL_KEYWORDS_TO_OBFUSCATE_PROPERTY).split("\\s*,\\s*"));
+        } else {
+            return List.of(
+                    "accountnumber",
+                    "authenticationdata",
+                    "bankaccountnumber",
+                    "banknumber",
+                    "bic",
+                    "cardvalidationnum",
+                    "cavv",
+                    "ccFirstName",
+                    "ccLastName",
+                    "ccNumber",
+                    "ccTrackData",
+                    "ccVerificationValue",
+                    "ccvv",
+                    "cvNumber",
+                    "cvc",
+                    "cvv",
+                    "email",
+                    "iban",
+                    "name",
+                    "number",
+                    "password",
+                    "xid");
+        }
     }
 }

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/PatternObfuscator.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/PatternObfuscator.java
@@ -91,7 +91,7 @@ public class PatternObfuscator extends Obfuscator {
         return Pattern.compile(key + pattern, DEFAULT_PATTERN_FLAGS);
     }
 
-    static Collection<String> loadKeywords() {
+    Collection<String> loadKeywords() {
         if (System.getProperty(KILLBILL_OBFUSCATE_KEYWORDS_PROPERTY) != null && !System.getProperty(KILLBILL_OBFUSCATE_KEYWORDS_PROPERTY).isEmpty()) {
             return Arrays.asList(System.getProperty(KILLBILL_OBFUSCATE_KEYWORDS_PROPERTY).split("\\s*,\\s*"));
         } else {
@@ -122,13 +122,22 @@ public class PatternObfuscator extends Obfuscator {
     }
 
     @VisibleForTesting
-    static Collection<String> loadPatterns() {
+    Collection<String> loadPatterns() {
         if (System.getProperty(KILLBILL_OBFUSCATE_KEY_VALUE_PATTERNS_PROPERTY) != null && !System.getProperty(KILLBILL_OBFUSCATE_KEY_VALUE_PATTERNS_PROPERTY).isEmpty()) {
-            final String separator = System.getProperty(KILLBILL_OBFUSCATE_PATTERNS_SEPARATOR_PROPERTY) != null && !System.getProperty(KILLBILL_OBFUSCATE_PATTERNS_SEPARATOR_PROPERTY).isEmpty() ? System.getProperty(KILLBILL_OBFUSCATE_PATTERNS_SEPARATOR_PROPERTY) : ",";
-            return Arrays.asList(System.getProperty(KILLBILL_OBFUSCATE_KEY_VALUE_PATTERNS_PROPERTY).split("\\s*"+separator+"\\s*"));
+            final String separator = loadPatternSeparator();
+            return Arrays.asList(System.getProperty(KILLBILL_OBFUSCATE_KEY_VALUE_PATTERNS_PROPERTY).split("\\s*" + separator + "\\s*"));
         } else {
             return List.of("\\s*=\\s*'([^']+)'",
                            "\\s*=\\s*\"([^\"]+)\"");
+        }
+    }
+
+    @VisibleForTesting
+    String loadPatternSeparator() {
+        if (System.getProperty(KILLBILL_OBFUSCATE_PATTERNS_SEPARATOR_PROPERTY) != null && !System.getProperty(KILLBILL_OBFUSCATE_PATTERNS_SEPARATOR_PROPERTY).isEmpty()) {
+            return System.getProperty(KILLBILL_OBFUSCATE_PATTERNS_SEPARATOR_PROPERTY);
+        } else {
+            return ",";
         }
     }
 

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/PatternObfuscator.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/PatternObfuscator.java
@@ -37,8 +37,8 @@ public class PatternObfuscator extends Obfuscator {
 
     private static final String KILLBILL_OBFUSCATE_PATTERNS_SEPARATOR_PROPERTY = "killbill.server.log.obfuscate.patterns.separator";
 
-    private static final Collection<String> DEFAULT_SENSITIVE_KEYS = loadKeywords();
-    private static final Collection<String> DEFAULT_STR_PATTERNS = loadPatterns();
+    private final Collection<String> defaultSensitiveKeys;
+    private final Collection<String> defaultStrPatterns;
 
     private final Collection<Pattern> patterns = new LinkedList<>();
 
@@ -52,7 +52,9 @@ public class PatternObfuscator extends Obfuscator {
 
     public PatternObfuscator(final Collection<Pattern> extraPatterns, final Collection<String> extraKeywords) {
         super();
-        final Collection<String> keywords = new ArrayList<>(DEFAULT_SENSITIVE_KEYS);
+        defaultSensitiveKeys = loadKeywords();
+        defaultStrPatterns = loadPatterns();
+        final Collection<String> keywords = new ArrayList<>(defaultSensitiveKeys);
         if (extraKeywords != null) {
             keywords.addAll(extraKeywords);
         }
@@ -61,7 +63,7 @@ public class PatternObfuscator extends Obfuscator {
             this.patterns.add(buildJSONPattern(sensitiveKey));
             this.patterns.add(buildXMLPattern(sensitiveKey));
             this.patterns.add(buildMultiValuesXMLPattern(sensitiveKey));
-            for (final String additionalPattern : DEFAULT_STR_PATTERNS) {
+            for (final String additionalPattern : defaultStrPatterns) {
                 this.patterns.add(buildKeyValuePatterns(additionalPattern, sensitiveKey));
             }
         }

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/PatternObfuscator.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/PatternObfuscator.java
@@ -29,10 +29,12 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class PatternObfuscator extends Obfuscator {
 
-    private static final String KILLBILL_KEYWORDS_TO_OBFUSCATE_PROPERTY = "killbill.server.log.keywordstoobfuscate";
     // Hide by default sensitive bank, PCI and PII data. For PANs, see LuhnMaskingObfuscator
-    private static final Collection<String> DEFAULT_SENSITIVE_KEYS = loadKeywordsToObfuscate();
+    private static final String KILLBILL_KEYWORDS_TO_OBFUSCATE_PROPERTY = "killbill.server.log.keywordstoobfuscate";
+    private static final String KILLBILL_KEY_VALUE_PATTERNS_PROPERTY = "killbill.server.log.keyvaluepatternstoobfuscate";
 
+    private static final Collection<String> DEFAULT_SENSITIVE_KEYS = loadKeywordsToObfuscate();
+    private static final Collection<String> DEFAULT_STR_PATTERNS = loadPatterns();
 
     private final Collection<Pattern> patterns = new LinkedList<>();
 
@@ -55,8 +57,9 @@ public class PatternObfuscator extends Obfuscator {
             this.patterns.add(buildJSONPattern(sensitiveKey));
             this.patterns.add(buildXMLPattern(sensitiveKey));
             this.patterns.add(buildMultiValuesXMLPattern(sensitiveKey));
-            this.patterns.add(buildKeyValuePattern1(sensitiveKey));
-            this.patterns.add(buildKeyValuePattern2(sensitiveKey));
+            for (final String additionalPattern : DEFAULT_STR_PATTERNS) {
+                this.patterns.add(buildKeyValuePatterns(additionalPattern, sensitiveKey));
+            }
         }
         this.patterns.addAll(extraPatterns);
     }
@@ -78,14 +81,8 @@ public class PatternObfuscator extends Obfuscator {
         return Pattern.compile(key + "</key>\\s*<value[^>]*>([^<\\n]+)</value>", DEFAULT_PATTERN_FLAGS);
     }
 
-    // Splunk-type logging
-    private Pattern buildKeyValuePattern1(final String key) {
-        return Pattern.compile(key + "\\s*=\\s*'([^']+)'", DEFAULT_PATTERN_FLAGS);
-    }
-
-    // Splunk-type logging
-    private Pattern buildKeyValuePattern2(final String key) {
-        return Pattern.compile(key + "\\s*=\\s*\"([^\"]+)\"", DEFAULT_PATTERN_FLAGS);
+    private Pattern buildKeyValuePatterns(final String pattern, final String key) {
+        return Pattern.compile(key + pattern, DEFAULT_PATTERN_FLAGS);
     }
 
     private static Collection<String> loadKeywordsToObfuscate() {
@@ -117,4 +114,14 @@ public class PatternObfuscator extends Obfuscator {
                     "xid");
         }
     }
+
+    private static Collection<String> loadPatterns() {
+        if (System.getProperty(KILLBILL_KEY_VALUE_PATTERNS_PROPERTY) != null && !System.getProperty(KILLBILL_KEY_VALUE_PATTERNS_PROPERTY).isEmpty()) {
+            return Arrays.asList(System.getProperty(KILLBILL_KEY_VALUE_PATTERNS_PROPERTY).split("\\s*,\\s*"));
+        } else {
+            return List.of("\\s*=\\s*'([^']+)'",
+                           "\\s*=\\s*\"([^\"]+)\"");
+        }
+    }
+
 }

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestPatternObfuscator.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestPatternObfuscator.java
@@ -43,8 +43,8 @@ public class TestPatternObfuscator {
     public void testLoadKeywords() {
         //without setting the killbill.server.log.obfuscate.patterns property
         System.clearProperty("killbill.server.log.obfuscate.keywords");
-        Collection<String> keywords = PatternObfuscator.loadKeywords();
-        Assert.assertEquals(22, keywords.size());
+        Collection<String> keywords = obfuscator.loadKeywords();
+        Assert.assertEquals(keywords.size(), 22);
         Collection<String> actual = List.of(
                 "accountnumber",
                 "authenticationdata",
@@ -72,8 +72,8 @@ public class TestPatternObfuscator {
 
         //after setting the the killbill.server.log.obfuscate.patterns property
         System.setProperty("killbill.server.log.obfuscate.keywords", "accountnumber,authenticationdata");
-        keywords = PatternObfuscator.loadKeywords();
-        Assert.assertEquals(2, keywords.size());
+        keywords = obfuscator.loadKeywords();
+        Assert.assertEquals(keywords.size(), 2);
         actual = List.of(
                 "accountnumber",
                 "authenticationdata");
@@ -83,24 +83,45 @@ public class TestPatternObfuscator {
 
     @Test
     public void testLoadPatterns() {
-        //without setting the killbill.server.log.obfuscate.patterns property
+        //without setting any properties
         System.clearProperty("killbill.server.log.obfuscate.patterns");
-        Collection<String> patterns = PatternObfuscator.loadPatterns();
-        Assert.assertEquals(2, patterns.size());
+        System.clearProperty("killbill.server.log.obfuscate.patterns.separator");
+        Collection<String> patterns = obfuscator.loadPatterns();
+        Assert.assertEquals(patterns.size(), 2);
         Collection<String> actual = List.of("\\s*=\\s*'([^']+)'",
                                             "\\s*=\\s*\"([^\"]+)\"");
         Assert.assertEquals(actual, patterns);
 
-        // after setting the killbill.server.log.obfuscate.patterns property
-        System.setProperty("killbill.server.log.obfuscate.patterns.separator", "#");
-        System.setProperty("killbill.server.log.obfuscate.patterns", "\\s*=\\s*'([^']+)'#\\s*=\\s*\"([^\"]+)#\\s*=\\s*([^ '\",{}]+)#\\s*:\\s*'([^'\",{}]+)'");
-        patterns = PatternObfuscator.loadPatterns();
-        Assert.assertEquals(4, patterns.size());
+        //without setting the killbill.server.log.obfuscate.patterns.separator property
+        System.setProperty("killbill.server.log.obfuscate.patterns", "\\s*=\\s*'([^']+)',\\s*=\\s*\"([^\"]+)\"");
+        patterns = obfuscator.loadPatterns();
+        Assert.assertEquals(patterns.size(), 2);
+        actual = List.of("\\s*=\\s*'([^']+)'",
+                         "\\s*=\\s*\"([^\"]+)\"");
+        Assert.assertEquals(actual, patterns);
+
+        // after setting the killbill.server.log.obfuscate.patterns property and killbill.server.log.obfuscate.patterns.separator property
+        System.setProperty("killbill.server.log.obfuscate.patterns.separator", "~");
+        System.setProperty("killbill.server.log.obfuscate.patterns", "\\s*=\\s*'([^']+)'~\\s*=\\s*\"([^\"]+)~\\s*=\\s*([^ '\",{}]+)~\\s*:\\s*'([^'\",{}]+)'");
+        patterns = obfuscator.loadPatterns();
+        Assert.assertEquals(patterns.size(), 4);
         actual = List.of("\\s*=\\s*'([^']+)'",
                          "\\s*=\\s*\"([^\"]+)",
                          "\\s*=\\s*([^ '\",{}]+)",
                          "\\s*:\\s*'([^'\",{}]+)'");
         Assert.assertEquals(actual, patterns);
+    }
+
+    @Test
+    public void testLoadPatternSeparator() {
+        //without setting the killbill.server.log.obfuscate.patterns.separator property
+        System.clearProperty("killbill.server.log.obfuscate.patterns.separator");
+        String patternSeparator = obfuscator.loadPatternSeparator();
+        Assert.assertEquals(patternSeparator, ",");
+        // after setting the killbill.server.log.obfuscate.patterns.separator property
+        System.setProperty("killbill.server.log.obfuscate.patterns.separator", "#");
+        patternSeparator = obfuscator.loadPatternSeparator();
+        Assert.assertEquals(patternSeparator, "#");
     }
 
     @Test(groups = "fast")

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestPatternObfuscator.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestPatternObfuscator.java
@@ -256,6 +256,67 @@ public class TestPatternObfuscator extends ServerTestSuiteNoDB {
 
     }
 
+    @Test(groups = "fast", enabled=false) //This tests passes only when killbill.server.log.keywordstoobfuscate=accountnumber,authenticationdata,banknumber,bic,cardvalidationnum,cavv,ccFirstName,ccLastName,ccNumber,ccTrackData,ccVerificationValue,ccvv,cvNumber,cvc,cvv,email,iban,name,number,password,xid,cell_phone is set as a system property. Disabled to prevent CI from failing
+    public void testJSONWithCellPhoneObfuscated() throws Exception {
+        verify("{\n" +
+               "  \"card\": {\n" +
+               "    \"id\": \"card_483etw4er9fg4vF3sQdrt3FG\",\n" +
+               "    \"object\": \"card\",\n" +
+               "    \"banknumber\": 4111111111111111,\n" +
+               "    \"cvv\" : 111,\n" +
+               "    \"cvv\": 111,\n" +
+               "    \"cvv\": \"111\",\n" +
+               "    \"data\": {\"cvv\" : 111 },\n" +
+               "    \"last4\": \"0000\",\n" +
+               "    \"brand\": \"Visa\",\n" +
+               "    \"funding\": \"credit\",\n" +
+               "    \"exp_month\": 6,\n" +
+               "    \"exp_year\": 2019,\n" +
+               "    \"fingerprint\": \"HOh74kZU387WlUvy\",\n" +
+               "    \"country\": \"US\",\n" +
+               "    \"name\": \"Bob Smith\",\n" +
+               "    \"cell_phone\": \"212-421-1278\",\n" +
+               "    \"address_line1\": null,\n" +
+               "    \"address_line2\": null,\n" +
+               "    \"address_city\": null,\n" +
+               "    \"address_state\": null,\n" +
+               "    \"address_zip\": null,\n" +
+               "    \"address_country\": null,\n" +
+               "    \"dynamic_last4\": \"4242\",\n" +
+               "    \"customer\": null,\n" +
+               "    \"type\": \"Visa\"}\n" +
+               "}",
+               "{\n" +
+               "  \"card\": {\n" +
+               "    \"id\": \"card_483etw4er9fg4vF3sQdrt3FG\",\n" +
+               "    \"object\": \"card\",\n" +
+               "    \"banknumber\": ****************,\n" +
+               "    \"cvv\" : ***,\n" +
+               "    \"cvv\": ***,\n" +
+               "    \"cvv\": *****,\n" +
+               "    \"data\": {\"cvv\" : ****},\n" +
+               "    \"last4\": \"0000\",\n" +
+               "    \"brand\": \"Visa\",\n" +
+               "    \"funding\": \"credit\",\n" +
+               "    \"exp_month\": 6,\n" +
+               "    \"exp_year\": 2019,\n" +
+               "    \"fingerprint\": \"HOh74kZU387WlUvy\",\n" +
+               "    \"country\": \"US\",\n" +
+               "    \"name\": ***********,\n" +
+               "    \"cell_phone\": **************,\n" +
+               "    \"address_line1\": null,\n" +
+               "    \"address_line2\": null,\n" +
+               "    \"address_city\": null,\n" +
+               "    \"address_state\": null,\n" +
+               "    \"address_zip\": null,\n" +
+               "    \"address_country\": null,\n" +
+               "    \"dynamic_last4\": \"4242\",\n" +
+               "    \"customer\": null,\n" +
+               "    \"type\": \"Visa\"}\n" +
+               "}");
+
+    }
+
     @Test(groups = "fast")
     public void testPayU() throws Exception {
         verify("<entry>\n" +

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestPatternObfuscator.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestPatternObfuscator.java
@@ -17,6 +17,12 @@
 
 package org.killbill.billing.server.log.obfuscators;
 
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.killbill.billing.server.log.ServerTestSuiteNoDB;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -27,6 +33,68 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 public class TestPatternObfuscator extends ServerTestSuiteNoDB {
 
     private final PatternObfuscator obfuscator = new PatternObfuscator();
+
+    @Test
+    public void testLoadKeywords() {
+        //without setting the killbill.server.log.obfuscate.patterns property
+        Collection<String> keywords =  PatternObfuscator.loadKeywords();
+        Assert.assertEquals(22, keywords.size());
+        Collection<String> actual = List.of(
+                "accountnumber",
+                "authenticationdata",
+                "bankaccountnumber",
+                "banknumber",
+                "bic",
+                "cardvalidationnum",
+                "cavv",
+                "ccFirstName",
+                "ccLastName",
+                "ccNumber",
+                "ccTrackData",
+                "ccVerificationValue",
+                "ccvv",
+                "cvNumber",
+                "cvc",
+                "cvv",
+                "email",
+                "iban",
+                "name",
+                "number",
+                "password",
+                "xid");
+        Assert.assertEquals(actual, keywords);
+
+        //after setting the the killbill.server.log.obfuscate.patterns property
+        System.setProperty("killbill.server.log.obfuscate.keywords","accountnumber,authenticationdata");
+        keywords =  PatternObfuscator.loadKeywords();
+        Assert.assertEquals(2, keywords.size());
+        actual = List.of(
+                "accountnumber",
+                "authenticationdata");
+        Assert.assertEquals(actual, keywords);
+
+    }
+
+    @Test
+    public void testLoadPatterns() {
+        //without setting the killbill.server.log.obfuscate.patterns property
+        Collection<String> patterns =  PatternObfuscator.loadPatterns();
+        Assert.assertEquals(2, patterns.size());
+        Collection<String> actual = List.of("\\s*=\\s*'([^']+)'",
+                                            "\\s*=\\s*\"([^\"]+)\"");
+        Assert.assertEquals(actual, patterns);
+
+        // after setting the killbill.server.log.obfuscate.patterns property
+        System.setProperty("killbill.server.log.obfuscate.patterns.separator", "#");
+        System.setProperty("killbill.server.log.obfuscate.patterns","\\s*=\\s*'([^']+)'#\\s*=\\s*\"([^\"]+)#\\s*=\\s*([^ '\",{}]+)#\\s*:\\s*'([^'\",{}]+)'");
+        patterns =  PatternObfuscator.loadPatterns();
+        Assert.assertEquals(4, patterns.size());
+        actual = List.of("\\s*=\\s*'([^']+)'",
+                         "\\s*=\\s*\"([^\"]+)",
+                         "\\s*=\\s*([^ '\",{}]+)",
+                         "\\s*:\\s*'([^'\",{}]+)'");
+        Assert.assertEquals(actual, patterns);
+    }
 
     @Test(groups = "fast")
     public void testAdyen() throws Exception {
@@ -256,8 +324,8 @@ public class TestPatternObfuscator extends ServerTestSuiteNoDB {
 
     }
 
-    @Test(groups = "fast", enabled=false) //This tests passes only when killbill.server.log.keywordstoobfuscate=accountnumber,authenticationdata,banknumber,bic,cardvalidationnum,cavv,ccFirstName,ccLastName,ccNumber,ccTrackData,ccVerificationValue,ccvv,cvNumber,cvc,cvv,email,iban,name,number,password,xid,cell_phone is set as a system property. Disabled to prevent CI from failing
-    public void testJSONWithCellPhoneObfuscated() throws Exception {
+    @Test(groups = "fast", description="test for custom keyword (cell_phone) in JSON", enabled=false) //works with -Dkillbill.server.log.obfuscate.keywords=accountnumber,authenticationdata,banknumber,bic,cardvalidationnum,cavv,ccFirstName,ccLastName,ccNumber,ccTrackData,ccVerificationValue,ccvv,cvNumber,cvc,cvv,email,iban,name,number,password,xid,cell_phone
+    public void testJSONWithCustomKeyWord() throws Exception {
         verify("{\n" +
                "  \"card\": {\n" +
                "    \"id\": \"card_483etw4er9fg4vF3sQdrt3FG\",\n" +
@@ -370,16 +438,35 @@ public class TestPatternObfuscator extends ServerTestSuiteNoDB {
                event);
     }
 
-    @Test(groups = "fast")
-    public void testPluginProperties() throws Exception {
+    @Test(groups = "fast", description="test for key='value', key=\"value\"")
+    public void testKeyValuePattern1() throws Exception { // works with default keywords/patterns
         verify("ENTERING onSuccessCall paymentMethodId='e92a3bfd-0713-4396-a1e2-ff46cb051f8c' ccVerificationValue='123' ccNumber = '4111111111111111' ccTrackData=\"XXX\" ccFirstName = \"John\" ccLastName=\"'Smith'\"",
                "ENTERING onSuccessCall paymentMethodId='e92a3bfd-0713-4396-a1e2-ff46cb051f8c' ccVerificationValue='***' ccNumber = '****************' ccTrackData=\"***\" ccFirstName = \"****\" ccLastName=\"*******\"");
     }
 
-    @Test(groups = "fast", enabled = false) // This tests passes only when killbill.server.log.keyvaluepatternstoobfuscate=\s*=\s*'([^']+)',\s*=\s*\"([^\"]+)\",\s*:\s*'([^']+)' is set as a system property. Disabled to prevent CI from failing
-    public void testAdditionalKeyValuePattern() throws Exception {
-        verify("paymentMethodId:'e92a3bfd-0713-4396-a1e2-ff46cb051f8c' ccVerificationValue:'123' ccNumber:'4111111111111111' ccTrackData=\"XXX\" ccFirstName = \"John\" ccLastName=\"'Smith'\"",
-               "paymentMethodId:'e92a3bfd-0713-4396-a1e2-ff46cb051f8c' ccVerificationValue:'***' ccNumber:'****************' ccTrackData=\"***\" ccFirstName = \"****\" ccLastName=\"*******\"");
+    @Test(groups = "fast", description = "test for key=value", enabled = false) //Works with -Dkillbill.server.log.obfuscate.patterns.separator=# -Dkillbill.server.log.obfuscate.patterns="\s*=\s*'([^']+)'#\s*=\s*\"([^\"]+)#\s*=\s*([^ '\",]+)"
+    public void testKeyValuePattern2() throws Exception {
+        verify("ENTERING onSuccessCall password=e92a3bfd password = ff46cb051f8c, ccNumber = '4111111111111111' ccTrackData=\"XXX\" ccFirstName = \"John\" ccLastName=\"'Smith'\"",
+               "ENTERING onSuccessCall password=******** password = ************, ccNumber = '****************' ccTrackData=\"***\" ccFirstName = \"****\" ccLastName=\"*******\"");
+    }
+
+    @Test(groups = "fast", description = "testing key:value", enabled = false) //Works with -Dkillbill.server.log.obfuscate.patterns.separator=# -Dkillbill.server.log.obfuscate.patterns=\s*=\s*'([^']+)'#\s*=\s*\"([^\"]+)#\s*:\s*'([^'\",{}]+)'
+    public void testKeyValuePattern3() throws Exception {
+        String testInput = "paymentMethodId:UUIDArgument{value=null},currency:USD,id:UUIDArgument{value=ae373eb5-0863-4707-b3d2-8c62d4516b72},reasonCode:'Create Account',migrated:null,class:class org.killbill.billing.callcontext.InternalCallContext,email:'Dnk910tlpslbb@gmail.com',callOrigin:INTERNAL,tenantRecordId:1,comments:'Create Account by ICO plugin',updatedBy:'spa-ico-plugin-cb',address2:'',address1:'508 e Prospect st'";
+        String expectedOutput = "paymentMethodId:UUIDArgument{value=null},currency:USD,id:UUIDArgument{value=ae373eb5-0863-4707-b3d2-8c62d4516b72},reasonCode:'Create Account',migrated:null,class:class org.killbill.billing.callcontext.InternalCallContext,email:'***********************',callOrigin:INTERNAL,tenantRecordId:1,comments:'Create Account by ICO plugin',updatedBy:'spa-ico-plugin-cb',address2:'',address1:'508 e Prospect st'";
+        verify(testInput, expectedOutput);
+    }
+
+    @Test(groups = "fast", description = "test key=\"value\" for firstName", enabled = false) //Works with -Dkillbill.server.log.obfuscate.patterns.separator=# -Dkillbill.server.log.obfuscate.patterns="\s*=\s*'([^']+)'#\s*=\s*\"([^\"]+)#\s*=\s*([^ '\",]+)"
+    public void testKeyValuePattern4() throws Exception {
+        verify("ENTERING onSuccessCall password=e92a3bfd password = ff46cb051f8c, ccNumber = '4111111111111111' ccTrackData=\"XXX\" firstName = \"santosh.kallihosurranga@gmail.com\" lastName=\"kallihosur ranga\"",
+               "ENTERING onSuccessCall password=******** password = ************, ccNumber = '****************' ccTrackData=\"***\" firstName = \"*********************************\" lastName=\"****************\"");
+    }
+
+    @Test(groups = "fast", description = "test req.requestURI keyword and key=value pattern", enabled = false) // works with -Dkillbill.server.log.obfuscate.patterns.separator=# -Dkillbill.server.log.obfuscate.keywords=req.requestURI -Dkillbill.server.log.obfuscate.patterns="\s*=\s*'([^']+)'#\s*=\s*\"([^\"]+)#\s*=\s*([^ '\",]+)"
+    public void testCustomKeywordAndKeyValuePattern() throws Exception {
+        verify("req.requestURI= /strommerce/1.0/kb/accounts/search/grucaunicegroi-4387@yopmail.com",
+               "req.requestURI= ******************************************************************");
     }
 
     private void verify(final String input, final ILoggingEvent event) {

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestPatternObfuscator.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/log/obfuscators/TestPatternObfuscator.java
@@ -376,6 +376,12 @@ public class TestPatternObfuscator extends ServerTestSuiteNoDB {
                "ENTERING onSuccessCall paymentMethodId='e92a3bfd-0713-4396-a1e2-ff46cb051f8c' ccVerificationValue='***' ccNumber = '****************' ccTrackData=\"***\" ccFirstName = \"****\" ccLastName=\"*******\"");
     }
 
+    @Test(groups = "fast", enabled = false) // This tests passes only when killbill.server.log.keyvaluepatternstoobfuscate=\s*=\s*'([^']+)',\s*=\s*\"([^\"]+)\",\s*:\s*'([^']+)' is set as a system property. Disabled to prevent CI from failing
+    public void testAdditionalKeyValuePattern() throws Exception {
+        verify("paymentMethodId:'e92a3bfd-0713-4396-a1e2-ff46cb051f8c' ccVerificationValue:'123' ccNumber:'4111111111111111' ccTrackData=\"XXX\" ccFirstName = \"John\" ccLastName=\"'Smith'\"",
+               "paymentMethodId:'e92a3bfd-0713-4396-a1e2-ff46cb051f8c' ccVerificationValue:'***' ccNumber:'****************' ccTrackData=\"***\" ccFirstName = \"****\" ccLastName=\"*******\"");
+    }
+
     private void verify(final String input, final ILoggingEvent event) {
         verify(input, input, event);
     }


### PR DESCRIPTION
Fix for custom keywords/key-value patterns for obfuscation.  In order to use this feature, the following additional system properties need to be set:

- killbill.server.log.obfuscate.keywords (defaults to `accountnumber,authenticationdata,banknumber,bic,cardvalidationnum,cavv,ccFirstName,ccLastName,ccNumber,ccTrackData,ccVerificationValue,ccvv,cvNumber,cvc,cvv,email,iban,name,number,password,xid,externalKey`)
- killbill.server.log.obfuscate.patterns (defaults to `\\s*=\\s*'([^']+)',\\s*=\\s*"([^"]+)"`)
- killbill.server.log.obfuscate.patterns.separator (defaults to `,`)

