### PR TITLE
Fix for 1934

### DIFF
--- a/api/src/main/java/org/killbill/billing/callcontext/InternalCallContext.java
+++ b/api/src/main/java/org/killbill/billing/callcontext/InternalCallContext.java
@@ -45,6 +45,7 @@ public class InternalCallContext extends InternalTenantContext {
 
     public InternalCallContext(final Long tenantRecordId,
                                @Nullable final Long accountRecordId,
+                               @Nullable final DateTimeZone accountTimeZone,
                                @Nullable final DateTimeZone fixedOffsetTimeZone,
                                @Nullable final DateTime referenceDateTime,
                                final UUID userToken,
@@ -55,7 +56,7 @@ public class InternalCallContext extends InternalTenantContext {
                                final String comment,
                                final DateTime createdDate,
                                final DateTime updatedDate) {
-        super(tenantRecordId, accountRecordId, fixedOffsetTimeZone, referenceDateTime);
+        super(tenantRecordId, accountRecordId, accountTimeZone, fixedOffsetTimeZone, referenceDateTime);
         this.userToken = userToken;
         this.createdBy = userName;
         this.updatedBy = userName;
@@ -72,6 +73,7 @@ public class InternalCallContext extends InternalTenantContext {
              null,
              null,
              null,
+             null,
              callContext.getUserToken(),
              callContext.getUserName(),
              callContext.getCallOrigin(),
@@ -82,9 +84,10 @@ public class InternalCallContext extends InternalTenantContext {
              utcNow);
     }
 
-    public InternalCallContext(final InternalCallContext context, final Long accountRecordId, final DateTimeZone fixedOffsetTimeZone, final DateTime referenceDateTime, final DateTime utcNow) {
+    public InternalCallContext(final InternalCallContext context, final Long accountRecordId, final DateTimeZone accountTimeZone, final DateTimeZone fixedOffsetTimeZone, final DateTime referenceDateTime, final DateTime utcNow) {
         this(context.getTenantRecordId(),
              accountRecordId,
+             accountTimeZone,
              fixedOffsetTimeZone,
              referenceDateTime,
              context.getUserToken(),
@@ -98,7 +101,7 @@ public class InternalCallContext extends InternalTenantContext {
     }
 
     public InternalCallContext(final InternalCallContext context, final DateTime updatedDate) {
-        this(context.getTenantRecordId(), context.getAccountRecordId(), context.getFixedOffsetTimeZone(), context.getReferenceDateTime(), context.getUserToken(), context.getCreatedBy(), context.getCallOrigin(),
+        this(context.getTenantRecordId(), context.getAccountRecordId(), context.getAccountTimeZone(), context.getFixedOffsetTimeZone(), context.getReferenceDateTime(), context.getUserToken(), context.getCreatedBy(), context.getCallOrigin(),
              context.getContextUserType(), context.getReasonCode(), context.getComments(), context.getCreatedDate(), updatedDate);
     }
 

--- a/api/src/main/java/org/killbill/billing/callcontext/InternalTenantContext.java
+++ b/api/src/main/java/org/killbill/billing/callcontext/InternalTenantContext.java
@@ -36,15 +36,16 @@ public class InternalTenantContext extends TimeAwareContext {
 
     public InternalTenantContext(final Long tenantRecordId,
                                  @Nullable final Long accountRecordId,
+                                 @Nullable final DateTimeZone accountTimeZone,
                                  @Nullable final DateTimeZone fixedOffsetTimeZone,
                                  @Nullable final DateTime referenceDateTime) {
-        super(fixedOffsetTimeZone, referenceDateTime);
+        super(accountTimeZone, fixedOffsetTimeZone, referenceDateTime);
         this.tenantRecordId = tenantRecordId;
         this.accountRecordId = accountRecordId;
     }
 
     public InternalTenantContext(final Long defaultTenantRecordId) {
-        this(defaultTenantRecordId, null, null, null);
+        this(defaultTenantRecordId, null, null, null, null);
     }
 
     public TenantContext toTenantContext(final UUID accountId, final UUID tenantId) {

--- a/api/src/main/java/org/killbill/billing/callcontext/TimeAwareContext.java
+++ b/api/src/main/java/org/killbill/billing/callcontext/TimeAwareContext.java
@@ -27,11 +27,13 @@ import org.killbill.clock.ClockUtil;
 
 public class TimeAwareContext {
 
+    private final DateTimeZone accountTimeZone;
     private final DateTimeZone fixedOffsetTimeZone;
     private final DateTime referenceDateTime;
     private final LocalTime referenceLocalTime;
 
-    public TimeAwareContext(@Nullable final DateTimeZone fixedOffsetTimeZone, @Nullable final DateTime referenceDateTime) {
+    public TimeAwareContext(@Nullable final DateTimeZone accountTimeZone, @Nullable final DateTimeZone fixedOffsetTimeZone, @Nullable final DateTime referenceDateTime) {
+        this.accountTimeZone = accountTimeZone;
         this.fixedOffsetTimeZone = fixedOffsetTimeZone;
         this.referenceDateTime = referenceDateTime;
         this.referenceLocalTime = computeReferenceTime(referenceDateTime);
@@ -39,13 +41,11 @@ public class TimeAwareContext {
 
     public DateTime toUTCDateTime(final LocalDate localDate) {
         validateContext();
-
         return ClockUtil.toUTCDateTime(localDate, getReferenceLocalTime(), getFixedOffsetTimeZone());
     }
 
     public LocalDate toLocalDate(final DateTime dateTime) {
         validateContext();
-
         return ClockUtil.toLocalDate(dateTime, getFixedOffsetTimeZone());
     }
 
@@ -69,6 +69,10 @@ public class TimeAwareContext {
     //@VisibleForTesting
     public DateTimeZone getFixedOffsetTimeZone() {
         return fixedOffsetTimeZone;
+    }
+
+    public DateTimeZone getAccountTimeZone() {
+        return accountTimeZone;
     }
 
     //@VisibleForTesting

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/extbus/TestBeatrixListener.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/extbus/TestBeatrixListener.java
@@ -127,7 +127,7 @@ public class TestBeatrixListener {
         InternalCallContext internalContext = new InternalCallContext(
                 TENANT_RECORD_ID,
                 ACCOUNT_RECORD_ID,
-                null,  null,
+                null,  null, null,
                 USER_TOKEN,
                 null, null, null, null, null, null, null
         );

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1255,6 +1255,8 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         private Period maxInvoiceLimit;
         private int maxRawUsagePreviousPeriod;
 
+        private AccountTzOffset accountTzOffset;
+
         public ConfigurableInvoiceConfig(final InvoiceConfig defaultInvoiceConfig) {
             this.defaultInvoiceConfig = defaultInvoiceConfig;
             reset();
@@ -1399,6 +1401,16 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         }
 
         @Override
+        public AccountTzOffset getAccountTzOffsetMode() {
+            return accountTzOffset;
+        }
+
+        @Override
+        public AccountTzOffset getAccountTzOffsetMode(final InternalTenantContext tenantContext) {
+            return getAccountTzOffsetMode();
+        }
+
+        @Override
         public InArrearMode getInArrearMode() {
             return inArrearMode;
         }
@@ -1448,6 +1460,10 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
             this.isZeroAmountUsageDisabled = isZeroAmountUsageDisabled;
         }
 
+        public void setAccountTzOffset(final AccountTzOffset accountTzOffset) {
+            this.accountTzOffset = accountTzOffset;
+        }
+
         public void reset() {
             isInvoicingSystemEnabled = defaultInvoiceConfig.isInvoicingSystemEnabled();
             shouldParkAccountsWithUnknownUsage = defaultInvoiceConfig.shouldParkAccountsWithUnknownUsage();
@@ -1456,6 +1472,7 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
             inArrearMode = defaultInvoiceConfig.getInArrearMode();
             maxInvoiceLimit = defaultInvoiceConfig.getMaxInvoiceLimit();
             maxRawUsagePreviousPeriod = defaultInvoiceConfig.getMaxRawUsagePreviousPeriod();
+            accountTzOffset = defaultInvoiceConfig.getAccountTzOffsetMode();
         }
     }
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestDSTUsageIssue.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestDSTUsageIssue.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration.usage;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.integration.TestIntegrationBase;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.entitlement.api.SubscriptionBundle;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.killbill.billing.util.features.KillbillFeatures;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+public class TestDSTUsageIssue extends TestIntegrationBase {
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogInArrearWithRecurringAndConsumableUsage");
+        allExtraProperties.put(KillbillFeatures.PROP_FEATURE_INVOICE_OPTIMIZATION, "true");
+        allExtraProperties.put("org.killbill.invoice.readMaxRawUsagePreviousPeriod", "0");
+        allExtraProperties.put("org.killbill.invoice.maxInvoiceLimit", "P1M");
+        allExtraProperties.put("org.killbill.invoice.disable.usage.zero.amount", "true");
+        allExtraProperties.put("org.killbill.invoice.item.result.behavior.mode", "DETAIL");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    @Test(groups = "slow", dataProvider = "referenceDate", alwaysRun = true)
+    public void testDSTUsageIssue(final LocalDate referenceDate) throws Exception {
+        final DateTimeZone accountTimeZone = DateTimeZone.forID("America/New_York");
+
+        final DateTime referenceTime = referenceDate.toDateTimeAtStartOfDay(accountTimeZone).plusHours(4);
+        clock.setTime(referenceTime);
+
+        final AccountData accountData = getAccountData(1, accountTimeZone, referenceTime);
+        final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
+        accountChecker.checkAccount(account.getId(), accountData, callContext);
+        add_AUTO_INVOICING_DRAFT_Tag(account.getId(), ObjectType.ACCOUNT);
+
+        // create subscription
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.NULL_INVOICE);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("trebuchet-usage-in-arrear");
+        final UUID subscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, 1, null, null, null), "bundleKey", LocalDate.parse("2023-03-01"), LocalDate.parse("2023-03-01"), false, true, Collections.emptyList(), callContext);
+        SubscriptionBundle bundle = subscriptionApi.getActiveSubscriptionBundleForExternalKey("bundleKey", callContext);
+
+        final List<DateTime> usageDates = List.of(
+                new DateTime(2023, 3, 1, 4, 0, accountTimeZone),    // ** First month, the usage hour needs to be >= referenceTime hour, after that it's ok if it's 0... could be an issue?
+                new DateTime(2023, 3, 15, 0, 0, accountTimeZone),
+                new DateTime(2023, 3, 31, 23, 59, accountTimeZone),
+                new DateTime(2023, 4, 1, 0, 0, accountTimeZone),
+                new DateTime(2023, 4, 1, 0, 1, accountTimeZone),
+                new DateTime(2023, 4, 15, 0, 0, accountTimeZone),
+                new DateTime(2023, 4, 30, 23, 59, accountTimeZone),
+                new DateTime(2023, 5, 1, 0, 0, accountTimeZone),
+                new DateTime(2023, 5, 1, 0, 1, accountTimeZone));
+
+        for (DateTime d : usageDates) {
+            recordUsageData(subscriptionId, d.toString(), "stones", d, BigDecimal.ONE, callContext);
+        }
+
+        // generate march invoice - expecting usage qty = 0
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        Invoice marchInvoice = invoiceUserApi.triggerInvoiceGeneration(account.getId(), LocalDate.parse("2023-04-01"), Collections.emptyList(), callContext);
+        invoiceUserApi.commitInvoice(marchInvoice.getId(), callContext);
+        marchInvoice = invoiceUserApi.getInvoice(marchInvoice.getId(), callContext);
+
+        // generate april invoice - expecting usage qty = 4
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        Invoice aprilInvoice = invoiceUserApi.triggerInvoiceGeneration(account.getId(), LocalDate.parse("2023-05-01"), Collections.emptyList(), callContext);
+        invoiceUserApi.commitInvoice(aprilInvoice.getId(), callContext);
+        aprilInvoice = invoiceUserApi.getInvoice(aprilInvoice.getId(), callContext);
+
+        // generate may invoice - expecting usage qty = 2
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        Invoice mayInvoice = invoiceUserApi.triggerInvoiceGeneration(account.getId(), LocalDate.parse("2023-06-01"), Collections.emptyList(), callContext);
+        invoiceUserApi.commitInvoice(mayInvoice.getId(), callContext);
+        mayInvoice = invoiceUserApi.getInvoice(mayInvoice.getId(), callContext);
+
+        // verify invoices
+        final InvoiceItem marchUsageItem = getUsageItem(marchInvoice);
+        final InvoiceItem aprilUsageItem = getUsageItem(aprilInvoice);
+        final InvoiceItem mayUsageItem = getUsageItem(mayInvoice);
+
+        final SoftAssert softAssert = new SoftAssert();
+
+        softAssert.assertTrue(marchUsageItem != null && marchUsageItem.getQuantity().compareTo(new BigDecimal("3")) == 0, "March qty is 3.");
+        softAssert.assertTrue(marchInvoice.getTrackingIds().containsAll(List.of("2023-03-01T04:00:00.000-05:00", "2023-03-15T00:00:00.000-04:00", "2023-03-31T23:59:00.000-04:00")), "March tracking ids match.");
+
+        softAssert.assertTrue(aprilUsageItem != null && aprilUsageItem.getQuantity().compareTo(new BigDecimal("4")) == 0, "April qty is 4.");
+        softAssert.assertTrue(aprilInvoice.getTrackingIds().containsAll(List.of("2023-04-01T00:00:00.000-04:00", "2023-04-01T00:01:00.000-04:00", "2023-04-15T00:00:00.000-04:00", "2023-04-30T23:59:00.000-04:00")), "April tracking ids match.");
+
+        softAssert.assertTrue(mayUsageItem != null && mayUsageItem.getQuantity().compareTo(new BigDecimal("2")) == 0, "May qty is 2.");
+        softAssert.assertTrue(mayInvoice.getTrackingIds().containsAll(List.of("2023-05-01T00:00:00.000-04:00", "2023-05-01T00:01:00.000-04:00")), "May tracking ids match.");
+
+        softAssert.assertAll();
+    }
+
+    @DataProvider(name = "referenceDate")
+    private LocalDate[] getReferenceDates() {
+        return new LocalDate[]{
+                LocalDate.parse("2023-03-15"),  // during DST
+                LocalDate.parse("2023-03-01")   // before DST
+        };
+    }
+
+    private InvoiceItem getUsageItem(final Invoice invoice) {
+        return invoice.getInvoiceItems().stream().filter(i -> i.getInvoiceItemType() == InvoiceItemType.USAGE).findFirst().orElse(null);
+    }
+
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestDSTUsageIssue.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestDSTUsageIssue.java
@@ -55,6 +55,7 @@ public class TestDSTUsageIssue extends TestIntegrationBase {
         allExtraProperties.put("org.killbill.invoice.maxInvoiceLimit", "P1M");
         allExtraProperties.put("org.killbill.invoice.disable.usage.zero.amount", "true");
         allExtraProperties.put("org.killbill.invoice.item.result.behavior.mode", "DETAIL");
+        allExtraProperties.put("org.killbill.invoice.usage.tz.mode", "VARIABLE");
         return super.getConfigSource(null, allExtraProperties);
     }
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInvoicingIssue.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInvoicingIssue.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration.usage;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.UUID;
+
+import org.joda.time.LocalDate;
+import org.joda.time.Period;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.integration.TestIntegrationBase;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceStatus;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestUsageInvoicingIssue extends TestIntegrationBase {
+
+
+    @BeforeMethod(groups = "slow")
+    public void beforeMethod() throws Exception {
+        super.beforeMethod();
+
+        invoiceConfig.setMaxInvoiceLimit(new Period("P1M"));
+        invoiceConfig.setMaxRawUsagePreviousPeriod(0);
+    }
+
+    @Test(groups = "slow")
+    public void testWithUsageInvoicingIssue() throws Exception {
+        clock.setDay(new LocalDate(2023, 8, 28));
+
+        final AccountData accountData = getAccountData(1);
+        final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
+        accountChecker.checkAccount(account.getId(), accountData, callContext);
+        add_AUTO_INVOICING_DRAFT_Tag(account.getId(), ObjectType.ACCOUNT);
+
+
+        // CREATE SUBSCRIPTION
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.NULL_INVOICE);
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("trebuchet-usage-in-arrear");
+        final UUID subscriptionId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, 1, null, null, null), "bundleKey", null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Record usage for 2023-08-29
+        recordUsageData(subscriptionId, "tracking-1", "stones", new LocalDate(2023, 8, 28), BigDecimal.valueOf(50L), callContext);
+
+        //generate invoice with date 2023-09-01 and commit it
+        Invoice invoice = invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 9, 1), Collections.emptyList(), callContext);
+        assertEquals(invoice.getStatus(), InvoiceStatus.DRAFT);
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        invoiceUserApi.commitInvoice(invoice.getId(), callContext);
+        assertListenerStatus();
+
+        //set date to 2023-09-21
+        clock.setDay(new LocalDate(2023, 9, 21));
+
+        //generate invoice with date 2023-10-01
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE); // no usage recorded so null invoice
+        invoice = invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 10, 1), Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+    }
+
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInvoicingIssue.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInvoicingIssue.java
@@ -30,9 +30,11 @@ import org.killbill.billing.account.api.Account;
 import org.killbill.billing.account.api.AccountData;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.beatrix.integration.TestIntegrationBase;
+import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
 import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
@@ -44,13 +46,6 @@ import static org.testng.Assert.assertEquals;
 
 public class TestUsageInvoicingIssue extends TestIntegrationBase {
 
-    @Override
-    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
-        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
-        allExtraProperties.putAll(DEFAULT_BEATRIX_PROPERTIES);
-        allExtraProperties.put(KillbillFeatures.PROP_FEATURE_INVOICE_OPTIMIZATION, "true");
-        return getConfigSource(null, allExtraProperties);
-    }
 
     @BeforeMethod(groups = "slow")
     public void beforeMethod() throws Exception {
@@ -60,13 +55,15 @@ public class TestUsageInvoicingIssue extends TestIntegrationBase {
         invoiceConfig.setMaxRawUsagePreviousPeriod(0);
     }
 
-    /*
-    1.  Set clock to 8/28, create new account, create new subscription w/ start date 8/28 billing in arrear w/ unit pricing, BCD = 1
-2.  Record some usage for period 8/28-8/31
-3.  Generate invoice w/ target date 9/1 and commit
-4.  Set clock to 9/21
-5.  Generate invoice w/ target date 10/1 and see the error!
-     */
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogInArrearWithRecurringAndUsage");
+        //allExtraProperties.putAll(DEFAULT_BEATRIX_PROPERTIES); //this adds the default catalog, so commented this out
+        allExtraProperties.put(KillbillFeatures.PROP_FEATURE_INVOICE_OPTIMIZATION, "true");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
     @Test(groups = "slow")
     public void testWithUsageInvoicingIssue() throws Exception {
         clock.setDay(new LocalDate(2023, 8, 28));
@@ -93,15 +90,30 @@ public class TestUsageInvoicingIssue extends TestIntegrationBase {
         invoiceUserApi.commitInvoice(invoice.getId(), callContext);
         assertListenerStatus();
 
-        //set date to 2023-09-21
-        clock.setDay(new LocalDate(2023, 9, 21));
+        invoice = invoiceUserApi.getInvoice(invoice.getId(), callContext);
+        assertEquals(invoice.getStatus(), InvoiceStatus.COMMITTED);
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 28), new LocalDate(2023, 9, 1), InvoiceItemType.USAGE, new BigDecimal("100.0")),
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 28), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("3.87")));
 
-        //generate invoice with date 2023-10-01
-        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE); // no usage recorded so null invoice
-        invoice = invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 10, 1), Collections.emptyList(), callContext);
+        //set date to 2023-09-21
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE); //why?
+        clock.setDay(new LocalDate(2023, 9, 21));
         assertListenerStatus();
 
