### PR TITLE
add nested loop for response.getHeaders() 

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/PluginResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/PluginResource.java
@@ -224,8 +224,10 @@ public class PluginResource extends JaxRsResourceBase {
 
         final Response.ResponseBuilder builder  = Response.status(response.getStatus())
                 .entity(byteArrayOutputStream.toByteArray());
-        for (String name : response.getHeaderNames()) {
-            builder.header(name, response.getHeaders(name));
+        for (final String name : response.getHeaderNames()) {
+            for (final String value : response.getHeaders(name)) {
+                builder.header(name, value);
+            }
         }
         if (response.getCharacterEncoding() != null) {
             builder.encoding(response.getCharacterEncoding());


### PR DESCRIPTION
Support multiple key/value header pairs.