### PR TITLE
invoice: Add fix and beatrix test for dry-run issue with blocking states

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationDryRunInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationDryRunInvoice.java
@@ -36,9 +36,12 @@ import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.catalog.api.PriceListSet;
 import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.entitlement.api.BlockingState;
+import org.killbill.billing.entitlement.api.BlockingStateType;
 import org.killbill.billing.entitlement.api.DefaultEntitlement;
 import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
 import org.killbill.billing.entitlement.api.Entitlement;
+import org.killbill.billing.entitlement.api.Subscription;
 import org.killbill.billing.entitlement.api.SubscriptionEventType;
 import org.killbill.billing.invoice.api.DryRunArguments;
 import org.killbill.billing.invoice.api.DryRunType;
@@ -47,6 +50,7 @@ import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
+import org.killbill.billing.junction.DefaultBlockingState;
 import org.killbill.billing.subscription.api.user.DefaultSubscriptionBase;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -752,4 +756,76 @@ public class TestIntegrationDryRunInvoice extends TestIntegrationBase {
         assertEquals(dryRunInvoice.getId(), draftInvoiceAgain.getId());
 
     }
+
+    @Test(groups = "slow")
+    public void testDryRunWithBCDUpdateAccountBlockUnBlock() throws Exception {
+        final DateTime initialCreationDate = new DateTime(2023, 8, 1, 0, 0, 0, 0, testTimeZone);
+        clock.setTime(initialCreationDate);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        // Create the subscription
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial", null);
+        final UUID subscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        final List<ExpectedInvoiceItemCheck> expectedInvoices = new ArrayList<ExpectedInvoiceItemCheck>();
+        expectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 1), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        final Invoice invoice = invoiceChecker.checkInvoice(account.getId(), 1, callContext, expectedInvoices);
+
+        //Trigger dry run with date=2023-11-01 - 1 invoice item as expected
+        Invoice dryRunInvoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(2023, 11, 1), DRY_RUN_TARGET_DATE_ARG, Collections.emptyList(), callContext);
+        List<ExpectedInvoiceItemCheck> dryRunExpectedInvoices = new ArrayList<>();
+        dryRunExpectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2023, 11, 1), new LocalDate(2023, 12, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        assertEquals(dryRunInvoice.getInvoiceItems().size(), 1);
+        invoiceChecker.checkInvoiceNoAudits(dryRunInvoice, dryRunExpectedInvoices);
+
+        //Move clock to 2023-08-27
+        clock.setTime(new DateTime(2023, 8, 27, 0, 0, 0, 0, testTimeZone));
+
+        //Trigger dry run with date=2023-11-01 - 1 invoice item as expected
+        dryRunInvoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(2023, 11, 1), DRY_RUN_TARGET_DATE_ARG, Collections.emptyList(), callContext);
+        dryRunExpectedInvoices = new ArrayList<>();
+        dryRunExpectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2023, 11, 1), new LocalDate(2023, 12, 1), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        assertEquals(dryRunInvoice.getInvoiceItems().size(), 1);
+        invoiceChecker.checkInvoiceNoAudits(dryRunInvoice, dryRunExpectedInvoices);
+
+        //update BCD
+        final Subscription subscription = subscriptionApi.getSubscriptionForEntitlementId(subscriptionId, false, callContext);
+        subscription.updateBCD(15, null, callContext);
+
+        //block with date=2023-09-01
+        final DateTime blockingDate = new DateTime(2023, 9, 1, 0, 0, 0, 0, testTimeZone);
+        final BlockingState block = new DefaultBlockingState(subscription.getId(), BlockingStateType.ACCOUNT, "subscriptionBlock", "svc2", false, false, true, blockingDate);
+        subscriptionApi.addBlockingState(block, blockingDate, Collections.emptyList(), callContext);
+
+        //unblock with date=2023-09-15
+        final DateTime unBlockingDate = new DateTime(2023, 9, 15, 0, 0, 0, 0, testTimeZone);
+        final BlockingState unBlock = new DefaultBlockingState(subscription.getId(), BlockingStateType.ACCOUNT, "subscriptionUnBlock", "svc2", false, false, false, unBlockingDate);
+        subscriptionApi.addBlockingState(unBlock, unBlockingDate, Collections.emptyList(), callContext);
+
+        //Dry Run with date =2023-09-01 - no invoice generated as expected
+        try {
+            dryRunInvoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(2023, 9, 1), DRY_RUN_TARGET_DATE_ARG, Collections.emptyList(), callContext);
+        } catch (final InvoiceApiException e) {
+            assertEquals(e.getCode(), INVOICE_NOTHING_TO_DO.getCode());
+        }
+
+        //Dry Run with date =2023-09-15 - invoice with one invoice item as expected
+        dryRunInvoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(2023, 9, 15), DRY_RUN_TARGET_DATE_ARG, Collections.emptyList(), callContext);
+        assertEquals(dryRunInvoice.getInvoiceItems().size(), 1);
+        dryRunExpectedInvoices = new ArrayList<>();
+        dryRunExpectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 15), new LocalDate(2023, 10, 15), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        invoiceChecker.checkInvoiceNoAudits(dryRunInvoice, dryRunExpectedInvoices);
+
+        //Dry Run with date =2023-10-15 - invoice with only the last invoice item as expected
+        dryRunInvoice = invoiceUserApi.triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(2023, 10, 15), DRY_RUN_TARGET_DATE_ARG, Collections.emptyList(), callContext);
+        assertEquals(dryRunInvoice.getInvoiceItems().size(), 1);
+        dryRunExpectedInvoices = new ArrayList<>();
+        dryRunExpectedInvoices.add(new ExpectedInvoiceItemCheck(new LocalDate(2023, 10, 15), new LocalDate(2023, 11, 15), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        invoiceChecker.checkInvoiceNoAudits(dryRunInvoice, dryRunExpectedInvoices);
+
+    }
+
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationDryRunInvoice.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationDryRunInvoice.java
@@ -797,12 +797,12 @@ public class TestIntegrationDryRunInvoice extends TestIntegrationBase {
 
         //block with date=2023-09-01
         final DateTime blockingDate = new DateTime(2023, 9, 1, 0, 0, 0, 0, testTimeZone);
-        final BlockingState block = new DefaultBlockingState(subscription.getId(), BlockingStateType.ACCOUNT, "subscriptionBlock", "svc2", false, false, true, blockingDate);
+        final BlockingState block = new DefaultBlockingState(account.getId(), BlockingStateType.ACCOUNT, "subscriptionBlock", "svc2", false, false, true, blockingDate);
         subscriptionApi.addBlockingState(block, blockingDate, Collections.emptyList(), callContext);
 
         //unblock with date=2023-09-15
         final DateTime unBlockingDate = new DateTime(2023, 9, 15, 0, 0, 0, 0, testTimeZone);
-        final BlockingState unBlock = new DefaultBlockingState(subscription.getId(), BlockingStateType.ACCOUNT, "subscriptionUnBlock", "svc2", false, false, false, unBlockingDate);
+        final BlockingState unBlock = new DefaultBlockingState(account.getId(), BlockingStateType.ACCOUNT, "subscriptionUnBlock", "svc2", false, false, false, unBlockingDate);
         subscriptionApi.addBlockingState(unBlock, unBlockingDate, Collections.emptyList(), callContext);
 
         //Dry Run with date =2023-09-01 - no invoice generated as expected

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -547,6 +547,21 @@ public class InvoiceDispatcher {
 
         final PriorityQueue<LocalDate> pq = new PriorityQueue<LocalDate>(allCandidateTargetDates);
 
+        final Invoice latestInvoice = accountInvoices.getInvoices().stream()
+                       .max(new Comparator<Invoice>() {
+            @Override
+            public int compare(final Invoice o1, final Invoice o2) {
+                return o1.getTargetDate().compareTo(o2.getTargetDate());
+            }
+        }).orElse(null);
+
+        for (final BillingEvent be : billingEvents) {
+            final LocalDate effDt = context.toLocalDate(be.getEffectiveDate());
+            if (latestInvoice == null || latestInvoice.getTargetDate().compareTo(effDt) < 0) {
+                pq.add(effDt);
+            }
+        }
+
         // Keeps track of generated invoices as we go through the list
         // The list is an ordered list of items merged from existing notifications and upcoming notifications, each of these the result of a previous invoice being generated.
         // Note: we reuse the underlying list from  the AccountInvoices to avoid recreating such object (which is feature dependent)

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
@@ -296,8 +296,8 @@ public class TestInvoice extends TestJaxrsBase {
 
         final LocalDate targetDt2 = effDt.plusDays(30);
         final Invoice dryRunInvoice2 = invoiceApi.generateDryRunInvoice(dryRunArg, accountJson.getAccountId(), targetDt2, NULL_PLUGIN_PROPERTIES, requestOptions);
-        // Two items for the FIXED & RECURRING price validating the future targetDate
-        assertEquals(dryRunInvoice2.getItems().size(), 2);
+        // One item for the RECURRING price validating the future targetDate
+        assertEquals(dryRunInvoice2.getItems().size(), 1);
     }
 
     @Test(groups = "slow", description = "Can retrieve invoice payments")


### PR DESCRIPTION
* 8975fea50137: Test and fix for issue #1920
* 29068811436: Modify 2 existing tests to match behavior as defined in issue - i.e an dry-run invoice with future target date only shows the items that would be returned at this time if everything is up to date, that is without items from possibly previous invoices.
