### PR TITLE
Harden invoice failures and improve logging. See #2211

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestHardenCatalogPlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestHardenCatalogPlugin.java
@@ -29,6 +29,7 @@ import org.joda.time.LocalDate;
 import org.joda.time.Period;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.api.FlakyRetryAnalyzer;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.DefaultVersionedCatalog;
@@ -115,7 +116,7 @@ public class TestHardenCatalogPlugin extends TestIntegrationBase {
         testCatalogPluginApi.reset();
     }
 
-    @Test(groups = "slow")
+    @Test(groups = "slow", retryAnalyzer = FlakyRetryAnalyzer.class)
     public void testCreateWithCatalogPluginRetryableException() throws Exception {
 
         testCatalogPluginApi.addCatalogVersion("org/killbill/billing/catalog/WeaponsHire.xml");
@@ -140,7 +141,7 @@ public class TestHardenCatalogPlugin extends TestIntegrationBase {
         assertListenerStatus();
     }
 
-    @Test(groups = "slow")
+    @Test(groups = "slow", retryAnalyzer = FlakyRetryAnalyzer.class)
     public void testCreateWithCatalogPluginSingleRuntimeException() throws Exception {
 
         testCatalogPluginApi.addCatalogVersion("org/killbill/billing/catalog/WeaponsHire.xml");
@@ -163,7 +164,7 @@ public class TestHardenCatalogPlugin extends TestIntegrationBase {
         assertListenerStatus();
     }
 
-    @Test(groups = "slow")
+    @Test(groups = "slow", retryAnalyzer = FlakyRetryAnalyzer.class)
     public void testCreateWithCatalogPluginNonSingleRuntimeException() throws Exception {
 
         testCatalogPluginApi.addCatalogVersion("org/killbill/billing/catalog/WeaponsHire.xml");

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestHardenCatalogPlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestHardenCatalogPlugin.java
@@ -216,18 +216,21 @@ public class TestHardenCatalogPlugin extends TestIntegrationBase {
         public VersionedPluginCatalog getVersionedPluginCatalog(final Iterable<PluginProperty> properties, final TenantContext tenantContext) {
             Assert.assertNotNull(versionedCatalog, "test did not initialize plugin catalog");
 
-            // Will throw once when we transition from 1 -> 0
-            if (throwOnZeroCounter > 0) {
-                throwOnZeroCounter--;
-                if (throwOnZeroCounter == 0) {
-                    // Re-increment for next round if we want to keep failing
-                    if (!throwOnce) {
-                        throwOnZeroCounter++;
-                    }
-                    if (retryPeriod != null) {
-                        throw new CatalogPluginApiRetryException(List.of(retryPeriod));
-                    } else {
-                        throw new RuntimeException("****  CATALOG PLUGIN RUNTIME EXCEPTION ****");
+            // Synchronized to protect the compound read-decrement-check-increment sequence from concurrent catalog lookups
+            synchronized (this) {
+                // Will throw once when we transition from 1 -> 0
+                if (throwOnZeroCounter > 0) {
+                    throwOnZeroCounter--;
+                    if (throwOnZeroCounter == 0) {
+                        // Re-increment for next round if we want to keep failing
+                        if (!throwOnce) {
+                            throwOnZeroCounter++;
+                        }
+                        if (retryPeriod != null) {
+                            throw new CatalogPluginApiRetryException(List.of(retryPeriod));
+                        } else {
+                            throw new RuntimeException("****  CATALOG PLUGIN RUNTIME EXCEPTION ****");
+                        }
                     }
                 }
             }

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1253,6 +1253,7 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         private final InvoiceConfig defaultInvoiceConfig;
         private boolean isInvoicingSystemEnabled;
         private boolean shouldParkAccountsWithUnknownUsage;
+        private boolean isParkAccountsOnAllExceptions;
         private boolean isZeroAmountUsageDisabled;
         private UsageDetailMode detailMode;
         private InArrearMode inArrearMode;
@@ -1457,6 +1458,16 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         }
 
         @Override
+        public boolean isParkAccountsOnAllExceptions() {
+            return isParkAccountsOnAllExceptions;
+        }
+
+        @Override
+        public boolean isParkAccountsOnAllExceptions(final InternalTenantContext tenantContext) {
+            return isParkAccountsOnAllExceptions();
+        }
+
+        @Override
         public List<TimeSpan> getRescheduleIntervalOnLock() {
             return defaultInvoiceConfig.getRescheduleIntervalOnLock();
         }
@@ -1481,6 +1492,7 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         public void reset() {
             isInvoicingSystemEnabled = defaultInvoiceConfig.isInvoicingSystemEnabled();
             shouldParkAccountsWithUnknownUsage = defaultInvoiceConfig.shouldParkAccountsWithUnknownUsage();
+            isParkAccountsOnAllExceptions = defaultInvoiceConfig.isParkAccountsOnAllExceptions();
             isZeroAmountUsageDisabled = defaultInvoiceConfig.isUsageZeroAmountDisabled();
             detailMode = defaultInvoiceConfig.getItemResultBehaviorMode();
             inArrearMode = defaultInvoiceConfig.getInArrearMode();

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithInvoicePlugin.java
@@ -44,6 +44,7 @@ import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.api.FlakyRetryAnalyzer;
 import org.killbill.billing.api.TestApiListener.NextEvent;
 import org.killbill.billing.beatrix.util.InvoiceChecker.ExpectedInvoiceItemCheck;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
@@ -180,6 +181,7 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
         testInvoicePluginApi.additionalInvoiceItem = null;
         testInvoicePluginApi.isAborted = false;
         testInvoicePluginApi.shouldUpdateDescription = false;
+        testInvoicePluginApi.shouldThrowException = false;
         testInvoicePluginApi.rescheduleDate = null;
         testInvoicePluginApi.wasRescheduled = false;
         testInvoicePluginApi.priorCallInvocationCalls = 0;
@@ -770,7 +772,7 @@ public class TestWithInvoicePlugin extends TestIntegrationBase {
         Assert.assertFalse(testInvoicePluginApi.wasRescheduled);
     }
 
-    @Test(groups = "slow")
+    @Test(groups = "slow", retryAnalyzer = FlakyRetryAnalyzer.class)
     public void testWithRetries() throws Exception {
 
         testInvoicePluginApi.taxItems = PerSubscriptionTaxItems;

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -333,8 +333,10 @@ public class InvoiceDispatcher {
                 throw new InvoiceApiException(e, ErrorCode.UNEXPECTED_ERROR, "Failed to generate invoice: failed to acquire lock");
             }
             if (!rescheduleProcessAccount(accountId, context)) {
-                log.warn("Failed to process invoice for accountId='{}', targetDate='{}', parking account", accountId, targetDate, e);
-                parkAccount(accountId, context);
+                log.warn("Failed to generate invoice for accountId='{}', targetDate='{}'", accountId, targetDate, e);
+                if (invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                    parkAccount(accountId, context);
+                }
             }
         } finally {
             if (lock != null) {
@@ -464,13 +466,22 @@ public class InvoiceDispatcher {
             printInvoiceTiming(invoiceTimings);
             return result;
         } catch (final CatalogApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                parkAccount(accountId, context);
+            }
             return Collections.emptyList();
         } catch (final AccountApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                parkAccount(accountId, context);
+            }
             return Collections.emptyList();
         } catch (final SubscriptionBaseApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                parkAccount(accountId, context);
+            }
             return Collections.emptyList();
         } catch (final InvoiceApiException e) {
             if (e.getCode() == ErrorCode.INVOICE_PLUGIN_API_ABORTED.getCode()) {
@@ -478,7 +489,6 @@ public class InvoiceDispatcher {
             }
 
             if (e.getCode() == ErrorCode.UNEXPECTED_ERROR.getCode() && !isDryRun) {
-                log.warn("Illegal invoicing state detected for accountId='{}', dryRunArguments='{}', parking account", accountId, dryRunArguments, e);
                 parkAccount(accountId, context);
             }
             throw e;

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -333,7 +333,8 @@ public class InvoiceDispatcher {
                 throw new InvoiceApiException(e, ErrorCode.UNEXPECTED_ERROR, "Failed to generate invoice: failed to acquire lock");
             }
             if (!rescheduleProcessAccount(accountId, context)) {
-                log.warn("Failed to process invoice for accountId='{}', targetDate='{}'", accountId, targetDate, e);
+                log.warn("Failed to process invoice for accountId='{}', targetDate='{}', parking account", accountId, targetDate, e);
+                parkAccount(accountId, context);
             }
         } finally {
             if (lock != null) {
@@ -350,9 +351,12 @@ public class InvoiceDispatcher {
         if (periods.size() == 0) {
             return false;
         }
-        // Since we can't keep track of attempts, we only look at the first value
+        // Unlike the QueueRetryException path (Paths B/C), the notification-queue path cannot track
+        // retry counts across reschedules, so exactly one reschedule is issued per failed attempt using
+        // the first period in the schedule. Each rescheduled notification that also fails re-issues a
+        // single reschedule with the same delay.
         final DateTime nextRescheduleDt = clock.getUTCNow().plus(periods.get(0));
-        log.info("Rescheduling invoice call at time {}", nextRescheduleDt);
+        log.info("Failed to acquire lock, rescheduling invoice for accountId='{}' at '{}'", accountId, nextRescheduleDt);
         invoiceDao.rescheduleInvoiceNotification(accountId, nextRescheduleDt, context);
         return true;
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -467,19 +467,19 @@ public class InvoiceDispatcher {
             return result;
         } catch (final CatalogApiException e) {
             log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
-            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+            if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
             return Collections.emptyList();
         } catch (final AccountApiException e) {
             log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
-            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+            if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
             return Collections.emptyList();
         } catch (final SubscriptionBaseApiException e) {
             log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
-            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+            if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
             return Collections.emptyList();
@@ -488,7 +488,7 @@ public class InvoiceDispatcher {
                 log.info("Invoice generation aborted by plugin for accountId='{}', targetDate='{}'", accountId, inputTargetDate);
                 return Collections.emptyList();
             }
-
+            // Only case where we park even if this is from an API call
             if (e.getCode() == ErrorCode.UNEXPECTED_ERROR.getCode() && !isDryRun) {
                 parkAccount(accountId, context);
             }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -472,6 +472,11 @@ public class InvoiceDispatcher {
             } else if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
+            // For non-API, non-dry-run paths the exception has been fully handled above (logged and parked if applicable).
+            // Rethrowing would only cause duplicate logging in the async callers that catch and swallow it anyway.
+            if (!isApiCall && !isDryRun) {
+                return Collections.emptyList();
+            }
             throw e;
         } catch (RuntimeException e) { // The case of LockFailedException was handled prior we enter this method.
             log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -488,12 +488,21 @@ public class InvoiceDispatcher {
                 log.info("Invoice generation aborted by plugin for accountId='{}', targetDate='{}'", accountId, inputTargetDate);
                 return Collections.emptyList();
             }
-            // Only case where we park even if this is from an API call
+            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            // Only case where we park even if this is from an API call and isParkAccountsOnAllExceptions is not explicitly set.
             if (e.getCode() == ErrorCode.UNEXPECTED_ERROR.getCode() && !isDryRun) {
+                parkAccount(accountId, context);
+            } else if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
             throw e;
-        } catch (final NoSuchNotificationQueue e) {
+        } catch (RuntimeException e) { // The case of LockFailedException was handled prior we enter this method.
+            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                parkAccount(accountId, context);
+            }
+            throw e;
+        } catch (final NoSuchNotificationQueue e) { /* Dry run use cases */
             throw new InvoiceApiException(ErrorCode.UNEXPECTED_ERROR, "Failed to retrieve future notifications from notificationQ");
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -44,7 +44,6 @@ import javax.inject.Inject;
 
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
-import org.joda.time.Period;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
@@ -332,35 +331,13 @@ public class InvoiceDispatcher {
             if (isApiCall) {
                 throw new InvoiceApiException(e, ErrorCode.UNEXPECTED_ERROR, "Failed to generate invoice: failed to acquire lock");
             }
-            if (!rescheduleProcessAccount(accountId, context)) {
-                log.warn("Failed to generate invoice for accountId='{}', targetDate='{}'", accountId, targetDate, e);
-                if (invoiceConfig.isParkAccountsOnAllExceptions(context)) {
-                    parkAccount(accountId, context);
-                }
-            }
+            log.warn("Failed to generate invoice for accountId='{}', targetDate='{}', could not acquire lock", accountId, targetDate, e);
+            throw new QueueRetryException(e, TimeSpanConverter.toListPeriod(invoiceConfig.getRescheduleIntervalOnLock(context)));
         } finally {
             if (lock != null) {
                 lock.release();
             }
         }
-        return Collections.emptyList();
-    }
-
-
-    private boolean rescheduleProcessAccount(final UUID accountId, final InternalCallContext context) {
-
-        final List<Period> periods = TimeSpanConverter.toListPeriod(invoiceConfig.getRescheduleIntervalOnLock(context));
-        if (periods.size() == 0) {
-            return false;
-        }
-        // Unlike the QueueRetryException path (Paths B/C), the notification-queue path cannot track
-        // retry counts across reschedules, so exactly one reschedule is issued per failed attempt using
-        // the first period in the schedule. Each rescheduled notification that also fails re-issues a
-        // single reschedule with the same delay.
-        final DateTime nextRescheduleDt = clock.getUTCNow().plus(periods.get(0));
-        log.info("Failed to acquire lock, rescheduling invoice for accountId='{}' at '{}'", accountId, nextRescheduleDt);
-        invoiceDao.rescheduleInvoiceNotification(accountId, nextRescheduleDt, context);
-        return true;
     }
 
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -485,6 +485,7 @@ public class InvoiceDispatcher {
             return Collections.emptyList();
         } catch (final InvoiceApiException e) {
             if (e.getCode() == ErrorCode.INVOICE_PLUGIN_API_ABORTED.getCode()) {
+                log.info("Invoice generation aborted by plugin for accountId='{}', targetDate='{}'", accountId, inputTargetDate);
                 return Collections.emptyList();
             }
 
@@ -708,6 +709,7 @@ public class InvoiceDispatcher {
         invoiceTimings.put(InvoiceTiming.PLUGINS_PRIOR_CALL, System.nanoTime() - startNano);
 
         if (priorCallResult.getRescheduleDate() != null) {
+            log.info("Invoice generation rescheduled by plugin for accountId='{}', targetDate='{}', rescheduled to '{}'", accountId, originalTargetDate, priorCallResult.getRescheduleDate());
             final FutureAccountNotifications futureAccountNotifications = createNextFutureNotificationDate(priorCallResult.getRescheduleDate(), billingEvents, internalCallContext);
             setFutureNotifications(account, futureAccountNotifications, internalCallContext);
             return null;

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -194,7 +194,7 @@ public class InvoiceDispatcher {
         try {
             processAccount(false, accountId, null, null, false, true, Collections.emptyList(), internalCallContext);
         } catch (final InvoiceApiException e) {
-            log.warn("Failed to process BCD change for accountId='{}'", accountId, e);
+            log.warn("Failed to generate invoice for accountId='{}', BCD change processing failed", accountId, e);
         }
     }
 
@@ -220,7 +220,7 @@ public class InvoiceDispatcher {
 
             processSubscriptionStartRequestedDateWithLock(accountId, transition, context);
         } catch (final LockFailedException e) {
-            log.warn("Failed to process RequestedSubscriptionInternalEvent for accountId='{}'", accountId, e);
+            log.warn("Failed to generate invoice for accountId='{}', could not acquire lock", accountId, e);
             throw new QueueRetryException(e, TimeSpanConverter.toListPeriod(invoiceConfig.getRescheduleIntervalOnLock(context)));
         } finally {
             if (lock != null) {
@@ -691,7 +691,7 @@ public class InvoiceDispatcher {
         try {
             account = accountApi.getImmutableAccountDataById(accountId, internalCallContext);
         } catch (final AccountApiException e) {
-            log.error("Unable to generate invoice for accountId='{}', a future notification has NOT been recorded", accountId, e);
+            log.warn("Failed to generate invoice for accountId='{}', a future notification has NOT been recorded", accountId, e);
             long startNano = System.nanoTime();
             invoicePluginDispatcher.onFailureCall(originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, inputProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
@@ -879,7 +879,7 @@ public class InvoiceDispatcher {
         try {
             account = accountApi.getImmutableAccountDataById(accountId, internalCallContext);
         } catch (final AccountApiException e) {
-            log.error("Unable to generate invoice for accountId='{}', a future notification has NOT been recorded", accountId, e);
+            log.warn("Failed to generate invoice for accountId='{}', a future notification has NOT been recorded", accountId, e);
             long startNano = System.nanoTime();
             invoicePluginDispatcher.onFailureCall(originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, inputProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
@@ -1353,7 +1353,7 @@ public class InvoiceDispatcher {
 
             processParentInvoiceForInvoiceGenerationWithLock(childAccount, childInvoiceId, context);
         } catch (final LockFailedException e) {
-            log.warn("Failed to process parent invoice for parentAccountId='{}'", childAccount.getParentAccountId().toString(), e);
+            log.warn("Failed to generate invoice for parentAccountId='{}', could not acquire lock", childAccount.getParentAccountId().toString(), e);
             throw new QueueRetryException(e, TimeSpanConverter.toListPeriod(invoiceConfig.getRescheduleIntervalOnLock(context)));
         } finally {
             if (lock != null) {
@@ -1440,7 +1440,7 @@ public class InvoiceDispatcher {
 
             processParentInvoiceForAdjustmentsWithLock(childAccount, childInvoiceId, context);
         } catch (final LockFailedException e) {
-            log.warn("Failed to process parent invoice for parentAccountId='{}'", childAccount.getParentAccountId().toString(), e);
+            log.warn("Failed to generate invoice for parentAccountId='{}', could not acquire lock", childAccount.getParentAccountId().toString(), e);
             throw new QueueRetryException(e, TimeSpanConverter.toListPeriod(invoiceConfig.getRescheduleIntervalOnLock(context)));
         } finally {
             if (lock != null) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -47,12 +47,14 @@ import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.commons.eventbus.AllowConcurrentEvents;
 import org.killbill.commons.eventbus.Subscribe;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
+import org.killbill.queue.api.QueueEvent;
 import org.killbill.queue.retry.RetryableService;
 import org.killbill.queue.retry.RetryableSubscriber;
 import org.killbill.queue.retry.RetryableSubscriber.SubscriberAction;
@@ -67,9 +69,12 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
 
     private static final Logger log = LoggerFactory.getLogger(InvoiceListener.class);
 
+    private final AccountInternalApi accountApi;
     private final InvoiceDispatcher dispatcher;
     private final InternalCallContextFactory internalCallContextFactory;
+    private final InvoiceConfig invoiceConfig;
     private final InvoiceInternalApi invoiceApi;
+    private final ParkedAccountsManager parkedAccountsManager;
     private final RetryableSubscriber retryableSubscriber;
     private final BusDispatcherOptimizer busDispatcherOptimizer;
     private final SubscriberQueueHandler subscriberQueueHandler;
@@ -79,13 +84,18 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                            final InternalCallContextFactory internalCallContextFactory,
                            final InvoiceDispatcher dispatcher,
                            final InvoiceInternalApi invoiceApi,
+                           final InvoiceConfig invoiceConfig,
+                           final ParkedAccountsManager parkedAccountsManager,
                            final NotificationQueueService notificationQueueService,
                            final BusDispatcherOptimizer busDispatcherOptimizer,
                            final Clock clock) {
         super(notificationQueueService);
+        this.accountApi = accountApi;
         this.dispatcher = dispatcher;
         this.internalCallContextFactory = internalCallContextFactory;
+        this.invoiceConfig = invoiceConfig;
         this.invoiceApi = invoiceApi;
+        this.parkedAccountsManager = parkedAccountsManager;
         this.busDispatcherOptimizer = busDispatcherOptimizer;
         this.subscriberQueueHandler = new SubscriberQueueHandler();
 
@@ -104,6 +114,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      dispatcher.processSubscriptionForInvoiceGeneration(event, context);
                                                  } catch (final InvoiceApiException e) {
                                                      log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 } catch (final RuntimeException e) {
+                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                     throw e;
                                                  }
                                              }
                                          });
@@ -122,8 +137,14 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      dispatcher.processAccountFromNotificationOrBusEvent(accountId, null, null, false, context);
                                                  } catch (final InvoiceApiException e) {
                                                      log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
                                                      log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 } catch (final RuntimeException e) {
+                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                     throw e;
                                                  }
                                              }
                                          });
@@ -142,8 +163,14 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
 
                                                  } catch (final InvoiceApiException e) {
                                                      log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
                                                      log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 } catch (final RuntimeException e) {
+                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                     throw e;
                                                  }
                                              }
                                          });
@@ -161,8 +188,14 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      }
                                                  } catch (final InvoiceApiException e) {
                                                      log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
                                                      log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 } catch (final RuntimeException e) {
+                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                     throw e;
                                                  }
                                              }
                                          });
@@ -175,9 +208,14 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      return;
                                                  }
 
-
-                                                 final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-                                                 dispatcher.processSubscriptionStartRequestedDate(event, context);
+                                                 try {
+                                                     final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+                                                     dispatcher.processSubscriptionStartRequestedDate(event, context);
+                                                 } catch (final RuntimeException e) {
+                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                     throw e;
+                                                 }
                                              }
                                          });
         subscriberQueueHandler.subscribe(AccountChangeInternalEvent.class,
@@ -188,8 +226,14 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      if ("billCycleDayLocal".equals(changedField.getFieldName()) &&
                                                          !Objects.equals(changedField.getOldValue(), changedField.getNewValue()) &&
                                                          !"0".equals(changedField.getOldValue())) {
-                                                         final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "AccountBCDChange", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-                                                         dispatcher.processAccountBCDChange(event.getAccountId(), context);
+                                                         try {
+                                                             final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "AccountBCDChange", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+                                                             dispatcher.processAccountBCDChange(event.getAccountId(), context);
+                                                         } catch (final RuntimeException e) {
+                                                             log.warn("Unable to process event {}", event, e);
+                                                             handleFailedInvoiceDispatch("AccountBCDChange", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                             throw e;
+                                                         }
                                                          return;
                                                      }
                                                  }
@@ -300,5 +344,37 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
     @Subscribe
     public void handleChildrenInvoiceAdjustmentEvent(final DefaultInvoiceAdjustmentEvent event) {
         handleEvent(event);
+    }
+
+    /**
+     * Called when the retry schedule is exhausted for a notification event.
+     * Subclasses of RetryableService can override this hook to take remedial action.
+     * Note: this method is intended to be called by RetryableService once killbill-commons adds the hook.
+     * searchKey1 = accountRecordId, searchKey2 = tenantRecordId.
+     */
+    public void onRetriesExhausted(final QueueEvent event, final Long searchKey1, final Long searchKey2) {
+        try {
+            final InternalCallContext context = internalCallContextFactory.createInternalCallContext(searchKey2, searchKey1, "InvoiceRetryExhausted", CallOrigin.INTERNAL, UserType.SYSTEM, null);
+            final UUID accountId = accountApi.getByRecordId(searchKey1, context);
+            log.warn("Failed to generate invoice for accountId='{}', all retries exhausted", accountId);
+            parkedAccountsManager.parkAccount(accountId, context);
+        } catch (final Exception e) {
+            log.warn("Unable to park account after retries exhausted for accountRecordId='{}'", searchKey1, e);
+        }
+    }
+
+    private void handleFailedInvoiceDispatch(final String eventDescription, final Long accountRecordId,
+                                             final Long tenantRecordId, final UUID userToken, final Exception e) {
+        if (!invoiceConfig.isParkAccountsOnAllExceptions()) {
+            return;
+        }
+        try {
+            final InternalCallContext context = internalCallContextFactory.createInternalCallContext(tenantRecordId, accountRecordId, eventDescription, CallOrigin.INTERNAL, UserType.SYSTEM, userToken);
+            final UUID accountId = accountApi.getByRecordId(accountRecordId, context);
+            log.warn("Failed to generate invoice for accountId='{}', event='{}'", accountId, eventDescription, e);
+            parkedAccountsManager.parkAccount(accountId, context);
+        } catch (final Exception inner) {
+            log.warn("Unable to park account after invoice failure for accountRecordId='{}'", accountRecordId, inner);
+        }
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -113,10 +113,10 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
                                                      dispatcher.processSubscriptionForInvoiceGeneration(event, context);
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final RuntimeException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
@@ -136,13 +136,13 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      final UUID accountId = accountApi.getByRecordId(event.getSearchKey1(), context);
                                                      dispatcher.processAccountFromNotificationOrBusEvent(accountId, null, null, false, context);
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final RuntimeException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
@@ -162,13 +162,13 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      }
 
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final RuntimeException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
@@ -187,13 +187,13 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                          dispatcher.processParentInvoiceForAdjustments(account, event.getInvoiceId(), context);
                                                      }
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final RuntimeException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
@@ -212,7 +212,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
                                                      dispatcher.processSubscriptionStartRequestedDate(event, context);
                                                  } catch (final RuntimeException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                      handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
@@ -230,7 +230,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                              final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "AccountBCDChange", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
                                                              dispatcher.processAccountBCDChange(event.getAccountId(), context);
                                                          } catch (final RuntimeException e) {
-                                                             log.warn("Unable to process event {}", event, e);
+                                                             log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                              handleFailedInvoiceDispatch("AccountBCDChange", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                              throw e;
                                                          }
@@ -305,7 +305,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         try {
             dispatcher.processSubscriptionForInvoiceGeneration(context.toLocalDate(eventDateTime), isRescheduled, context);
         } catch (final InvoiceApiException e) {
-            log.warn("Unable to process next billing date event, eventDateTime='{}'", eventDateTime, e);
+            log.warn("Failed to generate invoice for accountRecordId='{}', eventDateTime='{}'", accountRecordId, eventDateTime, e);
         }
     }
 
@@ -314,7 +314,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         try {
             dispatcher.processSubscriptionForInvoiceNotification(context.toLocalDate(eventDateTime), context);
         } catch (final InvoiceApiException e) {
-            log.warn("Unable to process event for invoice notification eventDateTime='{}'", eventDateTime, e);
+            log.warn("Failed to generate invoice for accountRecordId='{}', eventDateTime='{}'", accountRecordId, eventDateTime, e);
         }
     }
 
@@ -335,7 +335,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         } catch (final InvoiceApiException e) {
             // In case we commit parent invoice earlier we expect to see an INVOICE_INVALID_STATUS status
             if (ErrorCode.INVOICE_INVALID_STATUS.getCode() != e.getCode()) {
-                log.error(e.getMessage());
+                log.warn("Failed to commit parent invoice for invoiceId='{}'", invoiceId, e);
             }
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -346,12 +346,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         handleEvent(event);
     }
 