-        Thread.sleep(1000 * 3600);
+        //generate invoice with date 2023-10-01
+        invoice = invoiceUserApi.triggerInvoiceGeneration(account.getId(), new LocalDate(2023, 10, 1), Collections.emptyList(), callContext);
+        assertEquals(invoice.getStatus(), InvoiceStatus.DRAFT);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        invoiceUserApi.commitInvoice(invoice.getId(), callContext);
+        assertListenerStatus();
+
+        invoice = invoiceUserApi.getInvoice(invoice.getId(), callContext);
+        assertEquals(invoice.getStatus(), InvoiceStatus.COMMITTED);
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 1), new LocalDate(2023, 10, 1), InvoiceItemType.USAGE, BigDecimal.ZERO),
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 1), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("30.0")));
     }
 
 }

--- a/beatrix/src/test/resources/catalogs/testCatalogInArrearWithRecurringAndConsumableUsage/catalogTest.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogInArrearWithRecurringAndConsumableUsage/catalogTest.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2010-2013 Ning, Inc.
+  ~ Copyright 2014-2018 Groupon, Inc
+  ~ Copyright 2014-2018 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!-- Use cases covered so far: Tiered Product (Pistol/Shotgun/Assault-Rifle) 
+	Multiple changeEvent plan policies Multiple PlanAlignment (see below, trial 
+	add-on alignments and rescue discount package) Product transition rules Add 
+	on (Scopes, Hoster) Multi-pack addon (Extra-Ammo) Addon Trial aligned to 
+	base plan (holster-monthly-regular) Addon Trial aligned to creation (holster-monthly-special) 
+	Rescue discount package (assault-rifle-annual-rescue) Plan phase with a reccurring 
+	and a one off (refurbish-maintenance) Phan with more than 2 phase (gunclub 
+	discount plans) Use Cases to do: Tiered Add On Riskfree period -->
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2011-01-01T00:00:00+00:00</effectiveDate>
+    <catalogName>Firearms</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+        <currency>EUR</currency>
+        <currency>GBP</currency>
+    </currencies>
+
+    <units>
+        <unit name="stones"/>
+    </units>
+
+    <products>
+        <product name="Trebuchet">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>END_OF_TERM</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>END_OF_TERM</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+    </rules>
+    <plans>
+        <plan name="trebuchet-usage-in-arrear" prettyName="Trebuchet Monthly Plan">
+            <product>Trebuchet</product>
+            <recurringBillingMode>IN_ARREAR</recurringBillingMode>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>30.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+                <usages>
+                    <usage name="trebuchet-in-arrear-usage" billingMode="IN_ARREAR" usageType="CONSUMABLE">
+                        <billingPeriod>MONTHLY</billingPeriod>
+                        <tiers>
+                            <tier>
+                                <blocks>
+                                    <tieredBlock>
+                                        <unit>stones</unit>
+                                        <size>1</size>
+                                        <prices>
+                                            <price>
+                                                <currency>USD</currency>
+                                                <value>1</value>
+                                            </price>
+                                        </prices>
+                                        <max>-1</max>
+                                    </tieredBlock>
+                                </blocks>
+                            </tier>
+                        </tiers>
+                    </usage>
+                </usages>
+            </finalPhase>
+        </plan>
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>trebuchet-usage-in-arrear</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogInArrearWithRecurringAndUsage/catalogTest.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogInArrearWithRecurringAndUsage/catalogTest.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2010-2013 Ning, Inc.
+  ~ Copyright 2014-2018 Groupon, Inc
+  ~ Copyright 2014-2018 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!-- Use cases covered so far: Tiered Product (Pistol/Shotgun/Assault-Rifle) 
+	Multiple changeEvent plan policies Multiple PlanAlignment (see below, trial 
+	add-on alignments and rescue discount package) Product transition rules Add 
+	on (Scopes, Hoster) Multi-pack addon (Extra-Ammo) Addon Trial aligned to 
+	base plan (holster-monthly-regular) Addon Trial aligned to creation (holster-monthly-special) 
+	Rescue discount package (assault-rifle-annual-rescue) Plan phase with a reccurring 
+	and a one off (refurbish-maintenance) Phan with more than 2 phase (gunclub 
+	discount plans) Use Cases to do: Tiered Add On Riskfree period -->
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+    <effectiveDate>2011-01-01T00:00:00+00:00</effectiveDate>
+    <catalogName>Firearms</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+        <currency>EUR</currency>
+        <currency>GBP</currency>
+    </currencies>
+
+    <units>
+        <unit name="stones"/>
+    </units>
+
+    <products>
+        <product name="Trebuchet">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>END_OF_TERM</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>END_OF_TERM</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+    </rules>
+    <plans>
+        <plan name="trebuchet-usage-in-arrear" prettyName="Trebuchet Monthly Plan">
+            <product>Trebuchet</product>
+            <recurringBillingMode>IN_ARREAR</recurringBillingMode>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>30.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+                <usages>
+                    <usage name="trebuchet-in-arrear-usage" billingMode="IN_ARREAR" usageType="CAPACITY">
+                        <billingPeriod>MONTHLY</billingPeriod>
+                        <tiers>
+                            <tier>
+                                <limits>
+                                    <limit>
+                                        <unit>stones</unit>
+                                        <max>100</max>
+                                    </limit>
+                                </limits>
+                                <recurringPrice>
+                                    <price>
+                                        <currency>USD</currency>
+                                        <value>100</value>
+                                    </price>
+                                </recurringPrice>
+                            </tier>
+                            <tier>
+                                <limits>
+                                    <limit>
+                                        <unit>stones</unit>
+                                        <max>-1</max>
+                                    </limit>
+                                </limits>
+                                <recurringPrice>
+                                    <price>
+                                        <currency>USD</currency>
+                                        <value>1000</value>
+                                    </price>
+                                </recurringPrice>
+                            </tier>
+                        </tiers>
+                    </usage>
+                </usages>
+            </finalPhase>
+        </plan>
+    </plans>
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>trebuchet-usage-in-arrear</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+
+</catalog>

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -223,12 +223,28 @@ public class MultiTenantInvoiceConfig extends MultiTenantLockAwareConfigBase imp
         if (result != null){
             return UsageDetailMode.valueOf(result);
         }
