### PR TITLE
Fix for 1989 and 1990

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -204,8 +204,8 @@
                             <shadedClassifierName>load-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -219,7 +219,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.LoadCatalog</Main-Class>
@@ -240,8 +240,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -255,7 +255,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.CreateCatalogSchema</Main-Class>

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java
@@ -133,6 +133,20 @@ public class DefaultInvoiceInternalApi implements InvoiceInternalApi {
         }
 
         final InvoicePaymentModelDao refund = dao.createRefund(paymentId, paymentAttemptId, amount, isInvoiceAdjusted, invoiceItemIdsWithAmounts, transactionExternalKey, status, context);
+
+        // See https://github.com/killbill/killbill/issues/265
+        final CallContext callContext = internalCallContextFactory.createCallContext(context);
+        final DefaultInvoice invoice = getInvoiceByIdInternal(refund.getInvoiceId(), context);
+        final UUID accountId = invoice.getAccountId();
+        final WithAccountLock withAccountLock = new WithAccountLock() {
+            @Override
+            public Iterable<DefaultInvoice> prepareInvoices() throws InvoiceApiException {
+                return List.of(invoice);
+            }
+        };
+
+        final LinkedList<PluginProperty> pluginProperties = new LinkedList<PluginProperty>();
+        invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, pluginProperties, callContext);
         return new DefaultInvoicePayment(refund);
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -775,7 +775,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
             @Override
             public Iterable<DefaultInvoice> prepareInvoices() throws InvoiceApiException {
                 final InternalCallContext internalCallContext = internalCallContextFactory.createInternalCallContext(invoiceId, ObjectType.INVOICE, context);
-                final InvoiceModelDao rawInvoice = dao.getById(invoiceId, internalCallContext);
+                final InvoiceModelDao rawInvoice = dao.getById(invoiceId, true, internalCallContext);
                 if (rawInvoice.getStatus() == InvoiceStatus.COMMITTED) {
                     checkInvoiceNotRepaired(rawInvoice);
                     checkInvoiceDoesContainUsedGeneratedCredit(accountId, rawInvoice, context);

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -684,13 +684,25 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
         return invoices;
     }
 
-    @Override
     public void commitInvoice(final UUID invoiceId, final CallContext context) throws InvoiceApiException {
-        final InternalCallContext internalCallContext = internalCallContextFactory.createInternalCallContext(invoiceId, ObjectType.INVOICE, context);
-        // Update invoice status first prior we update CTD as we typically don't update CTD for non committed invoices.
-        dao.changeInvoiceStatus(invoiceId, InvoiceStatus.COMMITTED, internalCallContext);
-        final DefaultInvoice invoice = getInvoiceInternal(invoiceId, context);
-        dispatcher.setChargedThroughDates(invoice, internalCallContext);
+        final WithAccountLock withAccountLock = new WithAccountLock() {
+            @Override
+            public Iterable<DefaultInvoice> prepareInvoices() throws InvoiceApiException {
+                final InternalCallContext internalCallContext = internalCallContextFactory.createInternalCallContext(invoiceId, ObjectType.INVOICE, context);
+                // Update invoice status first prior we update CTD as we typically don't update CTD for non committed invoices.
+                dao.changeInvoiceStatus(invoiceId, InvoiceStatus.COMMITTED, internalCallContext);
+                final DefaultInvoice invoice = getInvoiceInternal(invoiceId, context);
+                dispatcher.setChargedThroughDates(invoice, internalCallContext);
+                return List.of(invoice);
+            }
+        };
+
+        final UUID accountId = getInvoiceInternal(invoiceId, context).getAccountId();
+
+        final LinkedList<PluginProperty> properties = new LinkedList<PluginProperty>();
+        properties.add(new PluginProperty(INVOICE_OPERATION, "commit", false));
+
+        invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context);
     }
 
     @Override