-    /**
-     * Called when the retry schedule is exhausted for a notification event.
-     * Subclasses of RetryableService can override this hook to take remedial action.
-     * Note: this method is intended to be called by RetryableService once killbill-commons adds the hook.
-     * searchKey1 = accountRecordId, searchKey2 = tenantRecordId.
-     */
+    @Override
     public void onRetriesExhausted(final QueueEvent event, final Long searchKey1, final Long searchKey2) {
         try {
             final InternalCallContext context = internalCallContextFactory.createInternalCallContext(searchKey2, searchKey1, "InvoiceRetryExhausted", CallOrigin.INTERNAL, UserType.SYSTEM, null);

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -47,7 +47,6 @@ import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
-import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.commons.eventbus.AllowConcurrentEvents;
@@ -72,7 +71,6 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
     private final AccountInternalApi accountApi;
     private final InvoiceDispatcher dispatcher;
     private final InternalCallContextFactory internalCallContextFactory;
-    private final InvoiceConfig invoiceConfig;
     private final InvoiceInternalApi invoiceApi;
     private final ParkedAccountsManager parkedAccountsManager;
     private final RetryableSubscriber retryableSubscriber;
@@ -84,7 +82,6 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                            final InternalCallContextFactory internalCallContextFactory,
                            final InvoiceDispatcher dispatcher,
                            final InvoiceInternalApi invoiceApi,
-                           final InvoiceConfig invoiceConfig,
                            final ParkedAccountsManager parkedAccountsManager,
                            final NotificationQueueService notificationQueueService,
                            final BusDispatcherOptimizer busDispatcherOptimizer,
@@ -93,7 +90,6 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         this.accountApi = accountApi;
         this.dispatcher = dispatcher;
         this.internalCallContextFactory = internalCallContextFactory;
-        this.invoiceConfig = invoiceConfig;
         this.invoiceApi = invoiceApi;
         this.parkedAccountsManager = parkedAccountsManager;
         this.busDispatcherOptimizer = busDispatcherOptimizer;
@@ -114,10 +110,8 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      dispatcher.processSubscriptionForInvoiceGeneration(event, context);
                                                  } catch (final InvoiceApiException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final RuntimeException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
                                              }
@@ -137,13 +131,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      dispatcher.processAccountFromNotificationOrBusEvent(accountId, null, null, false, context);
                                                  } catch (final InvoiceApiException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                     // AccountApiException here means the account could not be fetched before invoicing; log with recordId as accountId is unavailable
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}', account does not seem to exist", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                  } catch (final RuntimeException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
                                              }
