### PR TITLE
Changes for fixed proration

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1332,6 +1332,16 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
             return defaultInvoiceConfig.getMaxInvoiceLimit(tenantContext);
         }
 
+        @Override
+        public int getProrationFixedDays() {
+            return defaultInvoiceConfig.getProrationFixedDays();
+        }
+
+        @Override
+        public int getProrationFixedDays(final InternalTenantContext tenantContext) {
+            return defaultInvoiceConfig.getProrationFixedDays(tenantContext);
+        }
+
         public void setMaxInvoiceLimit(final Period value) {
             this.maxInvoiceLimit = value;
         }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestInvoiceFixedProration.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestInvoiceFixedProration.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
@@ -29,6 +30,7 @@ import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Entitlement;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.platform.api.KillbillConfigSource;
@@ -58,7 +60,7 @@ public class TestInvoiceFixedProration extends TestIntegrationBase {
         entitlementApi.createBaseEntitlement(account1.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey", null, null, false, false, Collections.emptyList(), callContext);
         assertListenerStatus();
 
-        //Prorated invoice generated for 2023-05-15 to 2023-05-23 for 4.65
+        //Prorated invoice generated for 2023-05-15 to 2023-05-23 for 5.32
         final List<Invoice> invoices1 = invoiceUserApi.getInvoicesByAccount(account1.getId(), false, false, true, callContext);
         assertEquals(invoices1.size(), 1);
         final List<ExpectedInvoiceItemCheck> toBeChecked1 = List.of(
@@ -76,7 +78,7 @@ public class TestInvoiceFixedProration extends TestIntegrationBase {
         entitlementApi.createBaseEntitlement(account2.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey2", null, null, false, false, Collections.emptyList(), callContext);
         assertListenerStatus();
 
-        //Prorated invoice generated for 2023-06-15 to 2023-06-23 for 4.65
+        //Prorated invoice generated for 2023-06-15 to 2023-06-23 for 5.32
         final List<Invoice> invoices2 = invoiceUserApi.getInvoicesByAccount(account2.getId(), false, false, true, callContext);
         assertEquals(invoices2.size(), 1);
         final List<ExpectedInvoiceItemCheck> toBeChecked2 = List.of(
@@ -123,5 +125,248 @@ public class TestInvoiceFixedProration extends TestIntegrationBase {
 
         invoiceChecker.checkInvoice(invoices2.get(0).getId(), callContext, toBeChecked2);
     }
+
+    @Test(groups = "slow")
+    public void testInvoiceTrailingProration1() throws Exception {
+        final LocalDate initialDate = new LocalDate(2023, 4, 23);
+        clock.setDay(initialDate);
+
+        //Set BCD=23
+        final Account account1 = createAccountWithNonOsgiPaymentMethod(getAccountData(23));
+        //Create subscription on 2023-04-23
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        final UUID entitlementId1 = entitlementApi.createBaseEntitlement(account1.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Full invoice generated for 2023-04-23 to 2023-05-23 for 19.95
+        List<Invoice> invoices1 = invoiceUserApi.getInvoicesByAccount(account1.getId(), false, false, true, callContext);
+        assertEquals(invoices1.size(), 1);
+        List<ExpectedInvoiceItemCheck> toBeChecked1 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 4, 23), new LocalDate(2023, 5, 23), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        invoiceChecker.checkInvoice(invoices1.get(0).getId(), callContext, toBeChecked1);
+
+        //Cancel on 2023-05-15
+        LocalDate cancelDate = new LocalDate(2023, 5, 15);
+        final Entitlement entitlement1 = entitlementApi.getEntitlementForId(entitlementId1, false, callContext);
+        entitlement1.cancelEntitlementWithDate(cancelDate, true, Collections.emptyList(), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE);
+        clock.setDay(cancelDate);
+        assertListenerStatus();
+
+        //Prorated invoice (REPAIR_ADJ) generated for 2023-05-15 to 2023-05-23 for 5.32
+        invoices1 = invoiceUserApi.getInvoicesByAccount(account1.getId(), false, false, true, callContext);
+        assertEquals(invoices1.size(), 2);
+        toBeChecked1 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 15), new LocalDate(2023, 5, 23), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-5.32")),
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 15), new LocalDate(2023, 5, 15), InvoiceItemType.CBA_ADJ, new BigDecimal("5.32")));
+        invoiceChecker.checkInvoice(invoices1.get(1).getId(), callContext, toBeChecked1);
+
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 5, 23));
+        assertListenerStatus();
+
+        //Set BCD=23
+        final Account account2 = createAccountWithNonOsgiPaymentMethod(getAccountData(23));
+        //Create subscription on 2023-05-23
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        final UUID entitlementId2 = entitlementApi.createBaseEntitlement(account2.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey2", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Full invoice generated for 2023-05-23 to 2023-06-23 for 19.95
+        List<Invoice> invoices2 = invoiceUserApi.getInvoicesByAccount(account2.getId(), false, false, true, callContext);
+        assertEquals(invoices2.size(), 1);
+        List<ExpectedInvoiceItemCheck> toBeChecked2 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 23), new LocalDate(2023, 6, 23), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        invoiceChecker.checkInvoice(invoices2.get(0).getId(), callContext, toBeChecked2);
+
+        //Cancel on 2023-06-15
+        cancelDate = new LocalDate(2023, 6, 15);
+        final Entitlement entitlement2 = entitlementApi.getEntitlementForId(entitlementId2, false, callContext);
+        entitlement2.cancelEntitlementWithDate(cancelDate, true, Collections.emptyList(), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE);
+        clock.setDay(cancelDate);
+        assertListenerStatus();
+
+        //Prorated invoice (REPAIR_ADJ) generated for 2023-06-15 to 2023-06-23 for 5.32
+        invoices2 = invoiceUserApi.getInvoicesByAccount(account2.getId(), false, false, true, callContext);
+        assertEquals(invoices2.size(), 2);
+        toBeChecked2 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 15), new LocalDate(2023, 6, 23), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-5.32")),
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 15), new LocalDate(2023, 6, 15), InvoiceItemType.CBA_ADJ, new BigDecimal("5.32")));
+        invoiceChecker.checkInvoice(invoices2.get(1).getId(), callContext, toBeChecked2);
+
+    }
+
+    @Test(groups = "slow")
+    public void testInvoiceTrailingProration2() throws Exception {
+        final LocalDate initialDate = new LocalDate(2023, 5, 15);
+        clock.setDay(initialDate);
+
+        //Set BCD=15
+        final Account account1 = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        //Create subscription on 2023-05-15
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        final UUID entitlementId1 = entitlementApi.createBaseEntitlement(account1.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Full invoice generated for 2023-05-15 to 2023-06-15 for 19.95
+        List<Invoice> invoices1 = invoiceUserApi.getInvoicesByAccount(account1.getId(), false, false, true, callContext);
+        assertEquals(invoices1.size(), 1);
+        List<ExpectedInvoiceItemCheck> toBeChecked1 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 15), new LocalDate(2023, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        invoiceChecker.checkInvoice(invoices1.get(0).getId(), callContext, toBeChecked1);
+
+        //Cancel on 2023-05-23
+        LocalDate cancelDate = new LocalDate(2023, 5, 23);
+        final Entitlement entitlement1 = entitlementApi.getEntitlementForId(entitlementId1, false, callContext);
+        entitlement1.cancelEntitlementWithDate(cancelDate, true, Collections.emptyList(), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE);
+        clock.setDay(cancelDate);
+        assertListenerStatus();
+
+        //Prorated invoice (REPAIR_ADJ) generated for 2023-05-23 to 2023-06-15 for 14.63
+        invoices1 = invoiceUserApi.getInvoicesByAccount(account1.getId(), false, false, true, callContext);
+        assertEquals(invoices1.size(), 2);
+        toBeChecked1 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 23), new LocalDate(2023, 6, 15), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-14.63")),
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 23), new LocalDate(2023, 5, 23), InvoiceItemType.CBA_ADJ, new BigDecimal("14.63")));
+        invoiceChecker.checkInvoice(invoices1.get(1).getId(), callContext, toBeChecked1);
+
+        busHandler.pushExpectedEvents(NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 6, 15));
+        assertListenerStatus();
+
+        //Set BCD=15
+        final Account account2 = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        //Create subscription on 2023-06-15
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        final UUID entitlementId2 = entitlementApi.createBaseEntitlement(account2.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey2", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Full invoice generated for 2023-06-15 to 2023-07-15 for 19.95
+        List<Invoice> invoices2 = invoiceUserApi.getInvoicesByAccount(account2.getId(), false, false, true, callContext);
+        assertEquals(invoices2.size(), 1);
+        List<ExpectedInvoiceItemCheck> toBeChecked2 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 15), new LocalDate(2023, 7, 15), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        invoiceChecker.checkInvoice(invoices2.get(0).getId(), callContext, toBeChecked2);
+
+        //Cancel on 2023-06-23
+        cancelDate = new LocalDate(2023, 6, 23);
+        final Entitlement entitlement2 = entitlementApi.getEntitlementForId(entitlementId2, false, callContext);
+        entitlement2.cancelEntitlementWithDate(cancelDate, true, Collections.emptyList(), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE);
+        clock.setDay(cancelDate);
+        assertListenerStatus();
+
+        //Prorated invoice (REPAIR_ADJ) generated for 2023-06-23 to 2023-07-15 for 14.63
+        invoices2 = invoiceUserApi.getInvoicesByAccount(account2.getId(), false, false, true, callContext);
+        assertEquals(invoices2.size(), 2);
+        toBeChecked2 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 23), new LocalDate(2023, 7, 15), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-14.63")),
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 23), new LocalDate(2023, 6, 23), InvoiceItemType.CBA_ADJ, new BigDecimal("14.63")));
+        invoiceChecker.checkInvoice(invoices2.get(1).getId(), callContext, toBeChecked2); //Test fails here
+
+    }
+
+    @Test(groups = "slow")
+    public void testInvoiceLeadingAndTrailingProration1() throws Exception {
+        final LocalDate initialDate = new LocalDate(2023, 5, 15);
+        clock.setDay(initialDate);
+
+        //Set BCD=23
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(23));
+        //Create subscription on 2023-05-15
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Prorated invoice generated for 2023-05-15 to 2023-05-23 for 5.32
+        List<Invoice> invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, true, callContext);
+        assertEquals(invoices.size(), 1);
+        List<ExpectedInvoiceItemCheck> toBeChecked = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 15), new LocalDate(2023, 5, 23), InvoiceItemType.RECURRING, new BigDecimal("5.32")));
+        invoiceChecker.checkInvoice(invoices.get(0).getId(), callContext, toBeChecked);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 5, 23)); //2023-05-23
+        assertListenerStatus();
+
+        //Full Invoice generated for 2023-05-23 to 2023-06-23
+        invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, true, callContext);
+        assertEquals(invoices.size(), 2);
+        toBeChecked = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 23), new LocalDate(2023, 6, 23), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        invoiceChecker.checkInvoice(invoices.get(1).getId(), callContext, toBeChecked);
+
+        //Cancel on 2023-06-15
+        LocalDate cancelDate = new LocalDate(2023, 6, 15);
+        final Entitlement entitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        entitlement1.cancelEntitlementWithDate(cancelDate, true, Collections.emptyList(), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE);
+        clock.setDay(cancelDate);
+        assertListenerStatus();
+
+        //Prorated invoice generated for 2023-06-15 to 2023-06-23 for 5.32
+        invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, true, callContext);
+        assertEquals(invoices.size(), 3);
+        toBeChecked = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 15), new LocalDate(2023, 6, 23), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-5.32")),
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 15), new LocalDate(2023, 6, 15), InvoiceItemType.CBA_ADJ, new BigDecimal("5.32")));
+        invoiceChecker.checkInvoice(invoices.get(2).getId(), callContext, toBeChecked);
+    }
+
+    @Test(groups = "slow")
+    public void testInvoiceLeadingAndTrailingProration2() throws Exception {
+        final LocalDate initialDate = new LocalDate(2023, 5, 23);
+        clock.setDay(initialDate);
+
+        //Set BCD=15
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        //Create subscription on 2023-05-23
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Prorated invoice generated for 2023-05-23 to 2023-06-15 for 14.63
+        List<Invoice> invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, true, callContext);
+        assertEquals(invoices.size(), 1);
+        List<ExpectedInvoiceItemCheck> toBeChecked = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 23), new LocalDate(2023, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("14.63")));
+        invoiceChecker.checkInvoice(invoices.get(0).getId(), callContext, toBeChecked);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 6, 15)); //2023-06-15
+        assertListenerStatus();
+
+        //Full Invoice generated for 2023-06-15 to 2023-07-15
+        invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, true, callContext);
+        assertEquals(invoices.size(), 2);
+        toBeChecked = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 15), new LocalDate(2023, 7, 15), InvoiceItemType.RECURRING, new BigDecimal("19.95")));
+        invoiceChecker.checkInvoice(invoices.get(1).getId(), callContext, toBeChecked);
+
+        //Cancel on 2023-06-23
+        LocalDate cancelDate = new LocalDate(2023, 6, 23);
+        final Entitlement entitlement1 = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        entitlement1.cancelEntitlementWithDate(cancelDate, true, Collections.emptyList(), callContext);
+
+        busHandler.pushExpectedEvents(NextEvent.BLOCK, NextEvent.CANCEL, NextEvent.INVOICE);
+        clock.setDay(cancelDate);
+        assertListenerStatus();
+
+        //Prorated invoice generated for 2023-06-23 to 2023-07-15 for 14.63
+        invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, true, callContext);
+        assertEquals(invoices.size(), 3);
+        toBeChecked = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 23), new LocalDate(2023, 7, 15), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-14.63")),
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 23), new LocalDate(2023, 6, 23), InvoiceItemType.CBA_ADJ, new BigDecimal("14.63")));
+        invoiceChecker.checkInvoice(invoices.get(2).getId(), callContext, toBeChecked);
+    }
+
 
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestInvoiceFixedProration.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestInvoiceFixedProration.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020-2024 Equinix, Inc
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestInvoiceFixedProration extends TestIntegrationBase {
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.put("org.killbill.invoice.proration.fixed.days", "30");
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/default");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    @Test(groups = "slow")
+    public void testInvoiceLeadingProration1() throws Exception {
+        final LocalDate initialDate = new LocalDate(2023, 5, 15);
+        clock.setDay(initialDate);
+
+        //Set BCD=23
+        final Account account1 = createAccountWithNonOsgiPaymentMethod(getAccountData(23));
+        //Create subscription on 2023-05-15
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        entitlementApi.createBaseEntitlement(account1.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Prorated invoice generated for 2023-05-15 to 2023-05-23 for 4.65
+        final List<Invoice> invoices1 = invoiceUserApi.getInvoicesByAccount(account1.getId(), false, false, true, callContext);
+        assertEquals(invoices1.size(), 1);
+        final List<ExpectedInvoiceItemCheck> toBeChecked1 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 15), new LocalDate(2023, 5, 23), InvoiceItemType.RECURRING, new BigDecimal("5.32")));
+        invoiceChecker.checkInvoice(invoices1.get(0).getId(), callContext, toBeChecked1);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.addMonths(1); //2023-06-15
+        assertListenerStatus();
+
+        //Set BCD=23
+        final Account account2 = createAccountWithNonOsgiPaymentMethod(getAccountData(23));
+        //Create subscription on 2023-06-15
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        entitlementApi.createBaseEntitlement(account2.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey2", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Prorated invoice generated for 2023-06-15 to 2023-06-23 for 4.65
+        final List<Invoice> invoices2 = invoiceUserApi.getInvoicesByAccount(account2.getId(), false, false, true, callContext);
+        assertEquals(invoices2.size(), 1);
+        final List<ExpectedInvoiceItemCheck> toBeChecked2 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 15), new LocalDate(2023, 6, 23), InvoiceItemType.RECURRING, new BigDecimal("5.32")));
+
+        invoiceChecker.checkInvoice(invoices2.get(0).getId(), callContext, toBeChecked2);
+    }
+
+    @Test(groups = "slow")
+    public void testInvoiceLeadingProration2() throws Exception {
+        final LocalDate initialDate = new LocalDate(2023, 5, 23);
+        clock.setDay(initialDate);
+
+        //Set BCD=15
+        final Account account1 = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        //Create subscription on 2023-05-23
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        entitlementApi.createBaseEntitlement(account1.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Prorated invoice generated for 2023-05-23 to 2023-06-15 for 14.63
+        final List<Invoice> invoices1 = invoiceUserApi.getInvoicesByAccount(account1.getId(), false, false, true, callContext);
+        assertEquals(invoices1.size(), 1);
+        final List<ExpectedInvoiceItemCheck> toBeChecked1 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 5, 23), new LocalDate(2023, 6, 15), InvoiceItemType.RECURRING, new BigDecimal("14.63")));
+        invoiceChecker.checkInvoice(invoices1.get(0).getId(), callContext, toBeChecked1);
+
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.addMonths(1); //2023-06-23
+        assertListenerStatus();
+
+        //Set BCD=15
+        final Account account2 = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+        //Create subscription on 2023-06-23
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        entitlementApi.createBaseEntitlement(account2.getId(), new DefaultEntitlementSpecifier(new PlanPhaseSpecifier("pistol-monthly-notrial"), null, null, null, null), "externalKey2", null, null, false, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Prorated invoice generated for 2023-06-23 to 2023-07-15 for 14.63
+        final List<Invoice> invoices2 = invoiceUserApi.getInvoicesByAccount(account2.getId(), false, false, true, callContext);
+        assertEquals(invoices2.size(), 1);
+        final List<ExpectedInvoiceItemCheck> toBeChecked2 = List.of(
+                new ExpectedInvoiceItemCheck(new LocalDate(2023, 6, 23), new LocalDate(2023, 7, 15), InvoiceItemType.RECURRING, new BigDecimal("14.63")));
+
+        invoiceChecker.checkInvoice(invoices2.get(0).getId(), callContext, toBeChecked2);
+    }
+
+}

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -142,6 +142,21 @@ public class MultiTenantInvoiceConfig extends MultiTenantLockAwareConfigBase imp
     }
 
     @Override
