### PR TITLE
Changes for recordRefund and createItemAdjustment

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java
@@ -76,7 +76,6 @@ public class InvoiceApiHelper {
                                                                     final boolean isDryRun,
                                                                     final WithAccountLock withAccountLock,
                                                                     final LinkedList<PluginProperty> inputProperties,
-                                                                    final boolean dispatchToPlugins,
                                                                     final CallContext contextMaybeWithoutAccountId) throws InvoiceApiException {
         // Invoked by User API call
         final LocalDate targetDate = null;
@@ -107,13 +106,10 @@ public class InvoiceApiHelper {
             final List<InvoiceModelDao> invoiceModelDaos = new LinkedList<InvoiceModelDao>();
             for (final DefaultInvoice invoiceForPlugin : invoicesForPlugins) {
 
-                if (dispatchToPlugins) {
                     // Call plugin(s)
                     final AdditionalInvoiceItemsResult itemsResult = invoicePluginDispatcher.updateOriginalInvoiceWithPluginInvoiceItems(invoiceForPlugin, isDryRun, context, pluginProperties, targetDate, existingInvoices, isRescheduled, internalCallContext);
                     // Could be a bit weird for a plugin to keep updating properties for each invoice
                     pluginProperties = itemsResult.getPluginProperties();
-
-                }
                 // Transformation to InvoiceModelDao
                 final InvoiceModelDao invoiceModelDao = new InvoiceModelDao(invoiceForPlugin);
                 final List<InvoiceItem> invoiceItems = invoiceForPlugin.getInvoiceItems();

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java
@@ -133,20 +133,6 @@ public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
         }
 
         final InvoicePaymentModelDao refund = dao.createRefund(paymentId, paymentAttemptId, amount, isInvoiceAdjusted, invoiceItemIdsWithAmounts, transactionExternalKey, status, context);
-
-        // See https://github.com/killbill/killbill/issues/265
-        final CallContext callContext = internalCallContextFactory.createCallContext(context);
-        final DefaultInvoice invoice = getInvoiceByIdInternal(refund.getInvoiceId(), context);
-        final UUID accountId = invoice.getAccountId();
-        final WithAccountLock withAccountLock = new WithAccountLock() {
-            @Override
-            public Iterable<DefaultInvoice> prepareInvoices() throws InvoiceApiException {
-                return List.of(invoice);
-            }
-        };
-
-        final LinkedList<PluginProperty> pluginProperties = new LinkedList<PluginProperty>();
-        invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, pluginProperties, callContext);
         return new DefaultInvoicePayment(refund);
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -456,7 +456,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
             originalProperties.forEach(properties::add);
         }
 
-        final Collection<InvoiceItem> dispatchedInvoiceItems = invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, false, context);
+        final Collection<InvoiceItem> dispatchedInvoiceItems = invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context);
 
         final Collection<InvoiceItem> adjustmentInvoiceItems = dispatchedInvoiceItems.stream()
                 .filter(invoiceItem -> InvoiceItemType.ITEM_ADJ.equals(invoiceItem.getInvoiceItemType()))
@@ -664,7 +664,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
             }
         };
 
-        return invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, true, context);
+        return invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context);
     }
 
     private void notifyBusOfInvoiceAdjustment(final UUID invoiceId, final UUID accountId, final InternalCallContext context) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -456,7 +456,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
             originalProperties.forEach(properties::add);
         }
 
-        final Collection<InvoiceItem> dispatchedInvoiceItems = invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context);
+        final Collection<InvoiceItem> dispatchedInvoiceItems = invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, false, context);
 
         final Collection<InvoiceItem> adjustmentInvoiceItems = dispatchedInvoiceItems.stream()
                 .filter(invoiceItem -> InvoiceItemType.ITEM_ADJ.equals(invoiceItem.getInvoiceItemType()))
@@ -664,7 +664,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
             }
         };
 
-        return invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context);
+        return invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, true, context);
     }
 
     private void notifyBusOfInvoiceAdjustment(final UUID invoiceId, final UUID accountId, final InternalCallContext context) {


### PR DESCRIPTION
Round 2 changes for #1950 

- Removed call to `invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems` for `recordRefund`
- Updated `invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems` to query the database and add existing invoices to the cache before invoking `dao.createInvoices`. This is so that the cache is queried for the [DefaultInvoiceUserApi.insertInvoiceItemAdjustment](https://github.com/killbill/killbill/blob/84d1e887d3203dedd381ac9b3ff3282bad155381/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java#L409C24-L409C51) code path.
