### PR TITLE
Work for 1952 - DRAFT PR for running tests

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -182,7 +182,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     @Override
     public List<Invoice> getInvoicesByGroup(final UUID accountId, final UUID groupId, final TenantContext context) {
         final InternalTenantContext internalTenantContext = internalCallContextFactory.createInternalTenantContext(accountId, context);
-        final List<InvoiceModelDao> invoicesByAccount = dao.getInvoicesByGroup(groupId, internalTenantContext);
+        final List<InvoiceModelDao> invoicesByAccount = dao.getInvoicesByGroup(groupId, true, internalTenantContext);
         return fromInvoiceModelDao(invoicesByAccount, getCatalogSafelyForPrettyNames(internalTenantContext));
     }
 
@@ -251,7 +251,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     public Invoice getInvoiceByNumber(final Integer number, final TenantContext context) throws InvoiceApiException {
         // The account record id will be populated in the DAO
         final InternalTenantContext internalTenantContextWithoutAccountRecordId = internalCallContextFactory.createInternalTenantContextWithoutAccountRecordId(context);
-        final InvoiceModelDao invoice = dao.getByNumber(number, true, internalTenantContextWithoutAccountRecordId);
+        final InvoiceModelDao invoice = dao.getByNumber(number, true, true, internalTenantContextWithoutAccountRecordId);
 
         final InternalTenantContext internalTenantContext = internalCallContextFactory.createInternalTenantContext(invoice.getAccountId(), context);
         return new DefaultInvoice(invoice, getCatalogSafelyForPrettyNames(internalTenantContext));
@@ -260,7 +260,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     @Override
     public Invoice getInvoiceByInvoiceItem(final UUID invoiceItemId, final TenantContext context) throws InvoiceApiException {
         final InternalTenantContext internalTenantContextWithoutAccountRecordId = internalCallContextFactory.createInternalTenantContextWithoutAccountRecordId(context);
-        final InvoiceModelDao invoice = dao.getByInvoiceItem(invoiceItemId, internalTenantContextWithoutAccountRecordId);
+        final InvoiceModelDao invoice = dao.getByInvoiceItem(invoiceItemId, true, internalTenantContextWithoutAccountRecordId);
 
         final InternalTenantContext internalTenantContext = internalCallContextFactory.createInternalTenantContext(invoice.getAccountId(), context);
         return new DefaultInvoice(invoice, getCatalogSafelyForPrettyNames(internalTenantContext));

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -151,7 +151,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
         final InternalTenantContext internalTenantContext = internalCallContextFactory.createInternalTenantContext(accountId, context);
         final List<InvoiceModelDao> invoicesByAccount = includesMigrated ?
                                                         dao.getAllInvoicesByAccount(includeVoidedInvoices, includeInvoiceComponents, internalTenantContext) :
-                                                        dao.getInvoicesByAccount(includeVoidedInvoices, includeInvoiceComponents, internalTenantContext);
+                                                        dao.getInvoicesByAccount(includeVoidedInvoices, includeInvoiceComponents, true, internalTenantContext);
 
         return fromInvoiceModelDao(invoicesByAccount, getCatalogSafelyForPrettyNames(internalTenantContext));
     }
@@ -159,7 +159,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     @Override
     public List<Invoice> getInvoicesByAccount(final UUID accountId, final LocalDate fromDate, final LocalDate upToDate, final boolean includeVoidedInvoices, final boolean includeInvoiceComponents, final TenantContext context) {
         final InternalTenantContext internalTenantContext = internalCallContextFactory.createInternalTenantContext(accountId, context);
-        final List<InvoiceModelDao> invoicesByAccount = dao.getInvoicesByAccount(includeVoidedInvoices, fromDate, upToDate, includeInvoiceComponents, internalTenantContext);
+        final List<InvoiceModelDao> invoicesByAccount = dao.getInvoicesByAccount(includeVoidedInvoices, fromDate, upToDate, includeInvoiceComponents, true, internalTenantContext);
         return fromInvoiceModelDao(invoicesByAccount, getCatalogSafelyForPrettyNames(internalTenantContext));
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -167,7 +167,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     }
 
     @Override
-    public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final Boolean includeInvoiceComponents, final InternalTenantContext context) {
+    public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final Boolean includeInvoiceComponents, final Boolean includeTrackingIds, final InternalTenantContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
         return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
@@ -180,7 +180,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                                                             .collect(Collectors.toUnmodifiableList());
 
             if (includeInvoiceComponents) {
-                invoiceDaoHelper.populateChildren(invoices, invoicesTags, false, true, entitySqlDaoWrapperFactory, context);
+                invoiceDaoHelper.populateChildren(invoices, invoicesTags, false, includeTrackingIds, entitySqlDaoWrapperFactory, context);
             }
 
             return invoices;
@@ -194,14 +194,14 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
     }
 
     @Override
