### PR TITLE
Fix for the computation of the phase effective date.

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogDiscountAndEvergreen.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogDiscountAndEvergreen.java
@@ -125,23 +125,18 @@ public class TestCatalogDiscountAndEvergreen extends TestIntegrationBase {
         assertListenerStatus();
         invoiceChecker.checkInvoice(account.getId(), 3, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 28), new LocalDate(2023, 5, 28), InvoiceItemType.RECURRING, new BigDecimal("4.95")));
 
-        //2023-05-29 - end of discount phase - prorated invoice corresponding to discount phase
-        clock.setTime(new DateTime(2023, 5, 29,3,47,56));
-        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
-        assertListenerStatus();
-        invoiceChecker.checkInvoice(account.getId(), 4, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 28), new LocalDate(2023, 5, 31), InvoiceItemType.RECURRING, new BigDecimal("0.48")));
-
-        //2023-06-01 - Prorated invoice corresponding to evergreen phase
-        clock.setTime(new DateTime(2023, 6, 1,3,47,56));
+        //2023-06-01
+        clock.addMonths(1);
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT, NextEvent.NULL_INVOICE);
         assertListenerStatus();
-        invoiceChecker.checkInvoice(account.getId(), 5, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 31), new LocalDate(2023, 6, 28), InvoiceItemType.RECURRING, new BigDecimal("22.54")));
+        invoiceChecker.checkInvoice(account.getId(), 4, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 28), new LocalDate(2023, 6, 28), InvoiceItemType.RECURRING, new BigDecimal("24.95")));
 
-        //2023-06-29 - Invoice corresponding to evergreen phase
-        clock.setTime(new DateTime(2023, 6, 29,3,47,56));
+        //2023-07-01
+        clock.addMonths(1);
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
         assertListenerStatus();
-        invoiceChecker.checkInvoice(account.getId(), 6, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 28), new LocalDate(2023, 7, 28), InvoiceItemType.RECURRING, new BigDecimal("24.95")));
+        invoiceChecker.checkInvoice(account.getId(), 5, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 28), new LocalDate(2023, 7, 28), InvoiceItemType.RECURRING, new BigDecimal("24.95")));
+
     }
 
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogDiscountAndEvergreen.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogDiscountAndEvergreen.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Subscription;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestCatalogDiscountAndEvergreen extends TestIntegrationBase {
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<>(extraProperties);
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogDiscountAndEvergreen");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    @Test(groups = "slow")
+    public void testCatalogDiscountAndEvergreenUTC() throws Exception {
+
+        // Set clock to 2023-02-28T3:47:56
+        final DateTime initialDateTime = new DateTime(2023, 2, 28,3,47,56);
+        clock.setTime(initialDateTime);
+
+        final AccountData accountData = getAccountData(28);
+        final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
+        assertEquals(account.getReferenceTime().compareTo(initialDateTime), 0); //Reference time set to 2023-02-28T3:47:56
+        accountChecker.checkAccount(account.getId(), accountData, callContext);
+
+        //standard-monthly has a 3-month discount phase followed by an evergreen phase
+
+        //CREATE SUBSCRIPTION
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("standard-monthly");
+        final UUID subscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+        subscriptionChecker.checkSubscriptionCreated(subscriptionId, internalCallContext);
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 2, 28), new LocalDate(2023, 3, 28), InvoiceItemType.RECURRING, new BigDecimal("4.95")));
+
+        //2023-03-28
+        clock.setTime(new DateTime(2023, 3, 28,3,47,56));
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        assertListenerStatus();
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 28), new LocalDate(2023, 4, 28), InvoiceItemType.RECURRING, new BigDecimal("4.95")));
+
+        //2023-04-28
+        clock.addMonths(1);
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        assertListenerStatus();
+        invoiceChecker.checkInvoice(account.getId(), 3, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 28), new LocalDate(2023, 5, 28), InvoiceItemType.RECURRING, new BigDecimal("4.95")));
+
+        //2023-05-28 - end of discount phase
+        clock.addMonths(1);
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT, NextEvent.NULL_INVOICE);
+        assertListenerStatus();
+        invoiceChecker.checkInvoice(account.getId(), 4, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 28), new LocalDate(2023, 6, 28), InvoiceItemType.RECURRING, new BigDecimal("24.95")));
+    }
+
+
+    @Test(groups = "slow")
+    public void testCatalogDiscountAndEvergreen() throws Exception {
+
+        // Set clock to 2023-03-01T3:47
+        final DateTime initialDateTime = new DateTime(2023, 3, 1,3,47,56);
+        clock.setTime(initialDateTime);
+
+        final AccountData accountData = getAccountData(28, DateTimeZone.forID("America/New_York"));
+        final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
+        assertEquals(account.getReferenceTime().compareTo(initialDateTime), 0); //Reference time set to 2023-03-01T3:47
+        accountChecker.checkAccount(account.getId(), accountData, callContext);
+
+        // CREATE SUBSCRIPTION
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("standard-monthly");
+        final UUID subscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, null, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+        subscriptionChecker.checkSubscriptionCreated(subscriptionId, internalCallContext);
+        Subscription subscription = subscriptionApi.getSubscriptionForEntitlementId(subscriptionId, false, callContext);
+        DateTime startDate = subscription.getBillingStartDate().toDateTime(DateTimeZone.forID("America/New_York"));
+        assertEquals(startDate.toLocalDate().compareTo(new LocalDate("2023-02-28")), 0); //Verify that startDate is 2023-02-28 in the user's timezone
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 2, 28), new LocalDate(2023, 3, 28), InvoiceItemType.RECURRING, new BigDecimal("4.95")));
+
+        //2023-04-01
+        clock.addMonths(1);
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        assertListenerStatus();
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 3, 28), new LocalDate(2023, 4, 28), InvoiceItemType.RECURRING, new BigDecimal("4.95")));
+
+        //2023-05-01
+        clock.addMonths(1);
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        assertListenerStatus();
+        invoiceChecker.checkInvoice(account.getId(), 3, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 28), new LocalDate(2023, 5, 28), InvoiceItemType.RECURRING, new BigDecimal("4.95")));
+
+        //2023-05-29 - end of discount phase - prorated invoice corresponding to discount phase
+        clock.setTime(new DateTime(2023, 5, 29,3,47,56));
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        assertListenerStatus();
+        invoiceChecker.checkInvoice(account.getId(), 4, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 28), new LocalDate(2023, 5, 31), InvoiceItemType.RECURRING, new BigDecimal("0.48")));
+
+        //2023-06-01 - Prorated invoice corresponding to evergreen phase
+        clock.setTime(new DateTime(2023, 6, 1,3,47,56));
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT, NextEvent.NULL_INVOICE);
+        assertListenerStatus();
+        invoiceChecker.checkInvoice(account.getId(), 5, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 31), new LocalDate(2023, 6, 28), InvoiceItemType.RECURRING, new BigDecimal("22.54")));
+
+        //2023-06-29 - Invoice corresponding to evergreen phase
+        clock.setTime(new DateTime(2023, 6, 29,3,47,56));
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        assertListenerStatus();
+        invoiceChecker.checkInvoice(account.getId(), 6, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 28), new LocalDate(2023, 7, 28), InvoiceItemType.RECURRING, new BigDecimal("24.95")));
+    }
+
+}