@@ -153,6 +145,8 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                              @Override
                                              public void run(final InvoiceCreationInternalEvent event) {
                                                  try {
+                                                     // If this fail, technically we should park account when isParkAccountsOnAllExceptions is set but 
+                                                     // since we can't extract account, there is nothing to park.
                                                      final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "CreateParentInvoice", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
                                                      final Account account = accountApi.getAccountById(event.getAccountId(), context);
 
@@ -163,13 +157,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
 
                                                  } catch (final InvoiceApiException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                     // AccountApiException here means the account could not be fetched before invoicing; log with recordId as accountId is unavailable
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}', account does not seem to exist", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                  } catch (final RuntimeException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
                                              }
@@ -188,13 +180,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      }
                                                  } catch (final InvoiceApiException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                     // AccountApiException here means the account could not be fetched before invoicing; log with recordId as accountId is unavailable
+                                                     log.warn("Failed to generate invoice for accountRecordId='{}', event='{}', account does not seem to exist", event.getSearchKey1(), event.getClass().getSimpleName(), e);
                                                  } catch (final RuntimeException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
                                              }
@@ -213,7 +203,6 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      dispatcher.processSubscriptionStartRequestedDate(event, context);
                                                  } catch (final RuntimeException e) {
                                                      log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                      throw e;
                                                  }
                                              }