-    public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final LocalDate fromDate, final LocalDate upToDate, final Boolean includeInvoiceComponents, final InternalTenantContext context) {
+    public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final LocalDate fromDate, final LocalDate upToDate, final Boolean includeInvoiceComponents, final Boolean includeTrackingIds, final InternalTenantContext context) {
         final List<Tag> invoicesTags = getInvoicesTags(context);
 
         return transactionalSqlDao.execute(true, entitySqlDaoWrapperFactory -> {
             final InvoiceSqlDao invoiceDao = entitySqlDaoWrapperFactory.become(InvoiceSqlDao.class);
             final List<InvoiceModelDao> invoices = getAllNonMigratedInvoicesByAccountAfterDate(includeVoidedInvoices, invoiceDao, fromDate, upToDate, context);
             if (includeInvoiceComponents) {
-                invoiceDaoHelper.populateChildren(invoices, invoicesTags, false, true, entitySqlDaoWrapperFactory, context);
+                invoiceDaoHelper.populateChildren(invoices, invoicesTags, false, includeTrackingIds, entitySqlDaoWrapperFactory, context);
             }
 
             return invoices;

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
@@ -67,9 +67,9 @@ public interface InvoiceDao extends EntityDao<InvoiceModelDao, Invoice, InvoiceA
 
     public List<InvoiceModelDao> getInvoicesByGroup(UUID groupId, Boolean includeTrackingIds, InternalTenantContext context);
 
-    List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final Boolean includeInvoiceComponents, InternalTenantContext context);
+    List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final Boolean includeInvoiceComponents, final Boolean includeTrackingIds, InternalTenantContext context);
 
-    List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, LocalDate fromDate, LocalDate upToDate, final Boolean includeInvoiceComponents, InternalTenantContext context);
+    List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, LocalDate fromDate, LocalDate upToDate, final Boolean includeInvoiceComponents, final Boolean includeTrackingIds, InternalTenantContext context);
 
     Pagination<InvoiceModelDao> searchInvoices(String searchKey, Long offset, Long limit, InternalTenantContext context);
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
@@ -61,11 +61,11 @@ public interface InvoiceDao extends EntityDao<InvoiceModelDao, Invoice, InvoiceA
 
     void rescheduleInvoiceNotification(final UUID accountId, final DateTime nextRescheduleDt, final InternalCallContext context);
 
-    InvoiceModelDao getByNumber(Integer number, Boolean includeInvoiceComponents, InternalTenantContext context) throws InvoiceApiException;
+    InvoiceModelDao getByNumber(Integer number, Boolean includeInvoiceComponents, Boolean includeTrackingIds, InternalTenantContext context) throws InvoiceApiException;
 
-    InvoiceModelDao getByInvoiceItem(final UUID uuid, final InternalTenantContext context) throws InvoiceApiException;
+    InvoiceModelDao getByInvoiceItem(final UUID uuid, Boolean includeTrackingIds, final InternalTenantContext context) throws InvoiceApiException;
 
