### PR TITLE
Fix overrides bug

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -204,8 +204,8 @@
                             <shadedClassifierName>load-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -219,7 +219,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.LoadCatalog</Main-Class>
@@ -240,8 +240,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -255,7 +255,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.CreateCatalogSchema</Main-Class>

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SubscriptionResourceHelpers.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SubscriptionResourceHelpers.java
@@ -93,7 +93,8 @@ public class SubscriptionResourceHelpers {
         if (priceOverrides != null) {
             for (final PhasePriceJson input : priceOverrides) {
                 Preconditions.checkNotNull(input);
-
+                Preconditions.checkArgument(input.getFixedPrice() != null || input.getRecurringPrice() != null || input.getUsagePrices() != null || (input.getUsagePrices() != null && !input.getUsagePrices().isEmpty()),
+                                            "At least one fixed price, one recurring price or one usage price must be overridden");
                 final List<UsagePriceOverride> usagePrices = new LinkedList<>();
                 if (input.getUsagePrices() != null) {
                     buildUsagePrices(currency, input, usagePrices);
@@ -212,8 +213,6 @@ public class SubscriptionResourceHelpers {
         final PlanPhaseSpecifier planPhaseSpecifier = spec.getPlanName() != null ?
                                                       new PlanPhaseSpecifier(spec.getPlanName(), phaseType) :
                                                       new PlanPhaseSpecifier(spec.getProductName(), spec.getBillingPeriod(), spec.getPriceListName(), phaseType);
-        final Currency resolvedCurrency = input.getFixedPrice() != null || input.getRecurringPrice() != null || (input.getUsagePrices() != null && !input.getUsagePrices().isEmpty()) ? currency : null;
-
         return new PlanPhasePriceOverride() {
 
             @Override
@@ -228,7 +227,7 @@ public class SubscriptionResourceHelpers {
 
             @Override
             public Currency getCurrency() {
-                return resolvedCurrency;
+                return currency;
             }
 
             @Override

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SubscriptionResourceHelpers.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SubscriptionResourceHelpers.java
@@ -212,7 +212,7 @@ public class SubscriptionResourceHelpers {
         final PlanPhaseSpecifier planPhaseSpecifier = spec.getPlanName() != null ?
                                                       new PlanPhaseSpecifier(spec.getPlanName(), phaseType) :
                                                       new PlanPhaseSpecifier(spec.getProductName(), spec.getBillingPeriod(), spec.getPriceListName(), phaseType);
-        final Currency resolvedCurrency = input.getFixedPrice() != null || input.getRecurringPrice() != null ? currency : null;
+        final Currency resolvedCurrency = input.getFixedPrice() != null || input.getRecurringPrice() != null || (input.getUsagePrices() != null && !input.getUsagePrices().isEmpty()) ? currency : null;
 
         return new PlanPhasePriceOverride() {
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SubscriptionResourceHelpers.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SubscriptionResourceHelpers.java
@@ -93,7 +93,7 @@ public class SubscriptionResourceHelpers {
         if (priceOverrides != null) {
             for (final PhasePriceJson input : priceOverrides) {
                 Preconditions.checkNotNull(input);
-                Preconditions.checkArgument(input.getFixedPrice() != null || input.getRecurringPrice() != null || input.getUsagePrices() != null || (input.getUsagePrices() != null && !input.getUsagePrices().isEmpty()),
+                Preconditions.checkArgument(input.getFixedPrice() != null || input.getRecurringPrice() != null ||  (input.getUsagePrices() != null && !input.getUsagePrices().isEmpty()),
                                             "At least one fixed price, one recurring price or one usage price must be overridden");
                 final List<UsagePriceOverride> usagePrices = new LinkedList<>();
                 if (input.getUsagePrices() != null) {

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -226,8 +226,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -241,7 +241,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.overdue.CreateOverdueConfigSchema</Main-Class>

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
@@ -2143,6 +2143,8 @@ public class TestEntitlement extends TestJaxrsBase {
         callbackServlet.assertListenerStatus();
         final Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE);
+        Assert.assertEquals(subscription.getPlanName(), "trebuchet-usage-in-arrear-1"); //overridden plan name
+
     }
 
 }


### PR DESCRIPTION
There is a bug in the code due to which it is currently not possible to override a usage price by itself, it is necessary to update either a fixed or a recurring price too. This PR attempts to address this bug.

See [this comment](https://github.com/killbill/killbill-aviate-plugin/pull/287#discussion_r1886239492).