-
         if (mode == UsageDetailMode.AGGREGATE || mode == UsageDetailMode.DETAIL) {
             return mode;
         }
-
         return UsageDetailMode.AGGREGATE;
+    }
+
+    @Override
+    public AccountTzOffset getAccountTzOffsetMode() {
+        final AccountTzOffset mode = staticConfig.getAccountTzOffsetMode();
+        if (mode == AccountTzOffset.FIXED || mode == AccountTzOffset.VARIABLE) {
+            return mode;
+        }
+        return AccountTzOffset.FIXED;
+    }
+
+    @Override
+    public AccountTzOffset getAccountTzOffsetMode(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("getAccountTzOffsetMode", tenantContext);
+        if (result != null){
+            return AccountTzOffset.valueOf(result);
+        }
+        return getAccountTzOffsetMode();
     }
 
     @Override

--- a/invoice/src/main/java/org/killbill/billing/invoice/usage/UsageClockUtil.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/usage/UsageClockUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020-2023 Equinix, Inc
+ * Copyright 2014-2023 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.usage;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.joda.time.Period;
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.clock.ClockUtil;
+
+//
+// We use a different logic for usage code to convert dates to guarantee some stability
+// across accounts created with the same TZ but at different dates during the year (daylight saving or standard).
+// See https://github.com/killbill/killbill/issues/1934 for an example of a scenario
+//
+// Instead of using the 'fixedOffsetTimeZone' from our context like we do in the rest of our code,
+// we use recompute the offset based on the effective date of the event (transition, targetDate, ...)
+// which means 2 accounts with same TZ would see the same results (given similar subscription, and usage points)
+//
+public class UsageClockUtil {
+
+    public UsageClockUtil() {
+    }
+
+    public static DateTime toDateTimeAtStartOfDay(final LocalDate input, final InternalTenantContext context) {
+        return toDateTimeAtStartOfDay(input, context.getAccountTimeZone());
+    }
+
+    private static DateTime toDateTimeAtStartOfDay(final LocalDate input, final DateTimeZone refTz) {
+
+        // We compute the date at the beginning of the day based on the account TZ
+        //
+        // We do not use the 'fixedOffsetTimeZone' from the context as it would produce different dates for different accounts
+        // (started at different time) during the year (daylight saving)
+        //
+        // So the 'tz' value is computed based on the input date (which is the same across all accounts, typically a transition or targetDate)
+        final DateTimeZone tz = DateTimeZone.forOffsetMillis(refTz.getOffset(input.toDateTimeAtStartOfDay(refTz).getMillis()));
+        return input.toDateTimeAtStartOfDay(tz).toDateTime(DateTimeZone.UTC);
+    }
+
+    public static  DateTime toDateTimeAtEndOfDay(final LocalDate input, final InternalTenantContext context) {
+        return toDateTimeAtEndOfDay(input, context.getAccountTimeZone());
+    }
+
+    private static DateTime toDateTimeAtEndOfDay(final LocalDate input, final DateTimeZone refTz) {
+        DateTime dateTimeAtStartOfDay = toDateTimeAtStartOfDay(input, refTz);
+        return dateTimeAtStartOfDay.plusDays(1).minus(Period.millis(1)).toDateTime(DateTimeZone.UTC);
+    }
+
+    public static LocalDate toLocalDate(final DateTime input, final InternalTenantContext context) {
+        return toLocalDate(input, context.getAccountTimeZone());
+    }
+
+    private static LocalDate toLocalDate(final DateTime input, final DateTimeZone refTz) {
+        return ClockUtil.toLocalDate(input, refTz);
+    }
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceTrackingSqlDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceTrackingSqlDao.java
@@ -208,6 +208,7 @@ public class TestInvoiceTrackingSqlDao extends InvoiceTestSuiteWithEmbeddedDB {
                                             final InvoiceTrackingSqlDao dao = entitySqlDaoWrapperFactory.become(InvoiceTrackingSqlDao.class);
                                             final InternalCallContext updatedContext = new InternalCallContext(internalCallContext.getTenantRecordId(),
                                                                                                                internalCallContext.getAccountRecordId(),
+                                                                                                               internalCallContext.getAccountTimeZone(),
                                                                                                                internalCallContext.getFixedOffsetTimeZone(),
                                                                                                                clock.getUTCNow(),
                                                                                                                internalCallContext.getUserToken(),

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SubscriptionResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SubscriptionResource.java
@@ -352,7 +352,7 @@ public class SubscriptionResource extends JaxRsResourceBase {
                 entitlementSpecifierList.add(spec);
             }
 
-            final TimeAwareContext timeAwareContext = new TimeAwareContext(account.getFixedOffsetTimeZone(), account.getReferenceTime());
+            final TimeAwareContext timeAwareContext = new TimeAwareContext(account.getTimeZone(), account.getFixedOffsetTimeZone(), account.getReferenceTime());
 
             final DateTime entitlementDateTime = getDateTimeFromInput(entitlementDate, timeAwareContext);
             final DateTime billingDateTime = getDateTimeFromInput(billingDate, timeAwareContext);
@@ -627,7 +627,7 @@ public class SubscriptionResource extends JaxRsResourceBase {
                     newEntitlement = current.cancelEntitlementWithPolicy(entitlementPolicy, pluginProperties, ctx);
                 } else if (billingPolicy != null && entitlementPolicy == null) {
                     final Account account = accountUserApi.getAccountById(current.getAccountId(), callContextNoAccountId);
-                    final TimeAwareContext timeAwareContext = new TimeAwareContext(account.getFixedOffsetTimeZone(), account.getReferenceTime());
+                    final TimeAwareContext timeAwareContext = new TimeAwareContext(account.getTimeZone(), account.getFixedOffsetTimeZone(), account.getReferenceTime());
                     //Since there is no DateTime version of cancelEntitlementWithDateOverrideBillingPolicy currently, the code below converts input DateTime to LocalDate and uses it. If in the future a DateTime version of this method is added, the code below needs to be updated accordingly
                     newEntitlement = isDateTime(requestedDate) ? current.cancelEntitlementWithDateOverrideBillingPolicy(timeAwareContext.toLocalDate(toDateTime(requestedDate)), billingPolicy, pluginProperties, ctx) : current.cancelEntitlementWithDateOverrideBillingPolicy(toLocalDate(requestedDate), billingPolicy, pluginProperties, ctx);                	
                 } else {

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/resources/TestDBRouterResource.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/resources/TestDBRouterResource.java
@@ -41,6 +41,7 @@ public class TestDBRouterResource implements JaxrsResource {
     private final MutableInternalCallContext internalCallContext = new MutableInternalCallContext(InternalCallContextFactory.INTERNAL_TENANT_RECORD_ID,
                                                                                                   1687L,
                                                                                                   DateTimeZone.UTC,
+                                                                                                  DateTimeZone.UTC,
                                                                                                   new DateTime(DateTimeZone.UTC),
                                                                                                   UUID.randomUUID(),
                                                                                                   UUID.randomUUID().toString(),

--- a/subscription/src/test/java/org/killbill/billing/subscription/alignment/TestPlanAligner.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/alignment/TestPlanAligner.java
@@ -84,7 +84,7 @@ public class TestPlanAligner extends SubscriptionTestSuiteNoDB {
 
         final DateTime inputLocalTz = input.toDateTime(tz);
 
-        final InternalTenantContext context = new InternalTenantContext(1L, 2L, tz, referenceTime);
+        final InternalTenantContext context = new InternalTenantContext(1L, 2L, tz, tz, referenceTime);
         final DateTime result = planAligner.addDuration(input, duration, context);
 
         // Note that initial time difference was 5 hours and now it is only 4 hours hence time component in UTC set to 2:47:56

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestDefaultSubscriptionBase.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestDefaultSubscriptionBase.java
@@ -276,7 +276,7 @@ public class TestDefaultSubscriptionBase extends SubscriptionTestSuiteNoDB {
 
         final BillingActionPolicy billingPolicy = BillingActionPolicy.START_OF_TERM;
         final BillingAlignment alignment = BillingAlignment.ACCOUNT;
-        final InternalTenantContext context = new InternalTenantContext(null, null,
+        final InternalTenantContext context = new InternalTenantContext(null, null, DateTimeZone.UTC,
                                                                         DateTimeZone.UTC, clock.getUTCNow());
 
         DateTime result = subscriptionBase.getEffectiveDateForPolicy(billingPolicy, alignment, context);

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -36,12 +36,26 @@ public interface InvoiceConfig extends LockAwareConfig {
     //
     String DEFAULT_NULL_PERIOD = "P200Y";
 
-    public enum UsageDetailMode {
+    enum AccountTzOffset {
+        /*
+         * Use the one time computation offset from when account was created, i.e context#fixedOffsetTimeZone.
+         * This is the same behavior we use for other invoice items (RECURRING)
+         */
+        FIXED,
+        /*
+         * Recompute offset based on where we are during the year, i.e context#accountTimeZone.
+         * This produces consistent results across similar accounts (same TZ, same subscriptions, usage points)
+         * even though they were started at different time during the year, i.e summer/winter.
+         */
+        VARIABLE,
+    }
+
+    enum UsageDetailMode {
         AGGREGATE,
         DETAIL,
     }
 
-    public enum InArrearMode {
+    enum InArrearMode {
         DEFAULT,
         GREEDY
     }
@@ -166,6 +180,17 @@ public interface InvoiceConfig extends LockAwareConfig {
     @Default("AGGREGATE")
     @Description("How the result for an item will be reported (aggregate mode or detail mode). ")
     UsageDetailMode getItemResultBehaviorMode(@Param("dummy") final InternalTenantContext tenantContext);
+
+
+    @Config("org.killbill.invoice.usage.tz.mode")
+    @Default("FIXED")
+    @Description("Behavior to include usage points with respect to day light saving")
+    AccountTzOffset getAccountTzOffsetMode();
+
+    @Config("org.killbill.invoice.usage.tz.mode")
+    @Default("FIXED")
+    @Description("Behavior to include usage points with respect to day light saving")
+    AccountTzOffset getAccountTzOffsetMode(@Param("dummy") final InternalTenantContext tenantContext);
 
     @Config("org.killbill.invoice.inArrear.mode")
     @Default("DEFAULT")

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestModule.java
@@ -51,6 +51,7 @@ public class GuicyKillbillTestModule extends KillBillModule {
         internalCallContext = new MutableInternalCallContext(InternalCallContextFactory.INTERNAL_TENANT_RECORD_ID,
                                                              1687L,
                                                              DateTimeZone.UTC,
+                                                             DateTimeZone.UTC,
                                                              clock.getUTCNow(),
                                                              UUID.randomUUID(),
                                                              UUID.randomUUID().toString(),

--- a/util/src/test/java/org/killbill/billing/callcontext/MutableInternalCallContext.java
+++ b/util/src/test/java/org/killbill/billing/callcontext/MutableInternalCallContext.java
@@ -45,6 +45,7 @@ public class MutableInternalCallContext extends InternalCallContext {
 
     public MutableInternalCallContext(final Long tenantRecordId,
                                       @Nullable final Long accountRecordId,
+                                      @Nullable final DateTimeZone accountTimeZone,
                                       @Nullable final DateTimeZone fixedOffsetTimeZone,
                                       @Nullable final DateTime referenceTime,
                                       final UUID userToken,
@@ -55,7 +56,7 @@ public class MutableInternalCallContext extends InternalCallContext {
                                       final String comment,
                                       final DateTime createdDate,
                                       final DateTime updatedDate) {
-        super(tenantRecordId, accountRecordId, fixedOffsetTimeZone, referenceTime, userToken, userName, callOrigin, userType, reasonCode, comment, createdDate, updatedDate);
+        super(tenantRecordId, accountRecordId, accountTimeZone, fixedOffsetTimeZone, referenceTime, userToken, userName, callOrigin, userType, reasonCode, comment, createdDate, updatedDate);
         this.initialAccountRecordId = accountRecordId;
         this.initialTenantRecordId = tenantRecordId;
         this.initialReferenceDateTimeZone = fixedOffsetTimeZone;

--- a/util/src/test/java/org/killbill/billing/util/callcontext/TestTimeAwareContext.java
+++ b/util/src/test/java/org/killbill/billing/util/callcontext/TestTimeAwareContext.java
@@ -173,7 +173,7 @@ public class TestTimeAwareContext extends UtilTestSuiteNoDB {
         while (currentDateTime.compareTo(endDateTime) <= 0) {
             for (final DateTimeZone dateTimeZone : dateTimeZones) {
                 for (final DateTime referenceDateTime : referenceDateTimes) {
-                    final TimeAwareContext timeAwareContext = new TimeAwareContext(dateTimeZone, referenceDateTime);
+                    final TimeAwareContext timeAwareContext = new TimeAwareContext(dateTimeZone, dateTimeZone, referenceDateTime);
 
                     final LocalDate computedLocalDate = timeAwareContext.toLocalDate(currentDateTime);
                     final DateTime computedDateTime = timeAwareContext.toUTCDateTime(computedLocalDate);


### PR DESCRIPTION
We introduce a different logic for usage code to convert dates to guarantee some stability across accounts created with the same TZ but at different dates during the year (daylight saving or standard). We isolated the code in such a way that we could easily revert (or make it configurable) if needed.