-    public List<InvoiceModelDao> getInvoicesByGroup(UUID groupId, InternalTenantContext context);
+    public List<InvoiceModelDao> getInvoicesByGroup(UUID groupId, Boolean includeTrackingIds, InternalTenantContext context);
 
     List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final Boolean includeInvoiceComponents, InternalTenantContext context);
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerExp.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerExp.java
@@ -80,7 +80,7 @@ public class InvoiceOptimizerExp extends InvoiceOptimizerBase {
         //
         final LocalDate beCutoffDt = isMaxInvoiceLimitSet ? cutoffDt.minus(maxInvoiceLimit) : null;
         final List<Invoice> existingInvoices = new LinkedList<Invoice>();
-        final List<InvoiceModelDao> invoicesByAccount = invoiceDao.getInvoicesByAccount(false, cutoffDt, null, true, callContext);
+        final List<InvoiceModelDao> invoicesByAccount = invoiceDao.getInvoicesByAccount(false, cutoffDt, null, true, false, callContext); //TODO_1952 - non API call, so passing includeTrackingIds=false. Revisit
         for (final InvoiceModelDao invoiceModelDao : invoicesByAccount) {
             existingInvoices.add(new DefaultInvoice(invoiceModelDao));
         }

--- a/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerNoop.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/optimizer/InvoiceOptimizerNoop.java
@@ -53,7 +53,7 @@ public class InvoiceOptimizerNoop extends InvoiceOptimizerBase {
 
         logDisabledFeatureIfNeeded(callContext);
         final List<Invoice> existingInvoices = new LinkedList<Invoice>();
-        final List<InvoiceModelDao> invoicesByAccount = invoiceDao.getInvoicesByAccount(false, true, callContext);
+        final List<InvoiceModelDao> invoicesByAccount = invoiceDao.getInvoicesByAccount(false, true, false, callContext); //TODO_1952 - non API call, so passing includeTrackingIds=false. Revisit
         for (final InvoiceModelDao invoiceModelDao : invoicesByAccount) {
             existingInvoices.add(new DefaultInvoice(invoiceModelDao));
         }

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcher.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcher.java
@@ -111,19 +111,19 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
 
         Invoice invoice = processAccountFromNotificationOrBusEventAndAssertResult(accountId, target, new DryRunFutureDateArguments(), false, context);
 
-        List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, true, context);
+        List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, true, true, context);
         Assert.assertEquals(invoices.size(), 0);
 
         // Try it again to double check
         invoice = processAccountFromNotificationOrBusEventAndAssertResult(accountId, target, new DryRunFutureDateArguments(), false, context);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, true, true, context);
         Assert.assertEquals(invoices.size(), 0);
 
         // This time no dry run
         invoice = processAccountFromNotificationOrBusEventAndAssertResult(accountId, target, null, false, context);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, true, true, context);
         Assert.assertEquals(invoices.size(), 1);
     }
 
@@ -207,7 +207,7 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
             Assert.assertTrue(e.getCause().getMessage().startsWith("Double billing detected"));
         }
         // Dry-run: no side effect on disk
-        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, context).size(), 1);
+        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, true,context).size(), 1);
         Assert.assertTrue(tagUserApi.getTagsForAccount(accountId, true, callContext).isEmpty());
 
         try {
@@ -217,7 +217,7 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
             Assert.assertEquals(e.getCode(), ErrorCode.UNEXPECTED_ERROR.getCode());
             Assert.assertTrue(e.getCause().getMessage().startsWith("Double billing detected"));
         }
-        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, context).size(), 1);
+        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, true,context).size(), 1);
         // No dry-run: account is parked
         final List<Tag> tags = tagUserApi.getTagsForAccount(accountId, false, callContext);
         Assert.assertEquals(tags.size(), 1);
@@ -236,7 +236,7 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
             Assert.assertTrue(e.getCause().getMessage().startsWith("Double billing detected"));
         }
         // Idempotency
-        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, context).size(), 1);
+        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, true, context).size(), 1);
         Assert.assertEquals(tagUserApi.getTagsForAccount(accountId, false, callContext), tags);
 
         // Fix state
@@ -256,14 +256,14 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
         // Dry-run and isApiCall=true: call goes through
         final List<Invoice> invoices1 = dispatcher.processAccount(true, accountId, target, new DryRunFutureDateArguments(), false, false, Collections.emptyList(), context);
         Assert.assertFalse(invoices1.isEmpty());
-        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, context).size(), 0);
+        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, true, context).size(), 0);
         // Dry-run: still parked
         Assert.assertEquals(tagUserApi.getTagsForAccount(accountId, false, callContext).size(), 1);
 
         // No dry-run and isApiCall=true: call goes through
         final List<Invoice> invoice2s = dispatcher.processAccount(true, accountId, target, null, false, false, Collections.emptyList(), context);
         Assert.assertFalse(invoice2s.isEmpty());
