### PR TITLE
jaxrs: Remove character encoding returned in the Content-Encoding. See #1901

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/PluginResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/PluginResource.java
@@ -229,9 +229,6 @@ public class PluginResource extends JaxRsResourceBase {
                 builder.header(name, value);
             }
         }
-        if (response.getCharacterEncoding() != null) {
-            builder.encoding(response.getCharacterEncoding());
-        }
         if (response.getContentType() != null) {
             builder.type(response.getContentType());
         }


### PR DESCRIPTION
In 24a361504a3ab we made a fix to add the content type but also incorrectly returned the character encoding returned in the Content-Encoding