### PR TITLE
Changes for 1951

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -204,8 +204,8 @@
                             <shadedClassifierName>load-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -219,7 +219,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.LoadCatalog</Main-Class>
@@ -240,8 +240,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -255,7 +255,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.CreateCatalogSchema</Main-Class>

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -760,7 +760,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
 
         final UUID accountId = getInvoiceInternal(invoiceId, context).getAccountId();
         final InternalCallContext internalCallContext = internalCallContextFactory.createInternalCallContext(invoiceId, ObjectType.INVOICE, context);
-        final InvoiceModelDao rawInvoice = dao.getById(invoiceId, internalCallContext);
+        final InvoiceModelDao rawInvoice = dao.getById(invoiceId, true, internalCallContext);
         if (rawInvoice.getStatus() == InvoiceStatus.COMMITTED) {
             checkInvoiceNotRepaired(rawInvoice);
             checkInvoiceDoesContainUsedGeneratedCredit(accountId, rawInvoice, context);

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
@@ -132,7 +132,7 @@ public class CBADao {
         final List<InvoiceModelDao> invoices = new ArrayList<>();
         for (UUID id : invoiceIds) {
             final InvoiceModelDao invoice = transInvoiceDao.getById(id.toString(), context);
-            invoiceDaoHelper.populateChildren(invoice, invoicesTags, false, entitySqlDaoWrapperFactory, context); //TODO_1951 - should this be true?
+            invoiceDaoHelper.populateChildren(invoice, invoicesTags, false, entitySqlDaoWrapperFactory, context);
             invoices.add(invoice);
         }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
@@ -132,7 +132,7 @@ public class CBADao {
         final List<InvoiceModelDao> invoices = new ArrayList<>();
         for (UUID id : invoiceIds) {
             final InvoiceModelDao invoice = transInvoiceDao.getById(id.toString(), context);
-            invoiceDaoHelper.populateChildren(invoice, invoicesTags, entitySqlDaoWrapperFactory, context);
+            invoiceDaoHelper.populateChildren(invoice, invoicesTags, false, entitySqlDaoWrapperFactory, context); //TODO_1951 - should this be true?
             invoices.add(invoice);
         }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
@@ -245,4 +245,6 @@ public interface InvoiceDao extends EntityDao<InvoiceModelDao, Invoice, InvoiceA
 
     List<AuditLogWithHistory> getInvoicePaymentAuditLogsWithHistoryForId(final UUID invoicePaymentId, final AuditLevel auditLevel, final InternalTenantContext context);
 
+    public InvoiceModelDao getById(final UUID invoiceId, final boolean includeRepairStatus, final InternalTenantContext context) throws InvoiceApiException;
+
 }

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
@@ -134,6 +134,13 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
         }
     }
 
+    @Override //TODO_1951 - revisit to check if anything else needs to be done
+    public InvoiceModelDao getById(final UUID id, final boolean includeInvoiceComponents, final InternalTenantContext context) {
+        synchronized (monitor) {
+            return invoices.get(id);
+        }
+    }
+
     @Override
     public InvoiceModelDao getByNumber(final Integer number, final Boolean includeInvoiceChildren, final InternalTenantContext context) {
         synchronized (monitor) {

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
@@ -134,8 +134,8 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
         }
     }
 
-    @Override //TODO_1951 - revisit to check if anything else needs to be done
-    public InvoiceModelDao getById(final UUID id, final boolean includeInvoiceComponents, final InternalTenantContext context) {
+    @Override
+    public InvoiceModelDao getById(final UUID id, final boolean includeRepairStatus, final InternalTenantContext context) {
         synchronized (monitor) {
             return invoices.get(id);
         }

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDaoHelper.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDaoHelper.java
@@ -231,7 +231,7 @@ public class TestInvoiceDaoHelper extends InvoiceTestSuiteWithEmbeddedDB {
         transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<Void>() {
             @Override
             public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                invoiceDaoHelper.populateChildren(List.of(invoice), tags, entitySqlDaoWrapperFactory, internalAccountContext);
+                invoiceDaoHelper.populateChildren(List.of(invoice), tags, false, entitySqlDaoWrapperFactory, internalAccountContext);
                 return null;
             }
         });
@@ -241,7 +241,7 @@ public class TestInvoiceDaoHelper extends InvoiceTestSuiteWithEmbeddedDB {
         transactionalSqlDao.execute(true, new EntitySqlDaoTransactionWrapper<Void>() {
             @Override
             public Void inTransaction(final EntitySqlDaoWrapperFactory entitySqlDaoWrapperFactory) throws Exception {
-                invoiceDaoHelper.populateChildren(invoice, tags, entitySqlDaoWrapperFactory, internalAccountContext);
+                invoiceDaoHelper.populateChildren(invoice, tags, false, entitySqlDaoWrapperFactory, internalAccountContext);
                 return null;
             }
         });

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -226,8 +226,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -241,7 +241,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.overdue.CreateOverdueConfigSchema</Main-Class>


### PR DESCRIPTION
Attempt to address #1951. Some comments:

1. This is the code path: [DefaultInvoiceDao.getById](https://github.com/killbill/killbill/blob/4153f85a3e84af28c3f748dad2da50e1845eb298/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java#L229) --> [InvoiceDaoHelper.populateChildren](https://github.com/killbill/killbill/blob/4153f85a3e84af28c3f748dad2da50e1845eb298/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDaoHelper.java#L249) --> [InvoiceDaoHelper.setInvoiceRepaired](https://github.com/killbill/killbill/blob/4153f85a3e84af28c3f748dad2da50e1845eb298/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDaoHelper.java#L392) --> [InvoiceItemSqlDao.getRepairMap](https://github.com/killbill/killbill/blob/4153f85a3e84af28c3f748dad2da50e1845eb298/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceItemSqlDao.java#L74). So basically, the `InvoiceItemSqlDao.getRepairMap` is invoked every time `DefaultInvoiceDao.getById` is invoked. 
2. The only place the repair status is read is in [DefaultInvoiceUserApi.java.voidInvoice](https://github.com/killbill/killbill/blob/4153f85a3e84af28c3f748dad2da50e1845eb298/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java#L759). In all other places, the repair status is not used. In fact, `DefaultInvoice` does not even have a field corresponding to the repair status
3. Due to this, I've updated the code to invoke `InvoiceDaoHelper.setInvoiceRepaired` only for the void invoice code path.

