### PR TITLE
Work for 1739 change alignment fix

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestAddonChangeAlignment.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestAddonChangeAlignment.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2020-2024 Equinix, Inc
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Subscription;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestAddonChangeAlignment extends TestIntegrationBase {
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<>(extraProperties);
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testAddonChangeAlignment");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentStartOfBundleEOTChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2024-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAO-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with start of bundle alignment on 2023-08-15 - change will not happen immediately
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOStartOfBundle-monthly");
+        addonSub.changePlan(new DefaultEntitlementSpecifier(newAddOnSpec), Collections.emptyList(), callContext);
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is still 2023-08-31 as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //move clock to 2023-08-31 - Phase change for BASE, ADDON plan CHANGE takes effect
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        //Both BASE and ADDON CTD set to 2023-09-01 - Noy sure if this is correct
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        // TEST fails here, ADDON CTD is 2023-09-04, I would expect it to be 2023-08-31 since START_OF_BUNDLE is used
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+    }
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentStartOfBundleImmediateChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2024-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAO-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with start of bundle alignment with requestedDate=2023-08-15 - change will happen immediately
+        busHandler.pushExpectedEvents(NextEvent.CHANGE, NextEvent.INVOICE);
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOStartOfBundle-monthly");
+        addonSub.changePlanWithDate(new DefaultEntitlementSpecifier(newAddOnSpec), clock.getUTCToday(), Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        // TEST fails here, ADDON CTD is 2023-09-04, I would expect it to be 2023-08-31 since START_OF_BUNDLE is used
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+    }
+
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentStartOfSubscriptionEOTChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2024-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAO-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with start of subscription alignment on 2023-08-15 - change will not happen immediately
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOStartOfSubscription-monthly");
+        addonSub.changePlan(new DefaultEntitlementSpecifier(newAddOnSpec), Collections.emptyList(), callContext);
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is still 2023-08-31 as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //move clock to 2023-08-31 - PHASE change for BASE, Plan CHANGE for ADDON
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        //Base CTD is 2023-09-01 - Not sure if this is correct
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        //ADDON CTD is 2023-09-04 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 4));
+
+    }
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentStartOfSubscriptionImmediateChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2024-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAO-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with start of subscription alignment with requestedDate=2023-08-15 - change will happen immediately
+        busHandler.pushExpectedEvents(NextEvent.CHANGE, NextEvent.INVOICE);
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOStartOfSubscription-monthly");
+        addonSub.changePlanWithDate(new DefaultEntitlementSpecifier(newAddOnSpec), clock.getUTCToday(), Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is 2023-09-04 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 4));
+
+        //move clock to 2023-08-31 - PHASE change for BASE
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT); //Need another NextEvent.PHASE for ADDON??
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        //Base CTD is 2023-09-01 - Not sure if this is correct
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        //ADDON CTD is 2023-09-04 - Not sure if this is correct
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 4));
+
+    }
+
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentChangeOfPlanEOTChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2024-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAO-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with change of plan alignment on 2023-08-15 - change will not happen immediately
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOChangeOfPlan-monthly");
+        addonSub.changePlan(new DefaultEntitlementSpecifier(newAddOnSpec), Collections.emptyList(), callContext);
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is still 2023-08-31 as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //move clock to 2023-08-31 - PHASE change for BASE, Plan CHANGE for ADDON
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        //Base CTD is 2023-09-01 - Not sure if this is correct
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        //ADDON CTD is 2023-09-30 - as expected (although CHANGE_OF_PLAN is used, the plan change takes effect at END_OF_TERM that is on 2023-08-31, hence ADDON CTD is 2023-09-30)
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 30));
+
+    }
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentChangeOfPlanImmediateChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2024-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAO-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with change of plan alignment with requestedDate=2023-08-15 - change will happen immediately
+        busHandler.pushExpectedEvents(NextEvent.CHANGE, NextEvent.INVOICE);
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOChangeOfPlan-monthly");
+        addonSub.changePlanWithDate(new DefaultEntitlementSpecifier(newAddOnSpec), clock.getUTCToday(), Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is still 2023-09-14 as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 14));
+
+        //move clock to 2023-08-31 - PHASE change for BASE
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT); //Need another NextEvent.PHASE for ADDON??
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        //Base CTD is 2023-09-01 - Not sure if this is correct
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        //ADDON CTD is 2023-09-14 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 14));
+
+    }
+
+
+
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestAddonChangeAlignment.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestAddonChangeAlignment.java
@@ -89,7 +89,7 @@ public class TestAddonChangeAlignment extends TestIntegrationBase {
         clock.setDay(new LocalDate(2023, 8, 31));
         assertListenerStatus();
 
-        //Both BASE and ADDON CTD set to 2023-09-01 - Noy sure if this is correct
+        // BASE CTD set to 2023-09-01 - Not sure if this is correct, shouldn't it be 2023-08-31??
         baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
         Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
 
@@ -135,6 +135,10 @@ public class TestAddonChangeAlignment extends TestIntegrationBase {
         final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOStartOfBundle-monthly");
         addonSub.changePlanWithDate(new DefaultEntitlementSpecifier(newAddOnSpec), clock.getUTCToday(), Collections.emptyList(), callContext);
         assertListenerStatus();
+
+        // BASE CTD set to 2023-08-31 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
 
         // TEST fails here, ADDON CTD is 2023-09-04, I would expect it to be 2023-08-31 since START_OF_BUNDLE is used
         addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestAddonChangeAlignment.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestAddonChangeAlignment.java
@@ -92,7 +92,7 @@ public class TestAddonChangeAlignment extends TestIntegrationBase {
         addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
         Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
 
-        //move clock to 2023-08-31 - Phase change for BASE, plan CHANGE for ADDON takes effect
+        //move clock to 2023-08-31 - Phase change for BASE, plan/phase CHANGE for ADDON takes effect
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
         clock.setDay(new LocalDate(2023, 8, 31));
         assertListenerStatus();
@@ -101,17 +101,17 @@ public class TestAddonChangeAlignment extends TestIntegrationBase {
                                     new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 31), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("32.26")),
                                     new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 31), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("3.23")));
 