-        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, context).size(), 1);
+        Assert.assertEquals(invoiceDao.getInvoicesByAccount(false, true, true, context).size(), 1);
         // No dry-run: now unparked
         Assert.assertEquals(tagUserApi.getTagsForAccount(accountId, false, callContext).size(), 0);
         Assert.assertEquals(tagUserApi.getTagsForAccount(accountId, true, callContext).size(), 1);

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceHelper.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceHelper.java
@@ -221,13 +221,13 @@ public class TestInvoiceHelper {
         Invoice invoice = generateInvoice(account.getId(), targetDate, new DryRunFutureDateArguments(), context);
         Assert.assertNotNull(invoice);
 
-        List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, true, context);
+        List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, true, true,context);
         Assert.assertEquals(invoices.size(), 0);
 
         invoice = generateInvoice(account.getId(), targetDate, null, context);
         Assert.assertNotNull(invoice);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, true, true,context);
         Assert.assertEquals(invoices.size(), 1);
 
         return invoice.getId();

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
@@ -142,7 +142,7 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
     }
 
     @Override
-    public InvoiceModelDao getByNumber(final Integer number, final Boolean includeInvoiceChildren, final InternalTenantContext context) {
+    public InvoiceModelDao getByNumber(final Integer number, final Boolean includeInvoiceChildren, final Boolean includeTrackingIds, final InternalTenantContext context) {
         synchronized (monitor) {
             for (final InvoiceModelDao invoice : invoices.values()) {
                 if (invoice.getInvoiceNumber().equals(number)) {
@@ -155,13 +155,13 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
     }
 
     @Override
-    public InvoiceModelDao getByInvoiceItem(final UUID invoiceItemId, final InternalTenantContext context) throws InvoiceApiException {
+    public InvoiceModelDao getByInvoiceItem(final UUID invoiceItemId, final Boolean includeTrackingIds, final InternalTenantContext context) throws InvoiceApiException {
         final InvoiceItemModelDao item = items.get(invoiceItemId);
         return (item != null) ? invoices.get(item.getInvoiceId()) : null;
     }
 
     @Override
-    public List<InvoiceModelDao> getInvoicesByGroup(final UUID groupId, final InternalTenantContext context) {
+    public List<InvoiceModelDao> getInvoicesByGroup(final UUID groupId, final Boolean includeTrackingIds, final InternalTenantContext context) {
         return null;
     }
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
@@ -173,7 +173,7 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
     }
 
     @Override
-    public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final Boolean includeInvoiceComponents, final InternalTenantContext context) {
+    public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final Boolean includeInvoiceComponents, final Boolean includeTrackingIds, final InternalTenantContext context) {
         final List<InvoiceModelDao> result = new ArrayList<InvoiceModelDao>();
 
         synchronized (monitor) {
@@ -191,7 +191,7 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
     }
 
     @Override
-    public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final LocalDate fromDate, final LocalDate upToDate, final Boolean includeInvoiceComponents, final InternalTenantContext context) {
+    public List<InvoiceModelDao> getInvoicesByAccount(final Boolean includeVoidedInvoices, final LocalDate fromDate, final LocalDate upToDate, final Boolean includeInvoiceComponents, final Boolean includeTrackingIds, final InternalTenantContext context) {
         final List<InvoiceModelDao> invoicesForAccount = new ArrayList<>();
         synchronized (monitor) {
             final UUID accountId = getAccountIdByRecordId(context.getAccountRecordId());

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDao.java
@@ -196,7 +196,7 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         final BigDecimal amount = BigDecimal.TEN;
         final Invoice createdInvoice = createAndGetInvoiceWithInvoiceItem(clock.getUTCToday(), clock.getUTCToday(), amount);
 
-        List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, true, context);
+        List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, true, true, context);
         assertNotNull(invoices);
         assertEquals(invoices.size(), 1);
         InvoiceModelDao thisInvoice = invoices.get(0);
@@ -207,7 +207,7 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         assertEquals(InvoiceModelDaoHelper.getRawBalanceForRegularInvoice(thisInvoice).compareTo(amount), 0);
 
         //without invoice components
-        invoices = invoiceDao.getInvoicesByAccount(false, false, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, false, true, context);
         assertNotNull(invoices);
         assertEquals(invoices.size(), 1);
         thisInvoice = invoices.get(0);
@@ -255,7 +255,7 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         // although labeled "invoice5", the clock use "minusDays(3)", so in assertion, this should be in 2nd element.
         final Invoice invoice5 = createAndGetInvoice(clock.getUTCToday().minusDays(3), clock.getUTCToday().minusDays(3));
 
-        final List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, true, context);
+        final List<InvoiceModelDao> invoices = invoiceDao.getInvoicesByAccount(false, true, true, context);
 
         assertNotNull(invoices);
         assertEquals(invoices.size(), 5);
@@ -375,19 +375,19 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         invoiceUtil.createInvoice(invoice2, context);
 
         List<InvoiceModelDao> invoices;
-        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 1, 1), null, true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 1, 1), null, true, true, context);
         assertEquals(invoices.size(), 2);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 10, 6), null, true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 10, 6), null, true, true, context);
         assertEquals(invoices.size(), 2);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 10, 11), null, true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 10, 11), null, true, true, context);
         assertEquals(invoices.size(), 1);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 12, 6), null, true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 12, 6), null, true, true, context);
         assertEquals(invoices.size(), 1);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2012, 1, 1), null, true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, new LocalDate(2012, 1, 1), null, true, true, context);
         assertEquals(invoices.size(), 0);
     }
 
