### PR TITLE
Global lock error resiliency

### DIFF
--- a/catalog/src/test/java/org/killbill/billing/catalog/TestCatalogService.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/TestCatalogService.java
@@ -18,9 +18,14 @@
 
 package org.killbill.billing.catalog;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.platform.api.KillbillService.ServiceException;
 import org.killbill.billing.util.config.definition.CatalogConfig;
+import org.skife.config.TimeSpan;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -29,6 +34,14 @@ public class TestCatalogService extends CatalogTestSuiteNoDB {
     @Test(groups = "fast")
     public void testCatalogServiceDirectory() throws ServiceException, CatalogApiException {
         final DefaultCatalogService service = new DefaultCatalogService(new CatalogConfig() {
+            @Override
+            public List<TimeSpan> getRescheduleIntervalOnLock() {
+                return Collections.emptyList();
+            }
+            @Override
+            public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
+                return Collections.emptyList();
+            }
             @Override
             public String getCatalogURI() {
                 return "org/killbill/billing/catalog/versionedCatalog";
@@ -48,10 +61,17 @@ public class TestCatalogService extends CatalogTestSuiteNoDB {
     public void testCatalogServiceFile() throws ServiceException, CatalogApiException {
         final DefaultCatalogService service = new DefaultCatalogService(new CatalogConfig() {
             @Override
+            public List<TimeSpan> getRescheduleIntervalOnLock() {
+                return Collections.emptyList();
+            }
+            @Override
+            public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
+                return Collections.emptyList();
+            }
+            @Override
             public String getCatalogURI() {
                 return "org/killbill/billing/catalog/WeaponsHire.xml";
             }
-
             @Override
             public Integer getCatalogThreadNb() {
                 return null;

--- a/catalog/src/test/java/org/killbill/billing/catalog/TestCatalogService.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/TestCatalogService.java
@@ -35,14 +35,6 @@ public class TestCatalogService extends CatalogTestSuiteNoDB {
     public void testCatalogServiceDirectory() throws ServiceException, CatalogApiException {
         final DefaultCatalogService service = new DefaultCatalogService(new CatalogConfig() {
             @Override
-            public List<TimeSpan> getRescheduleIntervalOnLock() {
-                return Collections.emptyList();
-            }
-            @Override
-            public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
-                return Collections.emptyList();
-            }
-            @Override
             public String getCatalogURI() {
                 return "org/killbill/billing/catalog/versionedCatalog";
             }
@@ -60,14 +52,6 @@ public class TestCatalogService extends CatalogTestSuiteNoDB {
     @Test(groups = "fast")
     public void testCatalogServiceFile() throws ServiceException, CatalogApiException {
         final DefaultCatalogService service = new DefaultCatalogService(new CatalogConfig() {
-            @Override
-            public List<TimeSpan> getRescheduleIntervalOnLock() {
-                return Collections.emptyList();
-            }
-            @Override
-            public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
-                return Collections.emptyList();
-            }
             @Override
             public String getCatalogURI() {
                 return "org/killbill/billing/catalog/WeaponsHire.xml";

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -38,7 +38,7 @@ public class MultiTenantInvoiceConfig extends MultiTenantConfigBase implements I
 
     @Inject
     public MultiTenantInvoiceConfig(@Named(KillBillModule.STATIC_CONFIG) final InvoiceConfig staticConfig, final CacheConfig cacheConfig) {
-        super(cacheConfig);
+        super(staticConfig, cacheConfig);
         this.staticConfig = staticConfig;
     }
 
@@ -260,21 +260,6 @@ public class MultiTenantInvoiceConfig extends MultiTenantConfigBase implements I
             return Boolean.parseBoolean(result);
         }
         return shouldParkAccountsWithUnknownUsage();
-    }
-
-    @Override
-    public List<TimeSpan> getRescheduleIntervalOnLock() {
-        return staticConfig.getRescheduleIntervalOnLock();
-    }
-
-    @Override
-    public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
-
-        final String result = getStringTenantConfig("getRescheduleIntervalOnLock", tenantContext);
-        if (result != null) {
-            return convertToListTimeSpan(result, "getRescheduleIntervalOnLock");
-        }
-        return getRescheduleIntervalOnLock();
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -28,10 +28,11 @@ import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.config.definition.KillbillConfig;
 import org.killbill.billing.util.config.tenant.CacheConfig;
 import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.config.tenant.MultiTenantLockAwareConfigBase;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.TimeSpan;
 
-public class MultiTenantInvoiceConfig extends MultiTenantConfigBase implements InvoiceConfig {
+public class MultiTenantInvoiceConfig extends MultiTenantLockAwareConfigBase implements InvoiceConfig {
 
 
     private final InvoiceConfig staticConfig;

--- a/overdue/src/main/java/org/killbill/billing/overdue/config/MultiTenantOverdueConfig.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/config/MultiTenantOverdueConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.config;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.util.config.definition.KillbillConfig;
+import org.killbill.billing.util.config.definition.OverdueConfig;
+import org.killbill.billing.util.config.tenant.CacheConfig;
+import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.glue.KillBillModule;
+import org.skife.config.TimeSpan;
+
+public class MultiTenantOverdueConfig extends MultiTenantConfigBase implements OverdueConfig {
+
+    private final OverdueConfig staticConfig;
+
+    @Inject
+    public MultiTenantOverdueConfig(@Named(KillBillModule.STATIC_CONFIG) final OverdueConfig staticConfig, final CacheConfig cacheConfig) {
+        super(cacheConfig);
+        this.staticConfig = staticConfig;
+    }
+
+    @Override
+    public List<TimeSpan> getRescheduleIntervalOnLock() {
+        return staticConfig.getRescheduleIntervalOnLock();
+    }
+
+    @Override
+    public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("getRescheduleIntervalOnLock", tenantContext);
+        if (result != null) {
+            return convertToListTimeSpan(result, "getRescheduleIntervalOnLock");
+        }
+        return getRescheduleIntervalOnLock();
+
+    }
+
+    @Override
+    protected Class<? extends KillbillConfig> getConfigClass() {
+        return OverdueConfig.class;
+    }
+}

--- a/overdue/src/main/java/org/killbill/billing/overdue/config/MultiTenantOverdueConfig.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/config/MultiTenantOverdueConfig.java
@@ -36,23 +36,8 @@ public class MultiTenantOverdueConfig extends MultiTenantConfigBase implements O
 
     @Inject
     public MultiTenantOverdueConfig(@Named(KillBillModule.STATIC_CONFIG) final OverdueConfig staticConfig, final CacheConfig cacheConfig) {
-        super(cacheConfig);
+        super(staticConfig, cacheConfig);
         this.staticConfig = staticConfig;
-    }
-
-    @Override
-    public List<TimeSpan> getRescheduleIntervalOnLock() {
-        return staticConfig.getRescheduleIntervalOnLock();
-    }
-
-    @Override
-    public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
-        final String result = getStringTenantConfig("getRescheduleIntervalOnLock", tenantContext);
-        if (result != null) {
-            return convertToListTimeSpan(result, "getRescheduleIntervalOnLock");
-        }
-        return getRescheduleIntervalOnLock();
-
     }
 
     @Override

--- a/overdue/src/main/java/org/killbill/billing/overdue/config/MultiTenantOverdueConfig.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/config/MultiTenantOverdueConfig.java
@@ -27,10 +27,11 @@ import org.killbill.billing.util.config.definition.KillbillConfig;
 import org.killbill.billing.util.config.definition.OverdueConfig;
 import org.killbill.billing.util.config.tenant.CacheConfig;
 import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.config.tenant.MultiTenantLockAwareConfigBase;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.TimeSpan;
 
-public class MultiTenantOverdueConfig extends MultiTenantConfigBase implements OverdueConfig {
+public class MultiTenantOverdueConfig extends MultiTenantLockAwareConfigBase implements OverdueConfig {
 
     private final OverdueConfig staticConfig;
 

--- a/overdue/src/main/java/org/killbill/billing/overdue/glue/DefaultOverdueModule.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/glue/DefaultOverdueModule.java
@@ -26,6 +26,7 @@ import org.killbill.billing.overdue.api.OverdueApi;
 import org.killbill.billing.overdue.caching.DefaultOverdueConfigCache;
 import org.killbill.billing.overdue.caching.OverdueCacheInvalidationCallback;
 import org.killbill.billing.overdue.caching.OverdueConfigCache;
+import org.killbill.billing.overdue.config.MultiTenantOverdueConfig;
 import org.killbill.billing.overdue.listener.OverdueListener;
 import org.killbill.billing.overdue.notification.OverdueAsyncBusNotifier;
 import org.killbill.billing.overdue.notification.OverdueAsyncBusPoster;
@@ -37,6 +38,7 @@ import org.killbill.billing.overdue.service.DefaultOverdueService;
 import org.killbill.billing.overdue.wrapper.OverdueWrapperFactory;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.tenant.api.TenantInternalApi.CacheInvalidationCallback;
+import org.killbill.billing.util.config.definition.OverdueConfig;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.ConfigurationObjectFactory;
 
@@ -54,6 +56,9 @@ public class DefaultOverdueModule extends KillBillModule implements OverdueModul
 
     @Override
     protected void configure() {
+
+        installConfig();
+
         installOverdueUserApi();
 
         installOverdueConfigCache();
@@ -73,6 +78,15 @@ public class DefaultOverdueModule extends KillBillModule implements OverdueModul
         bind(OverduePoster.class).annotatedWith(Names.named(OVERDUE_NOTIFIER_CHECK_NAMED)).to(OverdueCheckPoster.class).asEagerSingleton();
         bind(OverduePoster.class).annotatedWith(Names.named(OVERDUE_NOTIFIER_ASYNC_BUS_NAMED)).to(OverdueAsyncBusPoster.class).asEagerSingleton();
     }
+
+    protected void installConfig() {
+        installConfig(new ConfigurationObjectFactory(skifeConfigSource).build(OverdueConfig.class));
+    }
+    protected void installConfig(final OverdueConfig staticOverdueConfig) {
+        bind(OverdueConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(staticOverdueConfig);
+        bind(OverdueConfig.class).to(MultiTenantOverdueConfig.class).asEagerSingleton();
+    }
+
 
     protected void installOverdueService() {
         bind(OverdueService.class).to(DefaultOverdueService.class).asEagerSingleton();

--- a/overdue/src/main/java/org/killbill/billing/overdue/notification/OverdueAsyncBusNotifier.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/notification/OverdueAsyncBusNotifier.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 import org.killbill.billing.overdue.OverdueProperties;
 import org.killbill.billing.overdue.listener.OverdueDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.slf4j.Logger;
@@ -39,10 +40,12 @@ public class OverdueAsyncBusNotifier extends DefaultOverdueNotifierBase implemen
 
 
     @Inject
-    public OverdueAsyncBusNotifier(final NotificationQueueService notificationQueueService, final OverdueProperties config,
+    public OverdueAsyncBusNotifier(final NotificationQueueService notificationQueueService,
+                                   final OverdueProperties config,
                                    final InternalCallContextFactory internalCallContextFactory,
+                                   final Clock clock,
                                    final OverdueDispatcher dispatcher) {
-        super(notificationQueueService, config, internalCallContextFactory, dispatcher);
+        super(OVERDUE_ASYNC_BUS_NOTIFIER_QUEUE, notificationQueueService, config, clock, internalCallContextFactory, dispatcher);
     }
 
     @Override

--- a/overdue/src/main/java/org/killbill/billing/overdue/notification/OverdueCheckNotifier.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/notification/OverdueCheckNotifier.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 import org.killbill.billing.overdue.OverdueProperties;
 import org.killbill.billing.overdue.listener.OverdueDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.slf4j.Logger;
@@ -39,10 +40,12 @@ public class OverdueCheckNotifier extends DefaultOverdueNotifierBase implements 
 
 
     @Inject
-    public OverdueCheckNotifier(final NotificationQueueService notificationQueueService, final OverdueProperties config,
+    public OverdueCheckNotifier(final NotificationQueueService notificationQueueService,
+                                final OverdueProperties config,
+                                final Clock clock,
                                 final InternalCallContextFactory internalCallContextFactory,
                                 final OverdueDispatcher dispatcher) {
-        super(notificationQueueService, config, internalCallContextFactory, dispatcher);
+        super(OVERDUE_CHECK_NOTIFIER_QUEUE, notificationQueueService, config, clock, internalCallContextFactory, dispatcher);
     }
 
     @Override

--- a/overdue/src/main/java/org/killbill/billing/overdue/notification/OverdueNotifier.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/notification/OverdueNotifier.java
@@ -22,14 +22,16 @@ import java.util.UUID;
 import org.joda.time.DateTime;
 
 import org.killbill.notificationq.api.NotificationEvent;
+import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
+import org.killbill.notificationq.api.NotificationQueueService.NotificationQueueAlreadyExists;
 
 public interface OverdueNotifier {
 
-    public void initialize();
+    public void initialize() throws NotificationQueueAlreadyExists;
 
     public void start();
 
-    public void stop();
+    public void stop() throws NoSuchNotificationQueue;
 
     public abstract void handleReadyNotification(final NotificationEvent notificationKey, final DateTime eventDate, final UUID userToken, final Long accountRecordId, final Long tenantRecordId);
 

--- a/overdue/src/test/java/org/killbill/billing/overdue/notification/TestOverdueCheckNotifier.java
+++ b/overdue/src/test/java/org/killbill/billing/overdue/notification/TestOverdueCheckNotifier.java
@@ -74,7 +74,7 @@ public class TestOverdueCheckNotifier extends OverdueTestSuiteWithEmbeddedDB {
         cleanupAllTables();
 
         mockDispatcher = new OverdueDispatcherMock(internalCallContextFactory);
-        notifierForMock = new OverdueCheckNotifier(notificationQueueService, overdueProperties, internalCallContextFactory, mockDispatcher);
+        notifierForMock = new OverdueCheckNotifier(notificationQueueService, overdueProperties, clock, internalCallContextFactory, mockDispatcher);
 
         notifierForMock.initialize();
         notifierForMock.start();

--- a/payment/src/main/java/org/killbill/billing/payment/config/MultiTenantPaymentConfig.java
+++ b/payment/src/main/java/org/killbill/billing/payment/config/MultiTenantPaymentConfig.java
@@ -27,11 +27,12 @@ import org.killbill.billing.util.config.definition.KillbillConfig;
 import org.killbill.billing.util.config.definition.PaymentConfig;
 import org.killbill.billing.util.config.tenant.CacheConfig;
 import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.config.tenant.MultiTenantLockAwareConfigBase;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.Param;
 import org.skife.config.TimeSpan;
 
-public class MultiTenantPaymentConfig extends MultiTenantConfigBase implements PaymentConfig {
+public class MultiTenantPaymentConfig extends MultiTenantLockAwareConfigBase implements PaymentConfig {
 
     private final PaymentConfig staticConfig;
 

--- a/payment/src/main/java/org/killbill/billing/payment/config/MultiTenantPaymentConfig.java
+++ b/payment/src/main/java/org/killbill/billing/payment/config/MultiTenantPaymentConfig.java
@@ -37,7 +37,7 @@ public class MultiTenantPaymentConfig extends MultiTenantConfigBase implements P
 
     @Inject
     public MultiTenantPaymentConfig(@Named(KillBillModule.STATIC_CONFIG) final PaymentConfig staticConfig, final CacheConfig cacheConfig) {
-        super(cacheConfig);
+        super(staticConfig, cacheConfig);
         this.staticConfig = staticConfig;
     }
 
@@ -139,20 +139,6 @@ public class MultiTenantPaymentConfig extends MultiTenantConfigBase implements P
         return getPaymentControlPluginNames();
     }
 
-    @Override
-    public List<TimeSpan> getRescheduleIntervalOnLock() {
-        return staticConfig.getRescheduleIntervalOnLock();
-    }
-
-    @Override
-    public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
-
-        final String result = getStringTenantConfig("getRescheduleIntervalOnLock", tenantContext);
-        if (result != null) {
-            return convertToListTimeSpan(result, "getRescheduleIntervalOnLock");
-        }
-        return getRescheduleIntervalOnLock();
-    }
 
     @Override
     public TimeSpan getJanitorRunningRate() {

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/config/MultiTenantNotificationConfig.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/config/MultiTenantNotificationConfig.java
@@ -41,7 +41,7 @@ public class MultiTenantNotificationConfig extends MultiTenantConfigBase impleme
 
     @Inject
     public MultiTenantNotificationConfig(@Named(KillBillModule.STATIC_CONFIG) final NotificationConfig staticConfig, final CacheConfig cacheConfig) {
-        super(cacheConfig);
+        super(staticConfig, cacheConfig);
         this.staticConfig = staticConfig;
     }
 

--- a/subscription/src/main/java/org/killbill/billing/subscription/config/MultiTenantSubscriptionConfig.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/config/MultiTenantSubscriptionConfig.java
@@ -33,7 +33,7 @@ public class MultiTenantSubscriptionConfig extends MultiTenantConfigBase impleme
 
     @Inject
     public MultiTenantSubscriptionConfig(@Named(KillBillModule.STATIC_CONFIG) final SubscriptionConfig staticConfig, final CacheConfig cacheConfig) {
-        super(cacheConfig);
+        super(staticConfig, cacheConfig);
         this.staticConfig = staticConfig;
     }
 

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -27,7 +27,7 @@ import org.skife.config.Description;
 import org.skife.config.Param;
 import org.skife.config.TimeSpan;
 
-public interface InvoiceConfig extends KillbillConfig {
+public interface InvoiceConfig extends LockAwareConfig {
 
 
     // Default period value for when nothing is specified

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -187,17 +187,6 @@ public interface InvoiceConfig extends KillbillConfig {
     @Description("Whether to park accounts when usage data is recorded but not defined in the catalog")
     boolean shouldParkAccountsWithUnknownUsage(@Param("dummy") final InternalTenantContext tenantContext);
 
-    // Disabled by default
-    @Config("org.killbill.invoice.rescheduleIntervalOnLock")
-    @Default("30s, 1m, 1m, 3m, 3m, 10m")
-    @Description("Tme delay to reschedule an invoice run when lock is held")
-    List<TimeSpan> getRescheduleIntervalOnLock();
-
-    @Config("org.killbill.invoice.rescheduleIntervalOnLock")
-    @Default("30s, 1m, 1m, 3m, 3m, 10m")
-    @Description("Tme delay to reschedule an invoice run when lock is held")
-    List<TimeSpan> getRescheduleIntervalOnLock(@Param("dummy") final InternalTenantContext tenantContext);
-
     @Config("org.killbill.invoice.maxInvoiceLimit")
     @Default(DEFAULT_NULL_PERIOD)
     @Description("How far back in time should invoice generation look at")

--- a/util/src/main/java/org/killbill/billing/util/config/definition/KillbillConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/KillbillConfig.java
@@ -16,9 +16,28 @@
  */
 package org.killbill.billing.util.config.definition;
 
+import java.util.List;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.skife.config.Config;
+import org.skife.config.Default;
+import org.skife.config.Description;
+import org.skife.config.Param;
+import org.skife.config.TimeSpan;
+
 /*
  * Marker interface for killbill config files
  */
 public interface KillbillConfig {
+
+    @Config("org.killbill.rescheduleIntervalOnLock")
+    @Default("30s, 1m, 1m, 3m, 3m, 10m")
+    @Description("Tme delay to reschedule an invoice run when lock is held")
+    List<TimeSpan> getRescheduleIntervalOnLock();
+
+    @Config("org.killbill.rescheduleIntervalOnLock")
+    @Default("30s, 1m, 1m, 3m, 3m, 10m")
+    @Description("Tme delay to reschedule an invoice run when lock is held")
+    List<TimeSpan> getRescheduleIntervalOnLock(@Param("dummy") final InternalTenantContext tenantContext);
 
 }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/LockAwareConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/LockAwareConfig.java
@@ -25,9 +25,16 @@ import org.skife.config.Description;
 import org.skife.config.Param;
 import org.skife.config.TimeSpan;
 
-/*
- * Marker interface for killbill config files
- */
-public interface KillbillConfig {
+public interface LockAwareConfig extends KillbillConfig {
+
+    @Config("org.killbill.rescheduleIntervalOnLock")
+    @Default("30s, 1m, 1m, 3m, 3m, 10m")
+    @Description("Tme delay to reschedule an invoice run when lock is held")
+    List<TimeSpan> getRescheduleIntervalOnLock();
+
+    @Config("org.killbill.rescheduleIntervalOnLock")
+    @Default("30s, 1m, 1m, 3m, 3m, 10m")
+    @Description("Tme delay to reschedule an invoice run when lock is held")
+    List<TimeSpan> getRescheduleIntervalOnLock(@Param("dummy") final InternalTenantContext tenantContext);
 
 }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/MultiTenantEventConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/MultiTenantEventConfig.java
@@ -34,7 +34,7 @@ public class MultiTenantEventConfig extends MultiTenantConfigBase implements Eve
 
     @Inject
     public MultiTenantEventConfig(@Named(KillBillModule.STATIC_CONFIG) final EventConfig staticConfig, final CacheConfig cacheConfig) {
-        super(cacheConfig);
+        super(staticConfig, cacheConfig);
         this.staticConfig = staticConfig;
     }
 

--- a/util/src/main/java/org/killbill/billing/util/config/definition/OverdueConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/OverdueConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2020 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.config.definition;
+
+import java.util.List;
+
+import org.joda.time.Period;
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.skife.config.Config;
+import org.skife.config.Default;
+import org.skife.config.Description;
+import org.skife.config.Param;
+import org.skife.config.TimeSpan;
+
+public interface OverdueConfig extends KillbillConfig {
+
+    // Disabled by default
+    @Config("org.killbill.overdue.rescheduleIntervalOnLock")
+    @Default("30s, 1m, 1m, 3m, 3m, 10m")
+    @Description("Tme delay to reschedule an invoice run when lock is held")
+    List<TimeSpan> getRescheduleIntervalOnLock();
+
+    @Config("org.killbill.overdue.rescheduleIntervalOnLock")
+    @Default("30s, 1m, 1m, 3m, 3m, 10m")
+    @Description("Tme delay to reschedule an invoice run when lock is held")
+    List<TimeSpan> getRescheduleIntervalOnLock(@Param("dummy") final InternalTenantContext tenantContext);
+
+}

--- a/util/src/main/java/org/killbill/billing/util/config/definition/OverdueConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/OverdueConfig.java
@@ -17,27 +17,6 @@
 
 package org.killbill.billing.util.config.definition;
 
-import java.util.List;
-
-import org.joda.time.Period;
-import org.killbill.billing.callcontext.InternalTenantContext;
-import org.skife.config.Config;
-import org.skife.config.Default;
-import org.skife.config.Description;
-import org.skife.config.Param;
-import org.skife.config.TimeSpan;
-
 public interface OverdueConfig extends KillbillConfig {
-
-    // Disabled by default
-    @Config("org.killbill.overdue.rescheduleIntervalOnLock")
-    @Default("30s, 1m, 1m, 3m, 3m, 10m")
-    @Description("Tme delay to reschedule an invoice run when lock is held")
-    List<TimeSpan> getRescheduleIntervalOnLock();
-
-    @Config("org.killbill.overdue.rescheduleIntervalOnLock")
-    @Default("30s, 1m, 1m, 3m, 3m, 10m")
-    @Description("Tme delay to reschedule an invoice run when lock is held")
-    List<TimeSpan> getRescheduleIntervalOnLock(@Param("dummy") final InternalTenantContext tenantContext);
 
 }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/OverdueConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/OverdueConfig.java
@@ -17,6 +17,6 @@
 
 package org.killbill.billing.util.config.definition;
 
-public interface OverdueConfig extends KillbillConfig {
+public interface OverdueConfig extends LockAwareConfig {
 
 }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/PaymentConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/PaymentConfig.java
@@ -130,16 +130,6 @@ public interface PaymentConfig extends KillbillConfig {
     @Description("Maximum number of times the system will retry to grab global lock (with a 100ms wait each time)")
     int getMaxGlobalLockRetries();
 
-    @Config("org.killbill.payment.rescheduleIntervalOnLock")
-    @Default("30s, 1m, 1m, 3m, 3m, 10m")
-    @Description("Tme delay to reschedule an invoice run when lock is held")
-    List<TimeSpan> getRescheduleIntervalOnLock();
-
-    @Config("org.killbill.payment.rescheduleIntervalOnLock")
-    @Default("30s, 1m, 1m, 3m, 3m, 10m")
-    @Description("Tme delay to reschedule an invoice run when lock is held")
-    List<TimeSpan> getRescheduleIntervalOnLock(@Param("dummy") final InternalTenantContext tenantContext);
-
     @Config("org.killbill.payment.method.overwrite")
     @Default("false")
     @Description("Ability to overwrite an existing payment method from a control plugin")

--- a/util/src/main/java/org/killbill/billing/util/config/definition/PaymentConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/PaymentConfig.java
@@ -26,7 +26,7 @@ import org.skife.config.Description;
 import org.skife.config.Param;
 import org.skife.config.TimeSpan;
 
-public interface PaymentConfig extends KillbillConfig {
+public interface PaymentConfig extends LockAwareConfig {
 
     @Config("org.killbill.payment.retry.days")
     @Default("8,8,8")

--- a/util/src/main/java/org/killbill/billing/util/config/tenant/MultiTenantConfigBase.java
+++ b/util/src/main/java/org/killbill/billing/util/config/tenant/MultiTenantConfigBase.java
@@ -35,7 +35,7 @@ import org.skife.config.TimeSpan;
 public abstract class MultiTenantConfigBase implements KillbillConfig {
 
     private final Map<String, Method> methodsCache = new HashMap<>();
-    private final KillbillConfig staticConfig;
+    protected final KillbillConfig staticConfig;
 
     protected final CacheConfig cacheConfig;
 
@@ -52,26 +52,9 @@ public abstract class MultiTenantConfigBase implements KillbillConfig {
     }
 
     //
-    // The conversion methds are rather limited (but this is all we need).
+    // The conversion methods are rather limited (but this is all we need).
     // Ideally we could reuse the bully/Coercer from skife package, but those are kept private.
     //
-
-
-    @Override
-    public List<TimeSpan> getRescheduleIntervalOnLock() {
-        return staticConfig.getRescheduleIntervalOnLock();
-    }
-
-    @Override
-    public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
-
-        final String result = getStringTenantConfig("getRescheduleIntervalOnLock", tenantContext);
-        if (result != null) {
-            return convertToListTimeSpan(result, "getRescheduleIntervalOnLock");
-        }
-        return getRescheduleIntervalOnLock();
-    }
-
     protected List<String> convertToListString(final String value, final String methodName) {
         final Method method = getConfigStaticMethodWithChecking(methodName);
         final List<String> tokens = getTokens(method, value);

--- a/util/src/main/java/org/killbill/billing/util/config/tenant/MultiTenantConfigBase.java
+++ b/util/src/main/java/org/killbill/billing/util/config/tenant/MultiTenantConfigBase.java
@@ -32,9 +32,11 @@ import org.skife.config.Config;
 import org.skife.config.Separator;
 import org.skife.config.TimeSpan;
 
-public abstract class MultiTenantConfigBase {
+public abstract class MultiTenantConfigBase implements KillbillConfig {
 
     private final Map<String, Method> methodsCache = new HashMap<>();
+    private final KillbillConfig staticConfig;
+
     protected final CacheConfig cacheConfig;
 
     private static final Function<String, Integer> INT_CONVERTER = Integer::valueOf;
@@ -44,7 +46,8 @@ public abstract class MultiTenantConfigBase {
     private static final Function<String, BusInternalEventType> BUS_EVENT_TYPE_CONVERTER = BusInternalEventType::valueOf;
 
 
-    public MultiTenantConfigBase(final CacheConfig cacheConfig) {
+    public MultiTenantConfigBase(final KillbillConfig staticConfig, final CacheConfig cacheConfig) {
+        this.staticConfig = staticConfig;
         this.cacheConfig = cacheConfig;
     }
 
@@ -52,6 +55,22 @@ public abstract class MultiTenantConfigBase {
     // The conversion methds are rather limited (but this is all we need).
     // Ideally we could reuse the bully/Coercer from skife package, but those are kept private.
     //
+
+
+    @Override
+    public List<TimeSpan> getRescheduleIntervalOnLock() {
+        return staticConfig.getRescheduleIntervalOnLock();
+    }
+
+    @Override
+    public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
+
+        final String result = getStringTenantConfig("getRescheduleIntervalOnLock", tenantContext);
+        if (result != null) {
+            return convertToListTimeSpan(result, "getRescheduleIntervalOnLock");
+        }
+        return getRescheduleIntervalOnLock();
+    }
 
     protected List<String> convertToListString(final String value, final String methodName) {
         final Method method = getConfigStaticMethodWithChecking(methodName);

--- a/util/src/main/java/org/killbill/billing/util/config/tenant/MultiTenantLockAwareConfigBase.java
+++ b/util/src/main/java/org/killbill/billing/util/config/tenant/MultiTenantLockAwareConfigBase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2016 Groupon, Inc
+ * Copyright 2014-2016 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.config.tenant;
+
+import java.util.List;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.util.config.definition.LockAwareConfig;
+import org.skife.config.TimeSpan;
+
+public abstract class MultiTenantLockAwareConfigBase extends MultiTenantConfigBase implements LockAwareConfig {
+
+
+    public MultiTenantLockAwareConfigBase(final LockAwareConfig staticConfig, final CacheConfig cacheConfig) {
+        super(staticConfig, cacheConfig);
+    }
+
+
+    @Override
+    public List<TimeSpan> getRescheduleIntervalOnLock() {
+        return ((LockAwareConfig) staticConfig).getRescheduleIntervalOnLock();
+    }
+
+    @Override
+    public List<TimeSpan> getRescheduleIntervalOnLock(final InternalTenantContext tenantContext) {
+
+        final String result = getStringTenantConfig("getRescheduleIntervalOnLock", tenantContext);
+        if (result != null) {
+            return convertToListTimeSpan(result, "getRescheduleIntervalOnLock");
+        }
+        return getRescheduleIntervalOnLock();
+    }
+
+}

--- a/util/src/test/java/org/killbill/billing/util/config/TestTimeSpanConverter.java
+++ b/util/src/test/java/org/killbill/billing/util/config/TestTimeSpanConverter.java
@@ -75,7 +75,7 @@ public class TestTimeSpanConverter {
         final ConfigSource configSource = new ConfigSource() {
             @Override
             public String getString(final String propertyName) {
-                if ("org.killbill.invoice.rescheduleIntervalOnLock".equals(propertyName)) {
+                if ("org.killbill.rescheduleIntervalOnLock".equals(propertyName)) {
                     return "";
                 } else {
                     return null;

--- a/util/src/test/java/org/killbill/billing/util/config/TestTimeSpanConverter.java
+++ b/util/src/test/java/org/killbill/billing/util/config/TestTimeSpanConverter.java
@@ -21,6 +21,10 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 import org.joda.time.Period;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
+import org.killbill.billing.util.queue.QueueRetryException;
+import org.skife.config.ConfigSource;
+import org.skife.config.ConfigurationObjectFactory;
 import org.skife.config.TimeSpan;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -62,4 +66,30 @@ public class TestTimeSpanConverter {
         Assert.assertTrue(TimeSpanConverter.toListPeriod(null).isEmpty());
         Assert.assertTrue(TimeSpanConverter.toListPeriod(List.of()).isEmpty());
     }
+
+
+    @Test(groups = "fast")
+    public void testEmptyRescheduleIntervalOnLock() {
+
+        // Simulate a case where we don't want any retry schedule
+        final ConfigSource configSource = new ConfigSource() {
+            @Override
+            public String getString(final String propertyName) {
+                if ("org.killbill.invoice.rescheduleIntervalOnLock".equals(propertyName)) {
+                    return "";
+                } else {
+                    return null;
+                }
+            }
+        };
+        final InvoiceConfig invoiceConfig = new ConfigurationObjectFactory(configSource).build(InvoiceConfig.class);
+
+        final List<TimeSpan> retryIntervals = invoiceConfig.getRescheduleIntervalOnLock();
+        Assert.assertEquals(0, retryIntervals.size());
+
+        final List<Period> periods = TimeSpanConverter.toListPeriod(retryIntervals);
+        final QueueRetryException e = new QueueRetryException(null, periods);
+        Assert.assertEquals(0, e.getRetrySchedule().size());
+    }
+
 }


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/killbill/killbill/pull/1888

This PR adds the retry logic inside the overdue module when we receive a `LockFailedException`. This should conclude all the existing paths where we grab the global lock in Bill, and therefore fully address https://github.com/killbill/killbill/issues/1889

* https://github.com/killbill/killbill/pull/1894/commits/42109e4407bc51333644a9076617b03fb8b30509 adds a test to verify we correctly handle an empty config, i.e we default to not having any retry schedule. No behavior change, just a test.
* https://github.com/killbill/killbill/pull/1894/commits/8501c2a07b7c693305e51c23a75b1f453288b834 is the retry implementation for the overdue module. It adds a new `OverdueConfig` to allow configuring the retry schedule.
* https://github.com/killbill/killbill/pull/1894/commits/13d8209b51e37df6cc4a19de33e2e6c492e96369 simplifies the configuration to make it unique across modules
* https://github.com/killbill/killbill/pull/1894/commits/1cbeeedbcb31ae150261fc23f0295b6f35966d59 adds Beatrix test to verify the global lock schedule is correctly implemented for overdue.