### PR TITLE
profiles: Extend the existing ThreadNameBasedDiscriminator to make it usable from killbill plugins

### DIFF
--- a/profiles/killbill/src/test/java/org/killbill/billing/server/log/TestThreadNameBasedDiscriminator.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/log/TestThreadNameBasedDiscriminator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020-2024 Equinix, Inc
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.server.log;
+
+import org.killbill.billing.KillbillTestSuite;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestThreadNameBasedDiscriminator extends KillbillTestSuite {
+
+    @BeforeMethod(groups = "fast")
+    public void beforeMethod() {
+    }
+
+    @Test(groups = "fast")
+    public void testLookupNextToken() {
+        final String input = "org.killbill.billing.dao.foo.";
+
+        int next = ThreadNameBasedDiscriminator.lookupNextToken(input.toCharArray(), 0, "org.");
+        Assert.assertEquals(next, 4);
+
+        next = ThreadNameBasedDiscriminator.lookupNextToken(input.toCharArray(), next, "killbill.");
+        Assert.assertEquals(next, 13);
+
+        int nextInvalid = ThreadNameBasedDiscriminator.lookupNextToken(input.toCharArray(), next, "zilling.");
+        Assert.assertEquals(nextInvalid, -1);
+
+        next = ThreadNameBasedDiscriminator.lookupNextToken(input.toCharArray(), next, "billing.");
+        Assert.assertEquals(next, 21);
+
+        next = ThreadNameBasedDiscriminator.lookupNextToken(input.toCharArray(), next, "dao.");
+        Assert.assertEquals(next, 25);
+
+        next = ThreadNameBasedDiscriminator.lookupNextToken(input.toCharArray(), next, "foo.");
+        Assert.assertEquals(next, 29);
+
+        nextInvalid = ThreadNameBasedDiscriminator.lookupNextToken(input.toCharArray(), next, "end");
+        Assert.assertEquals(nextInvalid, -1);
+    }
+
+    @Test(groups = "fast")
+    public void testFindNextToken() {
+
+        final String input = "org.killbill.billing.dao.foo.";
+        String res = ThreadNameBasedDiscriminator.findNextToken(input.toCharArray(), 0, '.');
+        Assert.assertEquals(res, "org.");
+
+        int next = res.length();
+        res = ThreadNameBasedDiscriminator.findNextToken(input.toCharArray(), next, '.');
+        Assert.assertEquals(res, "killbill.");
+
+        next += res.length();
+        res = ThreadNameBasedDiscriminator.findNextToken(input.toCharArray(), next, '.');
+        Assert.assertEquals(res, "billing.");
+
+        next += res.length();
+        res = ThreadNameBasedDiscriminator.findNextToken(input.toCharArray(), next, '.');
+        Assert.assertEquals(res, "dao.");
+
+        next += res.length();
+        res = ThreadNameBasedDiscriminator.findNextToken(input.toCharArray(), next, '.');
+        Assert.assertEquals(res, "foo.");
+
+        next += res.length();
+        res = ThreadNameBasedDiscriminator.findNextToken(input.toCharArray(), next, '.');
+        Assert.assertNull(res);
+    }
+}


### PR DESCRIPTION
For instance, given a plugin 'myplugin', one can add an SIFT entry in the logback.xml to have the plugin split logs about jdbc. The exact name of the logfile would be of the form  `myplugin-sqltiming.<something>.out` where 'something' is based on the first stacktrace entry matching the pattern.

```
    <appender name="SIFT-myplugin-sqltiming" class="ch.qos.logback.classic.sift.SiftingAppender">
        <discriminator class="org.killbill.billing.server.log.ThreadNameBasedDiscriminator"/>
        <sift>
            <appender name="myplugin-sqltiming-${threadName}" class="ch.qos.logback.core.rolling.RollingFileAppender">
                <file>${LOGS_DIR:-./logs}/myplugin-sqltiming.${threadName}.out</file>
                <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                    <!-- rollover daily -->
                    <fileNamePattern>${LOGS_DIR:-./logs}/myplugin-sqltiming-%d{yyyy-MM-dd}.%i.${threadName}.out.gz</fileNamePattern>
                    <maxHistory>3</maxHistory>
                    <cleanHistoryOnStart>true</cleanHistoryOnStart>
                    <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                        <!-- or whenever the file size reaches 100MB -->
                        <maxFileSize>100MB</maxFileSize>
                    </timeBasedFileNamingAndTriggeringPolicy>
                </rollingPolicy>
                <encoder>
                    <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSZ", UTC} lvl='%level', log='%logger{0}', th='%thread', xff='%X{req.xForwardedFor}', rId='%X{req.requestId}', tok='%X{kb.userToken}', aRId='%X{kb.accountRecordId}', tRId='%X{kb.tenantRecordId}', %maskedMsg%n</pattern>
                </encoder>
            </appender>
        </sift>
    </appender>

    <logger name="com.killbill.billing.myplugin.dao" level="INFO" additivity="false">
        <appender-ref ref="SIFT-myplugin-sqltiming"/>
    </logger>
```

Notes:
1.  Another option would be have this discriminator class served from the plugin - an option I tried - but it adds logback dependency into plugin code, and tomcat is struggling to find the class (and throws NPE).
2. I introduced small methods to make it easy with the pattern matching and did not refactor existing code to leverage those to minimize risk - but I certainly could upon request.