@@ -403,13 +403,13 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         invoiceUtil.createInvoice(invoice2, context);
 
         List<InvoiceModelDao> invoices;
-        invoices = invoiceDao.getInvoicesByAccount(false, null, new LocalDate(2011, 12, 7), true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, null, new LocalDate(2011, 12, 7), true, true, context);
         assertEquals(invoices.size(), 2);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, null, new LocalDate(2011, 12, 5), true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, null, new LocalDate(2011, 12, 5), true, true, context);
         assertEquals(invoices.size(), 1);
 
-        invoices = invoiceDao.getInvoicesByAccount(false, null, new LocalDate(2011, 10, 5), true, context);
+        invoices = invoiceDao.getInvoicesByAccount(false, null, new LocalDate(2011, 10, 5), true, true, context);
         assertEquals(invoices.size(), 0);
 
     }
@@ -1077,13 +1077,13 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         invoices = invoiceDao.getUnpaidInvoicesByAccountId(accountId, null, upToDate, context);
         assertEquals(invoices.size(), 1);
 
-        List<InvoiceModelDao> allInvoicesByAccount = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 1, 1), null, true, context);
+        List<InvoiceModelDao> allInvoicesByAccount = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 1, 1), null, true, true, context);
         assertEquals(allInvoicesByAccount.size(), 1);
 
         // insert DRAFT invoice
         createCredit(accountId, new LocalDate(2011, 12, 31), BigDecimal.TEN, true);
 
-        allInvoicesByAccount = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 1, 1), null, true, context);
+        allInvoicesByAccount = invoiceDao.getInvoicesByAccount(false, new LocalDate(2011, 1, 1), null, true, true, context);
         assertEquals(allInvoicesByAccount.size(), 2);
         assertEquals(allInvoicesByAccount.get(0).getStatus(), InvoiceStatus.COMMITTED);
         assertEquals(allInvoicesByAccount.get(1).getStatus(), InvoiceStatus.DRAFT);
@@ -1858,14 +1858,14 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         assertNotNull(invoiceFromDB.getTrackingIds());
         assertEquals(invoiceFromDB.getTrackingIds().size(), 1);
 
-        invoicesFromDB = invoiceDao.getInvoicesByAccount(true, true, context);
+        invoicesFromDB = invoiceDao.getInvoicesByAccount(true, true, true, context);
         assertNotNull(invoicesFromDB);
         assertEquals(invoicesFromDB.size(), 1);
         invoiceFromDB = invoicesFromDB.get(0);
         assertNotNull(invoiceFromDB.getTrackingIds());
         assertEquals(invoiceFromDB.getTrackingIds().size(), 1);
 
