### PR TITLE
catalog: Remove synchronized statement when setting field values through reflection. See #2116

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/CatalogSafetyInitializer.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/CatalogSafetyInitializer.java
@@ -119,25 +119,20 @@ public class CatalogSafetyInitializer {
     }
 
     private static void initializeFieldWithValue(final Object obj, final Field f, final Object value) throws IllegalAccessException, ClassNotFoundException {
-        synchronized (perCatalogClassNonRequiredFields) {
-            f.setAccessible(true);
-            if (f.get(obj) == null) {
-                f.set(obj, value);
-            }
-            f.setAccessible(false);
+        f.setAccessible(true);
+        if (f.get(obj) == null) {
+            f.set(obj, value);
         }
+        f.setAccessible(false);
     }
 
     private static void initializeArrayIfNull(final Object obj, final Field f) throws IllegalAccessException, ClassNotFoundException {
-        synchronized (perCatalogClassNonRequiredFields) {
-            f.setAccessible(true);
-            if (f.get(obj) == null) {
-                f.set(obj, getZeroLengthArrayInitializer(f));
-            }
-            f.setAccessible(false);
+        f.setAccessible(true);
+        if (f.get(obj) == null) {
+            f.set(obj, getZeroLengthArrayInitializer(f));
         }
+        f.setAccessible(false);
     }
-
 
     private static Object[] getZeroLengthArrayInitializer(final Field f) throws ClassNotFoundException {
         // Yack... type erasure, why?


### PR DESCRIPTION
The reflection operations are not inherently thread-unsafe for independent object instances, so these synchronized statements are not useful. Also the creation of catalog occurs within one thread, so there is no concurrency issues.