--- a/beatrix/src/test/resources/catalogs/testCatalogDiscountAndEvergreen/discount-and-evergreen.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogDiscountAndEvergreen/discount-and-evergreen.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://docs.killbill.io/latest/catalog.xsd">
+	<effectiveDate>2019-01-01T00:00:00+00:00</effectiveDate>
+	<catalogName>ExampleCatalog</catalogName>
+	<recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+	<currencies>
+		<currency>USD</currency>
+	</currencies>
+	<products>
+		<product name="Standard">
+			<category>BASE</category>
+		</product>
+	</products>
+	<rules>
+		<changePolicy>
+			<changePolicyCase>
+				<policy>END_OF_TERM</policy>
+			</changePolicyCase>
+		</changePolicy>
+		<cancelPolicy>
+			<cancelPolicyCase>
+				<policy>END_OF_TERM</policy>
+			</cancelPolicyCase>
+		</cancelPolicy>
+	</rules>
+	<plans>
+		<plan name="standard-monthly">
+			<product>Standard</product>
+			<initialPhases>
+				<phase type="DISCOUNT">
+					<duration>
+						<unit>MONTHS</unit>
+						<number>3</number>
+					</duration>
+					<recurring>
+						<billingPeriod>MONTHLY</billingPeriod>
+						<recurringPrice>
+							<price>
+								<currency>USD</currency>
+								<value>4.95</value>
+							</price>
+						</recurringPrice>
+					</recurring>
+				</phase>
+			</initialPhases>
+			<finalPhase type="EVERGREEN">
+				<duration>
+					<unit>UNLIMITED</unit>
+				</duration>
+				<recurring>
+					<billingPeriod>MONTHLY</billingPeriod>
+					<recurringPrice>
+						<price>
+							<currency>USD</currency>
+							<value>24.95</value>
+						</price>
+					</recurringPrice>
+				</recurring>
+			</finalPhase>
+		</plan>
+	</plans>
+	<priceLists>
+		<defaultPriceList name="DEFAULT">
+			<plans>
+				<plan>standard-monthly</plan>
+			</plans>
+		</defaultPriceList>
+	</priceLists>
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogDiscountAndEvergreen/discount-and-evergreen.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogDiscountAndEvergreen/discount-and-evergreen.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2020-2020 Equinix, Inc
+  ~ Copyright 2014-2020 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
 <catalog
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://docs.killbill.io/latest/catalog.xsd">

