### PR TITLE
Deleted the org.killbill.template.invoiceFormatterFactoryClass property

### DIFF
--- a/api/src/main/java/org/killbill/billing/util/template/translation/TranslatorConfig.java
+++ b/api/src/main/java/org/killbill/billing/util/template/translation/TranslatorConfig.java
@@ -54,11 +54,6 @@ public interface TranslatorConfig {
     @Description("Path to the invoice template for accounts with MANUAL_PAY tag")
     String getManualPayTemplateName();
 
-    @Config("org.killbill.template.invoiceFormatterFactoryClass")
-    @Default("org.killbill.billing.invoice.template.formatters.DefaultInvoiceFormatterFactory")
-    @Description("Invoice formatter class")
-    Class<? extends InvoiceFormatterFactory> getInvoiceFormatterFactoryClass();
-
     @Config("org.killbill.template.invoiceFormatterFactoryPluginName")
     @DefaultNull
     @Description("Invoice formatter factory plugin name")

--- a/invoice/src/main/java/org/killbill/billing/invoice/glue/DefaultInvoiceModule.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/glue/DefaultInvoiceModule.java
@@ -51,6 +51,7 @@ import org.killbill.billing.invoice.optimizer.InvoiceOptimizerNoop;
 import org.killbill.billing.invoice.plugin.api.InvoiceFormatterFactory;
 import org.killbill.billing.invoice.plugin.api.InvoicePluginApi;
 import org.killbill.billing.invoice.template.bundles.DefaultResourceBundleFactory;
+import org.killbill.billing.invoice.template.formatters.DefaultInvoiceFormatterFactory;
 import org.killbill.billing.invoice.usage.RawUsageOptimizer;
 import org.killbill.billing.osgi.api.OSGIServiceRegistration;
 import org.killbill.billing.platform.api.KillbillConfigSource;
@@ -109,7 +110,7 @@ public class DefaultInvoiceModule extends KillBillModule implements InvoiceModul
         bind(NextBillingDatePoster.class).to(DefaultNextBillingDatePoster.class).asEagerSingleton();
         final TranslatorConfig config = new ConfigurationObjectFactory(skifeConfigSource).build(TranslatorConfig.class);
         bind(TranslatorConfig.class).toInstance(config);
-        bind(InvoiceFormatterFactory.class).to(config.getInvoiceFormatterFactoryClass()).asEagerSingleton();
+        bind(InvoiceFormatterFactory.class).to(DefaultInvoiceFormatterFactory.class).asEagerSingleton();
     }
 
     protected void installInvoiceDispatcher() {


### PR DESCRIPTION
While documenting the new properties, I realized that the `org.killbill.template.invoiceFormatterFactoryClass` property is no longer needed.  If at all a CustomInvoiceFormatter is required, it will be injected via the plugin. So only the `org.killbill.template.invoiceFormatterFactoryPluginName` property should suffice. 