@@ -759,17 +771,30 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     public void voidInvoice(final UUID invoiceId, final CallContext context) throws InvoiceApiException {
 
         final UUID accountId = getInvoiceInternal(invoiceId, context).getAccountId();
-        final InternalCallContext internalCallContext = internalCallContextFactory.createInternalCallContext(invoiceId, ObjectType.INVOICE, context);
-        final InvoiceModelDao rawInvoice = dao.getById(invoiceId, true, internalCallContext);
-        if (rawInvoice.getStatus() == InvoiceStatus.COMMITTED) {
-            checkInvoiceNotRepaired(rawInvoice);
-            checkInvoiceDoesContainUsedGeneratedCredit(accountId, rawInvoice, context);
-        }
+        final WithAccountLock withAccountLock = new WithAccountLock() {
+            @Override
+            public Iterable<DefaultInvoice> prepareInvoices() throws InvoiceApiException {
+                final InternalCallContext internalCallContext = internalCallContextFactory.createInternalCallContext(invoiceId, ObjectType.INVOICE, context);
+                final InvoiceModelDao rawInvoice = dao.getById(invoiceId, internalCallContext);
+                if (rawInvoice.getStatus() == InvoiceStatus.COMMITTED) {
+                    checkInvoiceNotRepaired(rawInvoice);
+                    checkInvoiceDoesContainUsedGeneratedCredit(accountId, rawInvoice, context);
+                }
 
-        final Invoice currentInvoice = new DefaultInvoice(rawInvoice, getCatalogSafelyForPrettyNames(internalCallContext));
-        checkInvoiceNotPaid(currentInvoice);
+                final Invoice currentInvoice = new DefaultInvoice(rawInvoice, getCatalogSafelyForPrettyNames(internalCallContext));
+                checkInvoiceNotPaid(currentInvoice);
 
-        dao.changeInvoiceStatus(invoiceId, InvoiceStatus.VOID, internalCallContext);
+                dao.changeInvoiceStatus(invoiceId, InvoiceStatus.VOID, internalCallContext);
+
+                final DefaultInvoice invoice = getInvoiceInternal(invoiceId, context);
+                return List.of(invoice);
+            }
+        };
+
+        final LinkedList<PluginProperty> properties = new LinkedList<PluginProperty>();
+        properties.add(new PluginProperty(INVOICE_OPERATION, "void", false));
+
+        invoiceApiHelper.dispatchToInvoicePluginsAndInsertItems(accountId, false, withAccountLock, properties, context);
     }
 
     @Override

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -226,8 +226,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -241,7 +241,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.overdue.CreateOverdueConfigSchema</Main-Class>


### PR DESCRIPTION
Fix for #1989 (See [433577b](https://github.com/killbill/killbill/pull/1991/commits/433577b3d8dd2042995b43cd4942884ce8c0f2ff)).

- As part of the fix for #1950, we had removed the call to [InvoiceApiHelper.dispatchToInvoicePluginsAndInsertItems](https://github.com/killbill/killbill/blob/b7dc94ada8f18513b49f1e5f58c930d49969ae22/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java#L75C30-L75C68) from the `commitInvoice`/`voidInvoice` methods. (See #1960). The reason for doing this was that [we thought](https://killbillio.slack.com/archives/G01C2P3V8G7/p1706662205027009?thread_ts=1706593497.615939&cid=G01C2P3V8G7) it was unnecessary to invoke invoice plugins as part of the commit/void calls. However, we now know that it is required to call invoice plugins in case of the void/commit calls, otherwise the Avatax integration tests fail.

- Thus, 433577b reverts the changes done to the  `commitInvoice`/`voidInvoice` methods. 

- This will not impact the performance improvements for #1950. As part of #1962, we have added [this change](https://github.com/killbill/killbill/blob/b7dc94ada8f18513b49f1e5f58c930d49969ae22/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java#L123:L134).  This will ensure that the `ExistingInvoiceMetadata` cache is populated and thus not cause the performance issue reported in https://github.com/killbill/killbill/issues/1950.


Fix for #1990 (See 4aed737)

- As part of the fix for #1950, we had removed the call to [InvoiceApiHelper.dispatchToInvoicePluginsAndInsertItems](https://github.com/killbill/killbill/blob/b7dc94ada8f18513b49f1e5f58c930d49969ae22/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java#L75C30-L75C68) from the [recordRefund](https://github.com/killbill/killbill/blob/b7dc94ada8f18513b49f1e5f58c930d49969ae22/invoice/src/main/java/org/killbill/billing/invoice/api/svcs/DefaultInvoiceInternalApi.java#L130) method (See #1962). However, this causes Avatax integration tests to fail. 
- 4aed737 reverts this change. 
- This will not impact the performance improvements for #1950.