-        // BASE CTD set to 2023-09-01, shouldn't this be 2023-08-31 as in the case of the IMMEDIATE test below?
+        // BASE CTD set to 2023-09-01 as expected
         baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
         Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
 
-        // ADDON CTD set to 2023-09-01, shouldn't this be 2023-08-31 as in the case of the IMMEDIATE test below?
+        // ADDON CTD set to 2023-09-01 - as expected (START_OF_BUNDLE alignment is used, so phases of the new ADDON are aligned with the BUNDLE start date. Since BUNDLE is started on 8/1, new ADDON TRIAL phase starts on 8/1  and ends on 8/31. Recurring PHASE starts on 8/31 and user is charged upto 9/1 since BCD is 1)
         addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
         Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
 
-        //move clock to 2023-09-30 - invoice for base and addon
+        //move clock to 2023-09-01 - invoice for base and addon
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
-        clock.setDay(new LocalDate(2023, 9, 30));
+        clock.setDay(new LocalDate(2023, 9, 1));
         assertListenerStatus();
 
         invoiceChecker.checkInvoice(account.getId(), 4, callContext,
@@ -175,7 +175,7 @@ public class TestAddonChangeAlignment extends TestIntegrationBase {
         baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
         Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
 
-        // ADDON CTD set to 2023-08-31 - as expected
+        // ADDON CTD set to 2023-08-31 - as expected (START_OF_BUNDLE alignment is used, so phases of the new ADDON are aligned with the BUNDLE start date. Since BUNDLE is started on 8/1, new ADDON TRIAL phase starts on 8/1  and ends on 8/31)
         addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
         Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
 
@@ -195,9 +195,9 @@ public class TestAddonChangeAlignment extends TestIntegrationBase {
         addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
         Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
 
-        //move clock to 2023-09-30 - invoice for base and addon
+        //move clock to 2023-09-1 - invoice for base and addon
         busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
-        clock.setDay(new LocalDate(2023, 9, 30));
+        clock.setDay(new LocalDate(2023, 9, 1));
         assertListenerStatus();
 
         invoiceChecker.checkInvoice(account.getId(), 5, callContext,
@@ -213,4 +213,387 @@ public class TestAddonChangeAlignment extends TestIntegrationBase {
         addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
         Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
     }
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentStartOfSubscriptionEOTChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2023-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 1), new LocalDate(2023, 8, 31), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAOStartOfBundleDefault-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 5), new LocalDate(2023, 8, 31), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with START_OF_SUBSCRIPTION alignment on 2023-08-15 - change will not happen immediately
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOStartOfSubscription-monthly");
+        addonSub.changePlan(new DefaultEntitlementSpecifier(newAddOnSpec), Collections.emptyList(), callContext);
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is still 2023-08-31 as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //move clock to 2023-08-31 - PHASE change for BASE, Plan CHANGE FOR ADDON
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 31), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("32.26")),
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 31), new LocalDate(2023, 9, 4), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //Base CTD is 2023-09-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        //ADDON CTD is 2023-09-04 - as expected (START_OF_SUBSCRIPTION alignment is used, so phases of the new ADDON are aligned with the old ADDON start date. Since old ADDON is started on 8/5, new ADDON TRIAL phase starts on 8/5  and ends on 9/4)
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 4));
+
+        //move clock to 2023-09-01 - RECURRING invoice for base
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 9, 1));
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 4, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 1), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("1000")));
+
+        //Base CTD is 2023-10-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+        //ADDON CTD is still 2023-09-04 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 4));
+
+        // move clock to 2023-09-04  PHASE change for addon (since START_OF_SUBSCRIPTION change alignment is used)
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 9, 4));
+        assertListenerStatus();
+
+        //PRORATED invoice for ADDON since BCD is 1
+        invoiceChecker.checkInvoice(account.getId(), 5, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 4), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("135")));
+
+        //Base CTD is still 2023-10-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+        //ADDON CTD is 2023-10-01 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+    }
+
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentStartOfSubscriptionImmediateChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2023-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 1), new LocalDate(2023, 8, 31), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAOStartOfBundleDefault-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 5), new LocalDate(2023, 8, 31), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with START_OF_SUBSCRIPTION alignment with IMMEDIATE policy - change will happen immediately
+        busHandler.pushExpectedEvents(NextEvent.CHANGE, NextEvent.INVOICE);
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOStartOfSubscription-monthly");
+        addonSub.changePlanOverrideBillingPolicy(new DefaultEntitlementSpecifier(newAddOnSpec), null, BillingActionPolicy.IMMEDIATE, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 3, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 15), new LocalDate(2023, 9, 4), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is 2023-09-04 as expected (START_OF_SUBSCRIPTION alignment is used, so phases of the new ADDON are aligned with the old ADDON start date. Since old ADDON is started on 8/5, new ADDON TRIAL phase starts on 8/5  and ends on 9/4)
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 4));
+
+        //move clock to 2023-08-31 - PHASE change for BASE
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 4, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 31), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("32.26")));
+
+        //Base CTD is 2023-09-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        //ADDON CTD is still 2023-09-04 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 4));
+
+        //move clock to 2023-09-01 - RECURRING invoice for base
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 9, 1));
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 5, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 1), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("1000")));
+
+        //Base CTD is 2023-10-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+        //ADDON CTD is still 2023-09-04 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 4));
+
+        // move clock to 2023-09-04  PHASE change for addon (since START_OF_SUBSCRIPTION change alignment is used)
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 9, 4));
+        assertListenerStatus();
+
+        //PRORATED invoice for ADDON since BCD is 1
+        invoiceChecker.checkInvoice(account.getId(), 6, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 4), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("135")));
+
+        //Base CTD is still 2023-10-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+        //ADDON CTD is 2023-10-01 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+    }
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentChangeOfPlanEOTChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2023-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 1), new LocalDate(2023, 8, 31), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAOStartOfBundleDefault-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 5), new LocalDate(2023, 8, 31), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with CHANGE_OF_PLAN alignment on 2023-08-15 - change will not happen immediately
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOChangeOfPlan-monthly");
+        addonSub.changePlan(new DefaultEntitlementSpecifier(newAddOnSpec), Collections.emptyList(), callContext);
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is still 2023-08-31 as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //move clock to 2023-08-31 - PHASE change for BASE, Plan CHANGE FOR ADDON
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT, NextEvent.NULL_INVOICE);
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 3, callContext,
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 31), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("32.26")),
+                                    new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 31), new LocalDate(2023, 9, 30), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //Base CTD is 2023-09-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        //ADDON CTD is 2023-09-30 as expected (CHANGE_OF_PLAN alignment is used, so phases of the new ADDON phases are aligned with plan change date. Since the CHANGE is effective on 8/31, new ADDON TRIAL phase starts on 8/31  and ends on 9/30)
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 30));
+
+        //move clock to 2023-09-01 - RECURRING invoice for base
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 9, 1));
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 4, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 1), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("1000")));
+
+        //Base CTD is 2023-10-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+        //ADDON CTD is still 2023-09-30 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 30));
+
+        // move clock to 2023-09-30  PHASE change for addon (since CHANGE_OF_PLAN change alignment is used)
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 9, 30));
+        assertListenerStatus();
+
+        //PRORATED invoice for ADDON since BCD is 1
+        invoiceChecker.checkInvoice(account.getId(), 5, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 30), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("6.67")));
+
+        //Base CTD is still 2023-10-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+        //ADDON CTD is 2023-10-01 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+    }
+
+
+    @Test(groups = "slow")
+    public void testChangeAlignmentChangeOfPlanImmediateChange() throws Exception {
+        final LocalDate today = new LocalDate(2023, 8, 1);
+        clock.setDay(today);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        //create base 2023-08-01
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("basic-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID baseEntId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), null, null, null, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 1, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 1), new LocalDate(2023, 8, 31), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //Base CTD is 2023-08-31 as expected
+        Subscription baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 5));
+
+        //create addon 2023-08-05
+        final PlanPhaseSpecifier addonSpec = new PlanPhaseSpecifier("BasicAOStartOfBundleDefault-monthly");
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE);
+        final UUID addonEntId = entitlementApi.addEntitlement(baseSub.getBundleId(), new DefaultEntitlementSpecifier(addonSpec), null, null, false, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 2, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 5), new LocalDate(2023, 8, 31), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //ADDON CTD is 2023-08-31 as expected
+        Subscription addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        clock.setDay(new LocalDate(2023, 8, 15));
+
+        //change addon with CHANGE_OF_PLAN alignment with IMMEDIATE policy - change will happen immediately
+        busHandler.pushExpectedEvents(NextEvent.CHANGE, NextEvent.INVOICE);
+        final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOChangeOfPlan-monthly");
+        addonSub.changePlanOverrideBillingPolicy(new DefaultEntitlementSpecifier(newAddOnSpec), null, BillingActionPolicy.IMMEDIATE, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 3, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 15), new LocalDate(2023, 9, 14), InvoiceItemType.FIXED, BigDecimal.ZERO));
+
+        //Base CTD is still 2023-08-31 as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 8, 31));
+
+        //ADDON CTD is 2023-09-14 as expected (CHANGE_OF_PLAN alignment is used, so phases of the new ADDON are aligned with the plan change date. Since the CHANGE is effective on 8/15, new ADDON TRIAL phase starts on 8/15  and ends on 9/14))
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 14));
+
+        //move clock to 2023-08-31 - PHASE change for BASE
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 8, 31));
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 4, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 8, 31), new LocalDate(2023, 9, 1), InvoiceItemType.RECURRING, new BigDecimal("32.26")));
+
+        //Base CTD is 2023-09-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 9, 1));
+
+        //ADDON CTD is still 2023-09-14 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 14));
+
+        //move clock to 2023-09-01 - RECURRING invoice for base
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 9, 1));
+        assertListenerStatus();
+
+        invoiceChecker.checkInvoice(account.getId(), 5, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 1), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("1000")));
+
+        //Base CTD is 2023-10-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+        //ADDON CTD is still 2023-09-14 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 9, 14));
+
+        // move clock to 2023-09-14  PHASE change for addon (since CHANGE_OF_PLAN change alignment is used)
+        busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        clock.setDay(new LocalDate(2023, 9, 14));
+        assertListenerStatus();
+
+        //PRORATED invoice for ADDON since BCD is 1
+        invoiceChecker.checkInvoice(account.getId(), 6, callContext, new ExpectedInvoiceItemCheck(new LocalDate(2023, 9, 14), new LocalDate(2023, 10, 1), InvoiceItemType.RECURRING, new BigDecimal("113.33")));
+
+        //Base CTD is still 2023-10-01 - as expected
+        baseSub = subscriptionApi.getSubscriptionForEntitlementId(baseEntId, false, callContext);
+        Assert.assertEquals(baseSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+        //ADDON CTD is 2023-10-01 - as expected
+        addonSub = subscriptionApi.getSubscriptionForEntitlementId(addonEntId, false, callContext);
+        Assert.assertEquals(addonSub.getChargedThroughDate(), new LocalDate(2023, 10, 1));
+    }
+
 }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestAddonChangeAlignment.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestAddonChangeAlignment.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.entitlement.api.DefaultEntitlementSpecifier;
 import org.killbill.billing.entitlement.api.Subscription;