-        invoicesFromDB = invoiceDao.getInvoicesByAccount(true, null, null, true, context);
+        invoicesFromDB = invoiceDao.getInvoicesByAccount(true, null, null, true, true, context);
         assertNotNull(invoicesFromDB);
         assertEquals(invoicesFromDB.size(), 1);
         invoiceFromDB = invoicesFromDB.get(0);

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/TestInvoiceDao.java
@@ -114,7 +114,7 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
 
         final InvoiceModelDao retrievedInvoice = invoiceDao.getById(invoice.getId(), context);
         invoiceUtil.checkInvoicesEqual(retrievedInvoice, invoice);
-        invoiceUtil.checkInvoicesEqual(invoiceDao.getByNumber(retrievedInvoice.getInvoiceNumber(), true, context), invoice);
+        invoiceUtil.checkInvoicesEqual(invoiceDao.getByNumber(retrievedInvoice.getInvoiceNumber(), true, true, context), invoice);
     }
 
     @Test(groups = "slow")
@@ -318,14 +318,14 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         }
 
         try {
-            invoiceDao.getByNumber(null, true, context);
+            invoiceDao.getByNumber(null, true, true, context);
             Assert.fail();
         } catch (InvoiceApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.INVOICE_INVALID_NUMBER.getCode());
         }
 
         try {
-            invoiceDao.getByNumber(Integer.MIN_VALUE, true, context);
+            invoiceDao.getByNumber(Integer.MIN_VALUE, true, true, context);
             Assert.fail();
         } catch (InvoiceApiException e) {
             Assert.assertEquals(e.getCode(), ErrorCode.INVOICE_NUMBER_NOT_FOUND.getCode());
@@ -1777,7 +1777,7 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
                                                                              BigDecimal.ONE, BigDecimal.ONE, Currency.USD);
         invoiceUtil.createInvoiceItem(recurringItem1, context);
 
-        final InvoiceModelDao targetInvoice = invoiceDao.getByInvoiceItem(recurringItem1.getId(), internalCallContext);
+        final InvoiceModelDao targetInvoice = invoiceDao.getByInvoiceItem(recurringItem1.getId(), true, internalCallContext);
         assertNotNull(targetInvoice);
         assertEquals(targetInvoice.getId(), invoiceId1);
         assertEquals(targetInvoice.getInvoiceItems().size(), 1);
@@ -1843,11 +1843,11 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         assertNotNull(invoiceFromDB.getTrackingIds());
         assertEquals(invoiceFromDB.getTrackingIds().size(), 1);
 
-        invoiceFromDB = invoiceDao.getByNumber(invoiceFromDB.getInvoiceNumber(), true, context);
+        invoiceFromDB = invoiceDao.getByNumber(invoiceFromDB.getInvoiceNumber(), true, true, context);
         assertNotNull(invoiceFromDB.getTrackingIds());
         assertEquals(invoiceFromDB.getTrackingIds().size(), 1);
 
-        invoiceFromDB = invoiceDao.getByInvoiceItem(invoiceItem.getId(), context);
+        invoiceFromDB = invoiceDao.getByInvoiceItem(invoiceItem.getId(), true, context);
         assertNotNull(invoiceFromDB.getTrackingIds());
         assertEquals(invoiceFromDB.getTrackingIds().size(), 1);
 
@@ -1872,7 +1872,7 @@ public class TestInvoiceDao extends InvoiceTestSuiteWithEmbeddedDB {
         assertNotNull(invoiceFromDB.getTrackingIds());
         assertEquals(invoiceFromDB.getTrackingIds().size(), 1);
 
-        invoicesFromDB = invoiceDao.getInvoicesByGroup(invoiceFromDB.getGrpId(), context);
+        invoicesFromDB = invoiceDao.getInvoicesByGroup(invoiceFromDB.getGrpId(), true, context);
         assertNotNull(invoicesFromDB);
         assertEquals(invoicesFromDB.size(), 1);
         invoiceFromDB = invoicesFromDB.get(0);


### PR DESCRIPTION
Round 2 changes:

- `includeTrackingIds` flag added to `getByNumber`, `getByBroup`, `getByInvoiceItem` DAO methods
-  `includeTrackingIds` flag added to `getInvoicesByAccount` DAO methods