### PR TITLE
Additional null check for invoiceFormatterFactory

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -204,8 +204,8 @@
                             <shadedClassifierName>load-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -219,7 +219,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.LoadCatalog</Main-Class>
@@ -240,8 +240,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -255,7 +255,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.catalog.CreateCatalogSchema</Main-Class>

--- a/invoice/src/main/java/org/killbill/billing/invoice/template/HtmlInvoiceGenerator.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/template/HtmlInvoiceGenerator.java
@@ -99,10 +99,13 @@ public class HtmlInvoiceGenerator {
         data.put("text", invoiceTranslator);
         data.put("account", account);
 
-        final InvoiceFormatterFactory invoiceFormatterFactory;
+        InvoiceFormatterFactory invoiceFormatterFactory;
         final String invoiceFormatterFactoryPluginName = config.getInvoiceFormatterFactoryPluginName();
         if (!Strings.isNullOrEmpty(invoiceFormatterFactoryPluginName)) {
             invoiceFormatterFactory = invoiceFormatterFactoryPluginRegistry.getServiceForName(invoiceFormatterFactoryPluginName);
+            if(invoiceFormatterFactory == null) {
+                invoiceFormatterFactory = builtInInvoiceFormatterFactory;
+            }
         } else {
             final Set<String> services = invoiceFormatterFactoryPluginRegistry.getAllServices();
             invoiceFormatterFactory = services.size() == 1 ? invoiceFormatterFactoryPluginRegistry.getServiceForName(services.iterator().next()) : builtInInvoiceFormatterFactory;

--- a/overdue/pom.xml
+++ b/overdue/pom.xml
@@ -226,8 +226,8 @@
                             <shadedClassifierName>xsd-tool</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                                     <resources>
                                         <resource>MANIFEST.MF</resource>
@@ -241,7 +241,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.properties.PropertiesTransformer">
                                     <resource>META-INF/io.netty.versions.properties</resource>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>org.killbill.billing.overdue.CreateOverdueConfigSchema</Main-Class>


### PR DESCRIPTION
Handles cases when the `org.killbill.template.invoiceFormatterFactoryPluginName` property is specified but the plugin is not configured.