### PR TITLE
fix: prevent CORS origin reflection with credentials

### DIFF
--- a/profiles/killbill/src/main/java/org/killbill/billing/server/filters/ResponseCorsFilter.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/filters/ResponseCorsFilter.java
@@ -18,8 +18,11 @@
 package org.killbill.billing.server.filters;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Singleton;
 import javax.servlet.Filter;
@@ -38,9 +41,20 @@ import org.killbill.commons.utils.net.HttpHeaders;
 @Singleton
 public class ResponseCorsFilter implements Filter {
 
+    private final Set<String> allowedOrigins;
     private final String allowedHeaders;
+    private final String exposedHeaders;
 
     public ResponseCorsFilter() {
+        final String originsProperty = System.getProperty("org.killbill.server.cors.allowed.origins", "");
+        if (originsProperty.isEmpty()) {
+            allowedOrigins = Collections.emptySet();
+        } else {
+            allowedOrigins = Stream.of(originsProperty.split(","))
+                                   .map(String::trim)
+                                   .collect(Collectors.toUnmodifiableSet());
+        }
+
         allowedHeaders = Joiner.on(",")
                                .join(List.of(HttpHeaders.AUTHORIZATION,
                                              HttpHeaders.CONTENT_TYPE,
@@ -56,6 +70,17 @@ public class ResponseCorsFilter implements Filter {
                                              JaxrsResource.HDR_PAGINATION_TOTAL_NB_RECORDS,
                                              JaxrsResource.HDR_REASON)
                                     );
+
+        // Expose pagination and location headers, but not auth credentials
+        exposedHeaders = Joiner.on(",")
+                               .join(List.of(HttpHeaders.CONTENT_TYPE,
+                                             HttpHeaders.LOCATION,
+                                             JaxrsResource.HDR_PAGINATION_CURRENT_OFFSET,
+                                             JaxrsResource.HDR_PAGINATION_MAX_NB_RECORDS,
+                                             JaxrsResource.HDR_PAGINATION_NEXT_OFFSET,
+                                             JaxrsResource.HDR_PAGINATION_NEXT_PAGE_URI,
+                                             JaxrsResource.HDR_PAGINATION_TOTAL_NB_RECORDS)
+                                    );
     }
 
     @Override
@@ -67,12 +92,21 @@ public class ResponseCorsFilter implements Filter {
         final HttpServletResponse res = (HttpServletResponse) response;
         final HttpServletRequest req = (HttpServletRequest) request;
 
-        final String origin = Objects.requireNonNullElse(req.getHeader(HttpHeaders.ORIGIN), "*");
-        res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+        final String origin = req.getHeader(HttpHeaders.ORIGIN);
+
+        if (origin != null && allowedOrigins.contains(origin)) {
+            // Origin is explicitly allowed — reflect it with credentials
+            res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+            res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        } else if (allowedOrigins.isEmpty()) {
+            // No allowlist configured — allow all origins WITHOUT credentials (safe default)
+            res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+        }
+        // If origin is present but not in allowlist, no CORS headers are added
+
         res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, DELETE, PUT, OPTIONS");
         res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, allowedHeaders);
-        res.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, allowedHeaders);
-        res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        res.addHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, exposedHeaders);
         chain.doFilter(request, response);
     }
 


### PR DESCRIPTION
## Security Fix: CORS Origin Reflection with Credentials

### Vulnerable Lines

**File:** [`ResponseCorsFilter.java#L70-L75`](https://github.com/killbill/killbill/blob/master/profiles/killbill/src/main/java/org/killbill/billing/server/filters/ResponseCorsFilter.java#L70-L75)

```java
final String origin = Objects.requireNonNullElse(req.getHeader(HttpHeaders.ORIGIN), "*");
res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);        // reflects ANY origin
res.addHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");   // with cookies
```

The filter is registered on `/*` via [`KillbillGuiceListener.java:104`](https://github.com/killbill/killbill/blob/master/profiles/killbill/src/main/java/org/killbill/billing/server/listeners/KillbillGuiceListener.java#L104) (originally scoped to Swagger UI, broadened to all paths).

### What could happen

Any website can make authenticated cross-origin requests to every Kill Bill API endpoint and read the full response. An attacker hosts a page, the victim visits it while logged into Kill Bill, and the attacker gets account data, invoices, payment methods, and API credentials. The attacker can also make state-changing requests (POST, PUT, DELETE) as the victim.

### How to verify

1. Start Kill Bill 0.24.16 via `docker compose` with `killbill/killbill:0.24.16` + `killbill/mariadb:0.24`
2. Send any request with an `Origin` header set to an arbitrary domain
3. Observe the origin reflected verbatim in `Access-Control-Allow-Origin` with `Access-Control-Allow-Credentials: true`
4. Repeat with a completely different origin to confirm it's universal, not a one-off

Full `curl --trace-ascii` HTTP dumps for three tests (preflight, authenticated GET, second unrelated origin): https://gist.github.com/ituatd/517bed2c39b889a0117b1e7d0a50f34e

### What this PR does

1. **Configurable origin allowlist** via system property `org.killbill.server.cors.allowed.origins` (comma-separated). Only listed origins get reflected with `Access-Control-Allow-Credentials: true`.

2. **Safe default when no allowlist is set**: responds with `Access-Control-Allow-Origin: *` without credentials. Browsers block credentialed requests when the origin is `*`.

3. **Removes sensitive headers from `Access-Control-Expose-Headers`**: `Authorization`, `X-Killbill-ApiKey`, and `X-Killbill-ApiSecret` are no longer exposed to cross-origin JavaScript. They remain in `Access-Control-Allow-Headers` so they can still be sent in requests.

### Backward compatibility

- **No allowlist configured** (default): CORS changes from "reflect any origin with credentials" to "wildcard without credentials". Non-credentialed cross-origin requests still work. Credentialed requests require explicitly configuring allowed origins.
- **Allowlist configured**: Only specified origins get credentialed access. Intended model for Kaui or other known frontends.

```properties
# In killbill.properties
org.killbill.server.cors.allowed.origins=https://kaui.example.com,https://admin.example.com
```

### Evidence

https://gist.github.com/ituatd/517bed2c39b889a0117b1e7d0a50f34e