+    public int getProrationFixedDays() {
+        return staticConfig.getProrationFixedDays();
+    }
+
+    @Override
+    public int getProrationFixedDays(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("getProrationFixedDays", tenantContext);
+        if (result != null) {
+            return Integer.parseInt(result);
+        }
+        return getProrationFixedDays();
+
+    }
+
+    @Override
     public int getMaxRawUsagePreviousPeriod() {
         return staticConfig.getMaxRawUsagePreviousPeriod();
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -95,7 +95,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
 
         final InvoicePruner invoicePruner = new InvoicePruner(existingInvoices);
         final Set<UUID> toBeIgnored = invoicePruner.getFullyRepairedItemsClosure();
-        final AccountItemTree accountItemTree = new AccountItemTree(account.getId(), invoiceId);
+        final AccountItemTree accountItemTree = new AccountItemTree(account.getId(), invoiceId, config);
         for (final Invoice invoice : existingInvoices.getInvoices()) {
             for (final InvoiceItem item : invoice.getInvoiceItems()) {
                 if (toBeIgnored.contains(item.getId())) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -347,7 +347,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // is to charge for that period
         //
         if (endDate != null && !endDate.isAfter(billingIntervalDetail.getFirstBillingCycleDate())) {
-            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, endDate, billingPeriod);
+            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, endDate, billingPeriod, config);
             final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(startDate, endDate, leadingProRationPeriods);
             results.add(itemData);
             return new RecurringInvoiceItemDataWithNextBillingCycleDate(results, billingIntervalDetail);
@@ -359,7 +359,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // ii) The endDate is is not null and is strictly after our firstBillingCycleDate (previous check)
         //
         if (billingIntervalDetail.getFirstBillingCycleDate().isAfter(startDate)) {
-            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, billingIntervalDetail.getFirstBillingCycleDate(), billingPeriod);
+            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, billingIntervalDetail.getFirstBillingCycleDate(), billingPeriod, config);
             if (leadingProRationPeriods != null && leadingProRationPeriods.compareTo(BigDecimal.ZERO) > 0) {
                 // Not common - add info in the logs for debugging purposes
                 final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(startDate, billingIntervalDetail.getFirstBillingCycleDate(), leadingProRationPeriods);
@@ -402,7 +402,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // Now we check if indeed we need a trailing proration and add that incomplete item
         //
         if (effectiveEndDate.isAfter(lastBillingCycleDate)) {
-            final BigDecimal trailingProRationPeriods = calculateProRationAfterLastBillingCycleDate(effectiveEndDate, lastBillingCycleDate, billingPeriod);
+            final BigDecimal trailingProRationPeriods = calculateProRationAfterLastBillingCycleDate(effectiveEndDate, lastBillingCycleDate, billingPeriod, config);
             if (trailingProRationPeriods.compareTo(BigDecimal.ZERO) > 0) {
                 // Not common - add info in the logs for debugging purposes
                 final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(lastBillingCycleDate, effectiveEndDate, trailingProRationPeriods);

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -95,7 +95,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
 
         final InvoicePruner invoicePruner = new InvoicePruner(existingInvoices);
         final Set<UUID> toBeIgnored = invoicePruner.getFullyRepairedItemsClosure();
-        final AccountItemTree accountItemTree = new AccountItemTree(account.getId(), invoiceId, config);
+        final AccountItemTree accountItemTree = new AccountItemTree(account.getId(), invoiceId, config.getProrationFixedDays());
         for (final Invoice invoice : existingInvoices.getInvoices()) {
             for (final InvoiceItem item : invoice.getInvoiceItems()) {
                 if (toBeIgnored.contains(item.getId())) {
@@ -347,7 +347,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // is to charge for that period
         //
         if (endDate != null && !endDate.isAfter(billingIntervalDetail.getFirstBillingCycleDate())) {
-            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, endDate, billingPeriod, config);
+            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, endDate, billingPeriod, config.getProrationFixedDays());
             final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(startDate, endDate, leadingProRationPeriods);
             results.add(itemData);
             return new RecurringInvoiceItemDataWithNextBillingCycleDate(results, billingIntervalDetail);
@@ -359,7 +359,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // ii) The endDate is is not null and is strictly after our firstBillingCycleDate (previous check)
         //
         if (billingIntervalDetail.getFirstBillingCycleDate().isAfter(startDate)) {
-            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, billingIntervalDetail.getFirstBillingCycleDate(), billingPeriod, config);
+            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, billingIntervalDetail.getFirstBillingCycleDate(), billingPeriod, config.getProrationFixedDays());
             if (leadingProRationPeriods != null && leadingProRationPeriods.compareTo(BigDecimal.ZERO) > 0) {
                 // Not common - add info in the logs for debugging purposes
                 final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(startDate, billingIntervalDetail.getFirstBillingCycleDate(), leadingProRationPeriods);
@@ -402,7 +402,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // Now we check if indeed we need a trailing proration and add that incomplete item
         //
         if (effectiveEndDate.isAfter(lastBillingCycleDate)) {
-            final BigDecimal trailingProRationPeriods = calculateProRationAfterLastBillingCycleDate(effectiveEndDate, lastBillingCycleDate, billingPeriod, config);
+            final BigDecimal trailingProRationPeriods = calculateProRationAfterLastBillingCycleDate(effectiveEndDate, lastBillingCycleDate, billingPeriod, config.getProrationFixedDays());
             if (trailingProRationPeriods.compareTo(BigDecimal.ZERO) > 0) {
                 // Not common - add info in the logs for debugging purposes
                 final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(lastBillingCycleDate, effectiveEndDate, trailingProRationPeriods);

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/FixedAndRecurringInvoiceItemGenerator.java
@@ -95,7 +95,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
 
         final InvoicePruner invoicePruner = new InvoicePruner(existingInvoices);
         final Set<UUID> toBeIgnored = invoicePruner.getFullyRepairedItemsClosure();
-        final AccountItemTree accountItemTree = new AccountItemTree(account.getId(), invoiceId, config.getProrationFixedDays());
+        final AccountItemTree accountItemTree = new AccountItemTree(account.getId(), invoiceId, config.getProrationFixedDays(internalCallContext));
         for (final Invoice invoice : existingInvoices.getInvoices()) {
             for (final InvoiceItem item : invoice.getInvoiceItems()) {
                 if (toBeIgnored.contains(item.getId())) {
@@ -347,7 +347,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // is to charge for that period
         //
         if (endDate != null && !endDate.isAfter(billingIntervalDetail.getFirstBillingCycleDate())) {
-            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, endDate, billingPeriod, config.getProrationFixedDays());
+            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, endDate, billingPeriod, config.getProrationFixedDays(internalCallContext));
             final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(startDate, endDate, leadingProRationPeriods);
             results.add(itemData);
             return new RecurringInvoiceItemDataWithNextBillingCycleDate(results, billingIntervalDetail);
@@ -359,7 +359,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // ii) The endDate is is not null and is strictly after our firstBillingCycleDate (previous check)
         //
         if (billingIntervalDetail.getFirstBillingCycleDate().isAfter(startDate)) {
-            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, billingIntervalDetail.getFirstBillingCycleDate(), billingPeriod, config.getProrationFixedDays());
+            final BigDecimal leadingProRationPeriods = calculateProRationBeforeFirstBillingPeriod(startDate, billingIntervalDetail.getFirstBillingCycleDate(), billingPeriod, config.getProrationFixedDays(internalCallContext));
             if (leadingProRationPeriods != null && leadingProRationPeriods.compareTo(BigDecimal.ZERO) > 0) {
                 // Not common - add info in the logs for debugging purposes
                 final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(startDate, billingIntervalDetail.getFirstBillingCycleDate(), leadingProRationPeriods);
@@ -402,7 +402,7 @@ public class FixedAndRecurringInvoiceItemGenerator extends InvoiceItemGenerator 
         // Now we check if indeed we need a trailing proration and add that incomplete item
         //
         if (effectiveEndDate.isAfter(lastBillingCycleDate)) {
-            final BigDecimal trailingProRationPeriods = calculateProRationAfterLastBillingCycleDate(effectiveEndDate, lastBillingCycleDate, billingPeriod, config.getProrationFixedDays());
+            final BigDecimal trailingProRationPeriods = calculateProRationAfterLastBillingCycleDate(effectiveEndDate, lastBillingCycleDate, billingPeriod, config.getProrationFixedDays(internalCallContext));
             if (trailingProRationPeriods.compareTo(BigDecimal.ZERO) > 0) {
                 // Not common - add info in the logs for debugging purposes
                 final RecurringInvoiceItemData itemData = new RecurringInvoiceItemData(lastBillingCycleDate, effectiveEndDate, trailingProRationPeriods);

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceDateUtils.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceDateUtils.java
@@ -26,7 +26,9 @@ import org.joda.time.Months;
 import org.joda.time.Weeks;
 import org.joda.time.Years;
 import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.currency.KillBillMoney;
+import org.killbill.commons.utils.annotation.VisibleForTesting;
 
 public class InvoiceDateUtils {
 
@@ -50,16 +52,16 @@ public class InvoiceDateUtils {
     }
 
     public static BigDecimal calculateProRationBeforeFirstBillingPeriod(final LocalDate startDate, final LocalDate nextBillingCycleDate,
-                                                                        final BillingPeriod billingPeriod) {
+                                                                        final BillingPeriod billingPeriod, final InvoiceConfig invoiceConfig) {
         final LocalDate previousBillingCycleDate = nextBillingCycleDate.minus(billingPeriod.getPeriod());
-        return calculateProrationBetweenDates(startDate, nextBillingCycleDate, previousBillingCycleDate, nextBillingCycleDate);
+        return calculateProrationBetweenDates(startDate, nextBillingCycleDate, previousBillingCycleDate, nextBillingCycleDate, invoiceConfig.getProrationFixedDays());
     }
 
     public static BigDecimal calculateProRationAfterLastBillingCycleDate(final LocalDate endDate, final LocalDate previousBillThroughDate,
-                                                                         final BillingPeriod billingPeriod) {
+                                                                         final BillingPeriod billingPeriod, final InvoiceConfig invoiceConfig) {
         // Note: assumption is that previousBillThroughDate is correctly aligned with the billing cycle day
         final LocalDate nextBillThroughDate = previousBillThroughDate.plus(billingPeriod.getPeriod());
-        return calculateProrationBetweenDates(previousBillThroughDate, endDate, previousBillThroughDate, nextBillThroughDate);
+        return calculateProrationBetweenDates(previousBillThroughDate, endDate, previousBillThroughDate, nextBillThroughDate, invoiceConfig.getProrationFixedDays());
     }
 
     /**
@@ -69,21 +71,33 @@ public class InvoiceDateUtils {
      * @param endDate                  end date of the prorated interval
      * @param previousBillingCycleDate start date of the period
      * @param nextBillingCycleDate     end date of the period
+     * @param fixedDaysInMonth         fixed days to consider in a month (to avoid proration)
      */
-    private static BigDecimal calculateProrationBetweenDates(final LocalDate startDate, final LocalDate endDate, final LocalDate previousBillingCycleDate, final LocalDate nextBillingCycleDate) {
-        final int daysBetween = Days.daysBetween(previousBillingCycleDate, nextBillingCycleDate).getDays();
-        return calculateProrationBetweenDates(startDate, endDate, daysBetween);
+    private static BigDecimal calculateProrationBetweenDates(final LocalDate startDate, final LocalDate endDate, final LocalDate previousBillingCycleDate, final LocalDate nextBillingCycleDate, final int fixedDaysInMonth) {
+        final int daysBetween = fixedDaysInMonth == 0 ? Days.daysBetween(previousBillingCycleDate, nextBillingCycleDate).getDays() : fixedDaysInMonth;
+        return calculateProrationBetweenDates(startDate, endDate, daysBetween, fixedDaysInMonth);
     }
 
-    public static BigDecimal calculateProrationBetweenDates(final LocalDate startDate, final LocalDate endDate, int daysBetween) {
+    public static BigDecimal calculateProrationBetweenDates(final LocalDate startDate, final LocalDate endDate, final int daysBetween, final int fixedDaysInMonth) {
         if (daysBetween <= 0) {
             return BigDecimal.ZERO;
         }
 
         final BigDecimal daysInPeriod = new BigDecimal(daysBetween);
-        final BigDecimal days = new BigDecimal(Days.daysBetween(startDate, endDate).getDays());
+        final BigDecimal days = fixedDaysInMonth == 0 ? new BigDecimal(Days.daysBetween(startDate, endDate).getDays()) : new BigDecimal(daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth));
 
         return days.divide(daysInPeriod, KillBillMoney.MAX_SCALE, KillBillMoney.ROUNDING_METHOD);
+    }
+
+    @VisibleForTesting
+    public static int daysBetweenWithFixedDaysInMonth(final LocalDate startDate, final LocalDate endDate, final int fixedDaysInMonth) {
+        final int daysBetween = Days.daysBetween(startDate, endDate).getDays();
+        final int lastDayOfMonth = startDate.dayOfMonth().withMaximumValue().getDayOfMonth();
+        if (lastDayOfMonth == fixedDaysInMonth) {
+            return daysBetween;
+        } else {
+            return daysBetween - (lastDayOfMonth - fixedDaysInMonth);
+        }
     }
 
     public static LocalDate advanceByNPeriods(final LocalDate initialDate, final BillingPeriod billingPeriod, final int nbPeriods) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceDateUtils.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceDateUtils.java
@@ -26,7 +26,6 @@ import org.joda.time.Months;
 import org.joda.time.Weeks;
 import org.joda.time.Years;
 import org.killbill.billing.catalog.api.BillingPeriod;
-import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.currency.KillBillMoney;
 import org.killbill.commons.utils.annotation.VisibleForTesting;
 
@@ -52,16 +51,16 @@ public class InvoiceDateUtils {
     }
 
     public static BigDecimal calculateProRationBeforeFirstBillingPeriod(final LocalDate startDate, final LocalDate nextBillingCycleDate,
-                                                                        final BillingPeriod billingPeriod, final InvoiceConfig invoiceConfig) {
+                                                                        final BillingPeriod billingPeriod, final int prorationFixedDays) {
         final LocalDate previousBillingCycleDate = nextBillingCycleDate.minus(billingPeriod.getPeriod());
-        return calculateProrationBetweenDates(startDate, nextBillingCycleDate, previousBillingCycleDate, nextBillingCycleDate, invoiceConfig.getProrationFixedDays());
+        return calculateProrationBetweenDates(startDate, nextBillingCycleDate, previousBillingCycleDate, nextBillingCycleDate, prorationFixedDays);
     }
 
     public static BigDecimal calculateProRationAfterLastBillingCycleDate(final LocalDate endDate, final LocalDate previousBillThroughDate,
-                                                                         final BillingPeriod billingPeriod, final InvoiceConfig invoiceConfig) {
+                                                                         final BillingPeriod billingPeriod, final int prorationFixedDays) {
         // Note: assumption is that previousBillThroughDate is correctly aligned with the billing cycle day
         final LocalDate nextBillThroughDate = previousBillThroughDate.plus(billingPeriod.getPeriod());
-        return calculateProrationBetweenDates(previousBillThroughDate, endDate, previousBillThroughDate, nextBillThroughDate, invoiceConfig.getProrationFixedDays());
+        return calculateProrationBetweenDates(previousBillThroughDate, endDate, previousBillThroughDate, nextBillThroughDate, prorationFixedDays);
     }
 
     /**

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceDateUtils.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceDateUtils.java
@@ -92,6 +92,9 @@ public class InvoiceDateUtils {
     @VisibleForTesting
     public static int daysBetweenWithFixedDaysInMonth(final LocalDate startDate, final LocalDate endDate, final int fixedDaysInMonth) {
         final int daysBetween = Days.daysBetween(startDate, endDate).getDays();
+        if(startDate.getMonthOfYear() == endDate.getMonthOfYear()) { //same month, no need for extra logic
+            return daysBetween;
+        }
         final int lastDayOfMonth = startDate.dayOfMonth().withMaximumValue().getDayOfMonth();
         if (lastDayOfMonth == fixedDaysInMonth) {
             return daysBetween;

--- a/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceDateUtils.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/generator/InvoiceDateUtils.java
@@ -95,11 +95,7 @@ public class InvoiceDateUtils {
             return daysBetween;
         }
         final int lastDayOfMonth = startDate.dayOfMonth().withMaximumValue().getDayOfMonth();
-        if (lastDayOfMonth == fixedDaysInMonth) {
-            return daysBetween;
-        } else {
-            return daysBetween - (lastDayOfMonth - fixedDaysInMonth);
-        }
+        return daysBetween - (lastDayOfMonth - fixedDaysInMonth);
     }
 
     public static LocalDate advanceByNPeriods(final LocalDate initialDate, final BillingPeriod billingPeriod, final int nbPeriods) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/AccountItemTree.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/AccountItemTree.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
-import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.commons.utils.Preconditions;
 import org.killbill.commons.utils.collect.Iterables;
 
@@ -58,16 +57,16 @@ public class AccountItemTree {
 
     private boolean isBuilt;
 
-    private InvoiceConfig invoiceConfig;
+    private int prorationFixedDays;
 
-    public AccountItemTree(final UUID accountId, final UUID targetInvoiceId, final InvoiceConfig invoiceConfig) {
+    public AccountItemTree(final UUID accountId, final UUID targetInvoiceId, final int prorationFixedDays) {
         this.accountId = accountId;
         this.targetInvoiceId = targetInvoiceId;
         this.subscriptionItemTree = new HashMap<UUID, SubscriptionItemTree>();
         this.isBuilt = false;
         this.allExistingItems = new LinkedList<InvoiceItem>();
         this.pendingItemAdj = new LinkedList<InvoiceItem>();
-        this.invoiceConfig = invoiceConfig;
+        this.prorationFixedDays = prorationFixedDays;
     }
 
     /**
@@ -123,7 +122,7 @@ public class AccountItemTree {
         }
 
         if (!subscriptionItemTree.containsKey(subscriptionId)) {
-            subscriptionItemTree.put(subscriptionId, new SubscriptionItemTree(subscriptionId, targetInvoiceId, invoiceConfig));
+            subscriptionItemTree.put(subscriptionId, new SubscriptionItemTree(subscriptionId, targetInvoiceId, prorationFixedDays));
         }
         final SubscriptionItemTree tree = subscriptionItemTree.get(subscriptionId);
         tree.addItem(existingItem);
@@ -145,7 +144,7 @@ public class AccountItemTree {
             final UUID subscriptionId = getSubscriptionId(item, null);
             SubscriptionItemTree tree = subscriptionItemTree.get(subscriptionId);
             if (tree == null) {
-                tree = new SubscriptionItemTree(subscriptionId, targetInvoiceId, invoiceConfig);
+                tree = new SubscriptionItemTree(subscriptionId, targetInvoiceId, prorationFixedDays);
                 subscriptionItemTree.put(subscriptionId, tree);
             }
             tree.mergeProposedItem(item);

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/AccountItemTree.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/AccountItemTree.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.commons.utils.Preconditions;
 import org.killbill.commons.utils.collect.Iterables;
 
@@ -57,13 +58,16 @@ public class AccountItemTree {
 
     private boolean isBuilt;
 
-    public AccountItemTree(final UUID accountId, final UUID targetInvoiceId) {
+    private InvoiceConfig invoiceConfig;
+
+    public AccountItemTree(final UUID accountId, final UUID targetInvoiceId, final InvoiceConfig invoiceConfig) {
         this.accountId = accountId;
         this.targetInvoiceId = targetInvoiceId;
         this.subscriptionItemTree = new HashMap<UUID, SubscriptionItemTree>();
         this.isBuilt = false;
         this.allExistingItems = new LinkedList<InvoiceItem>();
         this.pendingItemAdj = new LinkedList<InvoiceItem>();
+        this.invoiceConfig = invoiceConfig;
     }
 
     /**
@@ -119,7 +123,7 @@ public class AccountItemTree {
         }
 
         if (!subscriptionItemTree.containsKey(subscriptionId)) {
-            subscriptionItemTree.put(subscriptionId, new SubscriptionItemTree(subscriptionId, targetInvoiceId));
+            subscriptionItemTree.put(subscriptionId, new SubscriptionItemTree(subscriptionId, targetInvoiceId, invoiceConfig));
         }
         final SubscriptionItemTree tree = subscriptionItemTree.get(subscriptionId);
         tree.addItem(existingItem);
@@ -141,7 +145,7 @@ public class AccountItemTree {
             final UUID subscriptionId = getSubscriptionId(item, null);
             SubscriptionItemTree tree = subscriptionItemTree.get(subscriptionId);
             if (tree == null) {
-                tree = new SubscriptionItemTree(subscriptionId, targetInvoiceId);
+                tree = new SubscriptionItemTree(subscriptionId, targetInvoiceId, invoiceConfig);
                 subscriptionItemTree.put(subscriptionId, tree);
             }
             tree.mergeProposedItem(item);

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java
@@ -30,6 +30,7 @@ import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.generator.InvoiceDateUtils;
 import org.killbill.billing.invoice.model.RecurringInvoiceItem;
 import org.killbill.billing.invoice.model.RepairAdjInvoiceItem;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.commons.utils.Preconditions;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -151,7 +152,7 @@ public class Item {
 
         final Item[] result =  new Item[2];
 
-        final BigDecimal amount0 = InvoiceDateUtils.calculateProrationBetweenDates(startDate, splitDate, Days.daysBetween(startDate, endDate).getDays()).multiply(amount);
+        final BigDecimal amount0 = InvoiceDateUtils.calculateProrationBetweenDates(startDate, splitDate, Days.daysBetween(startDate, endDate).getDays(), 0).multiply(amount); //TODO_fixed_proration - setting to 0, revisit
         final BigDecimal amount1 = amount.subtract(amount0);
 
         result[0] = new Item(this, this.startDate, splitDate, amount0);
@@ -177,7 +178,7 @@ public class Item {
         final boolean prorated = !(newStartDate.compareTo(startDate) == 0 && newEndDate.compareTo(endDate) == 0);
 
         // Pro-ration is built by using the startDate, endDate and amount of this item instead of using the rate and a potential full period.
-        final BigDecimal positiveAmount = prorated ? InvoiceDateUtils.calculateProrationBetweenDates(newStartDate, newEndDate, nbTotalDays)
+        final BigDecimal positiveAmount = prorated ? InvoiceDateUtils.calculateProrationBetweenDates(newStartDate, newEndDate, nbTotalDays, 0) //TODO_fixed_proration - setting to 0, revisit
                                                                      .multiply(amount) : amount;
 
         if (action == ItemAction.ADD) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.tree.Item.ItemAction;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.commons.utils.Preconditions;
 import org.killbill.commons.utils.collect.Iterables;
 
@@ -44,13 +45,16 @@ public class ItemsInterval {
     private final ItemsNodeInterval interval;
     private final LinkedList<Item> items;
 
-    public ItemsInterval(final ItemsNodeInterval interval) {
-        this(interval, null);
+    private InvoiceConfig invoiceConfig;
+
+    public ItemsInterval(final ItemsNodeInterval interval, final InvoiceConfig invoiceConfig) {
+        this(interval, null, invoiceConfig);
     }
 
-    public ItemsInterval(final ItemsNodeInterval interval, final Item initialItem) {
+    public ItemsInterval(final ItemsNodeInterval interval, final Item initialItem, final InvoiceConfig invoiceConfig) {
         this.interval = interval;
         this.items = new LinkedList<>();
+        this.invoiceConfig = invoiceConfig;
         if (initialItem != null) {
             items.add(initialItem);
         }
@@ -135,7 +139,7 @@ public class ItemsInterval {
         final InvoiceItem proratedInvoiceItem = item.toProratedInvoiceItem(startDate, endDate);
         // Keep track of the repaired amount for this item
         item.incrementCurrentRepairedAmount(proratedInvoiceItem.getAmount().abs());
-        return new Item(proratedInvoiceItem, targetInvoiceId, item.getAction());
+        return new Item(proratedInvoiceItem, targetInvoiceId, item.getAction(), invoiceConfig);
     }
 
     private Item getResultingItem(final boolean mergeMode) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsInterval.java
@@ -32,7 +32,6 @@ import javax.annotation.Nullable;
 import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.tree.Item.ItemAction;
-import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.commons.utils.Preconditions;
 import org.killbill.commons.utils.collect.Iterables;
 
@@ -45,16 +44,16 @@ public class ItemsInterval {
     private final ItemsNodeInterval interval;
     private final LinkedList<Item> items;
 
-    private InvoiceConfig invoiceConfig;
+    private int prorationFixedDays;
 
-    public ItemsInterval(final ItemsNodeInterval interval, final InvoiceConfig invoiceConfig) {
-        this(interval, null, invoiceConfig);
+    public ItemsInterval(final ItemsNodeInterval interval, final int prorationFixedDays) {
+        this(interval, null, prorationFixedDays);
     }
 
-    public ItemsInterval(final ItemsNodeInterval interval, final Item initialItem, final InvoiceConfig invoiceConfig) {
+    public ItemsInterval(final ItemsNodeInterval interval, final Item initialItem, final int prorationFixedDays) {
         this.interval = interval;
         this.items = new LinkedList<>();
-        this.invoiceConfig = invoiceConfig;
+        this.prorationFixedDays = prorationFixedDays;
         if (initialItem != null) {
             items.add(initialItem);
         }
@@ -139,7 +138,7 @@ public class ItemsInterval {
         final InvoiceItem proratedInvoiceItem = item.toProratedInvoiceItem(startDate, endDate);
         // Keep track of the repaired amount for this item
         item.incrementCurrentRepairedAmount(proratedInvoiceItem.getAmount().abs());
-        return new Item(proratedInvoiceItem, targetInvoiceId, item.getAction(), invoiceConfig);
+        return new Item(proratedInvoiceItem, targetInvoiceId, item.getAction(), prorationFixedDays);
     }
 
     private Item getResultingItem(final boolean mergeMode) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.tree.Item.ItemAction;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.commons.utils.Preconditions;
 import org.killbill.commons.utils.annotation.VisibleForTesting;
 import org.killbill.billing.util.jackson.ObjectMapper;
@@ -49,22 +50,21 @@ public class ItemsNodeInterval extends NodeInterval {
 
     private final ItemsInterval items;
 
-    public ItemsNodeInterval() {
-        this.items = new ItemsInterval(this);
+    private InvoiceConfig invoiceConfig;
+
+    public ItemsNodeInterval(InvoiceConfig invoiceConfig) {
+        this.items = new ItemsInterval(this, invoiceConfig);
+        this.invoiceConfig = invoiceConfig;
     }
 
-    private ItemsNodeInterval(final ItemsInterval items) {
-        this.items = items;
-    }
-
-    public ItemsNodeInterval(final NodeInterval parent, final Item item) {
+    public ItemsNodeInterval(final NodeInterval parent, final Item item, InvoiceConfig invoiceConfig) {
         super(parent, item.getStartDate(), item.getEndDate());
-        this.items = new ItemsInterval(this, item);
+        this.items = new ItemsInterval(this, item, invoiceConfig);
     }
 
-    public ItemsNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate) {
+    public ItemsNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate, InvoiceConfig invoiceConfig) {
         super(parent, startDate, endDate);
-        this.items = new ItemsInterval(this);
+        this.items = new ItemsInterval(this, invoiceConfig);
     }
 
     public ItemsNodeInterval[] split(final LocalDate splitDate) {
@@ -80,8 +80,8 @@ public class ItemsNodeInterval extends NodeInterval {
 
         final Item[] splitItems = rawItems.get(0).split(splitDate);
 
-        final ItemsNodeInterval split1 = new ItemsNodeInterval(this.parent, splitItems[0]);
-        final ItemsNodeInterval split2 = new ItemsNodeInterval(this.parent, splitItems[1]);
+        final ItemsNodeInterval split1 = new ItemsNodeInterval(this.parent, splitItems[0], invoiceConfig);
+        final ItemsNodeInterval split2 = new ItemsNodeInterval(this.parent, splitItems[1], invoiceConfig);
         final ItemsNodeInterval[] result = new ItemsNodeInterval[2];
         result[0] = split1;
         result[1] = split2;

--- a/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/tree/ItemsNodeInterval.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.tree.Item.ItemAction;
-import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.commons.utils.Preconditions;
 import org.killbill.commons.utils.annotation.VisibleForTesting;
 import org.killbill.billing.util.jackson.ObjectMapper;
@@ -50,21 +49,21 @@ public class ItemsNodeInterval extends NodeInterval {
 
     private final ItemsInterval items;
 
-    private InvoiceConfig invoiceConfig;
+    private int prorationFixedDays;
 
-    public ItemsNodeInterval(InvoiceConfig invoiceConfig) {
-        this.items = new ItemsInterval(this, invoiceConfig);
-        this.invoiceConfig = invoiceConfig;
+    public ItemsNodeInterval(final int prorationFixedDays) {
+        this.items = new ItemsInterval(this, prorationFixedDays);
+        this.prorationFixedDays = prorationFixedDays;
     }
 
-    public ItemsNodeInterval(final NodeInterval parent, final Item item, InvoiceConfig invoiceConfig) {
+    public ItemsNodeInterval(final NodeInterval parent, final Item item, final int prorationFixedDays) {
         super(parent, item.getStartDate(), item.getEndDate());
-        this.items = new ItemsInterval(this, item, invoiceConfig);
+        this.items = new ItemsInterval(this, item, prorationFixedDays);
     }
 
-    public ItemsNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate, InvoiceConfig invoiceConfig) {
+    public ItemsNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate, final int prorationFixedDays) {
         super(parent, startDate, endDate);
-        this.items = new ItemsInterval(this, invoiceConfig);
+        this.items = new ItemsInterval(this, prorationFixedDays);
     }
 
     public ItemsNodeInterval[] split(final LocalDate splitDate) {
@@ -80,8 +79,8 @@ public class ItemsNodeInterval extends NodeInterval {
 
         final Item[] splitItems = rawItems.get(0).split(splitDate);
 
-        final ItemsNodeInterval split1 = new ItemsNodeInterval(this.parent, splitItems[0], invoiceConfig);
-        final ItemsNodeInterval split2 = new ItemsNodeInterval(this.parent, splitItems[1], invoiceConfig);
+        final ItemsNodeInterval split1 = new ItemsNodeInterval(this.parent, splitItems[0], prorationFixedDays);
+        final ItemsNodeInterval split2 = new ItemsNodeInterval(this.parent, splitItems[1], prorationFixedDays);
         final ItemsNodeInterval[] result = new ItemsNodeInterval[2];
         result[0] = split1;
         result[1] = split2;

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtils.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtils.java
@@ -32,7 +32,7 @@ public class TestInvoiceDateUtils extends InvoiceTestSuiteNoDB {
     public void testProRationAfterLastBillingCycleDate() throws Exception {
         final LocalDate endDate = new LocalDate("2012-06-02");
         final LocalDate previousBillThroughDate = new LocalDate("2012-03-02");
-        final BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        final BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("2.967741935"));
     }
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtils.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtils.java
@@ -32,7 +32,7 @@ public class TestInvoiceDateUtils extends InvoiceTestSuiteNoDB {
     public void testProRationAfterLastBillingCycleDate() throws Exception {
         final LocalDate endDate = new LocalDate("2012-06-02");
         final LocalDate previousBillThroughDate = new LocalDate("2012-03-02");
-        final BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY);
+        final BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
         Assert.assertEquals(proration, new BigDecimal("2.967741935"));
     }
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithFixedProration.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithFixedProration.java
@@ -41,24 +41,24 @@ public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB
     public void testProRationAfterLastBillingCycleDate() throws Exception {
         LocalDate endDate = new LocalDate("2023-06-15");
         LocalDate previousBillThroughDate = new LocalDate("2023-05-23");
-        BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
         endDate = new LocalDate("2023-07-15");
         previousBillThroughDate = new LocalDate("2023-06-23");
-        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
         //Feb
         endDate = new LocalDate("2023-03-15");
         previousBillThroughDate = new LocalDate("2023-02-23");
-        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
         //Feb with leap year
         endDate = new LocalDate("2024-03-15");
         previousBillThroughDate = new LocalDate("2024-02-23");
-        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
     }
@@ -67,24 +67,24 @@ public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB
     public void testProRationBeforeFirstBillingPeriod1() throws Exception {
         LocalDate startDate = new LocalDate("2023-05-23");
         LocalDate nextBillingCycleDate = new LocalDate("2023-06-15");
-        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
         startDate = new LocalDate("2023-06-23");
         nextBillingCycleDate = new LocalDate("2023-07-15");
-        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
         //Feb
         startDate = new LocalDate("2023-02-23");
         nextBillingCycleDate = new LocalDate("2023-03-15");
-        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
         //Feb with leap year
         startDate = new LocalDate("2024-02-23");
         nextBillingCycleDate = new LocalDate("2024-03-15");
-        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
     }
@@ -93,16 +93,16 @@ public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB
     public void testProRationBeforeFirstBillingPeriod2() throws Exception {
         LocalDate startDate = new LocalDate("2023-05-15");
         LocalDate nextBillingCycleDate = new LocalDate("2023-05-23");
-        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.266666667"));
 
         startDate = new LocalDate("2023-06-15");
         nextBillingCycleDate = new LocalDate("2023-06-23");
-        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.266666667"));
     }
 
-    @Test
+    @Test(groups = "fast")
     public void testDaysBetweenWithFixedDaysInMonthForSameMonth() {
         LocalDate startDate = new LocalDate("2023-05-15");
         LocalDate endDate = new LocalDate("2023-05-23");
@@ -127,7 +127,7 @@ public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB
         Assert.assertEquals(days, 8);
     }
 
-    @Test
+    @Test(groups = "fast")
     public void testDaysBetweenWithFixedDaysInMonthForDifferentMonths() {
         LocalDate startDate = new LocalDate("2023-05-23");
         LocalDate endDate = new LocalDate("2023-06-15");
@@ -152,9 +152,37 @@ public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB
         Assert.assertEquals(days, 22);
     }
 
-    @Test
+    @Test(groups = "fast")
     public void testDaysBetweenWithFixedDaysInMonth28() {
         final int fixedDaysInMonth = 28;
+
+        LocalDate startDate = new LocalDate("2023-05-23");
+        LocalDate endDate = new LocalDate("2023-06-15");
+        int days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
+        Assert.assertEquals(days, 20);
+
+        startDate = new LocalDate("2023-06-23");
+        endDate = new LocalDate("2023-07-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
+        Assert.assertEquals(days, 20);
+
+        //Feb
+        startDate = new LocalDate("2023-02-23");
+        endDate = new LocalDate("2023-03-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
+        Assert.assertEquals(days, 20);
+
+        //Feb wih leap year
+        startDate = new LocalDate("2024-02-23");
+        endDate = new LocalDate("2024-03-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
+        Assert.assertEquals(days, 20);
+
+    }
+
+    @Test(groups = "fast")
+    public void testDaysBetweenWithFixedDaysInMonth31() {
+        final int fixedDaysInMonth = 31;
 
         LocalDate startDate = new LocalDate("2023-05-23");
         LocalDate endDate = new LocalDate("2023-06-15");

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithFixedProration.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithFixedProration.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020-2024 Equinix, Inc
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.generator;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB {
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.put("org.killbill.invoice.proration.fixed.days", "30");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    @Test(groups = "fast")
+    public void testProRationAfterLastBillingCycleDate() throws Exception {
+        LocalDate endDate = new LocalDate("2023-06-15");
+        LocalDate previousBillThroughDate = new LocalDate("2023-05-23");
+        BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+        endDate = new LocalDate("2023-07-15");
+        previousBillThroughDate = new LocalDate("2023-06-23");
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+        //Feb
+        endDate = new LocalDate("2023-03-15");
+        previousBillThroughDate = new LocalDate("2023-02-23");
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+        //Feb with leap year
+        endDate = new LocalDate("2024-03-15");
+        previousBillThroughDate = new LocalDate("2024-02-23");
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+    }
+
+    @Test(groups = "fast")
+    public void testProRationBeforeFirstBillingPeriod() throws Exception {
+        LocalDate startDate = new LocalDate("2023-05-23");
+        LocalDate nextBillingCycleDate = new LocalDate("2023-06-15");
+        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+        startDate = new LocalDate("2023-06-23");
+        nextBillingCycleDate = new LocalDate("2023-07-15");
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+        //Feb
+        startDate = new LocalDate("2023-02-23");
+        nextBillingCycleDate = new LocalDate("2023-03-15");
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+        //Feb with leap year
+        startDate = new LocalDate("2024-02-23");
+        nextBillingCycleDate = new LocalDate("2024-03-15");
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+    }
+
+    @Test
+    public void testDaysBetweenWithFixedDaysInMonth() {
+        LocalDate startDate = new LocalDate("2023-05-23");
+        LocalDate endDate = new LocalDate("2023-06-15");
+        int days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());
+        Assert.assertEquals(days, 22);
+
+        startDate = new LocalDate("2023-06-23");
+        endDate = new LocalDate("2023-07-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());
+        Assert.assertEquals(days, 22);
+
+        //Feb
+        startDate = new LocalDate("2023-02-23");
+        endDate = new LocalDate("2023-03-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());
+        Assert.assertEquals(days, 22);
+
+        //Feb wih leap year
+        startDate = new LocalDate("2024-02-23");
+        endDate = new LocalDate("2024-03-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());
+        Assert.assertEquals(days, 22);
+    }
+
+    @Test
+    public void testDaysBetweenWithFixedDaysInMonth28() {
+        final int fixedDaysInMonth = 28;
+
+        LocalDate startDate = new LocalDate("2023-05-23");
+        LocalDate endDate = new LocalDate("2023-06-15");
+        int days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
+        Assert.assertEquals(days, 20);
+
+        startDate = new LocalDate("2023-06-23");
+        endDate = new LocalDate("2023-07-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
+        Assert.assertEquals(days, 20);
+
+        //Feb
+        startDate = new LocalDate("2023-02-23");
+        endDate = new LocalDate("2023-03-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
+        Assert.assertEquals(days, 20);
+
+        //Feb wih leap year
+        startDate = new LocalDate("2024-02-23");
+        endDate = new LocalDate("2024-03-15");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
+        Assert.assertEquals(days, 20);
+
+    }
+
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithFixedProration.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithFixedProration.java
@@ -180,32 +180,4 @@ public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB
 
     }
 
-    @Test(groups = "fast")
-    public void testDaysBetweenWithFixedDaysInMonth31() {
-        final int fixedDaysInMonth = 31;
-
-        LocalDate startDate = new LocalDate("2023-05-23");
-        LocalDate endDate = new LocalDate("2023-06-15");
-        int days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
-        Assert.assertEquals(days, 20);
-
-        startDate = new LocalDate("2023-06-23");
-        endDate = new LocalDate("2023-07-15");
-        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
-        Assert.assertEquals(days, 20);
-
-        //Feb
-        startDate = new LocalDate("2023-02-23");
-        endDate = new LocalDate("2023-03-15");
-        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
-        Assert.assertEquals(days, 20);
-
-        //Feb wih leap year
-        startDate = new LocalDate("2024-02-23");
-        endDate = new LocalDate("2024-03-15");
-        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, fixedDaysInMonth);
-        Assert.assertEquals(days, 20);
-
-    }
-
 }

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithFixedProration.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithFixedProration.java
@@ -64,7 +64,7 @@ public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB
     }
 
     @Test(groups = "fast")
-    public void testProRationBeforeFirstBillingPeriod() throws Exception {
+    public void testProRationBeforeFirstBillingPeriod1() throws Exception {
         LocalDate startDate = new LocalDate("2023-05-23");
         LocalDate nextBillingCycleDate = new LocalDate("2023-06-15");
         BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
@@ -89,8 +89,46 @@ public class TestInvoiceDateUtilsWithFixedProration extends InvoiceTestSuiteNoDB
 
     }
 
+    @Test(groups = "fast")
+    public void testProRationBeforeFirstBillingPeriod2() throws Exception {
+        LocalDate startDate = new LocalDate("2023-05-15");
+        LocalDate nextBillingCycleDate = new LocalDate("2023-05-23");
+        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.266666667"));
+
+        startDate = new LocalDate("2023-06-15");
+        nextBillingCycleDate = new LocalDate("2023-06-23");
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.266666667"));
+    }
+
     @Test
-    public void testDaysBetweenWithFixedDaysInMonth() {
+    public void testDaysBetweenWithFixedDaysInMonthForSameMonth() {
+        LocalDate startDate = new LocalDate("2023-05-15");
+        LocalDate endDate = new LocalDate("2023-05-23");
+        int days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());
+        Assert.assertEquals(days, 8);
+
+        startDate = new LocalDate("2023-06-15");
+        endDate = new LocalDate("2023-06-23");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());
+        Assert.assertEquals(days, 8);
+
+        //Feb
+        startDate = new LocalDate("2023-02-15");
+        endDate = new LocalDate("2023-02-23");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());
+        Assert.assertEquals(days, 8);
+
+        //Feb wih leap year
+        startDate = new LocalDate("2024-02-15");
+        endDate = new LocalDate("2024-02-23");
+        days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());
+        Assert.assertEquals(days, 8);
+    }
+
+    @Test
+    public void testDaysBetweenWithFixedDaysInMonthForDifferentMonths() {
         LocalDate startDate = new LocalDate("2023-05-23");
         LocalDate endDate = new LocalDate("2023-06-15");
         int days = InvoiceDateUtils.daysBetweenWithFixedDaysInMonth(startDate, endDate, invoiceConfig.getProrationFixedDays());

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithoutFixedProration.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithoutFixedProration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020-2024 Equinix, Inc
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.generator;
+
+import java.math.BigDecimal;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestInvoiceDateUtilsWithoutFixedProration extends InvoiceTestSuiteNoDB {
+
+    @Test(groups = "fast")
+    public void testProRationAfterLastBillingCycleDate() throws Exception {
+        LocalDate endDate = new LocalDate("2023-06-15");
+        LocalDate previousBillThroughDate = new LocalDate("2023-05-23");
+        BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.741935484"));
+
+        endDate = new LocalDate("2023-07-15");
+        previousBillThroughDate = new LocalDate("2023-06-23");
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+        //Feb
+        endDate = new LocalDate("2023-03-15");
+        previousBillThroughDate = new LocalDate("2023-02-23");
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.714285714"));
+
+        //Feb with leap year
+        endDate = new LocalDate("2024-03-15");
+        previousBillThroughDate = new LocalDate("2024-02-23");
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.724137931"));
+
+    }
+
+    @Test(groups = "fast")
+    public void testProRationBeforeFirstBillingPeriod() throws Exception {
+        LocalDate startDate = new LocalDate("2023-05-23");
+        LocalDate nextBillingCycleDate = new LocalDate("2023-06-15");
+        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.741935484"));
+
+        startDate = new LocalDate("2023-06-23");
+        nextBillingCycleDate = new LocalDate("2023-07-15");
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.733333333"));
+
+        //Feb
+        startDate = new LocalDate("2023-02-23");
+        nextBillingCycleDate = new LocalDate("2023-03-15");
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.714285714"));
+
+        //Feb with leap year
+        startDate = new LocalDate("2024-02-23");
+        nextBillingCycleDate = new LocalDate("2024-03-15");
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        Assert.assertEquals(proration, new BigDecimal("0.724137931"));
+
+    }
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithoutFixedProration.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/generator/TestInvoiceDateUtilsWithoutFixedProration.java
@@ -31,24 +31,24 @@ public class TestInvoiceDateUtilsWithoutFixedProration extends InvoiceTestSuiteN
     public void testProRationAfterLastBillingCycleDate() throws Exception {
         LocalDate endDate = new LocalDate("2023-06-15");
         LocalDate previousBillThroughDate = new LocalDate("2023-05-23");
-        BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        BigDecimal proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.741935484"));
 
         endDate = new LocalDate("2023-07-15");
         previousBillThroughDate = new LocalDate("2023-06-23");
-        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
         //Feb
         endDate = new LocalDate("2023-03-15");
         previousBillThroughDate = new LocalDate("2023-02-23");
-        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.714285714"));
 
         //Feb with leap year
         endDate = new LocalDate("2024-03-15");
         previousBillThroughDate = new LocalDate("2024-02-23");
-        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationAfterLastBillingCycleDate(endDate, previousBillThroughDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.724137931"));
 
     }
@@ -57,24 +57,24 @@ public class TestInvoiceDateUtilsWithoutFixedProration extends InvoiceTestSuiteN
     public void testProRationBeforeFirstBillingPeriod() throws Exception {
         LocalDate startDate = new LocalDate("2023-05-23");
         LocalDate nextBillingCycleDate = new LocalDate("2023-06-15");
-        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        BigDecimal proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.741935484"));
 
         startDate = new LocalDate("2023-06-23");
         nextBillingCycleDate = new LocalDate("2023-07-15");
-        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.733333333"));
 
         //Feb
         startDate = new LocalDate("2023-02-23");
         nextBillingCycleDate = new LocalDate("2023-03-15");
-        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.714285714"));
 
         //Feb with leap year
         startDate = new LocalDate("2024-02-23");
         nextBillingCycleDate = new LocalDate("2024-03-15");
-        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig);
+        proration = InvoiceDateUtils.calculateProRationBeforeFirstBillingPeriod(startDate, nextBillingCycleDate, BillingPeriod.MONTHLY, invoiceConfig.getProrationFixedDays());
         Assert.assertEquals(proration, new BigDecimal("0.724137931"));
 
     }

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
@@ -42,16 +42,16 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
     public static class DummyNodeInterval extends ItemsNodeInterval {
 
         private final UUID id;
-        private InvoiceConfig invoiceConfig;
+        private int prorationFixedDays;
 
-        public DummyNodeInterval(InvoiceConfig invoiceConfig) {
-            super(invoiceConfig);
+        public DummyNodeInterval(final int prorationFixedDays) {
+            super(prorationFixedDays);
             this.id = UUID.randomUUID();
-            this.invoiceConfig = invoiceConfig;
+            this.prorationFixedDays = prorationFixedDays;
         }
 
-        public DummyNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate, InvoiceConfig invoiceConfig) {
-            super(parent, startDate, endDate, invoiceConfig);
+        public DummyNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate, final int prorationFixedDays) {
+            super(parent, startDate, endDate, prorationFixedDays);
             this.id = UUID.randomUUID();
         }
 
@@ -66,8 +66,8 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
             Assert.assertNull(leftChild, "leftChild is not null");
             Assert.assertNull(rightSibling, "rightSibling is not null");
 
-            final DummyNodeInterval split1 = new DummyNodeInterval(this.parent, this.start, splitDate, invoiceConfig);
-            final DummyNodeInterval split2 = new DummyNodeInterval(this.parent, splitDate, this.end, invoiceConfig);
+            final DummyNodeInterval split1 = new DummyNodeInterval(this.parent, this.start, splitDate, prorationFixedDays);
+            final DummyNodeInterval split2 = new DummyNodeInterval(this.parent, splitDate, this.end, prorationFixedDays);
             final DummyNodeInterval[] result = new DummyNodeInterval[2];
             result[0] = split1;
             result[1] = split2;
@@ -118,7 +118,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddExistingItemSimple() {
-        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig.getProrationFixedDays());
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -150,7 +150,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddOverlapNode1() {
-        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig.getProrationFixedDays());
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -180,7 +180,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddOverlapNode2() {
-        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig.getProrationFixedDays());
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -213,7 +213,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddOverlapNode3() {
-        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig.getProrationFixedDays());
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -246,7 +246,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddOverlapNode4() {
-        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig.getProrationFixedDays());
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -279,7 +279,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testBuild() {
-        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig.getProrationFixedDays());
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -327,7 +327,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testWalkTree() {
-        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig.getProrationFixedDays());
 
         final DummyNodeInterval firstChildLevel0 = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(firstChildLevel0, CALLBACK);
@@ -401,7 +401,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
     }
 
     private DummyNodeInterval createNodeInterval(final LocalDate startDate, final LocalDate endDate) {
-        return new DummyNodeInterval(null, startDate, endDate, invoiceConfig);
+        return new DummyNodeInterval(null, startDate, endDate, invoiceConfig.getProrationFixedDays());
     }
 
     private DummyNodeInterval createNodeInterval(final String startDate, final String endDate) {

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestNodeInterval.java
@@ -28,6 +28,7 @@ import org.killbill.billing.invoice.InvoiceTestSuiteNoDB;
 import org.killbill.billing.invoice.tree.NodeInterval.AddNodeCallback;
 import org.killbill.billing.invoice.tree.NodeInterval.BuildNodeCallback;
 import org.killbill.billing.invoice.tree.NodeInterval.WalkCallback;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -41,13 +42,16 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
     public static class DummyNodeInterval extends ItemsNodeInterval {
 
         private final UUID id;
+        private InvoiceConfig invoiceConfig;
 
-        public DummyNodeInterval() {
+        public DummyNodeInterval(InvoiceConfig invoiceConfig) {
+            super(invoiceConfig);
             this.id = UUID.randomUUID();
+            this.invoiceConfig = invoiceConfig;
         }
 
-        public DummyNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate) {
-            super(parent, startDate, endDate);
+        public DummyNodeInterval(final NodeInterval parent, final LocalDate startDate, final LocalDate endDate, InvoiceConfig invoiceConfig) {
+            super(parent, startDate, endDate, invoiceConfig);
             this.id = UUID.randomUUID();
         }
 
@@ -62,8 +66,8 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
             Assert.assertNull(leftChild, "leftChild is not null");
             Assert.assertNull(rightSibling, "rightSibling is not null");
 
-            final DummyNodeInterval split1 = new DummyNodeInterval(this.parent, this.start, splitDate);
-            final DummyNodeInterval split2 = new DummyNodeInterval(this.parent, splitDate, this.end);
+            final DummyNodeInterval split1 = new DummyNodeInterval(this.parent, this.start, splitDate, invoiceConfig);
+            final DummyNodeInterval split2 = new DummyNodeInterval(this.parent, splitDate, this.end, invoiceConfig);
             final DummyNodeInterval[] result = new DummyNodeInterval[2];
             result[0] = split1;
             result[1] = split2;
@@ -114,7 +118,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddExistingItemSimple() {
-        final DummyNodeInterval root = new DummyNodeInterval();
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -146,7 +150,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddOverlapNode1() {
-        final DummyNodeInterval root = new DummyNodeInterval();
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -176,7 +180,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddOverlapNode2() {
-        final DummyNodeInterval root = new DummyNodeInterval();
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -209,7 +213,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddOverlapNode3() {
-        final DummyNodeInterval root = new DummyNodeInterval();
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -242,7 +246,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testAddOverlapNode4() {
-        final DummyNodeInterval root = new DummyNodeInterval();
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -275,7 +279,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testBuild() {
-        final DummyNodeInterval root = new DummyNodeInterval();
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
 
         final DummyNodeInterval top = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(top, CALLBACK);
@@ -323,7 +327,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void testWalkTree() {
-        final DummyNodeInterval root = new DummyNodeInterval();
+        final DummyNodeInterval root = new DummyNodeInterval(invoiceConfig);
 
         final DummyNodeInterval firstChildLevel0 = createNodeInterval("2014-01-01", "2014-02-01");
         root.addNode(firstChildLevel0, CALLBACK);
@@ -397,7 +401,7 @@ public class TestNodeInterval extends InvoiceTestSuiteNoDB {
     }
 
     private DummyNodeInterval createNodeInterval(final LocalDate startDate, final LocalDate endDate) {
-        return new DummyNodeInterval(null, startDate, endDate);
+        return new DummyNodeInterval(null, startDate, endDate, invoiceConfig);
     }
 
     private DummyNodeInterval createNodeInterval(final String startDate, final String endDate) {

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -69,7 +69,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startPeriod, endPeriod, fullAmount, monthlyRate, currency);
         final InvoiceItem item2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endPeriod, newEndPeriod, halfAmount, monthlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(item1);
         tree.addItem(item2);
         tree.build();
@@ -103,7 +103,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItemStartPeriod, existingItemEndPeriod, fullAmount, monthlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(item1);
         tree.build();
 
@@ -146,7 +146,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem1StartPeriod, existingItem1EndPeriod, fullAmount, monthlyRate, currency);
         final InvoiceItem item2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem2StartPeriod, existingItem2EndPeriod, fullAmount, monthlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(item1);
         tree.addItem(item2);
         tree.build();
@@ -198,7 +198,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem item3 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem3StartPeriod, existingItem3EndPeriod, fullAmount, monthlyRate, currency);
         final InvoiceItem item4 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem4StartPeriod, existingItem4EndPeriod, new BigDecimal("7"), monthlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(item1);
         tree.addItem(item2);
         tree.addItem(item3);
@@ -241,7 +241,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(annual1Prorated);
         expectedResult.add(annual2);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(annual1);
         tree.addItem(annual2);
         tree.addItem(repair);
@@ -260,7 +260,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final InvoiceItem annual = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, yearlyAmount, yearlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(annual);
         tree.build();
 
@@ -303,7 +303,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, startBlock, endBlock, new BigDecimal("-6.85"), currency, annual1.getId());
         final InvoiceItem annual2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endDate, newEndDate, yearlyAmount, yearlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(annual1);
         tree.addItem(repair);
         tree.addItem(annual2);
@@ -335,7 +335,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final InvoiceItem recurring1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount, rate, currency);
         final InvoiceItem repair1 = new RepairAdjInvoiceItem(invoiceId, accountId, blockDate, endDate, new BigDecimal("-23.96"), currency, recurring1.getId());
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(recurring1);
         tree.addItem(repair1);
         tree.build();
@@ -387,7 +387,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem newItem21 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startRepairDate21, endRepairDate22, amount, rate, currency);
         final InvoiceItem repair22 = new RepairAdjInvoiceItem(invoiceId, accountId, startRepairDate21, endRepairDate22, amount.negate(), currency, newItem2.getId());
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(initial);
         tree.addItem(newItem1);
         tree.addItem(repair1);
@@ -429,7 +429,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, "someelse", "someelse", "someelse", null, repairDate, endDate, amount2, rate2, currency);
         expectedResult.add(expected2);
 
-        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(initial);
         tree.addItem(newItem);
         tree.addItem(repair);
@@ -449,7 +449,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem tooLateRepair = new RepairAdjInvoiceItem(invoiceId, accountId, startDate, endDate.plusDays(1), rate.negate(), currency, initial.getId());
 
         List<InvoiceItem> result;
-        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(initial);
         tree.addItem(tooEarlyRepair);
         tree.build();
@@ -457,7 +457,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         result  = tree.getView();
         Assert.assertEquals(result.size(), 0);
 
-        tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(initial);
         tree.addItem(tooLateRepair);
         tree.build();
@@ -500,7 +500,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem expected3 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, repairDate2, endDate, amount3, rate3, currency);
         expectedResult.add(expected3);
 
-        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(initial);
         tree.addItem(newItem1);
         tree.addItem(repair1);
@@ -539,7 +539,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(expected3);
 
         // First test with items in order
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(initial);
         tree.addItem(block1);
         tree.addItem(block2);
@@ -570,7 +570,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(expected1);
         expectedResult.add(expected2);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(first);
         tree.addItem(second);
         tree.addItem(block1);
@@ -608,7 +608,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(annual);
 
         // First test with items in order
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(monthly1);
         tree.addItem(monthly2);
         tree.addItem(repair);
@@ -645,7 +645,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(annual);
 
         // First test with items in order
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(monthly1);
         tree.addItem(monthly2);
         tree.addItem(repair);
@@ -666,7 +666,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem recurring1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate1, endDate, amount, rate, currency);
         final InvoiceItem recurring2 = new RecurringInvoiceItem(UUID.randomUUID(), accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate1, endDate, amount, rate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(recurring1);
         tree.addItem(recurring2);
 
@@ -704,7 +704,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem repair2 = new RepairAdjInvoiceItem(invoiceId, accountId, repairDate2, endDate, amount2.negate(), currency, initial.getId());
 
         // Out-of-order insertion to show ordering doesn't matter
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(repair1);
         tree.addItem(repair2);
         tree.addItem(initial);
@@ -727,7 +727,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate = new BigDecimal("12.00");
         final BigDecimal monthlyAmount = monthlyRate;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.flatten(true);
 
         final InvoiceItem proposed1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
@@ -748,7 +748,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate = new BigDecimal("12.00");
         final BigDecimal monthlyAmount = monthlyRate;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -774,7 +774,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate2 = new BigDecimal("15.00");
         final BigDecimal monthlyAmount2 = monthlyRate2;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -801,7 +801,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -827,7 +827,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -853,7 +853,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -884,7 +884,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate = new BigDecimal("12.00");
         final BigDecimal monthlyAmount = monthlyRate;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         tree.addItem(monthly);
         tree.flatten(true);
@@ -906,7 +906,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         verifyResult(tree.getView(), expectedResult);
 
         // Dot it again but with proposed items out of order
-        final SubscriptionItemTree treeAgain = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree treeAgain = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthlyAgain = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         treeAgain.addItem(monthlyAgain);
         treeAgain.flatten(true);
@@ -936,7 +936,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate2 = new BigDecimal("20.00");
         final BigDecimal monthlyAmount2 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -971,7 +971,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate3 = new BigDecimal("29.95");
         final BigDecimal proratedAmount3 = new BigDecimal("23.19");
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem initial = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount1, rate1, currency);
         final InvoiceItem newItem1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, "foo", "foo", "foo", null, change1, endDate, proratedAmount2, rate2, currency);
         final InvoiceItem repair1 = new RepairAdjInvoiceItem(invoiceId, accountId, change1, endDate, new BigDecimal("-483.86"), currency, initial.getId());
@@ -1006,7 +1006,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyAmount = monthlyRate;
         final BigDecimal fixedAmount = new BigDecimal("5.00");
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         final InvoiceItem fixed = new FixedPriceInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, fixedAmount, currency);
         tree.addItem(monthly);
@@ -1032,7 +1032,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyAmount = monthlyRate;
         final BigDecimal fixedAmount = new BigDecimal("5.00");
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem monthly = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         tree.addItem(monthly);
         tree.flatten(true);
@@ -1060,7 +1060,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate1 = new BigDecimal("12.00");
         final BigDecimal amount1 = rate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem initial = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount1, rate1, currency);
         final InvoiceItem itemAdj = new ItemAdjInvoiceItem(initial, itemAdjDate, new BigDecimal("-2.00"), currency);
         tree.addItem(initial);
@@ -1090,7 +1090,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate1 = new BigDecimal("12.00");
         final BigDecimal amount1 = rate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem initial = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount1, rate1, currency);
         final InvoiceItem itemAdj = new ItemAdjInvoiceItem(initial, itemAdjDate, new BigDecimal("-10.00"), currency);
         tree.addItem(initial);
@@ -1120,7 +1120,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate1 = new BigDecimal("12.00");
         final BigDecimal amount1 = rate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem originalAdjusted = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount1, rate1, currency);
         final InvoiceItem itemAdj = new ItemAdjInvoiceItem(originalAdjusted, itemAdjDate, amount1.negate(), currency);
 
@@ -1158,7 +1158,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem monthly2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endMonthly1, endMonthly2, monthlyAmount, monthlyRate, currency);
 
         // First test with items in order
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         tree.addItem(monthly1);
         tree.addItem(monthly2);
         tree.flatten(true);
@@ -1181,7 +1181,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void verifyJson() throws IOException {
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final UUID id1 = UUID.fromString("e8ba6ce7-9bd4-417d-af53-70951ecaa99f");
         final InvoiceItem yearly1 = new RecurringInvoiceItem(id1, new DateTime(), invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, new LocalDate("2014-01-01"), new LocalDate("2015-01-01"), BigDecimal.TEN, BigDecimal.TEN, currency);
         tree.addItem(yearly1);
@@ -1212,7 +1212,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
 
         final InvoiceItem existing1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(existing1);
@@ -1243,7 +1243,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
 
         final InvoiceItem existing1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(existing1);
@@ -1270,7 +1270,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate = new BigDecimal("12.00");
         final BigDecimal amount = rate;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
 
         final InvoiceItem wrongInitialItem = new RecurringInvoiceItem(invoiceId,
                                                                       accountId,
@@ -1337,7 +1337,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyRate2 = new BigDecimal("24.00");
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
         final InvoiceItem freeMonthly = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, BigDecimal.ZERO, BigDecimal.ZERO, currency);
         tree.addItem(freeMonthly);
         final InvoiceItem payingMonthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyRate1, monthlyRate1, currency);
@@ -1360,7 +1360,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final LocalDate startDate = new LocalDate(2019, 11, 1);
         final LocalDate endDate = new LocalDate(2019, 12, 1);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
 
         final DateTime catalogEffectiveDate = new DateTime();
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestSubscriptionItemTree.java
@@ -69,7 +69,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startPeriod, endPeriod, fullAmount, monthlyRate, currency);
         final InvoiceItem item2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endPeriod, newEndPeriod, halfAmount, monthlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(item1);
         tree.addItem(item2);
         tree.build();
@@ -103,7 +103,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItemStartPeriod, existingItemEndPeriod, fullAmount, monthlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(item1);
         tree.build();
 
@@ -146,7 +146,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem item1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem1StartPeriod, existingItem1EndPeriod, fullAmount, monthlyRate, currency);
         final InvoiceItem item2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem2StartPeriod, existingItem2EndPeriod, fullAmount, monthlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(item1);
         tree.addItem(item2);
         tree.build();
@@ -198,7 +198,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem item3 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem3StartPeriod, existingItem3EndPeriod, fullAmount, monthlyRate, currency);
         final InvoiceItem item4 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, existingItem4StartPeriod, existingItem4EndPeriod, new BigDecimal("7"), monthlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(item1);
         tree.addItem(item2);
         tree.addItem(item3);
@@ -241,7 +241,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(annual1Prorated);
         expectedResult.add(annual2);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(annual1);
         tree.addItem(annual2);
         tree.addItem(repair);
@@ -260,7 +260,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final InvoiceItem annual = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, yearlyAmount, yearlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(annual);
         tree.build();
 
@@ -303,7 +303,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem repair = new RepairAdjInvoiceItem(invoiceId, accountId, startBlock, endBlock, new BigDecimal("-6.85"), currency, annual1.getId());
         final InvoiceItem annual2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endDate, newEndDate, yearlyAmount, yearlyRate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(annual1);
         tree.addItem(repair);
         tree.addItem(annual2);
@@ -335,7 +335,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
         final InvoiceItem recurring1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount, rate, currency);
         final InvoiceItem repair1 = new RepairAdjInvoiceItem(invoiceId, accountId, blockDate, endDate, new BigDecimal("-23.96"), currency, recurring1.getId());
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(recurring1);
         tree.addItem(repair1);
         tree.build();
@@ -387,7 +387,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem newItem21 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startRepairDate21, endRepairDate22, amount, rate, currency);
         final InvoiceItem repair22 = new RepairAdjInvoiceItem(invoiceId, accountId, startRepairDate21, endRepairDate22, amount.negate(), currency, newItem2.getId());
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(initial);
         tree.addItem(newItem1);
         tree.addItem(repair1);
@@ -429,7 +429,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem expected2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, "someelse", "someelse", "someelse", null, repairDate, endDate, amount2, rate2, currency);
         expectedResult.add(expected2);
 
-        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(initial);
         tree.addItem(newItem);
         tree.addItem(repair);
@@ -449,7 +449,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem tooLateRepair = new RepairAdjInvoiceItem(invoiceId, accountId, startDate, endDate.plusDays(1), rate.negate(), currency, initial.getId());
 
         List<InvoiceItem> result;
-        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(initial);
         tree.addItem(tooEarlyRepair);
         tree.build();
@@ -457,7 +457,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         result  = tree.getView();
         Assert.assertEquals(result.size(), 0);
 
-        tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(initial);
         tree.addItem(tooLateRepair);
         tree.build();
@@ -500,7 +500,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem expected3 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, repairDate2, endDate, amount3, rate3, currency);
         expectedResult.add(expected3);
 
-        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(initial);
         tree.addItem(newItem1);
         tree.addItem(repair1);
@@ -539,7 +539,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(expected3);
 
         // First test with items in order
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(initial);
         tree.addItem(block1);
         tree.addItem(block2);
@@ -570,7 +570,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(expected1);
         expectedResult.add(expected2);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(first);
         tree.addItem(second);
         tree.addItem(block1);
@@ -608,7 +608,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(annual);
 
         // First test with items in order
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(monthly1);
         tree.addItem(monthly2);
         tree.addItem(repair);
@@ -645,7 +645,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         expectedResult.add(annual);
 
         // First test with items in order
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(monthly1);
         tree.addItem(monthly2);
         tree.addItem(repair);
@@ -666,7 +666,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem recurring1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate1, endDate, amount, rate, currency);
         final InvoiceItem recurring2 = new RecurringInvoiceItem(UUID.randomUUID(), accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate1, endDate, amount, rate, currency);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(recurring1);
         tree.addItem(recurring2);
 
@@ -704,7 +704,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem repair2 = new RepairAdjInvoiceItem(invoiceId, accountId, repairDate2, endDate, amount2.negate(), currency, initial.getId());
 
         // Out-of-order insertion to show ordering doesn't matter
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(repair1);
         tree.addItem(repair2);
         tree.addItem(initial);
@@ -727,7 +727,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate = new BigDecimal("12.00");
         final BigDecimal monthlyAmount = monthlyRate;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.flatten(true);
 
         final InvoiceItem proposed1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
@@ -748,7 +748,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate = new BigDecimal("12.00");
         final BigDecimal monthlyAmount = monthlyRate;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -774,7 +774,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate2 = new BigDecimal("15.00");
         final BigDecimal monthlyAmount2 = monthlyRate2;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -801,7 +801,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -827,7 +827,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -853,7 +853,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -884,7 +884,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate = new BigDecimal("12.00");
         final BigDecimal monthlyAmount = monthlyRate;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         tree.addItem(monthly);
         tree.flatten(true);
@@ -906,7 +906,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         verifyResult(tree.getView(), expectedResult);
 
         // Dot it again but with proposed items out of order
-        final SubscriptionItemTree treeAgain = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree treeAgain = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthlyAgain = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         treeAgain.addItem(monthlyAgain);
         treeAgain.flatten(true);
@@ -936,7 +936,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate2 = new BigDecimal("20.00");
         final BigDecimal monthlyAmount2 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(monthly1);
         tree.flatten(true);
@@ -971,7 +971,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate3 = new BigDecimal("29.95");
         final BigDecimal proratedAmount3 = new BigDecimal("23.19");
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem initial = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount1, rate1, currency);
         final InvoiceItem newItem1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, "foo", "foo", "foo", null, change1, endDate, proratedAmount2, rate2, currency);
         final InvoiceItem repair1 = new RepairAdjInvoiceItem(invoiceId, accountId, change1, endDate, new BigDecimal("-483.86"), currency, initial.getId());
@@ -1006,7 +1006,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyAmount = monthlyRate;
         final BigDecimal fixedAmount = new BigDecimal("5.00");
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         final InvoiceItem fixed = new FixedPriceInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, fixedAmount, currency);
         tree.addItem(monthly);
@@ -1032,7 +1032,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyAmount = monthlyRate;
         final BigDecimal fixedAmount = new BigDecimal("5.00");
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem monthly = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount, monthlyRate, currency);
         tree.addItem(monthly);
         tree.flatten(true);
@@ -1060,7 +1060,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate1 = new BigDecimal("12.00");
         final BigDecimal amount1 = rate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem initial = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount1, rate1, currency);
         final InvoiceItem itemAdj = new ItemAdjInvoiceItem(initial, itemAdjDate, new BigDecimal("-2.00"), currency);
         tree.addItem(initial);
@@ -1090,7 +1090,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate1 = new BigDecimal("12.00");
         final BigDecimal amount1 = rate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem initial = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount1, rate1, currency);
         final InvoiceItem itemAdj = new ItemAdjInvoiceItem(initial, itemAdjDate, new BigDecimal("-10.00"), currency);
         tree.addItem(initial);
@@ -1120,7 +1120,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate1 = new BigDecimal("12.00");
         final BigDecimal amount1 = rate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem originalAdjusted = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, amount1, rate1, currency);
         final InvoiceItem itemAdj = new ItemAdjInvoiceItem(originalAdjusted, itemAdjDate, amount1.negate(), currency);
 
@@ -1158,7 +1158,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final InvoiceItem monthly2 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, endMonthly1, endMonthly2, monthlyAmount, monthlyRate, currency);
 
         // First test with items in order
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         tree.addItem(monthly1);
         tree.addItem(monthly2);
         tree.flatten(true);
@@ -1181,7 +1181,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
 
     @Test(groups = "fast")
     public void verifyJson() throws IOException {
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final UUID id1 = UUID.fromString("e8ba6ce7-9bd4-417d-af53-70951ecaa99f");
         final InvoiceItem yearly1 = new RecurringInvoiceItem(id1, new DateTime(), invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, new LocalDate("2014-01-01"), new LocalDate("2015-01-01"), BigDecimal.TEN, BigDecimal.TEN, currency);
         tree.addItem(yearly1);
@@ -1212,7 +1212,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
 
         final InvoiceItem existing1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(existing1);
@@ -1243,7 +1243,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyAmount1 = monthlyRate1;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
 
         final InvoiceItem existing1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyAmount1, monthlyRate1, currency);
         tree.addItem(existing1);
@@ -1270,7 +1270,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal rate = new BigDecimal("12.00");
         final BigDecimal amount = rate;
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
 
         final InvoiceItem wrongInitialItem = new RecurringInvoiceItem(invoiceId,
                                                                       accountId,
@@ -1337,7 +1337,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final BigDecimal monthlyRate1 = new BigDecimal("12.00");
         final BigDecimal monthlyRate2 = new BigDecimal("24.00");
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
         final InvoiceItem freeMonthly = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, BigDecimal.ZERO, BigDecimal.ZERO, currency);
         tree.addItem(freeMonthly);
         final InvoiceItem payingMonthly1 = new RecurringInvoiceItem(invoiceId, accountId, bundleId, subscriptionId, productName, planName, phaseName, null, startDate, endDate, monthlyRate1, monthlyRate1, currency);
@@ -1360,7 +1360,7 @@ public class TestSubscriptionItemTree extends InvoiceTestSuiteNoDB {
         final LocalDate startDate = new LocalDate(2019, 11, 1);
         final LocalDate endDate = new LocalDate(2019, 12, 1);
 
-        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig);
+        final SubscriptionItemTree tree = new SubscriptionItemTree(subscriptionId, invoiceId, invoiceConfig.getProrationFixedDays());
 
         final DateTime catalogEffectiveDate = new DateTime();
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestTreePrinter.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestTreePrinter.java
@@ -47,15 +47,15 @@ public class TestTreePrinter extends InvoiceTestSuiteNoDB {
         final InvoiceItem item = Mockito.mock(InvoiceItem.class);
         Mockito.when(item.getAmount()).thenReturn(BigDecimal.ZERO);
 
-        root = new ItemsNodeInterval(null, new Item(item, new LocalDate(2016, 1, 1), new LocalDate(2016, 2, 1), null, ItemAction.ADD));
+        root = new ItemsNodeInterval(null, new Item(item, new LocalDate(2016, 1, 1), new LocalDate(2016, 2, 1), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
 
-        node11 = new ItemsNodeInterval(root, new Item(item, new LocalDate(2016, 1, 10), new LocalDate(2016, 1, 15), null, ItemAction.ADD));
-        node21 = new ItemsNodeInterval(node11, new Item(item, new LocalDate(2016, 1, 10), new LocalDate(2016, 1, 12), null, ItemAction.ADD));
-        node22 = new ItemsNodeInterval(node11, new Item(item, new LocalDate(2016, 1, 14), new LocalDate(2016, 1, 15), null, ItemAction.ADD));
+        node11 = new ItemsNodeInterval(root, new Item(item, new LocalDate(2016, 1, 10), new LocalDate(2016, 1, 15), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
+        node21 = new ItemsNodeInterval(node11, new Item(item, new LocalDate(2016, 1, 10), new LocalDate(2016, 1, 12), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
+        node22 = new ItemsNodeInterval(node11, new Item(item, new LocalDate(2016, 1, 14), new LocalDate(2016, 1, 15), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
 
-        node12 = new ItemsNodeInterval(root, new Item(item, new LocalDate(2016, 1, 20), new LocalDate(2016, 1, 25), null, ItemAction.ADD));
-        node23 = new ItemsNodeInterval(node12, new Item(item, new LocalDate(2016, 1, 22), new LocalDate(2016, 1, 24), null, ItemAction.ADD));
-        node31 = new ItemsNodeInterval(node23, new Item(item, new LocalDate(2016, 1, 22), new LocalDate(2016, 1, 23), null, ItemAction.ADD));
+        node12 = new ItemsNodeInterval(root, new Item(item, new LocalDate(2016, 1, 20), new LocalDate(2016, 1, 25), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
+        node23 = new ItemsNodeInterval(node12, new Item(item, new LocalDate(2016, 1, 22), new LocalDate(2016, 1, 24), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
+        node31 = new ItemsNodeInterval(node23, new Item(item, new LocalDate(2016, 1, 22), new LocalDate(2016, 1, 23), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
     }
 
     @Test(groups = "fast")

--- a/invoice/src/test/java/org/killbill/billing/invoice/tree/TestTreePrinter.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/tree/TestTreePrinter.java
@@ -47,15 +47,15 @@ public class TestTreePrinter extends InvoiceTestSuiteNoDB {
         final InvoiceItem item = Mockito.mock(InvoiceItem.class);
         Mockito.when(item.getAmount()).thenReturn(BigDecimal.ZERO);
 
-        root = new ItemsNodeInterval(null, new Item(item, new LocalDate(2016, 1, 1), new LocalDate(2016, 2, 1), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
+        root = new ItemsNodeInterval(null, new Item(item, new LocalDate(2016, 1, 1), new LocalDate(2016, 2, 1), null, ItemAction.ADD, invoiceConfig.getProrationFixedDays()), invoiceConfig.getProrationFixedDays());
 
-        node11 = new ItemsNodeInterval(root, new Item(item, new LocalDate(2016, 1, 10), new LocalDate(2016, 1, 15), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
-        node21 = new ItemsNodeInterval(node11, new Item(item, new LocalDate(2016, 1, 10), new LocalDate(2016, 1, 12), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
-        node22 = new ItemsNodeInterval(node11, new Item(item, new LocalDate(2016, 1, 14), new LocalDate(2016, 1, 15), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
+        node11 = new ItemsNodeInterval(root, new Item(item, new LocalDate(2016, 1, 10), new LocalDate(2016, 1, 15), null, ItemAction.ADD, invoiceConfig.getProrationFixedDays()), invoiceConfig.getProrationFixedDays());
+        node21 = new ItemsNodeInterval(node11, new Item(item, new LocalDate(2016, 1, 10), new LocalDate(2016, 1, 12), null, ItemAction.ADD, invoiceConfig.getProrationFixedDays()), invoiceConfig.getProrationFixedDays());
+        node22 = new ItemsNodeInterval(node11, new Item(item, new LocalDate(2016, 1, 14), new LocalDate(2016, 1, 15), null, ItemAction.ADD, invoiceConfig.getProrationFixedDays()), invoiceConfig.getProrationFixedDays());
 
-        node12 = new ItemsNodeInterval(root, new Item(item, new LocalDate(2016, 1, 20), new LocalDate(2016, 1, 25), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
-        node23 = new ItemsNodeInterval(node12, new Item(item, new LocalDate(2016, 1, 22), new LocalDate(2016, 1, 24), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
-        node31 = new ItemsNodeInterval(node23, new Item(item, new LocalDate(2016, 1, 22), new LocalDate(2016, 1, 23), null, ItemAction.ADD, invoiceConfig), invoiceConfig);
+        node12 = new ItemsNodeInterval(root, new Item(item, new LocalDate(2016, 1, 20), new LocalDate(2016, 1, 25), null, ItemAction.ADD, invoiceConfig.getProrationFixedDays()), invoiceConfig.getProrationFixedDays());
+        node23 = new ItemsNodeInterval(node12, new Item(item, new LocalDate(2016, 1, 22), new LocalDate(2016, 1, 24), null, ItemAction.ADD, invoiceConfig.getProrationFixedDays()), invoiceConfig.getProrationFixedDays());
+        node31 = new ItemsNodeInterval(node23, new Item(item, new LocalDate(2016, 1, 22), new LocalDate(2016, 1, 23), null, ItemAction.ADD, invoiceConfig.getProrationFixedDays()), invoiceConfig.getProrationFixedDays());
     }
 
     @Test(groups = "fast")

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -222,4 +222,14 @@ public interface InvoiceConfig extends LockAwareConfig {
     @Description("How far back in time should invoice generation look at")
     Period getMaxInvoiceLimit(@Param("dummy") final InternalTenantContext tenantContext);
 
+    @Config("org.killbill.invoice.proration.fixed.days")
+    @Default("0")
+    @Description("Fixed number of days in a month to avoid proration")
+    int getProrationFixedDays();
+
+    @Config("org.killbill.invoice.proration.fixed.days")
+    @Default("0")
+    @Description("Fixed number of days in a month to avoid proration")
+    int getProrationFixedDays(@Param("dummy") final InternalTenantContext tenantContext);
+
 }


### PR DESCRIPTION
**Changes for fixed proration:**
1. Introduced a new property: `org.killbill.invoice.proration.fixed.days`
2. Added new tests: `TestInvoiceDateUtilsWithFixedProration` and `TestInvoiceDateUtilsWithoutFixedProration`
3. Tests run fine. I also did a round of manual testing via Kaui and that works fine too.

**Need your input on the following:**
The [Item](https://github.com/killbill/killbill/blob/master/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java) class also invokes the `InvoiceDateUtils.calculateProrationBetweenDates` [here](https://github.com/killbill/killbill/blob/38e4d3f0ea6d60282b4b87d7ac35341fcdd47290/invoice/src/main/java/org/killbill/billing/invoice/tree/Item.java#L154). Since this class does not have access to `InvoiceConfig`, I have passed the value `0` corresponding to `fixedDaysInMonth`. See  [this](https://github.com/killbill/killbill/compare/master...reshmabidikar:killbill:fixed-proration-2#diff-94c7eb4ba0f8059614e7f6c0c53fcc2cb5163035860ed880d5ce5ddc4ec48a8eL154) comment. I did not spend much time investigating what this class does and whether it requires reading the config parameter but if you think this is important, I'll look into it. Let me know.



