### PR TITLE
invoice: allow custom invoice sequences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       #   run: |
       #     bundle exec rake test:plugins TESTOPTS="--stop-on-failure"
       - name: Upload artifact on failure
-        uses: actions/upload-artifact@v2.3.1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failure-${{ matrix.database }}

--- a/account/src/main/java/org/killbill/billing/account/dao/DefaultAccountDao.java
+++ b/account/src/main/java/org/killbill/billing/account/dao/DefaultAccountDao.java
@@ -22,6 +22,7 @@ package org.killbill.billing.account.dao;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -200,7 +201,11 @@ public class DefaultAccountDao extends EntityDaoBase<AccountModelDao, Account, A
                                                  "created_by",
                                                  "created_date",
                                                  "updated_by",
-                                                 "updated_date"));
+                                                 "updated_date"),
+                                          Map.of("billing_cycle_day_local", Integer.class,
+                                                 "first_name_length", Integer.class,
+                                                 "is_payment_delegated_to_parent", Boolean.class,
+                                                 "migrated", Boolean.class));
         } else {
             searchQuery = new SearchQuery(SqlOperator.OR);
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>org.kill-bill.commons</groupId>
+            <artifactId>killbill-jdbi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-queue</artifactId>
         </dependency>
     </dependencies>

--- a/api/src/main/java/org/killbill/billing/customfield/CustomFieldInternalApi.java
+++ b/api/src/main/java/org/killbill/billing/customfield/CustomFieldInternalApi.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.customfield;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.callcontext.InternalCallContext;
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.util.api.CustomFieldApiException;
+import org.killbill.billing.util.customfield.CustomField;
+
+import org.skife.jdbi.v2.Handle;
+
+public interface CustomFieldInternalApi {
+
+    CustomField searchUniqueCustomField(final String key, final String value, final ObjectType objectType, final InternalTenantContext context);
+
+    List<CustomField> getCustomFieldsForObject(final UUID objectId, final ObjectType objectType, final InternalTenantContext context);
+
+    List<CustomField> getCustomFieldsForAccountType(final ObjectType objectType, final InternalTenantContext context);
+
+    void addCustomFieldsFromTransaction(final Handle handle, final List<CustomField> customFields, final InternalCallContext context) throws CustomFieldApiException;
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -130,6 +130,7 @@ import org.killbill.billing.usage.api.UsageApiException;
 import org.killbill.billing.usage.api.UsageRecord;
 import org.killbill.billing.usage.api.UsageUserApi;
 import org.killbill.billing.util.api.AuditUserApi;
+import org.killbill.billing.util.api.CustomFieldUserApi;
 import org.killbill.billing.util.api.RecordIdApi;
 import org.killbill.billing.util.api.TagApiException;
 import org.killbill.billing.util.api.TagDefinitionApiException;
@@ -338,6 +339,9 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
 
     @Inject
     protected PaymentDao paymentDao;
+
+    @Inject
+    protected CustomFieldUserApi customFieldUserApi;
 
     @Inject
     protected NotificationQueueService notificationQueueService;

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationWithAutoInvoiceDraft.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationWithAutoInvoiceDraft.java
@@ -152,7 +152,7 @@ public class TestIntegrationWithAutoInvoiceDraft extends TestIntegrationBase {
 
     @Test(groups = "slow")
     public void testAutoInvoicingDraftBasic() throws Exception {
-        clock.setTime(new DateTime(2017, 6, 16, 18, 24, 42, 0));
+        clock.setTime(new DateTime(2017, 6, 16, account.getReferenceTime().getHourOfDay(), account.getReferenceTime().getMinuteOfHour(), account.getReferenceTime().getSecondOfMinute(), 0));
         add_AUTO_INVOICING_DRAFT_Tag(account.getId(), ObjectType.ACCOUNT);
 
         final DefaultEntitlement bpEntitlement = createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey", productName, ProductCategory.BASE, term, NextEvent.CREATE, NextEvent.BLOCK);
@@ -215,7 +215,7 @@ public class TestIntegrationWithAutoInvoiceDraft extends TestIntegrationBase {
 
     @Test(groups = "slow")
     public void testAutoInvoicingDraftBasicWithCancellation() throws Exception {
-        clock.setTime(new DateTime(2017, 6, 16, 18, 24, 42, 0));
+        clock.setTime(new DateTime(2017, 6, 16, account.getReferenceTime().getHourOfDay(), account.getReferenceTime().getMinuteOfHour(), account.getReferenceTime().getSecondOfMinute(), 0));
         add_AUTO_INVOICING_DRAFT_Tag(account.getId(), ObjectType.ACCOUNT);
 
         final DefaultEntitlement bpEntitlement = createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey", productName, ProductCategory.BASE, term, NextEvent.CREATE, NextEvent.BLOCK);
@@ -276,7 +276,7 @@ public class TestIntegrationWithAutoInvoiceDraft extends TestIntegrationBase {
 
     @Test(groups = "slow")
     public void testWithExistingDraftInvoice() throws Exception {
-        clock.setTime(new DateTime(2017, 6, 16, 18, 24, 42, 0));
+        clock.setTime(new DateTime(2017, 6, 16, account.getReferenceTime().getHourOfDay(), account.getReferenceTime().getMinuteOfHour(), account.getReferenceTime().getSecondOfMinute(), 0));
         add_AUTO_INVOICING_DRAFT_Tag(account.getId(), ObjectType.ACCOUNT);
 
         final DefaultEntitlement bpEntitlement = createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey", productName, ProductCategory.BASE, term, NextEvent.CREATE, NextEvent.BLOCK);
@@ -345,7 +345,7 @@ public class TestIntegrationWithAutoInvoiceDraft extends TestIntegrationBase {
 
     @Test(groups = "slow")
     public void testAutoInvoicingReuseDraftBasic() throws Exception {
-        clock.setTime(new DateTime(2017, 6, 16, 18, 24, 42, 0));
+        clock.setTime(new DateTime(2017, 6, 16, account.getReferenceTime().getHourOfDay(), account.getReferenceTime().getMinuteOfHour(), account.getReferenceTime().getSecondOfMinute(), 0));
 
         // Set both AUTO_INVOICING_DRAFT and AUTO_INVOICING_REUSE_DRAFT
         add_AUTO_INVOICING_DRAFT_Tag(account.getId(), ObjectType.ACCOUNT);

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
@@ -1084,7 +1084,8 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
     public void testCustomInvoiceNumber() throws Exception {
         // We take april as it has 30 days (easier to play with BCD)
         // Set clock to the initial start date - we implicitly assume here that the account timezone is UTC
-        clock.setDay(new LocalDate(2012, 4, 1));
+        final LocalDate startDate = new LocalDate(2012, 4, 1);
+        clock.setDay(startDate);
 
         final AccountData accountData = getAccountData(1);
         final Account account = createAccountWithNonOsgiPaymentMethod(accountData);
@@ -1102,8 +1103,9 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
         Assert.assertEquals(testInvoicePluginApi.priorCallInvocationCalls, 1);
         Assert.assertEquals((int) invoice1.getInvoiceNumber(), 677400001);
 
-        // TODO Check getByNumber which is implemented differently than other APIs
-        //Assert.assertEquals((int) invoiceUserApi.getInvoiceByNumber(invoice1.getInvoiceNumber(), callContext).getInvoiceNumber(), 677400001);
+        Assert.assertEquals((int) invoiceUserApi.getInvoiceByNumber(invoice1.getInvoiceNumber(), callContext).getInvoiceNumber(), 677400001);
+        Assert.assertEquals((int) invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, false, callContext).get(0).getInvoiceNumber(), 677400001);
+        Assert.assertEquals((int) invoiceUserApi.getInvoicesByAccount(account.getId(), startDate, clock.getUTCToday(), false, false, callContext).get(0).getInvoiceNumber(), 677400001);
 
         // Move to Evergreen PHASE
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -1114,8 +1116,9 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
         Assert.assertEquals(testInvoicePluginApi.priorCallInvocationCalls, 2);
         Assert.assertEquals((int) invoice2.getInvoiceNumber(), 677400002);
 
-        // TODO Check getByNumber which is implemented differently than other APIs
-        //Assert.assertEquals((int) invoiceUserApi.getInvoiceByNumber(invoice2.getInvoiceNumber(), callContext).getInvoiceNumber(), 677400002);
+        Assert.assertEquals((int) invoiceUserApi.getInvoiceByNumber(invoice2.getInvoiceNumber(), callContext).getInvoiceNumber(), 677400002);
+        Assert.assertEquals((int) invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, false, callContext).get(1).getInvoiceNumber(), 677400002);
+        Assert.assertEquals((int) invoiceUserApi.getInvoicesByAccount(account.getId(), startDate, clock.getUTCToday(), false, false, callContext).get(1).getInvoiceNumber(), 677400002);
 
         // No more sequencing
         testInvoicePluginApi.invoiceNumberSequenceStart = -1;

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
@@ -1114,9 +1114,12 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
         Assert.assertEquals(testInvoicePluginApi.priorCallInvocationCalls, 1);
         Assert.assertEquals((int) invoice1.getInvoiceNumber(), 677400001);
 
+        // Test the various APIs to ensure we pull the right invoice number
+        Assert.assertEquals((int) invoiceUserApi.getInvoice(invoice1.getId(), callContext).getInvoiceNumber(), 677400001);
         Assert.assertEquals((int) invoiceUserApi.getInvoiceByNumber(invoice1.getInvoiceNumber(), callContext).getInvoiceNumber(), 677400001);
         Assert.assertEquals((int) invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, false, callContext).get(0).getInvoiceNumber(), 677400001);
         Assert.assertEquals((int) invoiceUserApi.getInvoicesByAccount(account.getId(), startDate, clock.getUTCToday(), false, false, callContext).get(0).getInvoiceNumber(), 677400001);
+        Assert.assertEquals((int) invoiceUserApi.getInvoices(0L, 1L, callContext).iterator().next().getInvoiceNumber(), 677400001);
 
         // Move to Evergreen PHASE
         busHandler.pushExpectedEvents(NextEvent.PHASE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
@@ -1127,9 +1130,12 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
         Assert.assertEquals(testInvoicePluginApi.priorCallInvocationCalls, 2);
         Assert.assertEquals((int) invoice2.getInvoiceNumber(), 677400002);
 
+        // Test the various APIs to ensure we pull the right invoice number
+        Assert.assertEquals((int) invoiceUserApi.getInvoice(invoice2.getId(), callContext).getInvoiceNumber(), 677400002);
         Assert.assertEquals((int) invoiceUserApi.getInvoiceByNumber(invoice2.getInvoiceNumber(), callContext).getInvoiceNumber(), 677400002);
         Assert.assertEquals((int) invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, false, callContext).get(1).getInvoiceNumber(), 677400002);
         Assert.assertEquals((int) invoiceUserApi.getInvoicesByAccount(account.getId(), startDate, clock.getUTCToday(), false, false, callContext).get(1).getInvoiceNumber(), 677400002);
+        Assert.assertEquals((int) invoiceUserApi.getInvoices(1L, 1L, callContext).iterator().next().getInvoiceNumber(), 677400002);
 
         // Test credits
         isCommitVoidTest = true;

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
@@ -20,6 +20,7 @@ package org.killbill.billing.beatrix.integration;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -181,6 +182,7 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
         testInvoicePluginApi.wasRescheduled = false;
         testInvoicePluginApi.priorCallInvocationCalls = 0;
         testInvoicePluginApi.onSuccessInvocationCalls = 0;
+        testInvoicePluginApi.invoiceNumberSequenceStart = -1;
         testInvoicePluginApi.taxItems = NoTaxItems;
         testInvoicePluginApi.grpResult = NullInvoiceGroupingResult;
         testInvoicePluginApi.checkPluginProperties = NoCheckPluginProperties;
@@ -1310,7 +1312,7 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
                 assertNotNull(invoiceContext.getExistingInvoices());
             }
 
-            final List<PluginProperty> adjustedPluginProperties = new LinkedList<>();
+            final Collection<PluginProperty> adjustedPluginProperties = new LinkedList<>();
             if (invoiceNumberSequenceStart > 0) {
                 // There's only one test that uses the grouping function and 3 invoices are expected
                 final int numbersToGenerate = grpResult == NullInvoiceGroupingResult ? 1 : 3;

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInvoicingIssue.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/usage/TestUsageInvoicingIssue.java
@@ -49,6 +49,10 @@ public class TestUsageInvoicingIssue extends TestIntegrationBase {
 
     @BeforeMethod(groups = "slow")
     public void beforeMethod() throws Exception {
+        if (hasFailed()) {
+            return;
+        }
+
         super.beforeMethod();
 
         invoiceConfig.setMaxInvoiceLimit(new Period("P1M"));

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -606,7 +606,8 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                                  "created_by",
                                                  "created_date",
                                                  "updated_by",
-                                                 "updated_date"));
+                                                 "updated_date"),
+                                          Map.of("migrated", Boolean.class));
         } else {
             searchQuery = new SearchQuery(SqlOperator.OR);
             searchQuery.addSearchClause("id", SqlOperator.EQ, searchKey);

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDaoHelper.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDaoHelper.java
@@ -239,6 +239,20 @@ public class InvoiceDaoHelper {
                                         invoiceItemToBeAdjusted.getCatalogEffectiveDate(), effectiveDate, effectiveDate, amountToAdjust.negate(), null, currencyForAdjustment, invoiceItemToBeAdjusted.getId());
     }
 
+    public void populateInvoiceModelDao(final InvoiceModelDao invoice,
+                                        final List<CustomField> invoiceCustomFields,
+                                        final List<Tag> invoicesTags) {
+        setInvoiceWrittenOff(invoice, invoicesTags);
+        setInvoiceNumber(invoice, invoiceCustomFields);
+    }
+
+    public void populateInvoiceModelDao(final Iterable<InvoiceModelDao> invoices,
+                                        final List<CustomField> invoiceCustomFields,
+                                        final List<Tag> invoicesTags) {
+        setInvoicesWrittenOff(invoices, invoicesTags);
+        setInvoiceNumber(invoices, invoiceCustomFields);
+    }
+
     public void populateChildren(final InvoiceModelDao invoice,
                                  final List<CustomField> invoiceCustomFields,
                                  final List<Tag> invoicesTags,
@@ -249,14 +263,14 @@ public class InvoiceDaoHelper {
         setInvoiceItemsWithinTransaction(invoice, entitySqlDaoWrapperFactory, context);
         setInvoicePaymentsWithinTransaction(invoice, entitySqlDaoWrapperFactory, context);
         setTrackingIdsFromTransaction(invoice, entitySqlDaoWrapperFactory, context);
-        setInvoiceWrittenOff(invoice, invoicesTags);
         if(includeRepairStatus) {
             setInvoiceRepaired(invoice, entitySqlDaoWrapperFactory, context);
         }
         if (!invoice.isParentInvoice()) {
             setParentInvoice(invoice, invoiceCustomFields, invoicesTags, entitySqlDaoWrapperFactory, context);
         }
-        setInvoiceNumber(invoice, invoiceCustomFields);
+
+        populateInvoiceModelDao(invoice, invoiceCustomFields, invoicesTags);
     }
 
     public void populateChildren(final Iterable<InvoiceModelDao> invoices,
@@ -273,7 +287,6 @@ public class InvoiceDaoHelper {
         setInvoiceItemsWithinTransaction(invoices, entitySqlDaoWrapperFactory, context);
         setInvoicePaymentsWithinTransaction(invoices, entitySqlDaoWrapperFactory, context);
         setTrackingIdsFromTransaction(invoices, entitySqlDaoWrapperFactory, context);
-        setInvoicesWrittenOff(invoices, invoicesTags);
         if (includeRepairStatus) {
             setInvoicesRepaired(invoices, entitySqlDaoWrapperFactory, context);
         }
@@ -286,7 +299,7 @@ public class InvoiceDaoHelper {
             setParentInvoice(nonParentInvoices, invoiceCustomFields, invoicesTags, entitySqlDaoWrapperFactory, context);
         }
 
-        setInvoiceNumber(invoices, invoiceCustomFields);
+        populateInvoiceModelDao(invoices, invoiceCustomFields, invoicesTags);
     }
 
     public List<InvoiceModelDao> getAllInvoicesByAccountFromTransaction(final Boolean includeVoidedInvoices,

--- a/invoice/src/test/java/org/killbill/billing/invoice/optimizer/TestInvoiceOptimizerExp.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/optimizer/TestInvoiceOptimizerExp.java
@@ -64,6 +64,10 @@ public class TestInvoiceOptimizerExp extends InvoiceTestSuiteNoDB {
 
     @BeforeClass(groups = "fast")
     public void setup() throws AccountApiException, SubscriptionBaseApiException {
+        if (hasFailed()) {
+            return;
+        }
+
         account = invoiceUtil.createAccount(callContext);
         subscription = invoiceUtil.createSubscription();
     }

--- a/payment/src/main/java/org/killbill/billing/payment/dao/DefaultPaymentDao.java
+++ b/payment/src/main/java/org/killbill/billing/payment/dao/DefaultPaymentDao.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -274,7 +275,8 @@ public class DefaultPaymentDao extends EntityDaoBase<PaymentModelDao, Payment, P
                                                  "created_by",
                                                  "created_date",
                                                  "updated_by",
-                                                 "updated_date"));
+                                                 "updated_date"),
+                                          Map.of());
         } else {
             searchQuery = new SearchQuery(SqlOperator.OR);
             final String likeSearchKey = String.format("%%%s%%", searchKey);
@@ -616,11 +618,11 @@ public class DefaultPaymentDao extends EntityDaoBase<PaymentModelDao, Payment, P
                                                  "external_key",
                                                  "account_id",
                                                  "plugin_name",
-                                                 "is_active",
                                                  "created_by",
                                                  "created_date",
                                                  "updated_by",
-                                                 "updated_date"));
+                                                 "updated_date"),
+                                          Map.of());
         } else {
             searchQuery = new SearchQuery(SqlOperator.OR);
             final String likeSearchKey = String.format("%%%s%%", searchKey);

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
@@ -204,7 +204,8 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
                                                  "created_by",
                                                  "created_date",
                                                  "updated_by",
-                                                 "updated_date"));
+                                                 "updated_date"),
+                                          Map.of());
         } else {
             searchQuery = new SearchQuery(SqlOperator.OR);
             searchQuery.addSearchClause("id", SqlOperator.EQ, searchKey);

--- a/util/src/main/java/org/killbill/billing/util/customfield/DefaultCustomFieldInternalApi.java
+++ b/util/src/main/java/org/killbill/billing/util/customfield/DefaultCustomFieldInternalApi.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.customfield;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.callcontext.InternalCallContext;
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.customfield.CustomFieldInternalApi;
+import org.killbill.billing.util.api.CustomFieldApiException;
+import org.killbill.billing.util.customfield.dao.CustomFieldDao;
+import org.killbill.billing.util.customfield.dao.CustomFieldModelDao;
+import org.killbill.billing.util.customfield.dao.DefaultCustomFieldDao;
+import org.killbill.billing.util.entity.Pagination;
+import org.killbill.billing.util.entity.dao.DefaultPaginationHelper.SourcePaginationBuilder;
+import org.killbill.commons.utils.collect.Iterators;
+import org.skife.jdbi.v2.Handle;
+
+import static org.killbill.billing.util.customfield.api.DefaultCustomFieldUserApi.CUSTOM_FIELD_MODEL_DAO_CUSTOM_FIELD_FUNCTION;
+import static org.killbill.billing.util.customfield.api.DefaultCustomFieldUserApi.createCustomFieldModelDao;
+import static org.killbill.billing.util.customfield.api.DefaultCustomFieldUserApi.withCustomFieldsTransform;
+import static org.killbill.billing.util.entity.dao.DefaultPaginationHelper.getEntityPaginationNoException;
+
+public class DefaultCustomFieldInternalApi implements CustomFieldInternalApi {
+
+    private final CustomFieldDao customFieldDao;
+
+    @Inject
+    public DefaultCustomFieldInternalApi(final CustomFieldDao customFieldDao) {
+        this.customFieldDao = customFieldDao;
+    }
+
+    @Override
+    public CustomField searchUniqueCustomField(final String key, final String value, final ObjectType objectType, final InternalTenantContext context) {
+        final String searchKey = String.format("_q=1&object_type=%s&is_active=1&field_name=%s&field_value=%s", objectType, key, value);
+        final Pagination<CustomField> page = getEntityPaginationNoException(1L,
+                                                                                    new SourcePaginationBuilder<CustomFieldModelDao, CustomFieldApiException>() {
+                                                                                        @Override
+                                                                                        public Pagination<CustomFieldModelDao> build() {
+                                                                                            return customFieldDao.searchCustomFields(searchKey, 0L, 1L, context);
+                                                                                        }
+                                                                                    },
+                                                                                    CUSTOM_FIELD_MODEL_DAO_CUSTOM_FIELD_FUNCTION);
+        return Iterators.<CustomField>getLast(page.iterator(), null);
+    }
+
+    @Override
+    public List<CustomField> getCustomFieldsForObject(final UUID objectId, final ObjectType objectType, final InternalTenantContext context) {
+        return withCustomFieldsTransform(customFieldDao.getCustomFieldsForObject(objectId, objectType, context));
+    }
+
+    @Override
+    public List<CustomField> getCustomFieldsForAccountType(final ObjectType objectType, final InternalTenantContext context) {
+        return withCustomFieldsTransform(customFieldDao.getCustomFieldsForAccountType(objectType, context));
+    }
+
+    @Override
+    public void addCustomFieldsFromTransaction(final Handle handle, final List<CustomField> customFields, final InternalCallContext context) throws CustomFieldApiException {
+        if (!customFields.isEmpty()) {
+            final List<CustomFieldModelDao> transformed = customFields.stream()
+                                                                      .map(input -> createCustomFieldModelDao(input, context.getCreatedDate(), false))
+                                                                      .collect(Collectors.toList());
+            ((DefaultCustomFieldDao) customFieldDao).create(handle, transformed, context);
+        }
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/customfield/DefaultCustomFieldInternalApi.java
+++ b/util/src/main/java/org/killbill/billing/util/customfield/DefaultCustomFieldInternalApi.java
@@ -51,7 +51,7 @@ public class DefaultCustomFieldInternalApi implements CustomFieldInternalApi {
 
     @Override
     public CustomField searchUniqueCustomField(final String key, final String value, final ObjectType objectType, final InternalTenantContext context) {
-        final String searchKey = String.format("_q=1&object_type=%s&is_active=1&field_name=%s&field_value=%s", objectType, key, value);
+        final String searchKey = String.format("_q=1&object_type=%s&field_name=%s&field_value=%s", objectType, key, value);
         final Pagination<CustomField> page = getEntityPaginationNoException(1L,
                                                                                     new SourcePaginationBuilder<CustomFieldModelDao, CustomFieldApiException>() {
                                                                                         @Override

--- a/util/src/main/java/org/killbill/billing/util/customfield/IntegerCustomField.java
+++ b/util/src/main/java/org/killbill/billing/util/customfield/IntegerCustomField.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.customfield;
+
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.entity.EntityBase;
+import org.killbill.billing.util.UUIDs;
+import org.killbill.billing.util.customfield.dao.CustomFieldModelDao;
+
+public class IntegerCustomField extends EntityBase implements CustomField {
+
+    private final String fieldName;
+    private final Integer fieldValue;
+    private final UUID objectId;
+    private final ObjectType objectType;
+
+    public IntegerCustomField(final String name, final Integer value, final ObjectType objectType, final UUID objectId, final DateTime createdDate) {
+        this(UUIDs.randomUUID(), name, value, objectType, objectId, createdDate);
+    }
+
+    public IntegerCustomField(final UUID id, final String name, final Integer value, final ObjectType objectType, final UUID objectId, final DateTime createdDate) {
+        super(id, createdDate, createdDate);
+        this.fieldName = name;
+        this.fieldValue = value;
+        this.objectId = objectId;
+        this.objectType = objectType;
+    }
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public String getFieldValue() {
+        return fieldValue.toString();
+    }
+
+    public ObjectType getObjectType() {
+        return objectType;
+    }
+
+    public UUID getObjectId() {
+        return objectId;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("StringCustomField");
+        sb.append("{fieldName='").append(fieldName).append('\'');
+        sb.append(", fieldValue='").append(fieldValue).append('\'');
+        sb.append(", objectId=").append(objectId);
+        sb.append(", objectType=").append(objectType);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final IntegerCustomField that = (IntegerCustomField) o;
+
+        if (fieldName != null ? !fieldName.equals(that.fieldName) : that.fieldName != null) {
+            return false;
+        }
+        if (fieldValue != null ? !fieldValue.equals(that.fieldValue) : that.fieldValue != null) {
+            return false;
+        }
+        if (objectId != null ? !objectId.equals(that.objectId) : that.objectId != null) {
+            return false;
+        }
+        if (objectType != that.objectType) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+        result = 31 * result + (fieldValue != null ? fieldValue.hashCode() : 0);
+        result = 31 * result + (objectId != null ? objectId.hashCode() : 0);
+        result = 31 * result + (objectType != null ? objectType.hashCode() : 0);
+        return result;
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/customfield/dao/DefaultCustomFieldDao.java
+++ b/util/src/main/java/org/killbill/billing/util/customfield/dao/DefaultCustomFieldDao.java
@@ -21,6 +21,7 @@ package org.killbill.billing.util.customfield.dao;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -217,13 +218,13 @@ public class DefaultCustomFieldDao extends EntityDaoBase<CustomFieldModelDao, Cu
                                           Set.of("id",
                                                  "object_id",
                                                  "object_type",
-                                                 "is_active",
                                                  "field_name",
                                                  "field_value",
                                                  "created_by",
                                                  "created_date",
                                                  "updated_by",
-                                                 "updated_date"));
+                                                 "updated_date"),
+                                          Map.of());
         } else {
             searchQuery = new SearchQuery(SqlOperator.OR);
 

--- a/util/src/main/java/org/killbill/billing/util/customfield/dao/DefaultCustomFieldDao.java
+++ b/util/src/main/java/org/killbill/billing/util/customfield/dao/DefaultCustomFieldDao.java
@@ -21,7 +21,6 @@ package org.killbill.billing.util.customfield.dao;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -55,12 +54,12 @@ import org.killbill.billing.util.entity.dao.EntityDaoBase;
 import org.killbill.billing.util.entity.dao.EntitySqlDao;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
-import org.killbill.billing.util.entity.dao.SearchAttribute;
 import org.killbill.billing.util.entity.dao.SearchQuery;
 import org.killbill.billing.util.entity.dao.SqlOperator;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus;
 import org.killbill.clock.Clock;
+import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.IDBI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,6 +107,11 @@ public class DefaultCustomFieldDao extends EntityDaoBase<CustomFieldModelDao, Cu
                         .become(CustomFieldSqlDao.class)
                         .getByAccountRecordId(context));
         return List.copyOf(result);
+    }
+
+    public void create(final Handle handle, final List<CustomFieldModelDao> entities, final InternalCallContext context) throws CustomFieldApiException {
+        final CustomFieldSqlDao sqlDao = handle.attach(CustomFieldSqlDao.class);
+        super.bulkCreate(sqlDao, entities, context);
     }
 
     @Override

--- a/util/src/main/java/org/killbill/billing/util/glue/CustomFieldModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/CustomFieldModule.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2010-2011 Ning, Inc.
- * Copyright 2014 Groupon, Inc
- * Copyright 2014 The Billing Project, LLC
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2020 Groupon, Inc
+ * Copyright 2014-2024 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -18,8 +18,10 @@
 
 package org.killbill.billing.util.glue;
 
+import org.killbill.billing.customfield.CustomFieldInternalApi;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.api.CustomFieldUserApi;
+import org.killbill.billing.util.customfield.DefaultCustomFieldInternalApi;
 import org.killbill.billing.util.customfield.api.DefaultCustomFieldUserApi;
 import org.killbill.billing.util.customfield.dao.CustomFieldDao;
 import org.killbill.billing.util.customfield.dao.DefaultCustomFieldDao;
@@ -34,10 +36,15 @@ public class CustomFieldModule extends KillBillModule {
     protected void configure() {
         installCustomFieldDao();
         installCustomFieldUserApi();
+        installCustomFieldInternalApi();
     }
 
     protected void installCustomFieldUserApi() {
         bind(CustomFieldUserApi.class).to(DefaultCustomFieldUserApi.class).asEagerSingleton();
+    }
+
+    protected void installCustomFieldInternalApi() {
+        bind(CustomFieldInternalApi.class).to(DefaultCustomFieldInternalApi.class).asEagerSingleton();
     }
 
     protected void installCustomFieldDao() {

--- a/util/src/test/java/org/killbill/billing/DBTestingHelper.java
+++ b/util/src/test/java/org/killbill/billing/DBTestingHelper.java
@@ -92,6 +92,11 @@ public class DBTestingHelper extends PlatformDBTestingHelper {
                 installDDLSilently(resourceName);
             }
         }
+
+        // MySQL client 9.0 support
+        if ("true".equals(System.getProperty("org.killbill.billing.dbi.test.mysql.v9"))) {
+            getInstance().executeScript(String.format("ALTER USER '%s'@'%%' IDENTIFIED WITH caching_sha2_password BY '%s'", instance.getUsername(), instance.getPassword()));
+        }
     }
 
     private void installDDLSilently(final String resourceName) throws IOException {

--- a/util/src/test/java/org/killbill/billing/util/UtilTestSuiteWithEmbeddedDB.java
+++ b/util/src/test/java/org/killbill/billing/util/UtilTestSuiteWithEmbeddedDB.java
@@ -37,6 +37,7 @@ import org.killbill.billing.util.broadcast.dao.BroadcastDao;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.config.definition.SecurityConfig;
+import org.killbill.billing.util.customfield.DefaultCustomFieldInternalApi;
 import org.killbill.billing.util.customfield.api.DefaultCustomFieldUserApi;
 import org.killbill.billing.util.customfield.dao.CustomFieldDao;
 import org.killbill.billing.util.dao.NonEntityDao;
@@ -80,6 +81,8 @@ public abstract class UtilTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuite
     protected DefaultTagUserApi tagUserApi;
     @Inject
     protected DefaultCustomFieldUserApi customFieldUserApi;
+    @Inject
+    protected DefaultCustomFieldInternalApi customFieldInternalApi;
     @Inject
     protected CustomFieldDao customFieldDao;
     @Inject

--- a/util/src/test/java/org/killbill/billing/util/customfield/TestDefaultCustomFieldInternalApi.java
+++ b/util/src/test/java/org/killbill/billing/util/customfield/TestDefaultCustomFieldInternalApi.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.customfield;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.util.UtilTestSuiteWithEmbeddedDB;
+import org.killbill.billing.util.api.CustomFieldApiException;
+import org.killbill.billing.util.customfield.dao.CustomFieldModelDao;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class TestDefaultCustomFieldInternalApi extends UtilTestSuiteWithEmbeddedDB {
+
+    @Test(groups = "slow")
+    public void testSearchUniqueCustomField() throws CustomFieldApiException {
+        final UUID accountId = UUID.randomUUID();
+        final ObjectType objectType = ObjectType.ACCOUNT;
+
+        final String fieldName = "TestField1";
+        final String fieldValue = "1"; // Choosing a number on purpose (verify typing in SearchQuery)
+
+        eventsListener.pushExpectedEvent(NextEvent.CUSTOM_FIELD);
+        final CustomFieldModelDao customFieldModelDao = new CustomFieldModelDao(internalCallContext.getCreatedDate(), fieldName, fieldValue, accountId, objectType);
+        customFieldDao.create(customFieldModelDao, internalCallContext);
+        assertListenerStatus();
+
+        CustomField customField = customFieldInternalApi.searchUniqueCustomField(fieldName, fieldValue, objectType, internalCallContext);
+        Assert.assertNotNull(customField);
+        Assert.assertEquals(customField.getId(), customFieldModelDao.getId());
+
+        eventsListener.pushExpectedEvent(NextEvent.CUSTOM_FIELD);
+        customFieldDao.deleteCustomFields(List.of(customField.getId()), internalCallContext);
+        assertListenerStatus();
+
+        customField = customFieldInternalApi.searchUniqueCustomField(fieldName, fieldValue, objectType, internalCallContext);
+        Assert.assertNull(customField);
+    }
+}


### PR DESCRIPTION
Allow invoice plugins to control the invoice number by sending the plugin property INVOICE_SEQUENCE_NUMBER in getAdditionalInvoiceItems#AdditionalItemsResult.

Invoice presentment (including prefix/suffix/etc.) can be customized using an custom InvoiceFormatter in the plugin (for HTML invoices, email notifications, etc.).