### PR TITLE
Fix infinite loop issue. See #2091

### DIFF
--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig/Insurance-v1.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig/Insurance-v1.xml
@@ -39,6 +39,9 @@
         <product name="Collision">
             <category>BASE</category>
         </product>
+        <product name="Comprehensive">
+            <category>BASE</category>
+        </product>
     </products>
 
     <rules>
@@ -109,13 +112,63 @@
                 </recurring>
             </finalPhase>
         </plan>
-
+        <plan name="comprehensive-monthly-with-trial">
+            <product>Comprehensive</product>
+            <initialPhases>
+                <phase prettyName="" type="TRIAL">
+                    <duration>
+                        <unit>DAYS</unit>
+                        <number>7</number>
+                    </duration>
+                    <fixed type="ONE_TIME">
+                        <fixedPrice>
+                            <price>
+                                <currency>GBP</currency>
+                                <value>0.0</value>
+                            </price>
+                            <price>
+                                <currency>EUR</currency>
+                                <value>0.0</value>
+                            </price>
+                            <price>
+                                <currency>USD</currency>
+                                <value>0.0</value>
+                            </price>
+                        </fixedPrice>
+                    </fixed>
+                    <usages/>
+                </phase>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>49.95</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>49.95</value>
+                        </price>
+                        <price>
+                            <currency>USD</currency>
+                            <value>49.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
     </plans>
     <priceLists>
         <defaultPriceList name="DEFAULT">
             <plans>
                 <plan>liability-monthly-no-trial</plan>
                 <plan>collision-monthly-no-trial</plan>
+                <plan>comprehensive-monthly-with-trial</plan>
             </plans>
         </defaultPriceList>
     </priceLists>

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig/Insurance-v2.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsCustomConfig/Insurance-v2.xml
@@ -39,6 +39,9 @@
         <product name="Collision">
             <category>BASE</category>
         </product>
+        <product name="Comprehensive">
+            <category>BASE</category>
+        </product>
     </products>
 
     <rules>
@@ -111,14 +114,64 @@
                 </recurring>
             </finalPhase>
         </plan>
-
-
+        <plan name="comprehensive-monthly-with-trial">
+            <effectiveDateForExistingSubscriptions>2022-04-02T00:00:00Z</effectiveDateForExistingSubscriptions>
+            <product>Comprehensive</product>
+            <initialPhases>
+                <phase prettyName="" type="TRIAL">
+                    <duration>
+                        <unit>DAYS</unit>
+                        <number>7</number>
+                    </duration>
+                    <fixed type="ONE_TIME">
+                        <fixedPrice>
+                            <price>
+                                <currency>GBP</currency>
+                                <value>0.0</value>
+                            </price>
+                            <price>
+                                <currency>EUR</currency>
+                                <value>0.0</value>
+                            </price>
+                            <price>
+                                <currency>USD</currency>
+                                <value>0.0</value>
+                            </price>
+                        </fixedPrice>
+                    </fixed>
+                    <usages/>
+                </phase>
+            </initialPhases>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>GBP</currency>
+                            <value>59.95</value>
+                        </price>
+                        <price>
+                            <currency>EUR</currency>
+                            <value>59.95</value>
+                        </price>
+                        <price>
+                            <currency>USD</currency>
+                            <value>59.95</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+        </plan>
     </plans>
     <priceLists>
         <defaultPriceList name="DEFAULT">
             <plans>
                 <plan>liability-monthly-no-trial</plan>
                 <plan>collision-monthly-no-trial</plan>
+                <plan>comprehensive-monthly-with-trial</plan>
             </plans>
         </defaultPriceList>
     </priceLists>

--- a/util/src/main/java/org/killbill/billing/util/bcd/BillCycleDayCalculator.java
+++ b/util/src/main/java/org/killbill/billing/util/bcd/BillCycleDayCalculator.java
@@ -77,6 +77,10 @@ public abstract class BillCycleDayCalculator {
 
 
     private static LocalDate alignToNextBillCycleDate(final LocalDate prevTransitionDate, final LocalDate curTransitionDate, /* date to be aligned */ final int billingCycleDay, final BillingPeriod billingPeriod) {
+        // Trivial case, nothing to align with
+        if (billingPeriod == BillingPeriod.NO_BILLING_PERIOD) {
+            return curTransitionDate;
+        }
         // billingCycleDay alignment only makes sense for month based BillingPeriod (MONTHLY, QUARTERLY, BIANNUAL, ANNUAL)
         final boolean isMonthBased = (billingPeriod.getPeriod().getMonths() | billingPeriod.getPeriod().getYears()) > 0;
         if (!isMonthBased) {


### PR DESCRIPTION
In a scenario with org.killbill.subscription.align.effectiveDateForExistingSubscriptions=true, the main fix is to avoid generating a billing transition when there is no recurring section.

Also added some logic to handle NO_BILLING_PERIOD in BillCycleDayCalculator#alignToNextBillCycleDate to avoid ever entering this while loop without a way to exit it.

Added a test case that reproduces the issue.