@@ -231,7 +220,6 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                              dispatcher.processAccountBCDChange(event.getAccountId(), context);
                                                          } catch (final RuntimeException e) {
                                                              log.warn("Failed to generate invoice for accountRecordId='{}', event='{}'", event.getSearchKey1(), event.getClass().getSimpleName(), e);
-                                                             handleFailedInvoiceDispatch("AccountBCDChange", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                              throw e;
                                                          }
                                                          return;
@@ -358,18 +346,5 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         }
     }
 
-    private void handleFailedInvoiceDispatch(final String eventDescription, final Long accountRecordId,
-                                             final Long tenantRecordId, final UUID userToken, final Exception e) {
-        if (!invoiceConfig.isParkAccountsOnAllExceptions()) {
-            return;
-        }
-        try {
-            final InternalCallContext context = internalCallContextFactory.createInternalCallContext(tenantRecordId, accountRecordId, eventDescription, CallOrigin.INTERNAL, UserType.SYSTEM, userToken);
-            final UUID accountId = accountApi.getByRecordId(accountRecordId, context);
-            log.warn("Failed to generate invoice for accountId='{}', event='{}'", accountId, eventDescription, e);
-            parkedAccountsManager.parkAccount(accountId, context);
-        } catch (final Exception inner) {
-            log.warn("Unable to park account after invoice failure for accountRecordId='{}'", accountRecordId, inner);
-        }
-    }
 }