--- a/subscription/src/main/java/org/killbill/billing/subscription/alignment/BaseAligner.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/alignment/BaseAligner.java
@@ -19,19 +19,24 @@
 package org.killbill.billing.subscription.alignment;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.Duration;
 
 public class BaseAligner {
 
-    protected DateTime addDuration(final DateTime input, final Duration duration) {
-        return addOrRemoveDuration(input, duration, true);
+    protected DateTime addDuration(final DateTime input, final Duration duration, final InternalTenantContext context) {
+        return addOrRemoveDuration(input, duration, true, context);
     }
 
-    protected DateTime removeDuration(final DateTime input, final Duration duration) {
-        return addOrRemoveDuration(input, duration, false);
+    protected DateTime removeDuration(final DateTime input, final Duration duration, final InternalTenantContext context) {
+        return addOrRemoveDuration(input, duration, false, context);
     }
 
-    private DateTime addOrRemoveDuration(final DateTime input, final Duration duration, final boolean add) {
-        return add ? input.plus(duration.toJodaPeriod()) : input.minus(duration.toJodaPeriod());
+    private DateTime addOrRemoveDuration(final DateTime input, final Duration duration, final boolean add, final InternalTenantContext context) {
+        final DateTime inputInAccountTz = input.toDateTime(context.getFixedOffsetTimeZone());
+        final DateTime resultInAccountTz = add ? inputInAccountTz.plus(duration.toJodaPeriod()) : inputInAccountTz.minus(duration.toJodaPeriod());
+        return resultInAccountTz.toDateTime(DateTimeZone.UTC);
     }
 }

--- a/subscription/src/main/java/org/killbill/billing/subscription/alignment/PlanAligner.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/alignment/PlanAligner.java
@@ -204,7 +204,7 @@ public class PlanAligner extends BaseAligner {
                 throw new SubscriptionBaseError(String.format("Unknown PlanAlignmentCreate %s", alignment));
         }
 
-        return getPhaseAlignments(plan, initialPhase, planStartDate);
+        return getPhaseAlignments(plan, initialPhase, planStartDate, context);
     }
 
     private TimedPhase getTimedPhaseOnChange(final DefaultSubscriptionBase subscription,
@@ -277,11 +277,11 @@ public class PlanAligner extends BaseAligner {
                 throw new SubscriptionBaseError(String.format("Unknown PlanAlignmentChange %s", alignment));
         }
 
-        final List<TimedPhase> timedPhases = getPhaseAlignments(nextPlan, initialPhase, planStartDate);
+        final List<TimedPhase> timedPhases = getPhaseAlignments(nextPlan, initialPhase, planStartDate, context);
         return getTimedPhase(timedPhases, effectiveDate, which);
     }
 
-    private List<TimedPhase> getPhaseAlignments(final Plan plan, @Nullable final PhaseType initialPhase, final DateTime initialPhaseStartDate) throws SubscriptionBaseApiException {
+    private List<TimedPhase> getPhaseAlignments(final Plan plan, @Nullable final PhaseType initialPhase, final DateTime initialPhaseStartDate, final InternalTenantContext context) throws SubscriptionBaseApiException {
         if (plan == null) {
             return Collections.emptyList();
         }
@@ -303,7 +303,7 @@ public class PlanAligner extends BaseAligner {
             // STEPH check for duration null instead TimeUnit UNLIMITED
             if (cur.getPhaseType() != PhaseType.EVERGREEN) {
                 final Duration curPhaseDuration = cur.getDuration();
-                nextPhaseStart = addDuration(curPhaseStart, curPhaseDuration);
+                nextPhaseStart = addDuration(curPhaseStart, curPhaseDuration, context);
                 if (nextPhaseStart == null) {
                     throw new SubscriptionBaseError(String.format("Unexpected non ending UNLIMITED phase for plan %s",
                                                                   plan.getName()));


### PR DESCRIPTION
This fixes #1923. Use case:

```
TZ=America/New_York

CREATE: 2023-03-01 03:47:56 UTC |  2023-02-28 22:47:56 NY
PHASE: 2023-06-01 03:47:56 UTC   |  2023-05-28 22:47:56 NY  (and not 2023-05-31 22:47:56 NY)
```

If we don't compute the date when adding the duration for the phase using the date in the account TZ, we end up with the wrong date, ie. `2023-06-01 03:47:56 UTC `.

Looked through the code, and did not see any other places where we add duration and need this logic of adding the duration  on the date into the account TZ