@@ -133,7 +134,8 @@ public class TestAddonChangeAlignment extends TestIntegrationBase {
         //change addon with start of bundle alignment with requestedDate=2023-08-15 - change will happen immediately
         busHandler.pushExpectedEvents(NextEvent.CHANGE, NextEvent.INVOICE);
         final PlanPhaseSpecifier newAddOnSpec = new PlanPhaseSpecifier("BasicAOStartOfBundle-monthly");
-        addonSub.changePlanWithDate(new DefaultEntitlementSpecifier(newAddOnSpec), clock.getUTCToday(), Collections.emptyList(), callContext);
+        //addonSub.changePlanWithDate(new DefaultEntitlementSpecifier(newAddOnSpec), clock.getUTCToday(), Collections.emptyList(), callContext);
+        addonSub.changePlanOverrideBillingPolicy(new DefaultEntitlementSpecifier(newAddOnSpec), null, BillingActionPolicy.IMMEDIATE, Collections.emptyList(), callContext);
         assertListenerStatus();
 
         // BASE CTD set to 2023-08-31 - as expected

--- a/beatrix/src/test/resources/catalogs/testAddonChangeAlignment/catalog-change-alignment.xml
+++ b/beatrix/src/test/resources/catalogs/testAddonChangeAlignment/catalog-change-alignment.xml
@@ -32,17 +32,17 @@
     <product name="Basic">
       <category>BASE</category>
       <available>
-        <addonProduct>BasicAO</addonProduct>
-        <addonProduct>BasicAOStartOfBundle</addonProduct>
+        <addonProduct>BasicAOStartOfBundleDefault</addonProduct>
+        <addonProduct>BasicAOStartOfBundleCustom</addonProduct>
         <addonProduct>BasicAOStartOfSubscription</addonProduct>
         <addonProduct>BasicAOChangeOfPlan</addonProduct>
         <addonProduct>BasicAOChangeOfPricelist</addonProduct>
       </available>
     </product>
-    <product name="BasicAO">
+    <product name="BasicAOStartOfBundleDefault">
       <category>ADD_ON</category>
     </product>
-    <product name="BasicAOStartOfBundle">
+    <product name="BasicAOStartOfBundleCustom">
       <category>ADD_ON</category>
     </product>
     <product name="BasicAOStartOfSubscription">
@@ -65,7 +65,7 @@
 
     <changeAlignment>
       <changeAlignmentCase>
-        <toProduct>BasicAOStartOfBundle</toProduct>
+        <toProduct>BasicAOStartOfBundleCustom</toProduct>
         <alignment>START_OF_BUNDLE</alignment>
       </changeAlignmentCase>
       <changeAlignmentCase>
@@ -90,9 +90,9 @@
         <productCategory>BASE</productCategory>
         <policy>END_OF_TERM</policy>
       </cancelPolicyCase>
-        <cancelPolicyCase>
-            <policy>IMMEDIATE</policy>
-        </cancelPolicyCase>
+      <cancelPolicyCase>
+        <policy>IMMEDIATE</policy>
+      </cancelPolicyCase>
     </cancelPolicy>
 
     <createAlignment>
@@ -145,8 +145,8 @@
         </recurring>
       </finalPhase>
     </plan>
-    <plan name="BasicAO-monthly">
-      <product>BasicAO</product>
+    <plan name="BasicAOStartOfBundleDefault-monthly">
+      <product>BasicAOStartOfBundleDefault</product>
       <initialPhases>
         <phase type="TRIAL">
           <duration>
@@ -175,8 +175,8 @@
         </recurring>
       </finalPhase>
     </plan>
-    <plan name="BasicAOStartOfBundle-monthly">
-      <product>BasicAOStartOfBundle</product>
+    <plan name="BasicAOStartOfBundleCustom-monthly">
+      <product>BasicAOStartOfBundleCustom</product>
       <initialPhases>
         <phase type="TRIAL">
           <duration>
@@ -300,8 +300,8 @@
     <defaultPriceList name="DEFAULT">
       <plans>
         <plan>basic-monthly</plan>
-        <plan>BasicAO-monthly</plan>
-        <plan>BasicAOStartOfBundle-monthly</plan>
+        <plan>BasicAOStartOfBundleDefault-monthly</plan>
+        <plan>BasicAOStartOfBundleCustom-monthly</plan>
         <plan>BasicAOStartOfSubscription-monthly</plan>
         <plan>BasicAOChangeOfPlan-monthly</plan>
         <plan>BasicAOChangeOfPricelist-monthly</plan>

--- a/beatrix/src/test/resources/catalogs/testAddonChangeAlignment/catalog-change-alignment.xml
+++ b/beatrix/src/test/resources/catalogs/testAddonChangeAlignment/catalog-change-alignment.xml
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2010-2013 Ning, Inc.
+  ~
+  ~ Ning licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="CatalogSchema.xsd ">
+
+  <!-- Effective after the v1 -->
+  <effectiveDate>2013-02-08T00:00:01+00:00</effectiveDate>
+  <catalogName>Movies</catalogName>
+
+  <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+  <currencies>
+    <currency>USD</currency>
+  </currencies>
+
+  <products>
+    <product name="Basic">
+      <category>BASE</category>
+      <available>
+        <addonProduct>BasicAO</addonProduct>
+        <addonProduct>BasicAOStartOfBundle</addonProduct>
+        <addonProduct>BasicAOStartOfSubscription</addonProduct>
+        <addonProduct>BasicAOChangeOfPlan</addonProduct>
+        <addonProduct>BasicAOChangeOfPricelist</addonProduct>
+      </available>
+    </product>
+    <product name="BasicAO">
+      <category>ADD_ON</category>
+    </product>
+    <product name="BasicAOStartOfBundle">
+      <category>ADD_ON</category>
+    </product>
+    <product name="BasicAOStartOfSubscription">
+      <category>ADD_ON</category>
+    </product>
+    <product name="BasicAOChangeOfPlan">
+      <category>ADD_ON</category>
+    </product>
+    <product name="BasicAOChangeOfPricelist">
+      <category>ADD_ON</category>
+    </product>
+  </products>
+
+  <rules>
+    <changePolicy>
+      <changePolicyCase>
+        <policy>END_OF_TERM</policy>
+      </changePolicyCase>
+    </changePolicy>
+
+    <changeAlignment>
+      <changeAlignmentCase>
+        <toProduct>BasicAOStartOfBundle</toProduct>
+        <alignment>START_OF_BUNDLE</alignment>
+      </changeAlignmentCase>
+      <changeAlignmentCase>
+        <toProduct>BasicAOStartOfSubscription</toProduct>
+        <alignment>START_OF_SUBSCRIPTION</alignment>
+      </changeAlignmentCase>
+      <changeAlignmentCase>
+        <toProduct>BasicAOChangeOfPlan</toProduct>
+        <alignment>CHANGE_OF_PLAN</alignment>
+      </changeAlignmentCase>
+      <changeAlignmentCase>
+        <toProduct>BasicAOChangeOfPricelist</toProduct>
+        <alignment>CHANGE_OF_PRICELIST</alignment>
+      </changeAlignmentCase>
+      <changeAlignmentCase>
+        <alignment>START_OF_BUNDLE</alignment>
+      </changeAlignmentCase>
+    </changeAlignment>
+
+    <cancelPolicy>
+      <cancelPolicyCase>
+        <productCategory>BASE</productCategory>
+        <policy>END_OF_TERM</policy>
+      </cancelPolicyCase>
+        <cancelPolicyCase>
+            <policy>IMMEDIATE</policy>
+        </cancelPolicyCase>
+    </cancelPolicy>
+
+    <createAlignment>
+      <createAlignmentCase>
+        <alignment>START_OF_BUNDLE</alignment>
+      </createAlignmentCase>
+    </createAlignment>
+
+    <billingAlignment>
+      <billingAlignmentCase>
+        <alignment>ACCOUNT</alignment>
+      </billingAlignmentCase>
+    </billingAlignment>
+
+    <priceList>
+      <priceListCase>
+        <toPriceList>DEFAULT</toPriceList>
+      </priceListCase>
+    </priceList>
+  </rules>
+
+  <plans>
+    <plan name="basic-monthly">
+      <product>Basic</product>
+      <initialPhases>
+        <phase type="TRIAL">
+          <duration>
+            <unit>DAYS</unit>
+            <number>30</number>
+          </duration>
+          <fixed>
+            <fixedPrice>
+              <!-- empty price implies $0 -->
+            </fixedPrice>
+          </fixed>
+        </phase>
+      </initialPhases>
+      <finalPhase type="EVERGREEN">
+        <duration>
+          <unit>UNLIMITED</unit>
+        </duration>
+        <recurring>
+          <billingPeriod>MONTHLY</billingPeriod>
+          <recurringPrice>
+            <price>
+              <currency>USD</currency>
+              <value>1000.00</value>
+            </price>
+          </recurringPrice>
+        </recurring>
+      </finalPhase>
+    </plan>
+    <plan name="BasicAO-monthly">
+      <product>BasicAO</product>
+      <initialPhases>
+        <phase type="TRIAL">
+          <duration>
+            <unit>DAYS</unit>
+            <number>30</number>
+          </duration>
+          <fixed>
+            <fixedPrice>
+              <!-- empty price implies $0 -->
+            </fixedPrice>
+          </fixed>
+        </phase>
+      </initialPhases>
+      <finalPhase type="EVERGREEN">
+        <duration>
+          <unit>UNLIMITED</unit>
+        </duration>
+        <recurring>
+          <billingPeriod>MONTHLY</billingPeriod>
+          <recurringPrice>
+            <price>
+              <currency>USD</currency>
+              <value>100.00</value>
+            </price>
+          </recurringPrice>
+        </recurring>
+      </finalPhase>
+    </plan>
+    <plan name="BasicAOStartOfBundle-monthly">
+      <product>BasicAOStartOfBundle</product>
+      <initialPhases>
+        <phase type="TRIAL">
+          <duration>
+            <unit>DAYS</unit>
+            <number>30</number>
+          </duration>
+          <fixed>
+            <fixedPrice>
+              <!-- empty price implies $0 -->
+            </fixedPrice>
+          </fixed>
+        </phase>
+      </initialPhases>
+      <finalPhase type="EVERGREEN">
+        <duration>
+          <unit>UNLIMITED</unit>
+        </duration>
+        <recurring>
+          <billingPeriod>MONTHLY</billingPeriod>
+          <recurringPrice>
+            <price>
+              <currency>USD</currency>
+              <value>100.00</value>
+            </price>
+          </recurringPrice>
+        </recurring>
+      </finalPhase>
+    </plan>
+    <plan name="BasicAOStartOfSubscription-monthly">
+      <product>BasicAOStartOfSubscription</product>
+      <initialPhases>
+        <phase type="TRIAL">
+          <duration>
+            <unit>DAYS</unit>
+            <number>30</number>
+          </duration>
+          <fixed>
+            <fixedPrice>
+              <!-- empty price implies $0 -->
+            </fixedPrice>
+          </fixed>
+        </phase>
+      </initialPhases>
+      <finalPhase type="EVERGREEN">
+        <duration>
+          <unit>UNLIMITED</unit>
+        </duration>
+        <recurring>
+          <billingPeriod>MONTHLY</billingPeriod>
+          <recurringPrice>
+            <price>
+              <currency>USD</currency>
+              <value>150.00</value>
+            </price>
+          </recurringPrice>
+        </recurring>
+      </finalPhase>
+    </plan>
+    <plan name="BasicAOChangeOfPlan-monthly">
+      <product>BasicAOChangeOfPlan</product>
+      <initialPhases>
+        <phase type="TRIAL">
+          <duration>
+            <unit>DAYS</unit>
+            <number>30</number>
+          </duration>
+          <fixed>
+            <fixedPrice>
+              <!-- empty price implies $0 -->
+            </fixedPrice>
+          </fixed>
+        </phase>
+      </initialPhases>
+      <finalPhase type="EVERGREEN">
+        <duration>
+          <unit>UNLIMITED</unit>
+        </duration>
+        <recurring>
+          <billingPeriod>MONTHLY</billingPeriod>
+          <recurringPrice>
+            <price>
+              <currency>USD</currency>
+              <value>200.00</value>
+            </price>
+          </recurringPrice>
+        </recurring>
+      </finalPhase>
+    </plan>
+    <plan name="BasicAOChangeOfPricelist-monthly">
+      <product>BasicAOChangeOfPricelist</product>
+      <initialPhases>
+        <phase type="TRIAL">
+          <duration>
+            <unit>DAYS</unit>
+            <number>30</number>
+          </duration>
+          <fixed>
+            <fixedPrice>
+              <!-- empty price implies $0 -->
+            </fixedPrice>
+          </fixed>
+        </phase>
+      </initialPhases>
+      <finalPhase type="EVERGREEN">
+        <duration>
+          <unit>UNLIMITED</unit>
+        </duration>
+        <recurring>
+          <billingPeriod>MONTHLY</billingPeriod>
+          <recurringPrice>
+            <price>
+              <currency>USD</currency>
+              <value>250.00</value>
+            </price>
+          </recurringPrice>
+        </recurring>
+      </finalPhase>
+    </plan>
+  </plans>
+  <priceLists>
+    <defaultPriceList name="DEFAULT">
+      <plans>
+        <plan>basic-monthly</plan>
+        <plan>BasicAO-monthly</plan>
+        <plan>BasicAOStartOfBundle-monthly</plan>
+        <plan>BasicAOStartOfSubscription-monthly</plan>
+        <plan>BasicAOChangeOfPlan-monthly</plan>
+        <plan>BasicAOChangeOfPricelist-monthly</plan>
+      </plans>
+    </defaultPriceList>
+  </priceLists>
+</catalog>

--- a/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemBase.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/model/InvoiceItemBase.java
@@ -242,6 +242,8 @@ public abstract class InvoiceItemBase extends EntityBase implements InvoiceItem 
 
         final InvoiceItemBase that = (InvoiceItemBase) o;
 
+        final boolean isFixedItem = getInvoiceItemType() == InvoiceItemType.FIXED;
+
         if (getInvoiceItemType() != null ? !getInvoiceItemType().equals(that.getInvoiceItemType()) : that.getInvoiceItemType() != null) {
             return false;
         }
@@ -260,7 +262,8 @@ public abstract class InvoiceItemBase extends EntityBase implements InvoiceItem 
         if (safeCompareTo(startDate, that.startDate) != 0) {
             return false;
         }
-        if (safeCompareTo(endDate, that.endDate) != 0) {
+        if (!isFixedItem && safeCompareTo(endDate, that.endDate) != 0) {
+        //if (safeCompareTo(endDate, that.endDate) != 0) {
             return false;
         }
         if (safeCompareTo(amount, that.amount) != 0) {


### PR DESCRIPTION
Includes test and fix for change add-on plan with  `START_OF_BUNDLE` alignment.
- Tests are same as those written on top of master (See https://github.com/killbill/killbill/pull/2041)
- Fix includes eliminating duplicate item

**Edit:** Added https://github.com/killbill/killbill/pull/2042/commits/5945652789868ca71f4389984e806c2a7f07c345 with 
`START_OF_SUBSCRIPTION/CHANGE_OF_PLAN` tests. 