+

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -199,16 +199,21 @@ public class InvoicePluginDispatcher {
 
         Iterable<PluginProperty> inputPluginProperties = pluginProperties;
         for (final InvoicePluginApi invoicePlugin : invoicePlugins) {
-            if (isSuccess) {
-                final OnSuccessInvoiceResult res1 = invoicePlugin.onSuccessCall(invoiceContext, inputPluginProperties);
-                if (res1 != null && res1.getAdjustedPluginProperties() != null) {
-                    inputPluginProperties = res1.getAdjustedPluginProperties();
+            try {
+                if (isSuccess) {
+                    final OnSuccessInvoiceResult res1 = invoicePlugin.onSuccessCall(invoiceContext, inputPluginProperties);
+                    if (res1 != null && res1.getAdjustedPluginProperties() != null) {
+                        inputPluginProperties = res1.getAdjustedPluginProperties();
+                    }
+                } else {
+                    final OnFailureInvoiceResult res2 = invoicePlugin.onFailureCall(invoiceContext, inputPluginProperties);
+                    if (res2 != null && res2.getAdjustedPluginProperties() != null) {
+                        inputPluginProperties = res2.getAdjustedPluginProperties();
+                    }
                 }
-            } else {
-                final OnFailureInvoiceResult res2 = invoicePlugin.onFailureCall(invoiceContext, inputPluginProperties);
-                if (res2 != null && res2.getAdjustedPluginProperties() != null) {
-                    inputPluginProperties = res2.getAdjustedPluginProperties();
-                }
+            } catch (final RuntimeException e) {
+                log.warn("Invoice plugin {} threw an exception during {} call for targetDate='{}'",
+                         invoicePlugin, isSuccess ? "onSuccessCall" : "onFailureCall", targetDate, e);
             }
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -188,7 +188,7 @@ public class InvoicePluginDispatcher {
                                   final CallContext callContext,
                                   final Iterable<PluginProperty> pluginProperties,
                                   final InternalTenantContext internalTenantContext) {
-        final Collection<InvoicePluginApi> invoicePlugins = getInvoicePlugins(internalTenantContext).values();
+        final Map<String, InvoicePluginApi> invoicePlugins = getInvoicePlugins(internalTenantContext);
         if (invoicePlugins.isEmpty()) {
             return;
         }
@@ -198,7 +198,9 @@ public class InvoicePluginDispatcher {
         final InvoiceContext invoiceContext = new DefaultInvoiceContext(targetDate, clonedInvoice, existingInvoices, isDryRun, isRescheduled, callContext);
 
         Iterable<PluginProperty> inputPluginProperties = pluginProperties;
-        for (final InvoicePluginApi invoicePlugin : invoicePlugins) {
+        for (final Entry<String, InvoicePluginApi> entry : invoicePlugins.entrySet()) {
+            final String invoicePluginName = entry.getKey();
+            final InvoicePluginApi invoicePlugin = entry.getValue();
             try {
                 if (isSuccess) {
                     final OnSuccessInvoiceResult res1 = invoicePlugin.onSuccessCall(invoiceContext, inputPluginProperties);
@@ -213,7 +215,7 @@ public class InvoicePluginDispatcher {
                 }
             } catch (final RuntimeException e) {
                 log.warn("Invoice plugin {} threw an exception during {} call for targetDate='{}'",
-                         invoicePlugin, isSuccess ? "onSuccessCall" : "onFailureCall", targetDate, e);
+                         invoicePluginName, isSuccess ? "onSuccessCall" : "onFailureCall", targetDate, e);
             }
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/ParkedAccountsManager.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/ParkedAccountsManager.java
@@ -27,10 +27,14 @@ import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.tag.TagInternalApi;
 import org.killbill.billing.util.api.TagApiException;
 import org.killbill.billing.util.api.TagDefinitionApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.killbill.billing.util.tag.dao.SystemTags.PARK_TAG_DEFINITION_ID;
 
 public class ParkedAccountsManager {
+
+    private static final Logger log = LoggerFactory.getLogger(ParkedAccountsManager.class);
 
     private final TagInternalApi tagApi;
 
@@ -41,6 +45,7 @@ public class ParkedAccountsManager {
 
     // Idempotent
     public void parkAccount(final UUID accountId, final InternalCallContext internalCallContext) throws TagApiException {
+        log.warn("Parking account for accountId='{}'", accountId);
         try {
             tagApi.addTag(accountId, ObjectType.ACCOUNT, PARK_TAG_DEFINITION_ID, internalCallContext);
         } catch (final TagApiException e) {
@@ -51,6 +56,7 @@ public class ParkedAccountsManager {
     }
 
     public void unparkAccount(final UUID accountId, final InternalCallContext internalCallContext) throws TagApiException {
+        log.warn("Unparking account for accountId='{}'", accountId);
         tagApi.removeTag(accountId, ObjectType.ACCOUNT, PARK_TAG_DEFINITION_ID, internalCallContext);
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -295,6 +295,20 @@ public class MultiTenantInvoiceConfig extends MultiTenantLockAwareConfigBase imp
     }
 
     @Override
+    public boolean isParkAccountsOnAllExceptions() {
+        return staticConfig.isParkAccountsOnAllExceptions();
+    }
+
+    @Override
+    public boolean isParkAccountsOnAllExceptions(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("isParkAccountsOnAllExceptions", tenantContext);
+        if (result != null) {
+            return Boolean.parseBoolean(result);
+        }
+        return isParkAccountsOnAllExceptions();
+    }
+
+    @Override
     protected Class<? extends KillbillConfig> getConfigClass() {
         return InvoiceConfig.class;
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -436,14 +436,6 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
         });
     }
 
-    @Override
-    public void rescheduleInvoiceNotification(final UUID accountId, final DateTime nextRescheduleDt, final InternalCallContext context) {
-        transactionalSqlDao.execute(false, entitySqlDaoWrapperFactory -> {
-            nextBillingDatePoster.insertNextBillingNotificationFromTransaction(entitySqlDaoWrapperFactory, accountId, Collections.emptySet(), nextRescheduleDt, true, context);
-            return null;
-        });
-    }
-
     public List<InvoiceItemModelDao> createInvoices(final Iterable<InvoiceModelDao> inputInvoices,
                                                     @Nullable final BillingEventSet billingEvents,
                                                     final Set<InvoiceTrackingModelDao> trackingIds,

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/InvoiceDao.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.callcontext.InternalCallContext;
@@ -58,8 +57,6 @@ public interface InvoiceDao extends EntityDao<InvoiceModelDao, Invoice, InvoiceA
                                                       final InternalCallContext context);
 
     InvoiceStatus getInvoiceStatus(final UUID invoiceId, final InternalTenantContext context) throws InvoiceApiException;
-
-    void rescheduleInvoiceNotification(final UUID accountId, final DateTime nextRescheduleDt, final InternalCallContext context);
 
     InvoiceModelDao getByNumber(Integer number, Boolean includeInvoiceComponents, InternalTenantContext context) throws InvoiceApiException;
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/notification/DefaultNextBillingDateNotifier.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/notification/DefaultNextBillingDateNotifier.java
@@ -117,11 +117,8 @@ public class DefaultNextBillingDateNotifier extends RetryableService implements 
         listener.handleEventForInvoiceNotification(eventDateTime, userToken, accountRecordId, tenantRecordId);
     }
 
-    /**
-     * Delegates retry exhaustion handling to the InvoiceListener.
-     * Note: this method is intended to be called by RetryableService once killbill-commons adds the hook.
-     */
-    public void onRetriesExhausted(final QueueEvent event, final Long searchKey1, final Long searchKey2) {
+    @Override
+    protected void onRetriesExhausted(final QueueEvent event, final Long searchKey1, final Long searchKey2) {
         listener.onRetriesExhausted(event, searchKey1, searchKey2);
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/notification/DefaultNextBillingDateNotifier.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/notification/DefaultNextBillingDateNotifier.java
@@ -33,6 +33,7 @@ import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
 import org.killbill.notificationq.api.NotificationQueueService.NotificationQueueAlreadyExists;
 import org.killbill.notificationq.api.NotificationQueueService.NotificationQueueHandler;
+import org.killbill.queue.api.QueueEvent;
 import org.killbill.queue.retry.RetryableHandler;
 import org.killbill.queue.retry.RetryableService;
 import org.slf4j.Logger;
@@ -114,5 +115,13 @@ public class DefaultNextBillingDateNotifier extends RetryableService implements 
 
     private void processEventForInvoiceNotification(final DateTime eventDateTime, final UUID userToken, final Long accountRecordId, final Long tenantRecordId) {
         listener.handleEventForInvoiceNotification(eventDateTime, userToken, accountRecordId, tenantRecordId);
+    }
+
+    /**
+     * Delegates retry exhaustion handling to the InvoiceListener.
+     * Note: this method is intended to be called by RetryableService once killbill-commons adds the hook.
+     */
+    public void onRetriesExhausted(final QueueEvent event, final Long searchKey1, final Long searchKey2) {
+        listener.onRetriesExhausted(event, searchKey1, searchKey2);
     }
 }

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.invoice.api.InvoiceInternalApi;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
@@ -41,9 +42,11 @@ public class TestInvoiceNotificationQListener extends InvoiceListener {
                                             final InternalCallContextFactory internalCallContextFactory,
                                             final InvoiceDispatcher dispatcher,
                                             final InvoiceInternalApi invoiceApi,
+                                            final InvoiceConfig invoiceConfig,
+                                            final ParkedAccountsManager parkedAccountsManager,
                                             final BusDispatcherOptimizer busOptimizer,
                                             final NotificationQueueService notificationQueueService) {
-        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, notificationQueueService, busOptimizer, clock);
+        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, invoiceConfig, parkedAccountsManager, notificationQueueService, busOptimizer, clock);
     }
 
     @Override

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
@@ -26,7 +26,6 @@ import org.joda.time.DateTime;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.invoice.api.InvoiceInternalApi;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
-import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
@@ -42,11 +41,10 @@ public class TestInvoiceNotificationQListener extends InvoiceListener {
                                             final InternalCallContextFactory internalCallContextFactory,
                                             final InvoiceDispatcher dispatcher,
                                             final InvoiceInternalApi invoiceApi,
-                                            final InvoiceConfig invoiceConfig,
                                             final ParkedAccountsManager parkedAccountsManager,
                                             final BusDispatcherOptimizer busOptimizer,
                                             final NotificationQueueService notificationQueueService) {
-        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, invoiceConfig, parkedAccountsManager, notificationQueueService, busOptimizer, clock);
+        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, parkedAccountsManager, notificationQueueService, busOptimizer, clock);
     }
 
     @Override

--- a/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/dao/MockInvoiceDao.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.account.api.Account;
@@ -82,11 +81,6 @@ public class MockInvoiceDao extends MockEntityDaoBase<InvoiceModelDao, Invoice, 
             }
             return invoice.getStatus();
         }
-    }
-
-    @Override
-    public void rescheduleInvoiceNotification(final UUID accountId, final DateTime nextRescheduleDt, final InternalCallContext context) {
-
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.146.68</version>
+        <version>0.146.70</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.24.18-SNAPSHOT</version>

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -212,6 +212,16 @@ public interface InvoiceConfig extends LockAwareConfig {
     @Description("Whether to park accounts when usage data is recorded but not defined in the catalog")
     boolean shouldParkAccountsWithUnknownUsage(@Param("dummy") final InternalTenantContext tenantContext);
 
+    @Config("org.killbill.invoice.parkAccountsOnAllExceptions")
+    @Default("true")
+    @Description("Whether to park accounts on all unrecoverable invoice processing failures (lock failure, subscriber exceptions, billing event fetch failures)")
+    boolean isParkAccountsOnAllExceptions();
+
+    @Config("org.killbill.invoice.parkAccountsOnAllExceptions")
+    @Default("true")
+    @Description("Whether to park accounts on all unrecoverable invoice processing failures (lock failure, subscriber exceptions, billing event fetch failures)")
+    boolean isParkAccountsOnAllExceptions(@Param("dummy") final InternalTenantContext tenantContext);
+
     @Config("org.killbill.invoice.maxInvoiceLimit")
     @Default(DEFAULT_NULL_PERIOD)
     @Description("How far back in time should invoice generation look at")


### PR DESCRIPTION
This PR addresses the 4 subtasks from https://github.com/killbill/killbill/issues/2211
• Tighten lock-failure retry handling for consistency across all paths - see #2207. 
• Park accounts on unrecoverable invoice processing failures - see #2208
•  Uniform WARN logging across all invoice failure paths - see #2209 
• Add logging when invoice run is aborted or rescheduled by a plugin - see #2210 

**Behavior**

1. Retries
• Retry invoice runs using schedule for transient (retryable) errors - e.g. failure to grab global account lock [ALREADY EXISTING] # schedule configurable using `org.killbill.rescheduleIntervalOnLock`

2. Park accounts when:
• Invoice run issued from events or APIs leads to Illegal invoicing [ALREADY EXISTING]
• Invoice run issued from events (not APIs) leads to any exceptions that is not retried - [NEW BEHAVIOR] # This can be disabled using `org.killbill.invoice.parkAccountsOnAllExceptions=false`.
• Invoice run retry exhaustion - see point 1. [NEW BEHAVIOR]

**Alerts**

The following logs have been rework/enhanced to improve ability to alert around invoice failure.

1. Uniformize the WARN errors when:
• Invoice fails to make it easier to generate alerts: `Failed to generate invoice for`
• Accounts are parked/unparked: `Parking account for accountId` v.s. `Unparking account for accountId`
• Failure to park account: `Unable to park account`

2. Add missing logging for invoice control plugin:
• Abort invoicing: `Invoice generation aborted by plugin for accountId`
• Reschedule invoicing: `Invoice generation rescheduled by plugin for accountId`


Also: Added some retries around flaky (non stable tests).

Notes: I am not quite sure if this is should be rebased on top of `maint-for-0-24-x` and issue the release from there. TBD with @xsalefter 
