### PR TITLE
Usage billing

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInArrear.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
@@ -39,6 +40,7 @@ import org.killbill.billing.entitlement.api.BlockingState;
 import org.killbill.billing.entitlement.api.BlockingStateType;
 import org.killbill.billing.entitlement.api.DefaultEntitlement;
 import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Subscription;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.junction.DefaultBlockingState;
@@ -780,4 +782,144 @@ public class TestUsageInArrear extends TestIntegrationBase {
                                     new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 21), new LocalDate(2012, 5, 21), InvoiceItemType.CBA_ADJ, new BigDecimal("2399.95")));
 
     }
+
+    @Test(groups = "slow")
+    public void testRecordUsageOnLastDayWithDate() throws Exception {
+        // We take april as it has 30 days (easier to play with BCD)
+        // Set clock to the initial start date - we implicitly assume here that the account timezone is UTC
+        final DateTime initialDateTime = new DateTime(2012, 4, 1, 7, 0, 0);
+        clock.setTime(initialDateTime);
+
+        final AccountData accountData = getAccountData(1);
+        final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
+        assertEquals(account.getReferenceTime().compareTo(initialDateTime), 0); //Reference time set to 2012-04-01T7:00
+        accountChecker.checkAccount(account.getId(), accountData, callContext);
+
+        //
+        // CREATE SUBSCRIPTION AND EXPECT BOTH EVENTS: NextEvent.CREATE, NextEvent.BLOCK NextEvent.INVOICE
+        //
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial");
+        final UUID baseSubscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+        subscriptionChecker.checkSubscriptionCreated(baseSubscriptionId, internalCallContext);
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+
+        //
+        // ADD ADD_ON ON THE SAME DAY
+        //
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("bullets-usage-in-arrear");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
+        final UUID addonSubscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(addonSpec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        final Subscription aoSubscription = subscriptionApi.getSubscriptionForEntitlementId(addonSubscriptionId, false, callContext);
+
+        //Record usage for 2012-04-30 - this usage is included in the invoice
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new LocalDate(2012, 4, 30), BigDecimal.valueOf(100L), callContext);
+        //Record usage for 2012-05-01 - this usage is NOT included in the invoice - Should it be included?
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new LocalDate(2012, 5, 1), BigDecimal.valueOf(100L), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); //Move to 2012-05-01
+        assertListenerStatus();
+        final Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2012, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")), new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.USAGE, new BigDecimal("2.95")));
+        invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-1"), internalCallContext);
+    }
+
+    @Test(groups = "slow")
+    public void testRecordUsageOnLastDayWithDateTime() throws Exception {
+        // We take april as it has 30 days (easier to play with BCD)
+        // Set clock to the initial start date - we implicitly assume here that the account timezone is UTC
+        final DateTime initialDateTime = new DateTime(2012, 4, 1, 7, 0, 0);
+        clock.setTime(initialDateTime);
+
+        final AccountData accountData = getAccountData(1);
+        final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
+        assertEquals(account.getReferenceTime().compareTo(initialDateTime), 0); //Reference time set to 2012-04-01T7:00
+        accountChecker.checkAccount(account.getId(), accountData, callContext);
+
+        //
+        // CREATE SUBSCRIPTION AND EXPECT BOTH EVENTS: NextEvent.CREATE, NextEvent.BLOCK NextEvent.INVOICE
+        //
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial");
+        final UUID baseSubscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+        subscriptionChecker.checkSubscriptionCreated(baseSubscriptionId, internalCallContext);
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+
+        //
+        // ADD ADD_ON ON THE SAME DAY
+        //
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("bullets-usage-in-arrear");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
+        final UUID addonSubscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(addonSpec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        final Subscription aoSubscription = subscriptionApi.getSubscriptionForEntitlementId(addonSubscriptionId, false, callContext);
+
+        //Record usage for 2012-04-30T2:00 - this usage is included in the invoice
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new DateTime(2012, 4, 30, 2, 0, 0), BigDecimal.valueOf(100L), callContext);
+        //Record usage for 2012-05-01T2:00 - this usage is NOT included in the invoice - Should it be included since it is recorded before the reference time?
+        recordUsageData(aoSubscription.getId(), "tracking-2", "bullets", new DateTime(2012, 5, 1, 2, 0, 0), BigDecimal.valueOf(100L), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); //Move to 2012-05-01
+        assertListenerStatus();
+        final Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2012, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")), new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.USAGE, new BigDecimal("2.95")));
+        invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-1"), internalCallContext);
+    }
+
+    @Test(groups = "slow")
+    public void testRecordUsageOnLastDayWithDateTime2() throws Exception {
+        // We take april as it has 30 days (easier to play with BCD)
+        // Set clock to the initial start date - we implicitly assume here that the account timezone is UTC
+        final DateTime initialDateTime = new DateTime(2012, 4, 1, 7, 0, 0);
+        clock.setTime(initialDateTime);
+
+        final AccountData accountData = getAccountData(1);
+        final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
+        assertEquals(account.getReferenceTime().compareTo(initialDateTime), 0); //Reference time set to 2012-04-01T7:00
+        accountChecker.checkAccount(account.getId(), accountData, callContext);
+
+        //
+        // CREATE SUBSCRIPTION AND EXPECT BOTH EVENTS: NextEvent.CREATE, NextEvent.BLOCK NextEvent.INVOICE
+        //
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial");
+        final UUID baseSubscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+        subscriptionChecker.checkSubscriptionCreated(baseSubscriptionId, internalCallContext);
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+
+        //
+        // ADD ADD_ON ON THE SAME DAY
+        //
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("bullets-usage-in-arrear");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.NULL_INVOICE);
+        final UUID addonSubscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(addonSpec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        final Subscription aoSubscription = subscriptionApi.getSubscriptionForEntitlementId(addonSubscriptionId, false, callContext);
+
+        //Record usage for 2012-05-01T2:00 - this usage is NOT included in the invoice - Should it be included since it is recorded before the reference time?
+        recordUsageData(aoSubscription.getId(), "tracking-1", "bullets", new DateTime(2012, 5, 1, 2, 0, 0), BigDecimal.valueOf(100L), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); //Move to 2012-05-01
+        assertListenerStatus();
+        //Test fails at this line below as a $0 invoice item is created corresponding to USAGE
+        //        Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2012, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")), new ExpectedInvoiceItemCheck(new LocalDate(2012, 4, 1), new LocalDate(2012, 5, 1), InvoiceItemType.USAGE, new BigDecimal("2.95")));
+        //        invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-1"), internalCallContext);
+
+        //the USAGE item is included in the subsequent invoice
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); //Move to 2012-06-01
+        assertListenerStatus();
+        final Invoice curInvoice = invoiceChecker.checkInvoice(account.getId(), 3, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2012, 6, 1), new LocalDate(2012, 7, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")), new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 1), new LocalDate(2012, 6, 1), InvoiceItemType.USAGE, new BigDecimal("2.95")));
+        invoiceChecker.checkTrackingIds(curInvoice, Set.of("tracking-1"), internalCallContext);
+
+    }
+
 }

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -204,8 +204,8 @@
                             <shadedClassifierName>load-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -219,7 +219,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.LoadCatalog</Main-Class>
@@ -240,8 +240,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -255,7 +255,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.CreateCatalogSchema</Main-Class>

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -226,8 +226,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -241,7 +241,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.overdue.CreateOverdueConfigSchema</Main-Class>


### PR DESCRIPTION
Test for usage billing issue. New tests demonstrate that:

- Usage recorded for last billing day is not included in the invoice if account is created in UTC time zone
- Usage recorded for last billing day is included in the invoice if account is created in PST time zone