### PR TITLE
complete joda removal from java client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.146.77</version>
+        <version>0.146.78</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.24.19-SNAPSHOT</version>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -296,6 +296,7 @@
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
             <artifactId>killbill-client-java</artifactId>
+            <version>1.3.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -296,7 +296,6 @@
         <dependency>
             <groupId>org.kill-bill.billing</groupId>
             <artifactId>killbill-client-java</artifactId>
-            <version>1.3.12-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.kill-bill.billing</groupId>

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/KillbillClient.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/KillbillClient.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.killbill.billing.GuicyKillbillTestSuiteWithEmbeddedDB;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.Currency;

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccountTimeline.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccountTimeline.java
@@ -19,13 +19,14 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoiceItems;
 import org.killbill.billing.client.model.gen.Account;
@@ -52,7 +53,8 @@ public class TestAccountTimeline extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can retrieve the timeline without audits")
     public void testAccountTimeline() throws Exception {
-        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault()));
+        final ZonedDateTime newTime = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setTime(toJodaDateTime(newTime));
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -65,19 +67,21 @@ public class TestAccountTimeline extends TestJaxrsBase {
         Assert.assertNotNull(timeline.getInvoices().get(0).getBundleKeys());
 
         final List<EventSubscription> events = timeline.getBundles().get(0).getSubscriptions().get(0).getEvents();
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(0).getEffectiveDate())), new org.joda.time.LocalDate(2012, 4, 25));
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(0).getEffectiveDate())), toJodaLocalDate(LocalDate.of(2012, 4, 25)));
         Assert.assertEquals(events.get(0).getEventType(), SubscriptionEventType.START_ENTITLEMENT);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(1).getEffectiveDate())), new org.joda.time.LocalDate(2012, 4, 25));
+
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(1).getEffectiveDate())), toJodaLocalDate(LocalDate.of(2012, 4, 25)));
         Assert.assertEquals(events.get(1).getEventType(), SubscriptionEventType.START_BILLING);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(2).getEffectiveDate())), new org.joda.time.LocalDate(2012, 5, 25));
+
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(2).getEffectiveDate())), toJodaLocalDate(LocalDate.of(2012, 5, 25)));
         Assert.assertEquals(events.get(2).getEventType(), SubscriptionEventType.PHASE);
     }
 
     @Test(groups = "slow", description = "Can retrieve the timeline with audits")
     public void testAccountTimelineWithAudits() throws Exception {
-        final DateTime startTime = clock.getUTCNow();
+        final ZonedDateTime startTime = toJavaZonedDateTime(clock.getUTCNow());
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
-        final DateTime endTime = clock.getUTCNow();
+        final ZonedDateTime endTime = toJavaZonedDateTime(clock.getUTCNow());
 
         // Add credit
         final Invoice invoice = accountApi.getInvoicesForAccount(accountJson.getAccountId(), null, null, null, requestOptions).get(1);
@@ -118,7 +122,7 @@ public class TestAccountTimeline extends TestJaxrsBase {
         verifyBundles(accountJson.getAccountId(), startTime, endTime);
     }
 
-    private void verifyPayments(final UUID accountId, final DateTime startTime, final DateTime endTime,
+    private void verifyPayments(final UUID accountId, final ZonedDateTime startTime, final ZonedDateTime endTime,
                                 final BigDecimal refundAmount, final BigDecimal chargebackAmount) throws Exception {
         for (final AuditLevel auditLevel : AuditLevel.values()) {
             final AccountTimeline timeline = getAccountTimeline(accountId, auditLevel);
@@ -189,7 +193,7 @@ public class TestAccountTimeline extends TestJaxrsBase {
         }
     }
 
-    private void verifyInvoices(final UUID accountId, final DateTime startTime, final DateTime endTime) throws Exception {
+    private void verifyInvoices(final UUID accountId, final ZonedDateTime startTime, final ZonedDateTime endTime) throws Exception {
         for (final AuditLevel auditLevel : AuditLevel.values()) {
             final AccountTimeline timeline = getAccountTimeline(accountId, auditLevel);
 
@@ -215,7 +219,7 @@ public class TestAccountTimeline extends TestJaxrsBase {
         }
     }
 
-    private void verifyCredits(final UUID accountId, final DateTime startTime, final DateTime endTime, final BigDecimal creditAmount) throws Exception {
+    private void verifyCredits(final UUID accountId, final ZonedDateTime startTime, final ZonedDateTime endTime, final BigDecimal creditAmount) throws Exception {
         for (final AuditLevel auditLevel : AuditLevel.values()) {
             final AccountTimeline timeline = getAccountTimeline(accountId, auditLevel);
 
@@ -235,7 +239,7 @@ public class TestAccountTimeline extends TestJaxrsBase {
         }
     }
 
-    private void verifyBundles(final UUID accountId, final DateTime startTime, final DateTime endTime) throws Exception {
+    private void verifyBundles(final UUID accountId, final ZonedDateTime startTime, final ZonedDateTime endTime) throws Exception {
         for (final AuditLevel auditLevel : AuditLevel.values()) {
             final AccountTimeline timeline = getAccountTimeline(accountId, auditLevel);
 
@@ -295,9 +299,10 @@ public class TestAccountTimeline extends TestJaxrsBase {
 
     private void verifyAuditLog(final AuditLog auditLogJson, final ChangeType changeType, @Nullable final String reasonCode,
                                 @Nullable final String comments, @Nullable final String changedBy,
-                                final DateTime startTime, final DateTime endTime) {
+                                final ZonedDateTime startTime, final ZonedDateTime endTime) {
         Assert.assertEquals(auditLogJson.getChangeType(), changeType.toString());
-        Assert.assertFalse(toJodaDateTime(auditLogJson.getChangeDate()).isBefore(startTime));
+        // Preserve Joda behavior that, according to copilot, their isBefore() using millis, while JDK may use nanos.
+        Assert.assertFalse(auditLogJson.getChangeDate().toInstant().toEpochMilli() < startTime.toInstant().toEpochMilli());
         // Flaky
         //Assert.assertFalse(toJodaDateTime(auditLogJson.getChangeDate()).isAfter(endTime));
         Assert.assertEquals(auditLogJson.getReasonCode(), reasonCode);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccountTimeline.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccountTimeline.java
@@ -88,7 +88,7 @@ public class TestAccountTimeline extends TestJaxrsBase {
 
         final InvoiceItems credits = new InvoiceItems();
         credits.add(credit);
-        creditApi.createCredits(credits, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+        creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // Add refund
         final Payment postedPayment = accountApi.getPaymentsForAccount(accountJson.getAccountId(), NULL_PLUGIN_PROPERTIES, requestOptions).get(0);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccountTimeline.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccountTimeline.java
@@ -24,8 +24,8 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoiceItems;
 import org.killbill.billing.client.model.gen.Account;
@@ -52,7 +52,7 @@ public class TestAccountTimeline extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can retrieve the timeline without audits")
     public void testAccountTimeline() throws Exception {
-        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, 0));
+        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -65,11 +65,11 @@ public class TestAccountTimeline extends TestJaxrsBase {
         Assert.assertNotNull(timeline.getInvoices().get(0).getBundleKeys());
 
         final List<EventSubscription> events = timeline.getBundles().get(0).getSubscriptions().get(0).getEvents();
-        Assert.assertEquals(internalCallContext.toLocalDate(events.get(0).getEffectiveDate()), new LocalDate(2012, 4, 25));
+        Assert.assertEquals(internalCallContext.toLocalDate(events.get(0).getEffectiveDate()), LocalDate.of(2012, 4, 25));
         Assert.assertEquals(events.get(0).getEventType(), SubscriptionEventType.START_ENTITLEMENT);
-        Assert.assertEquals(internalCallContext.toLocalDate(events.get(1).getEffectiveDate()), new LocalDate(2012, 4, 25));
+        Assert.assertEquals(internalCallContext.toLocalDate(events.get(1).getEffectiveDate()), LocalDate.of(2012, 4, 25));
         Assert.assertEquals(events.get(1).getEventType(), SubscriptionEventType.START_BILLING);
-        Assert.assertEquals(internalCallContext.toLocalDate(events.get(2).getEffectiveDate()), new LocalDate(2012, 5, 25));
+        Assert.assertEquals(internalCallContext.toLocalDate(events.get(2).getEffectiveDate()), LocalDate.of(2012, 5, 25));
         Assert.assertEquals(events.get(2).getEventType(), SubscriptionEventType.PHASE);
     }
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccountTimeline.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAccountTimeline.java
@@ -24,8 +24,8 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import java.time.ZonedDateTime;
-import java.time.LocalDate;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoiceItems;
 import org.killbill.billing.client.model.gen.Account;
@@ -52,7 +52,7 @@ public class TestAccountTimeline extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can retrieve the timeline without audits")
     public void testAccountTimeline() throws Exception {
-        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
+        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault()));
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -65,11 +65,11 @@ public class TestAccountTimeline extends TestJaxrsBase {
         Assert.assertNotNull(timeline.getInvoices().get(0).getBundleKeys());
 
         final List<EventSubscription> events = timeline.getBundles().get(0).getSubscriptions().get(0).getEvents();
-        Assert.assertEquals(internalCallContext.toLocalDate(events.get(0).getEffectiveDate()), LocalDate.of(2012, 4, 25));
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(0).getEffectiveDate())), new org.joda.time.LocalDate(2012, 4, 25));
         Assert.assertEquals(events.get(0).getEventType(), SubscriptionEventType.START_ENTITLEMENT);
-        Assert.assertEquals(internalCallContext.toLocalDate(events.get(1).getEffectiveDate()), LocalDate.of(2012, 4, 25));
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(1).getEffectiveDate())), new org.joda.time.LocalDate(2012, 4, 25));
         Assert.assertEquals(events.get(1).getEventType(), SubscriptionEventType.START_BILLING);
-        Assert.assertEquals(internalCallContext.toLocalDate(events.get(2).getEffectiveDate()), LocalDate.of(2012, 5, 25));
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(2).getEffectiveDate())), new org.joda.time.LocalDate(2012, 5, 25));
         Assert.assertEquals(events.get(2).getEventType(), SubscriptionEventType.PHASE);
     }
 
@@ -297,9 +297,9 @@ public class TestAccountTimeline extends TestJaxrsBase {
                                 @Nullable final String comments, @Nullable final String changedBy,
                                 final DateTime startTime, final DateTime endTime) {
         Assert.assertEquals(auditLogJson.getChangeType(), changeType.toString());
-        Assert.assertFalse(auditLogJson.getChangeDate().isBefore(startTime));
+        Assert.assertFalse(toJodaDateTime(auditLogJson.getChangeDate()).isBefore(startTime));
         // Flaky
-        //Assert.assertFalse(auditLogJson.getChangeDate().isAfter(endTime));
+        //Assert.assertFalse(toJodaDateTime(auditLogJson.getChangeDate()).isAfter(endTime));
         Assert.assertEquals(auditLogJson.getReasonCode(), reasonCode);
         Assert.assertEquals(auditLogJson.getComments(), comments);
         Assert.assertEquals(auditLogJson.getChangedBy(), changedBy);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAdmin.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestAdmin.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.JaxrsResource;
@@ -86,8 +87,8 @@ public class TestAdmin extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testAdminInvoiceEndpoint() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final List<UUID> accounts = new LinkedList<UUID>();
         for (int i = 0; i < 5; i++) {

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestBundle.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestBundle.java
@@ -18,14 +18,12 @@
 
 package org.killbill.billing.jaxrs;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.model.BlockingStates;
@@ -101,8 +99,8 @@ public class TestBundle extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can transfer bundle")
     public void testBundleTransfer() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -162,8 +160,8 @@ public class TestBundle extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Block a bundle")
     public void testBlockBundle() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -174,14 +172,15 @@ public class TestBundle extends TestJaxrsBase {
         final Subscription entitlement = createSubscription(accountJson.getAccountId(), bundleExternalKey, productName,
                                                            ProductCategory.BASE, term);
 
-        Bundles existingBundles = bundleApi.getBundleByKey(bundleExternalKey, requestOptions);
+        final Bundles existingBundles = bundleApi.getBundleByKey(bundleExternalKey, requestOptions);
         assertEquals(existingBundles.size(), 1);
         final Bundle bundle = existingBundles.get(0);
         assertEquals(bundle.getAccountId(), accountJson.getAccountId());
         assertEquals(bundle.getExternalKey(), bundleExternalKey);
 
         final BlockingState blockingState = new BlockingState(bundle.getBundleId(), "block", "service", false, true, true, null, BlockingStateType.SUBSCRIPTION_BUNDLE, null);
-        bundleApi.addBundleBlockingState(bundle.getBundleId(), blockingState, toJavaLocalDate(clock.getToday(DateTimeZone.forID(accountJson.getTimeZone()))), Collections.emptyMap(), requestOptions);
+        var clockGetToday = clockGetToday(accountJson.getTimeZone());
+        bundleApi.addBundleBlockingState(bundle.getBundleId(), blockingState, toJavaLocalDate(clockGetToday), Collections.emptyMap(), requestOptions);
 
         final Subscription subscription = subscriptionApi.getSubscription(entitlement.getSubscriptionId(), requestOptions);
         assertEquals(subscription.getState(), EntitlementState.BLOCKED);
@@ -189,7 +188,8 @@ public class TestBundle extends TestJaxrsBase {
         clock.addDays(1);
 
         final BlockingState unblockingState = new BlockingState(bundle.getBundleId(), "unblock", "service", false, false, false, null, BlockingStateType.SUBSCRIPTION_BUNDLE, null);
-        bundleApi.addBundleBlockingState(bundle.getBundleId(), unblockingState, toJavaLocalDate(clock.getToday(DateTimeZone.forID(accountJson.getTimeZone()))), Collections.emptyMap(), requestOptions);
+        clockGetToday = clockGetToday(accountJson.getTimeZone());
+        bundleApi.addBundleBlockingState(bundle.getBundleId(), unblockingState, toJavaLocalDate(clockGetToday), Collections.emptyMap(), requestOptions);
 
         final Subscription subscription2 = subscriptionApi.getSubscription(entitlement.getSubscriptionId(), requestOptions);
         assertEquals(subscription2.getState(), EntitlementState.ACTIVE);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestBundle.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestBundle.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.model.BlockingStates;
@@ -101,8 +101,8 @@ public class TestBundle extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can transfer bundle")
     public void testBundleTransfer() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -162,8 +162,8 @@ public class TestBundle extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Block a bundle")
     public void testBlockBundle() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -181,7 +181,7 @@ public class TestBundle extends TestJaxrsBase {
         assertEquals(bundle.getExternalKey(), bundleExternalKey);
 
         final BlockingState blockingState = new BlockingState(bundle.getBundleId(), "block", "service", false, true, true, null, BlockingStateType.SUBSCRIPTION_BUNDLE, null);
-        bundleApi.addBundleBlockingState(bundle.getBundleId(), blockingState, clock.getToday(DateTimeZone.forID(accountJson.getTimeZone())), Collections.emptyMap(), requestOptions);
+        bundleApi.addBundleBlockingState(bundle.getBundleId(), blockingState, clock.getToday(ZoneId.of(accountJson.getTimeZone())), Collections.emptyMap(), requestOptions);
 
         final Subscription subscription = subscriptionApi.getSubscription(entitlement.getSubscriptionId(), requestOptions);
         assertEquals(subscription.getState(), EntitlementState.BLOCKED);
@@ -189,7 +189,7 @@ public class TestBundle extends TestJaxrsBase {
         clock.addDays(1);
 
         final BlockingState unblockingState = new BlockingState(bundle.getBundleId(), "unblock", "service", false, false, false, null, BlockingStateType.SUBSCRIPTION_BUNDLE, null);
-        bundleApi.addBundleBlockingState(bundle.getBundleId(), unblockingState, clock.getToday(DateTimeZone.forID(accountJson.getTimeZone())), Collections.emptyMap(), requestOptions);
+        bundleApi.addBundleBlockingState(bundle.getBundleId(), unblockingState, clock.getToday(ZoneId.of(accountJson.getTimeZone())), Collections.emptyMap(), requestOptions);
 
         final Subscription subscription2 = subscriptionApi.getSubscription(entitlement.getSubscriptionId(), requestOptions);
         assertEquals(subscription2.getState(), EntitlementState.ACTIVE);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestBundle.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestBundle.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import java.time.ZonedDateTime;
-import java.time.ZoneId;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.model.BlockingStates;
@@ -101,8 +101,8 @@ public class TestBundle extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can transfer bundle")
     public void testBundleTransfer() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -162,8 +162,8 @@ public class TestBundle extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Block a bundle")
     public void testBlockBundle() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -181,7 +181,7 @@ public class TestBundle extends TestJaxrsBase {
         assertEquals(bundle.getExternalKey(), bundleExternalKey);
 
         final BlockingState blockingState = new BlockingState(bundle.getBundleId(), "block", "service", false, true, true, null, BlockingStateType.SUBSCRIPTION_BUNDLE, null);
-        bundleApi.addBundleBlockingState(bundle.getBundleId(), blockingState, clock.getToday(ZoneId.of(accountJson.getTimeZone())), Collections.emptyMap(), requestOptions);
+        bundleApi.addBundleBlockingState(bundle.getBundleId(), blockingState, toJavaLocalDate(clock.getToday(DateTimeZone.forID(accountJson.getTimeZone()))), Collections.emptyMap(), requestOptions);
 
         final Subscription subscription = subscriptionApi.getSubscription(entitlement.getSubscriptionId(), requestOptions);
         assertEquals(subscription.getState(), EntitlementState.BLOCKED);
@@ -189,7 +189,7 @@ public class TestBundle extends TestJaxrsBase {
         clock.addDays(1);
 
         final BlockingState unblockingState = new BlockingState(bundle.getBundleId(), "unblock", "service", false, false, false, null, BlockingStateType.SUBSCRIPTION_BUNDLE, null);
-        bundleApi.addBundleBlockingState(bundle.getBundleId(), unblockingState, clock.getToday(ZoneId.of(accountJson.getTimeZone())), Collections.emptyMap(), requestOptions);
+        bundleApi.addBundleBlockingState(bundle.getBundleId(), unblockingState, toJavaLocalDate(clock.getToday(DateTimeZone.forID(accountJson.getTimeZone()))), Collections.emptyMap(), requestOptions);
 
         final Subscription subscription2 = subscriptionApi.getSubscription(entitlement.getSubscriptionId(), requestOptions);
         assertEquals(subscription2.getState(), EntitlementState.ACTIVE);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCatalog.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCatalog.java
@@ -31,8 +31,8 @@ import java.util.UUID;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import org.killbill.billing.catalog.DefaultVersionedCatalog;
 import org.killbill.billing.catalog.api.BillingMode;
 import org.killbill.billing.catalog.api.BillingPeriod;
@@ -116,7 +116,7 @@ public class TestCatalog extends TestJaxrsBase {
         final Catalogs catalogsJson = catalogApi.getCatalogJson(null, null, requestOptions);
 
         Assert.assertEquals(catalogsJson.get(0).getName(), "Firearms");
-        Assert.assertEquals(catalogsJson.get(0).getEffectiveDate().toLocalDate(), new LocalDate("2011-01-01"));
+        Assert.assertEquals(catalogsJson.get(0).getEffectiveDate().toLocalDate(), LocalDate.parse("2011-01-01"));
         Assert.assertEquals(catalogsJson.get(0).getCurrencies().size(), 3);
         Assert.assertEquals(catalogsJson.get(0).getProducts().size(), 15);
         Assert.assertEquals(catalogsJson.get(0).getPriceLists().size(), 7);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCatalog.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCatalog.java
@@ -72,7 +72,7 @@ public class TestCatalog extends TestJaxrsBase {
     public void testMatchJsonXmlCatalogProductSize() throws Exception {
         uploadTenantCatalog("org/killbill/billing/server/ProductsWithoutPlan.xml", false);
         final Catalogs catalogsJson = catalogApi.getCatalogJson(null, null, requestOptions);
-        final String catalogsXml = catalogApi.getCatalogXml(DateTime.parse("2024-01-30T15:44:40Z"), null, requestOptions);
+        final String catalogsXml = catalogApi.getCatalogXml(ZonedDateTime.parse("2024-01-30T15:44:40Z"), null, requestOptions);
         final StaticCatalog xmlCatalog = (catalogFromXML(catalogsXml)).getCurrentVersion();
         final int sizeOfProductsInXmlCatalog = xmlCatalog.getProducts().size();
         final int sizeOfProductsInJsonCatalog = catalogsJson.get(0).getProducts().size();
@@ -165,7 +165,7 @@ public class TestCatalog extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Try to retrieve catalog with an effective date in the past")
     public void testCatalogWithEffectiveDateInThePast() throws Exception {
-        final List<Catalog> catalogsJson = catalogApi.getCatalogJson(DateTime.parse("2008-01-01"), null, requestOptions);
+        final List<Catalog> catalogsJson = catalogApi.getCatalogJson(ZonedDateTime.parse("2008-01-01T00:00:00+00:00"), null, requestOptions);
         // We expect to see our catalogTest.xml (date in the past returns the first version. See #760
         Assert.assertEquals(catalogsJson.size(), 1);
     }
@@ -250,9 +250,9 @@ public class TestCatalog extends TestJaxrsBase {
     @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1308")
     public void testGetCatalogVersions() throws Exception {
         uploadTenantCatalog("org/killbill/billing/server/SpyCarBasic.xml", false);
-        List<DateTime> versions = catalogApi.getCatalogVersions(null, requestOptions);
+        List<ZonedDateTime> versions = catalogApi.getCatalogVersions(null, requestOptions);
         Assert.assertEquals(versions.size(), 1);
-        Assert.assertEquals(versions.get(0).compareTo(DateTime.parse("2013-02-08T00:00:00+00:00")), 0);
+        Assert.assertEquals(versions.get(0).toInstant(), java.time.Instant.parse("2013-02-08T00:00:00Z"));
 
         List<Catalog> catalogsJson = catalogApi.getCatalogJson(null, null, requestOptions);
         Assert.assertEquals(catalogsJson.size(), 1);
@@ -263,25 +263,25 @@ public class TestCatalog extends TestJaxrsBase {
         uploadTenantCatalog("org/killbill/billing/server/SpyCarBasic.v2.xml", false);
         versions = catalogApi.getCatalogVersions(null, requestOptions);
         Assert.assertEquals(versions.size(), 2);
-        Assert.assertEquals(versions.get(0).compareTo(DateTime.parse("2013-02-08T00:00:00+00:00")), 0);
-        Assert.assertEquals(versions.get(1).compareTo(DateTime.parse("2014-02-08T00:00:00+00:00")), 0);
+        Assert.assertEquals(versions.get(0).toInstant(), java.time.Instant.parse("2013-02-08T00:00:00Z"));
+        Assert.assertEquals(versions.get(1).toInstant(), java.time.Instant.parse("2014-02-08T00:00:00Z"));
 
         catalogsJson = catalogApi.getCatalogJson(null, null, requestOptions);
         Assert.assertEquals(catalogsJson.size(), 2);
 
-        catalogsJson = catalogApi.getCatalogJson(DateTime.parse("2013-02-08T00:00:00+00:00"), null, requestOptions);
+        catalogsJson = catalogApi.getCatalogJson(ZonedDateTime.parse("2013-02-08T00:00:00+00:00"), null, requestOptions);
         Assert.assertEquals(catalogsJson.size(), 1);
 
-        catalogsXml = catalogApi.getCatalogXml(DateTime.parse("2013-02-08T00:00:00+00:00"), null, requestOptions);
+        catalogsXml = catalogApi.getCatalogXml(ZonedDateTime.parse("2013-02-08T00:00:00+00:00"), null, requestOptions);
         Assert.assertEquals(catalogFromXML(catalogsXml).getVersions().size(), 1);
 
         versions = catalogApi.getCatalogVersions(null, requestOptions);
         Assert.assertEquals(versions.size(), 2);
 
-        catalogsJson = catalogApi.getCatalogJson(DateTime.parse("2014-02-08T00:00:00+00:00"), null, requestOptions);
+        catalogsJson = catalogApi.getCatalogJson(ZonedDateTime.parse("2014-02-08T00:00:00+00:00"), null, requestOptions);
         Assert.assertEquals(catalogsJson.size(), 1);
 
-        catalogsXml = catalogApi.getCatalogXml(DateTime.parse("2014-02-08T00:00:00+00:00"), null, requestOptions);
+        catalogsXml = catalogApi.getCatalogXml(ZonedDateTime.parse("2014-02-08T00:00:00+00:00"), null, requestOptions);
         Assert.assertEquals(catalogFromXML(catalogsXml).getVersions().size(), 1);
 
         versions = catalogApi.getCatalogVersions(null, requestOptions);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCredit.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCredit.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
@@ -62,11 +63,11 @@ public class TestCredit extends TestJaxrsBase {
 
         final InvoiceItems credits = new InvoiceItems();
         credits.add(credit);
-        InvoiceItems createdCredits = creditApi.createCredits(credits, clock.getUTCToday(), false, NULL_PLUGIN_PROPERTIES, requestOptions);
+        InvoiceItems createdCredits = creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), false, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         final UUID invoiceId = createdCredits.get(0).getInvoiceId();
         credit.setInvoiceId(invoiceId);
-        createdCredits = creditApi.createCredits(credits, clock.getUTCToday(), false, NULL_PLUGIN_PROPERTIES, requestOptions);
+        createdCredits = creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), false, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // We can't just compare the object via .equals() due e.g. to the invoice id
         assertEquals(createdCredits.get(0).getAccountId(), accountJson.getAccountId());
@@ -93,7 +94,7 @@ public class TestCredit extends TestJaxrsBase {
 
         final InvoiceItems credits = new InvoiceItems();
         credits.add(credit);
-        final LocalDate creditEffectiveDate = clock.getUTCToday().minusMonths(1);
+        final LocalDate creditEffectiveDate = toJavaLocalDate(clock.getUTCToday().minusMonths(1));
         InvoiceItems createdCredits = creditApi.createCredits(credits, creditEffectiveDate, false, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // We can't just compare the object via .equals() due e.g. to the invoice id
@@ -120,7 +121,7 @@ public class TestCredit extends TestJaxrsBase {
         final InvoiceItems credits = new InvoiceItems();
         credits.add(credit);
 
-        final InvoiceItems objFromJson = creditApi.createCredits(credits, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final InvoiceItems objFromJson = creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertTrue(objFromJson.get(0).getAmount().compareTo(creditAmount) == 0);
     }
 
@@ -134,7 +135,7 @@ public class TestCredit extends TestJaxrsBase {
         credits.add(credit);
 
         // Try to create the credit
-        final InvoiceItems result = creditApi.createCredits(credits, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final InvoiceItems result = creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(result.size(), 0);
     }
 
@@ -148,7 +149,7 @@ public class TestCredit extends TestJaxrsBase {
 
         // Try to create the credit
         try {
-            creditApi.createCredits(credits, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+            creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
             fail();
         } catch (final KillBillClientException e) {
         }

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCredit.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCredit.java
@@ -22,7 +22,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoiceItems;
 import org.killbill.billing.client.model.gen.Account;
@@ -51,7 +50,7 @@ public class TestCredit extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can add a credit to an existing invoice")
     public void testAddCreditToInvoice() throws Exception {
-        final DateTime effectiveDate = clock.getUTCNow();
+        final LocalDate effectiveDate = toJavaLocalDate(clock.getUTCNow());
         final BigDecimal creditAmount = BigDecimal.ONE;
         final InvoiceItem credit = new InvoiceItem();
         credit.setAccountId(accountJson.getAccountId());
@@ -73,7 +72,7 @@ public class TestCredit extends TestJaxrsBase {
         assertEquals(createdCredits.get(0).getAccountId(), accountJson.getAccountId());
         assertEquals(createdCredits.get(0).getInvoiceId(), invoiceId);
         assertEquals(createdCredits.get(0).getAmount().compareTo(creditAmount), 0);
-        assertEquals(createdCredits.get(0).getStartDate().compareTo(toJavaLocalDate(effectiveDate.toLocalDate())), 0);
+        assertEquals(createdCredits.get(0).getStartDate().compareTo(effectiveDate), 0);
         assertEquals(createdCredits.get(0).getDescription().compareTo("description"), 0);
         assertEquals(createdCredits.get(0).getQuantity().compareTo(new BigDecimal("5")), 0);
         assertEquals(createdCredits.get(0).getRate().compareTo(BigDecimal.TEN), 0);
@@ -82,7 +81,6 @@ public class TestCredit extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can add a credit with a different date to an existing invoice")
     public void testAddCreditWithDifferentDateToInvoice() throws Exception {
-        final DateTime effectiveDate = clock.getUTCNow();
         final BigDecimal creditAmount = BigDecimal.ONE;
         final InvoiceItem credit = new InvoiceItem();
         credit.setAccountId(accountJson.getAccountId());

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCredit.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCredit.java
@@ -21,8 +21,7 @@ package org.killbill.billing.jaxrs;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
+import java.time.ZonedDateTime;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoiceItems;
 import org.killbill.billing.client.model.gen.Account;

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCredit.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestCredit.java
@@ -21,7 +21,7 @@ package org.killbill.billing.jaxrs;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-import java.time.ZonedDateTime;
+import org.joda.time.DateTime;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoiceItems;
 import org.killbill.billing.client.model.gen.Account;
@@ -72,7 +72,7 @@ public class TestCredit extends TestJaxrsBase {
         assertEquals(createdCredits.get(0).getAccountId(), accountJson.getAccountId());
         assertEquals(createdCredits.get(0).getInvoiceId(), invoiceId);
         assertEquals(createdCredits.get(0).getAmount().compareTo(creditAmount), 0);
-        assertEquals(createdCredits.get(0).getStartDate().compareTo(effectiveDate.toLocalDate()), 0);
+        assertEquals(createdCredits.get(0).getStartDate().compareTo(toJavaLocalDate(effectiveDate.toLocalDate())), 0);
         assertEquals(createdCredits.get(0).getDescription().compareTo("description"), 0);
         assertEquals(createdCredits.get(0).getQuantity().compareTo(new BigDecimal("5")), 0);
         assertEquals(createdCredits.get(0).getRate().compareTo(BigDecimal.TEN), 0);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
@@ -19,6 +19,9 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -28,8 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.awaitility.Awaitility;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.DefaultPriceListSet;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.BillingPeriod;
@@ -75,8 +76,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can change plan and cancel a subscription")
     public void testEntitlementInTrialOk() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -134,9 +135,7 @@ public class TestEntitlement extends TestJaxrsBase {
         // Retrieves to check EndDate
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         assertNotNull(subscription.getCancelledDate());
-        // Convert ZonedDateTime to Joda DateTime for toLocalDate() method
-        final org.joda.time.DateTime cancelledDateTime = new org.joda.time.DateTime(subscription.getCancelledDate().toInstant().toEpochMilli());
-        assertEquals(internalCallContext.toLocalDate(cancelledDateTime).compareTo(clock.getUTCToday()), 0);
+        assertEquals(internalCallContext.toLocalDate(toJodaDateTime(subscription.getCancelledDate())).compareTo(clock.getUTCToday()), 0);
 
         final Bundles accountBundles = accountApi.getAccountBundles(accountJson.getAccountId(), null, null, requestOptions);
         assertEquals(accountBundles.size(), 1);
@@ -156,8 +155,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can cancel and uncancel a subscription")
     public void testEntitlementUncancel() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -240,8 +239,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can override billing policy on change")
     public void testOverridePolicy() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -276,8 +275,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can override a price when creating a subscription")
     public void testOverridePrice() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -381,8 +380,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create a base entitlement and also addOns entitlements under the same bundle")
     public void testEntitlementWithAddOnsWithWRITTEN_OFF() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final String bundleExternalKey = "bundleKey12346542";
 
@@ -467,8 +466,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create a bulk of base entitlement and addOns under the same transaction")
     public void testCreateEntitlementsWithAddOnsThenCloseAccountWithItemAdjustment() throws Exception { //TODO_1739 - Test disabled due to behavior change, revisit
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccount();
 
@@ -583,8 +582,8 @@ public class TestEntitlement extends TestJaxrsBase {
     @Test(groups = "slow", description = "Create a bulk of base entitlements and addOns under the same transaction",
             expectedExceptions = KillBillClientException.class, expectedExceptionsMessageRegExp = "SubscriptionJson productName needs to be set when no planName is specified")
     public void testCreateSubscriptionsWithoutBase() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -636,8 +635,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create addOns in a bundle where BP subscription already exist")
     public void testEntitlementsWithAddOnsAndAlreadyExistingBP() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -687,8 +686,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a future entitlement date")
     public void testCreateSubscriptionEntitlementInTheFuture() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -700,7 +699,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         // Verify callCompletion works (related to https://github.com/killbill/killbill/issues/1193)
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate.toLocalDate().plusMonths(1)),
+                                                                                initialDate.toLocalDate().plusMonths(1),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -711,9 +710,9 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING);
-        Assert.assertEquals(entitlementJson.getChargedThroughDate(), toJavaLocalDate(initialDate.plusMonths(1).toLocalDate()));
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate().plusMonths(1));
+        Assert.assertEquals(entitlementJson.getChargedThroughDate(), initialDate.plusMonths(1).toLocalDate());
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate.toLocalDate());
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate.toLocalDate().plusMonths(1));
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
         Assert.assertEquals(entitlementJson.getProductCategory(), input.getProductCategory());
         Assert.assertEquals(entitlementJson.getBillingPeriod(), input.getBillingPeriod());
@@ -733,8 +732,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a future billing date")
     public void testCreateSubscriptionBillingInTheFuture() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -747,7 +746,7 @@ public class TestEntitlement extends TestJaxrsBase {
         // Verify callCompletion works (related to https://github.com/killbill/killbill/issues/1193)
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 null,
-                                                                                toJavaLocalDate(initialDate.toLocalDate().plusMonths(1)),
+                                                                                initialDate.toLocalDate().plusMonths(1),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -758,8 +757,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
         Assert.assertNull(entitlementJson.getChargedThroughDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate().plusMonths(1));
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate());
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate.toLocalDate().plusMonths(1));
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate.toLocalDate());
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
         Assert.assertEquals(entitlementJson.getProductCategory(), input.getProductCategory());
         Assert.assertEquals(entitlementJson.getBillingPeriod(), input.getBillingPeriod());
@@ -780,13 +779,14 @@ public class TestEntitlement extends TestJaxrsBase {
     @Test(groups = "slow", description = "Can create an entitlement with a future billing date v2 -- see https://github.com/killbill/killbill/pull/1234#discussion_r332148759")
     public void testCreateSubscriptionBillingInTheFutureV2() throws Exception {
         // 2012-04-25T00:03:42.000Z
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
         // Move clock back to 2012-04-25T00:01:42.000Z (we want a reference time in the future)
-        clock.setTime(new DateTime(2012, 4, 25, 0, 1, 42, DateTimeZone.getDefault()));
+        final ZonedDateTime newTime = ZonedDateTime.of(2012, 4, 25, 0, 1, 42, 0, ZoneId.systemDefault());
+        clock.setTime(toJodaDateTime(newTime));
 
         final Subscription input = new Subscription();
         input.setAccountId(accountJson.getAccountId());
@@ -808,8 +808,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
         Assert.assertNull(entitlementJson.getChargedThroughDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate());
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate.toLocalDate());
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate.toLocalDate());
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
         Assert.assertEquals(entitlementJson.getProductCategory(), input.getProductCategory());
         Assert.assertEquals(entitlementJson.getBillingPeriod(), input.getBillingPeriod());
@@ -831,8 +831,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a past billing date")
     public void testCreateSubscriptionBillingInThePast() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -845,7 +845,7 @@ public class TestEntitlement extends TestJaxrsBase {
         // Verify callCompletion works (related to https://github.com/killbill/killbill/issues/1193)
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 null,
-                                                                                toJavaLocalDate(initialDate.toLocalDate().minusMonths(1)),
+                                                                                initialDate.toLocalDate().minusMonths(1),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -857,8 +857,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
         verifyChargedThroughDate(entitlementJson.getSubscriptionId(), java.time.LocalDate.parse("2012-05-24"));
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate().minusMonths(1));
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate());
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate.toLocalDate().minusMonths(1));
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate.toLocalDate());
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
         Assert.assertEquals(entitlementJson.getProductCategory(), input.getProductCategory());
         Assert.assertEquals(entitlementJson.getBillingPeriod(), input.getBillingPeriod());
@@ -1158,8 +1158,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription")
     public void testOverwriteEntitlementBCDOnCreate() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1186,8 +1186,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription when changing plan")
     public void testOverwriteEntitlementBCDOnChange() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1228,8 +1228,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription")
     public void testMoveEntitlementBCD() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1265,8 +1265,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can update the quantity associated with the subscription")
     public void testUpdateEntitlementQuantity() throws Exception {
-        final DateTime initialDate = new DateTime(2022, 11, 28, 15, 7, 0, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2022, 11, 28, 15, 7, 0, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1291,8 +1291,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create subscription and change plan using planName")
     public void testEntitlementUsingPlanName() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1330,8 +1330,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can changePlan and undo changePlan on a subscription")
     public void testEntitlementUndoChangePlan() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1403,8 +1403,8 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertNotNull(catalog2);
 
 
-        final DateTime initialDate = new DateTime(2014, 1, 2, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2014, 1, 2, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1462,11 +1462,11 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertNull(subscription.getPrices().get(2).getFixedPrice());
         Assert.assertEquals(subscription.getPrices().get(2).getRecurringPrice(), new BigDecimal("1200.00"));
     }
-    
+
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDate() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1477,11 +1477,11 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        final org.joda.time.LocalDate creationDate = initialDate.plusDays(5);
+        final LocalDate creationDate = initialDate.plusDays(5);
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(creationDate),
-                                                                                toJavaLocalDate(creationDate),
+                                                                                creationDate,
+                                                                                creationDate,
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -1491,10 +1491,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING); // Still PENDING since creationDate is not reached
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), creationDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), creationDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), creationDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), creationDate);
 
-        clock.setDay(creationDate);
+        clock.setDay(toJodaLocalDate(creationDate));
 
         final Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //now ACTIVE
@@ -1503,8 +1503,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDateTime() throws Exception {
-        final DateTime initialDateTime = new DateTime(2012, 4, 25, 10, 30, 0, DateTimeZone.getDefault());
-        clock.setTime(initialDateTime);
+        final ZonedDateTime initialDateTime = ZonedDateTime.of(2012, 4, 25, 10, 30, 0, 0, ZoneId.systemDefault());
+        clock.setTime(toJodaDateTime(initialDateTime));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1515,11 +1515,11 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        final DateTime futureDateTime = new DateTime(2012, 4, 30, 11, 30, 0, DateTimeZone.getDefault());
+        final ZonedDateTime futureDateTime = ZonedDateTime.of(2012, 4, 30, 11, 30, 0, 0, ZoneId.systemDefault());
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaZonedDateTime(futureDateTime),
-                                                                                toJavaZonedDateTime(futureDateTime),
+                                                                                futureDateTime,
+                                                                                futureDateTime,
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -1529,10 +1529,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING); // Still PENDING since creationDate is not reached
-        Assert.assertEquals(toJodaDateTime(entitlementJson.getBillingStartDate()).toInstant(), futureDateTime.toInstant());
-        Assert.assertEquals(toJodaDateTime(entitlementJson.getStartDate()).toInstant(), futureDateTime.toInstant());
+        Assert.assertEquals(entitlementJson.getBillingStartDate().toInstant(), futureDateTime.toInstant());
+        Assert.assertEquals(entitlementJson.getStartDate().toInstant(), futureDateTime.toInstant());
 
-        clock.setTime(futureDateTime);
+        clock.setTime(toJodaDateTime(futureDateTime));
 
         final Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //now ACTIVE
@@ -1541,8 +1541,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDateTimeDifferentDatesForBillingAndEntitlement() throws Exception {
-        final DateTime initialDateTime = new DateTime(2012, 4, 25, 10, 30, 0, DateTimeZone.getDefault());
-        clock.setTime(initialDateTime);
+        final ZonedDateTime initialDateTime = ZonedDateTime.of(2012, 4, 25, 10, 30, 0, 0, ZoneId.systemDefault());
+        clock.setTime(toJodaDateTime(initialDateTime));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1553,12 +1553,12 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        final DateTime billingDateTime = new DateTime(2012, 4, 28, 11, 30, 0, DateTimeZone.getDefault());
-        final DateTime entitlementDateTime = new DateTime(2012, 4, 30, 8, 45, 0, DateTimeZone.getDefault());
+        final ZonedDateTime billingDateTime = ZonedDateTime.of(2012, 4, 28, 11, 30, 0, 0, ZoneId.systemDefault());
+        final ZonedDateTime entitlementDateTime = ZonedDateTime.of(2012, 4, 30, 8, 45, 0, 0, ZoneId.systemDefault());
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaZonedDateTime(entitlementDateTime),
-                                                                                toJavaZonedDateTime(billingDateTime),
+                                                                                entitlementDateTime,
+                                                                                billingDateTime,
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -1568,15 +1568,15 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING); // Still PENDING since entitlementDateTime is not reached
-        Assert.assertEquals(toJodaDateTime(entitlementJson.getBillingStartDate()).toInstant(), billingDateTime.toInstant());
-        Assert.assertEquals(toJodaDateTime(entitlementJson.getStartDate()).toInstant(), entitlementDateTime.toInstant());
+        Assert.assertEquals(entitlementJson.getBillingStartDate().toInstant(), billingDateTime.toInstant());
+        Assert.assertEquals(entitlementJson.getStartDate().toInstant(), entitlementDateTime.toInstant());
 
-        clock.setTime(billingDateTime);
+        clock.setTime(toJodaDateTime(billingDateTime));
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.PENDING); // Still PENDING since entitlementDateTime is not reached
 
-        clock.setTime(entitlementDateTime);
+        clock.setTime(toJodaDateTime(entitlementDateTime));
 
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //now ACTIVE
@@ -1585,8 +1585,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCancelSubscriptionWithDate() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1597,7 +1597,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList("notrial");
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate),
+                                                                                initialDate,
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1608,31 +1608,31 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate);
 
-        final org.joda.time.LocalDate cancelDate = clock.getUTCToday().plusDays(5);
+        final LocalDate cancelDate = toJavaLocalDate(clock.getUTCToday().plusDays(5));
 
-        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), toJavaLocalDate(cancelDate), null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // useRequestedDateForBilling defaults to false, so billing will be cancelled as per the default billing policy in the catalog
-        //subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), toJavaLocalDate(cancelDate), false, null, null, null, true, NULL_PLUGIN_PROPERTIES, requestOptions); // use this to set useRequestedDateForBilling=true
+        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), cancelDate, null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // useRequestedDateForBilling defaults to false, so billing will be cancelled as per the default billing policy in the catalog
+        //subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), cancelDate, false, null, null, null, true, NULL_PLUGIN_PROPERTIES, requestOptions); // use this to set useRequestedDateForBilling=true
 
         // Retrieves with GET
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //Still active since cancelDate is not yet reached
 
-        clock.setDay(cancelDate);
+        clock.setDay(toJodaLocalDate(cancelDate));
 
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
 
         Assert.assertEquals(subscription.getState(), EntitlementState.CANCELLED);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(subscription.getCancelledDate())), cancelDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(subscription.getBillingEndDate())), initialDate.plusMonths(1));  //since default billing policy is EOT, billing end date is 1 month from start date
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(subscription.getCancelledDate()))), cancelDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(subscription.getBillingEndDate()))), initialDate.plusMonths(1));  //since default billing policy is EOT, billing end date is 1 month from start date
     }
 
     @Test(groups = "slow")
     public void testCancelSubscriptionWithDateTime() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1643,7 +1643,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList("notrial");
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate),
+                                                                                initialDate,
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1654,31 +1654,32 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate);
 
-        final DateTime cancelDateTime = new DateTime(2012, 4, 30, 11, 30, 0, DateTimeZone.getDefault());
+        final ZonedDateTime cancelDateTime = ZonedDateTime.of(2012, 4, 30, 11, 30, 0, 0, ZoneId.systemDefault());
 
-        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), toJavaZonedDateTime(cancelDateTime), null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // Unlike cancelWithDate, in this case, the cancelDateTime is used for both entitlement and billing
+        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), cancelDateTime, null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // Unlike cancelWithDate, in this case, the cancelDateTime is used for both entitlement and billing
 
         // Retrieves with GET
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //Still active since cancelDateTime is not yet reached
 
-        clock.setTime(cancelDateTime);
+        clock.setTime(toJodaDateTime(cancelDateTime));
 
         // Retrieves with GET
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
 
         Assert.assertEquals(subscription.getState(), EntitlementState.CANCELLED);
-        Assert.assertEquals(toJodaDateTime(subscription.getCancelledDate()).toInstant(), cancelDateTime.toInstant());
-        Assert.assertEquals(toJodaDateTime(subscription.getBillingEndDate()).toInstant(), cancelDateTime.toInstant());
+        // Calling .toInstant() to preserve previous assertion (when still using Joda). See 984a82d66021aca7a8fc70aa00fc1442503d3a11.
+        Assert.assertEquals(subscription.getCancelledDate().toInstant(), cancelDateTime.toInstant());
+        Assert.assertEquals(subscription.getBillingEndDate().toInstant(), cancelDateTime.toInstant());
     }
 
     @Test(groups = "slow")
     public void testChangeSubscriptionPlanWithDate() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1689,7 +1690,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate),
+                                                                                initialDate,
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1700,40 +1701,40 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate);
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
 
-        final org.joda.time.LocalDate changeDate = clock.getUTCToday().plusDays(5);
+        final LocalDate changeDate = toJavaLocalDate(clock.getUTCToday().plusDays(5));
 
         final Subscription newSubscriptionPlan = new Subscription();
         newSubscriptionPlan.setSubscriptionId(entitlementJson.getSubscriptionId());
         newSubscriptionPlan.setPlanName("pistol-monthly");
 
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newSubscriptionPlan, toJavaLocalDate(changeDate), true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newSubscriptionPlan, changeDate, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, null, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // Retrieves with GET
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE);
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName()); //still old plan since changeDate is not reached
 
-        clock.setDay(changeDate);
+        clock.setDay(toJodaLocalDate(changeDate));
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(newSubscriptionPlan.getPlanName(), subscription.getPlanName()); //now on new plan
-        
+
         final List<EventSubscription> events = subscription.getEvents();
         assertNotNull(events);
         assertEquals(events.get(0).getEventType(), SubscriptionEventType.START_ENTITLEMENT);
         assertEquals(events.get(1).getEventType(), SubscriptionEventType.START_BILLING);
         assertEquals(events.get(2).getEventType(), SubscriptionEventType.CHANGE);
-        assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(2).getEffectiveDate())), changeDate);  
-        
+        assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(events.get(2).getEffectiveDate()))), changeDate);
+
     }
 
     @Test(groups = "slow")
     public void testChangeSubscriptionPlanWithDateTime() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1744,7 +1745,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate),
+                                                                                initialDate,
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1755,39 +1756,39 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate);
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
 
-        final DateTime changeDateTime = new DateTime(2012, 4, 25, 10, 50, 0, DateTimeZone.getDefault());
+        final ZonedDateTime changeDateTime = ZonedDateTime.of(2012, 4, 25, 10, 50, 0, 0, ZoneId.systemDefault());
 
         final Subscription newSubscriptionPlan = new Subscription();
         newSubscriptionPlan.setSubscriptionId(entitlementJson.getSubscriptionId());
         newSubscriptionPlan.setPlanName("pistol-monthly");
 
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newSubscriptionPlan, toJavaZonedDateTime(changeDateTime), true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newSubscriptionPlan, changeDateTime, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, null, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // Retrieves with GET
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE);
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName()); //still old plan since changeDate is not reached
 
-        clock.setTime(changeDateTime);
+        clock.setTime(toJodaDateTime(changeDateTime));
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(newSubscriptionPlan.getPlanName(), subscription.getPlanName()); //now on new plan
-        
+
         final List<EventSubscription> events = subscription.getEvents();
         assertNotNull(events);
         assertEquals(events.get(0).getEventType(), SubscriptionEventType.START_ENTITLEMENT);
         assertEquals(events.get(1).getEventType(), SubscriptionEventType.START_BILLING);
         assertEquals(events.get(2).getEventType(), SubscriptionEventType.CHANGE);
-        assertEquals(toJodaDateTime(events.get(2).getEffectiveDate()).toInstant(), changeDateTime.toInstant());  
+        assertEquals(events.get(2).getEffectiveDate().toInstant(), changeDateTime.toInstant());
     }
 
     @Test(groups = "slow")
     public void testBlockBundleWithDate() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1798,7 +1799,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate),
+                                                                                initialDate,
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1809,10 +1810,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate);
 
-        final org.joda.time.LocalDate blockDate = clock.getUTCToday().plusDays(5);
+        final LocalDate blockDate = toJavaLocalDate(clock.getUTCToday().plusDays(5));
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -1820,7 +1821,7 @@ public class TestEntitlement extends TestJaxrsBase {
         state.setIsBlockEntitlement(true);
         state.setService("service1");
         state.setStateName("STATE1");
-        bundleApi.addBundleBlockingState(entitlementJson.getBundleId(), state, toJavaLocalDate(blockDate), NULL_PLUGIN_PROPERTIES, requestOptions);
+        bundleApi.addBundleBlockingState(entitlementJson.getBundleId(), state, blockDate, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         //Retrieve account blocking states
         final BlockingStates blockingStates = accountApi.getBlockingStates(accountJson.getAccountId(),
@@ -1833,7 +1834,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
         state = blockingStates.iterator().next();
         Assert.assertEquals(state.getStateName(), "STATE1");
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate())), blockDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate()))), blockDate);
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //state still ACTIVE since blockDate is not reached
@@ -1844,13 +1845,13 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(subscription.getState(), EntitlementState.BLOCKED); //now blocked
 
     }
-    
- 
+
+
 
     @Test(groups = "slow")
     public void testBlockBundleWithDateTime() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1861,7 +1862,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate),
+                                                                                initialDate,
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1872,10 +1873,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate);
 
-        final DateTime blockDateTime = new DateTime(2012, 4, 30, 11, 45, 0, DateTimeZone.getDefault());
+        final ZonedDateTime blockDateTime = ZonedDateTime.of(2012, 4, 30, 11, 45, 0, 0, ZoneId.systemDefault());
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -1883,7 +1884,7 @@ public class TestEntitlement extends TestJaxrsBase {
         state.setIsBlockEntitlement(true);
         state.setService("service1");
         state.setStateName("STATE1");
-        bundleApi.addBundleBlockingState(entitlementJson.getBundleId(), state, toJavaZonedDateTime(blockDateTime), NULL_PLUGIN_PROPERTIES, requestOptions);
+        bundleApi.addBundleBlockingState(entitlementJson.getBundleId(), state, blockDateTime, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         //Retrieve account blocking states
         final BlockingStates blockingStates = accountApi.getBlockingStates(accountJson.getAccountId(),
@@ -1896,22 +1897,23 @@ public class TestEntitlement extends TestJaxrsBase {
 
         state = blockingStates.iterator().next();
         Assert.assertEquals(state.getStateName(), "STATE1");
-        Assert.assertEquals(toJodaDateTime(state.getEffectiveDate()).toInstant(), blockDateTime.toInstant());
+        // Calling .toInstant() to preserve previous assertion (when still using Joda). See 984a82d66021aca7a8fc70aa00fc1442503d3a11.
+        Assert.assertEquals(state.getEffectiveDate().toInstant(), blockDateTime.toInstant());
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //state still ACTIVE since blockDateTime is not reached
 
-        clock.setTime(blockDateTime);
+        clock.setTime(toJodaDateTime(blockDateTime));
 
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.BLOCKED); //now blocked
 
     }
-    
+
     @Test(groups = "slow")
     public void testBlockSubscriptionWithDate() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1922,7 +1924,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate),
+                                                                                initialDate,
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1933,10 +1935,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate);
 
-        final org.joda.time.LocalDate blockDate = clock.getUTCToday().plusDays(5);
+        final LocalDate blockDate = toJavaLocalDate(clock.getUTCToday().plusDays(5));
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -1944,7 +1946,7 @@ public class TestEntitlement extends TestJaxrsBase {
         state.setIsBlockEntitlement(true);
         state.setService("service1");
         state.setStateName("STATE1");
-        subscriptionApi.addSubscriptionBlockingState(entitlementJson.getSubscriptionId(), state, toJavaLocalDate(blockDate), NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.addSubscriptionBlockingState(entitlementJson.getSubscriptionId(), state, blockDate, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         //Retrieve account blocking states
         final BlockingStates blockingStates = accountApi.getBlockingStates(accountJson.getAccountId(),
@@ -1959,11 +1961,11 @@ public class TestEntitlement extends TestJaxrsBase {
 
         state = itr.next();
         Assert.assertEquals(state.getStateName(), "ENT_STARTED");
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate()))), initialDate);
 
         state = itr.next();
         Assert.assertEquals(state.getStateName(), "STATE1");
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate())), blockDate);        
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate()))), blockDate);
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //state still ACTIVE since blockDate is not reached
@@ -1973,12 +1975,12 @@ public class TestEntitlement extends TestJaxrsBase {
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.BLOCKED); //now blocked
 
-    }    
-    
+    }
+
     @Test(groups = "slow")
     public void testBlockSubscriptionWithDateTime() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1989,7 +1991,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                toJavaLocalDate(initialDate),
+                                                                                initialDate,
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -2000,10 +2002,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate()))), initialDate);
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate()))), initialDate);
 
-        final DateTime blockDateTime = new DateTime(2012, 4, 30, 11, 45, 0, DateTimeZone.getDefault());
+        final ZonedDateTime blockDateTime = ZonedDateTime.of(2012, 4, 30, 11, 45, 0, 0, ZoneId.systemDefault());
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -2011,7 +2013,7 @@ public class TestEntitlement extends TestJaxrsBase {
         state.setIsBlockEntitlement(true);
         state.setService("service1");
         state.setStateName("STATE1");
-        subscriptionApi.addSubscriptionBlockingState(entitlementJson.getSubscriptionId(), state, toJavaZonedDateTime(blockDateTime), NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.addSubscriptionBlockingState(entitlementJson.getSubscriptionId(), state, blockDateTime, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         //Retrieve account blocking states
         final BlockingStates blockingStates = accountApi.getBlockingStates(accountJson.getAccountId(),
@@ -2026,21 +2028,21 @@ public class TestEntitlement extends TestJaxrsBase {
 
         state = itr.next();
         Assert.assertEquals(state.getStateName(), "ENT_STARTED");
-        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate())), initialDate);
-        
+        Assert.assertEquals(toJavaLocalDate(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate()))), initialDate);
+
         state = itr.next();
         Assert.assertEquals(state.getStateName(), "STATE1");
-        Assert.assertEquals(toJodaDateTime(state.getEffectiveDate()).toInstant(), blockDateTime.toInstant());        
+        Assert.assertEquals(state.getEffectiveDate().toInstant(), blockDateTime.toInstant());
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //state still ACTIVE since blockDate is not reached
 
-        clock.setTime(blockDateTime);
+        clock.setTime(toJodaDateTime(blockDateTime));
 
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.BLOCKED); //now blocked
 
-    }        
+    }
 
     private void verifyChargedThroughDate(final UUID subscriptionId, final java.time.LocalDate ctd) {
         // The call completion may return after the INVOICE event was received and prior the CTD was updated as it
@@ -2056,8 +2058,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithEmptyOverrides() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -2091,8 +2093,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithOnlyUsageOverrides() throws Exception {
-        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
@@ -28,9 +28,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.awaitility.Awaitility;
-import java.time.ZonedDateTime;
-import java.time.LocalDate;
-import java.time.ZoneId;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.DefaultPriceListSet;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.BillingPeriod;
@@ -76,8 +75,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can change plan and cancel a subscription")
     public void testEntitlementInTrialOk() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -117,7 +116,7 @@ public class TestEntitlement extends TestJaxrsBase {
         newInput.setBillingPeriod(entitlementJson.getBillingPeriod());
         newInput.setPriceList(entitlementJson.getPriceList());
         callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CHANGE, ExtBusEventType.SUBSCRIPTION_CHANGE, ExtBusEventType.INVOICE_CREATION);
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newInput, (LocalDate) null, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newInput, (java.time.LocalDate) null, null, NULL_PLUGIN_PROPERTIES, requestOptions);
         callbackServlet.assertListenerStatus();
         Assert.assertNotNull(subscription);
 
@@ -130,14 +129,14 @@ public class TestEntitlement extends TestJaxrsBase {
         callbackServlet.assertListenerStatus();
 
         // Cancel IMM (Billing EOT)
-        subscriptionApi.cancelSubscriptionPlan(newInput.getSubscriptionId(), (LocalDate) null, null, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.cancelSubscriptionPlan(newInput.getSubscriptionId(), (java.time.LocalDate) null, null, null, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // Retrieves to check EndDate
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         assertNotNull(subscription.getCancelledDate());
         // Convert ZonedDateTime to Joda DateTime for toLocalDate() method
         final org.joda.time.DateTime cancelledDateTime = new org.joda.time.DateTime(subscription.getCancelledDate().toInstant().toEpochMilli());
-        assertEquals(internalCallContext.toLocalDate(cancelledDateTime).compareTo(LocalDate.now()), 0);
+        assertEquals(internalCallContext.toLocalDate(cancelledDateTime).compareTo(clock.getUTCToday()), 0);
 
         final Bundles accountBundles = accountApi.getAccountBundles(accountJson.getAccountId(), null, null, requestOptions);
         assertEquals(accountBundles.size(), 1);
@@ -157,8 +156,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can cancel and uncancel a subscription")
     public void testEntitlementUncancel() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -193,7 +192,7 @@ public class TestEntitlement extends TestJaxrsBase {
         callbackServlet.assertListenerStatus();
 
         // Cancel EOT
-        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), (LocalDate) null, EntitlementActionPolicy.END_OF_TERM,
+        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), (java.time.LocalDate) null, EntitlementActionPolicy.END_OF_TERM,
                                                BillingActionPolicy.END_OF_TERM, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // Retrieves to check EndDate
@@ -232,17 +231,17 @@ public class TestEntitlement extends TestJaxrsBase {
         subscription.setBillingPeriod(BillingPeriod.ANNUAL);
         subscription.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        subscriptionApi.changeSubscriptionPlan(subscriptionId, subscription, (LocalDate) null, null, null, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(subscriptionId, subscription, (java.time.LocalDate) null, null, null, requestOptions);
 
-        subscriptionApi.cancelSubscriptionPlan(subscriptionId, (LocalDate) null, null, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.cancelSubscriptionPlan(subscriptionId, (java.time.LocalDate) null, null, null, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         assertNull(subscriptionApi.getSubscription(subscriptionId, requestOptions));
     }
 
     @Test(groups = "slow", description = "Can override billing policy on change")
     public void testOverridePolicy() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -269,7 +268,7 @@ public class TestEntitlement extends TestJaxrsBase {
         newInput.setProductCategory(ProductCategory.BASE);
         newInput.setBillingPeriod(BillingPeriod.MONTHLY);
         newInput.setPriceList(subscriptionJson.getPriceList());
-        subscriptionApi.changeSubscriptionPlan(subscriptionJson.getSubscriptionId(), newInput, (LocalDate) null, BillingActionPolicy.IMMEDIATE, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(subscriptionJson.getSubscriptionId(), newInput, (java.time.LocalDate) null, BillingActionPolicy.IMMEDIATE, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         objFromJson = subscriptionApi.getSubscription(subscriptionJson.getSubscriptionId(), requestOptions);
         assertEquals(objFromJson.getBillingPeriod(), BillingPeriod.MONTHLY);
@@ -277,8 +276,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can override a price when creating a subscription")
     public void testOverridePrice() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -303,7 +302,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.INVOICE_CREATION,
                                            ExtBusEventType.INVOICE_PAYMENT_SUCCESS,
                                            ExtBusEventType.PAYMENT_SUCCESS);
-        final Subscription subscription = subscriptionApi.createSubscription(input, (LocalDate) null, (LocalDate) null, null, null, false, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final Subscription subscription = subscriptionApi.createSubscription(input, (java.time.LocalDate) null, (java.time.LocalDate) null, null, null, false, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
         callbackServlet.assertListenerStatus();
         Assert.assertEquals(subscription.getPrices().size(), 2);
 
@@ -347,7 +346,7 @@ public class TestEntitlement extends TestJaxrsBase {
         final Subscription newInput = new Subscription();
         newInput.setSubscriptionId(subscription2.getSubscriptionId());
         newInput.setPlanName("pistol-monthly");
-        subscriptionApi.changeSubscriptionPlan(subscription2.getSubscriptionId(), newInput, (LocalDate) null, BillingActionPolicy.IMMEDIATE, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(subscription2.getSubscriptionId(), newInput, (java.time.LocalDate) null, BillingActionPolicy.IMMEDIATE, NULL_PLUGIN_PROPERTIES, requestOptions);
         final Subscription subscription3 = subscriptionApi.getSubscription(subscription.getSubscriptionId(), requestOptions);
 
         Assert.assertEquals(subscription3.getEvents().size(), 4);
@@ -382,8 +381,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create a base entitlement and also addOns entitlements under the same bundle")
     public void testEntitlementWithAddOnsWithWRITTEN_OFF() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final String bundleExternalKey = "bundleKey12346542";
 
@@ -420,7 +419,7 @@ public class TestEntitlement extends TestJaxrsBase {
         subscriptions.add(addOn1);
         subscriptions.add(addOn2);
 
-        final Bundle bundle = subscriptionApi.createSubscriptionWithAddOns(subscriptions, (LocalDate) null, (LocalDate) null, null, null, null, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final Bundle bundle = subscriptionApi.createSubscriptionWithAddOns(subscriptions, (java.time.LocalDate) null, (java.time.LocalDate) null, null, null, null, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertNotNull(bundle);
         assertEquals(bundle.getExternalKey(), bundleExternalKey);
         assertEquals(bundle.getSubscriptions().size(), 3);
@@ -468,8 +467,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create a bulk of base entitlement and addOns under the same transaction")
     public void testCreateEntitlementsWithAddOnsThenCloseAccountWithItemAdjustment() throws Exception { //TODO_1739 - Test disabled due to behavior change, revisit
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccount();
 
@@ -584,8 +583,8 @@ public class TestEntitlement extends TestJaxrsBase {
     @Test(groups = "slow", description = "Create a bulk of base entitlements and addOns under the same transaction",
             expectedExceptions = KillBillClientException.class, expectedExceptionsMessageRegExp = "SubscriptionJson productName needs to be set when no planName is specified")
     public void testCreateSubscriptionsWithoutBase() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -637,8 +636,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create addOns in a bundle where BP subscription already exist")
     public void testEntitlementsWithAddOnsAndAlreadyExistingBP() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -649,7 +648,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setProductCategory(ProductCategory.BASE);
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
-        final Subscription subscription = subscriptionApi.createSubscription(input, (LocalDate) null, (LocalDate) null, null, null, null, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final Subscription subscription = subscriptionApi.createSubscription(input, (java.time.LocalDate) null, (java.time.LocalDate) null, null, null, null, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         final Subscription addOn1 = new Subscription();
         addOn1.setAccountId(accountJson.getAccountId());
@@ -688,8 +687,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a future entitlement date")
     public void testCreateSubscriptionEntitlementInTheFuture() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -701,7 +700,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         // Verify callCompletion works (related to https://github.com/killbill/killbill/issues/1193)
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate.toLocalDate().plusMonths(1),
+                                                                                toJavaLocalDate(initialDate.toLocalDate().plusMonths(1)),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -712,7 +711,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING);
-        Assert.assertEquals(entitlementJson.getChargedThroughDate(), initialDate.plusMonths(1).toLocalDate());
+        Assert.assertEquals(entitlementJson.getChargedThroughDate(), toJavaLocalDate(initialDate.plusMonths(1).toLocalDate()));
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate());
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate().plusMonths(1));
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
@@ -734,8 +733,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a future billing date")
     public void testCreateSubscriptionBillingInTheFuture() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -748,7 +747,7 @@ public class TestEntitlement extends TestJaxrsBase {
         // Verify callCompletion works (related to https://github.com/killbill/killbill/issues/1193)
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 null,
-                                                                                initialDate.toLocalDate().plusMonths(1),
+                                                                                toJavaLocalDate(initialDate.toLocalDate().plusMonths(1)),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -781,13 +780,13 @@ public class TestEntitlement extends TestJaxrsBase {
     @Test(groups = "slow", description = "Can create an entitlement with a future billing date v2 -- see https://github.com/killbill/killbill/pull/1234#discussion_r332148759")
     public void testCreateSubscriptionBillingInTheFutureV2() throws Exception {
         // 2012-04-25T00:03:42.000Z
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
         // Move clock back to 2012-04-25T00:01:42.000Z (we want a reference time in the future)
-        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 1, 42, 0, ZoneId.systemDefault()));
+        clock.setTime(new DateTime(2012, 4, 25, 0, 1, 42, DateTimeZone.getDefault()));
 
         final Subscription input = new Subscription();
         input.setAccountId(accountJson.getAccountId());
@@ -798,7 +797,7 @@ public class TestEntitlement extends TestJaxrsBase {
         // Verify callCompletion works (related to https://github.com/killbill/killbill/issues/1193)
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 null,
-                                                                                LocalDate.of(2012, 4, 25),
+                                                                                java.time.LocalDate.of(2012, 4, 25),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -832,8 +831,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a past billing date")
     public void testCreateSubscriptionBillingInThePast() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -846,7 +845,7 @@ public class TestEntitlement extends TestJaxrsBase {
         // Verify callCompletion works (related to https://github.com/killbill/killbill/issues/1193)
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 null,
-                                                                                initialDate.toLocalDate().minusMonths(1),
+                                                                                toJavaLocalDate(initialDate.toLocalDate().minusMonths(1)),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -857,7 +856,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        verifyChargedThroughDate(entitlementJson.getSubscriptionId(), LocalDate.parse("2012-05-24"));
+        verifyChargedThroughDate(entitlementJson.getSubscriptionId(), java.time.LocalDate.parse("2012-05-24"));
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate().minusMonths(1));
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate());
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
@@ -928,7 +927,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.ENTITLEMENT_CREATION,
                                            ExtBusEventType.ACCOUNT_CHANGE,
                                            ExtBusEventType.INVOICE_CREATION); // The BCD is updated in that case
-        final Subscription subscriptionJson = subscriptionApi.createSubscription(input, (LocalDate) null, (LocalDate) null, null, null, null, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final Subscription subscriptionJson = subscriptionApi.createSubscription(input, (java.time.LocalDate) null, (java.time.LocalDate) null, null, null, null, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertNotNull(subscriptionJson);
         callbackServlet.assertListenerStatus();
 
@@ -951,7 +950,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.INVOICE_CREATION);
         subscriptionApi.changeSubscriptionPlan(subscriptionJson.getSubscriptionId(),
                                                newInput,
-                                               (LocalDate) null,
+                                               (java.time.LocalDate) null,
                                                true,
                                                DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC,
                                                BillingActionPolicy.IMMEDIATE,
@@ -967,7 +966,7 @@ public class TestEntitlement extends TestJaxrsBase {
         callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CANCEL,
                                            ExtBusEventType.ENTITLEMENT_CANCEL);
         subscriptionApi.cancelSubscriptionPlan(newInput.getSubscriptionId(),
-                                               (LocalDate) null,
+                                               (java.time.LocalDate) null,
                                                true,
                                                DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC,
                                                null,
@@ -1006,8 +1005,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.SUBSCRIPTION_CREATION,
                                            ExtBusEventType.ENTITLEMENT_CREATION); // Note that the BCD isn't set
         final Subscription subscriptionJson = subscriptionApi.createSubscription(input,
-        		                                                                 (LocalDate) null,
-        		                                                                 (LocalDate) null,
+        		                                                                 (java.time.LocalDate) null,
+        		                                                                 (java.time.LocalDate) null,
                                                                                  false,
                                                                                  false,
                                                                                  false,
@@ -1036,7 +1035,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.SUBSCRIPTION_CHANGE);
         subscriptionApi.changeSubscriptionPlan(subscriptionJson.getSubscriptionId(),
                                                newInput,
-                                               (LocalDate) null,
+                                               (java.time.LocalDate) null,
                                                true,
                                                DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC,
                                                BillingActionPolicy.IMMEDIATE,
@@ -1053,7 +1052,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.SUBSCRIPTION_CANCEL,
                                            ExtBusEventType.ENTITLEMENT_CANCEL);
         subscriptionApi.cancelSubscriptionPlan(newInput.getSubscriptionId(),
-                                               (LocalDate) null,
+                                               (java.time.LocalDate) null,
                                                true,
                                                DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC,
                                                null,
@@ -1092,8 +1091,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.ENTITLEMENT_CREATION,
                                            ExtBusEventType.ACCOUNT_CHANGE); // The BCD is updated in that case
         final Subscription subscriptionJson = subscriptionApi.createSubscription(input,
-        		                                                                 (LocalDate) null,
-        		                                                                 (LocalDate) null,
+        		                                                                 (java.time.LocalDate) null,
+        		                                                                 (java.time.LocalDate) null,
                                                                                  false,
                                                                                  false,
                                                                                  false,
@@ -1129,7 +1128,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.SUBSCRIPTION_CHANGE);
         subscriptionApi.changeSubscriptionPlan(subscriptionJson.getSubscriptionId(),
                                                newInput,
-                                               (LocalDate) null,
+                                               (java.time.LocalDate) null,
                                                true,
                                                DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC,
                                                BillingActionPolicy.IMMEDIATE,
@@ -1146,7 +1145,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.SUBSCRIPTION_CANCEL,
                                            ExtBusEventType.ENTITLEMENT_CANCEL);
         subscriptionApi.cancelSubscriptionPlan(newInput.getSubscriptionId(),
-        									   (LocalDate) null,
+        									   (java.time.LocalDate) null,
                                                true,
                                                DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC,
                                                null,
@@ -1159,8 +1158,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription")
     public void testOverwriteEntitlementBCDOnCreate() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1169,7 +1168,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setAccountId(accountJson.getAccountId());
         input.setPlanName("shotgun-monthly");
         input.setBillCycleDayLocal(28);
-        final Subscription subscription = subscriptionApi.createSubscription(input, (LocalDate) null, (LocalDate) null, true, false, null, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final Subscription subscription = subscriptionApi.createSubscription(input, (java.time.LocalDate) null, (java.time.LocalDate) null, true, false, null, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(subscription.getBillCycleDayLocal().intValue(), 28);
         callbackServlet.assertListenerStatus();
 
@@ -1187,8 +1186,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription when changing plan")
     public void testOverwriteEntitlementBCDOnChange() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1217,20 +1216,20 @@ public class TestEntitlement extends TestJaxrsBase {
         newInput.setBillCycleDayLocal(28);
 
         callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CHANGE,  ExtBusEventType.SUBSCRIPTION_CHANGE, ExtBusEventType.SUBSCRIPTION_BCD_CHANGE, ExtBusEventType.INVOICE_CREATION);
-        subscriptionApi.changeSubscriptionPlan(subscription.getSubscriptionId(), newInput, LocalDate.of(2012, 5, 28), null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(subscription.getSubscriptionId(), newInput, java.time.LocalDate.of(2012, 5, 28), null, NULL_PLUGIN_PROPERTIES, requestOptions);
         callbackServlet.assertListenerStatus();
 
         Subscription refreshedSubscription = subscriptionApi.getSubscription(subscription.getSubscriptionId(), requestOptions);
         Assert.assertNotNull(refreshedSubscription);
 
         // We charged a full period 2012-05-28 - 2012-06-28 based on the new BCD
-        verifyChargedThroughDate(refreshedSubscription.getSubscriptionId(), LocalDate.of(2012, 6, 28));
+        verifyChargedThroughDate(refreshedSubscription.getSubscriptionId(), java.time.LocalDate.of(2012, 6, 28));
     }
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription")
     public void testMoveEntitlementBCD() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1266,8 +1265,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can update the quantity associated with the subscription")
     public void testUpdateEntitlementQuantity() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2022, 11, 28, 15, 7, 00, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2022, 11, 28, 15, 7, 0, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1292,8 +1291,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create subscription and change plan using planName")
     public void testEntitlementUsingPlanName() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1303,8 +1302,8 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setPlanName("shotgun-monthly");
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-        		                                                               (LocalDate) null,
-                                                                               (LocalDate) null,
+        		                                                               (java.time.LocalDate) null,
+                                                                               (java.time.LocalDate) null,
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -1321,7 +1320,7 @@ public class TestEntitlement extends TestJaxrsBase {
         newInput.setAccountId(entitlementJson.getAccountId());
         newInput.setSubscriptionId(entitlementJson.getSubscriptionId());
         newInput.setPlanName("pistol-monthly");
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newInput, (LocalDate) null, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newInput, (java.time.LocalDate) null, null, NULL_PLUGIN_PROPERTIES, requestOptions);
         final Subscription newEntitlementJson = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(newEntitlementJson.getProductName(), "Pistol");
         Assert.assertEquals(newEntitlementJson.getBillingPeriod(), BillingPeriod.MONTHLY);
@@ -1331,8 +1330,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can changePlan and undo changePlan on a subscription")
     public void testEntitlementUndoChangePlan() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1354,13 +1353,13 @@ public class TestEntitlement extends TestJaxrsBase {
         newInput.setPriceList(entitlementJson.getPriceList());
 
         callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CHANGE);
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newInput, LocalDate.of(2012, 4, 28), null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newInput, java.time.LocalDate.of(2012, 4, 28), null, NULL_PLUGIN_PROPERTIES, requestOptions);
         Subscription refreshedSubscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         callbackServlet.assertListenerStatus();
         Assert.assertNotNull(refreshedSubscription);
 
-        final Interval it = new Interval(clock.getUTCNow(), clock.getUTCNow().plusDays(1));
-        clock.addDeltaFromReality(it.toDurationMillis());
+        final long durationMillis = clock.getUTCNow().plusDays(1).getMillis() - clock.getUTCNow().getMillis();
+        clock.addDeltaFromReality(durationMillis);
 
         // We get 2 SUBSCRIPTION_CHANGE events, one for requested and one or effective, which are the same.
         callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CHANGE, ExtBusEventType.SUBSCRIPTION_CHANGE);
@@ -1404,8 +1403,8 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertNotNull(catalog2);
 
 
-        final DateTime initialDate = ZonedDateTime.of(2014, 1, 2, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2014, 1, 2, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1419,8 +1418,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                            ExtBusEventType.ACCOUNT_CHANGE,  // The BCD is updated in that case
                                            ExtBusEventType.INVOICE_CREATION); // $0 Fixed price
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-        		                                                                (LocalDate) null,
-        		                                                                (LocalDate) null,
+        		                                                                (java.time.LocalDate) null,
+        		                                                                (java.time.LocalDate) null,
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -1443,7 +1442,7 @@ public class TestEntitlement extends TestJaxrsBase {
         clock.addDays(8); // 2014-02-09
 
         callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CHANGE, ExtBusEventType.SUBSCRIPTION_CHANGE);
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), input, (LocalDate) null, BillingActionPolicy.IMMEDIATE, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), input, (java.time.LocalDate) null, BillingActionPolicy.IMMEDIATE, NULL_PLUGIN_PROPERTIES, requestOptions);
         Subscription refreshedSubscription1 = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         callbackServlet.assertListenerStatus();
         Assert.assertNotNull(refreshedSubscription1);
@@ -1466,7 +1465,7 @@ public class TestEntitlement extends TestJaxrsBase {
     
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDate() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1478,11 +1477,11 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        final LocalDate creationDate = initialDate.plusDays(5);
+        final org.joda.time.LocalDate creationDate = initialDate.plusDays(5);
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                creationDate,
-                                                                                creationDate,
+                                                                                toJavaLocalDate(creationDate),
+                                                                                toJavaLocalDate(creationDate),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -1504,7 +1503,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDateTime() throws Exception {
-        final ZonedDateTime initialDateTime = ZonedDateTime.of(2012, 4, 25, 10, 30, 0, 0, ZoneId.systemDefault());
+        final DateTime initialDateTime = new DateTime(2012, 4, 25, 10, 30, 0, DateTimeZone.getDefault());
         clock.setTime(initialDateTime);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1516,11 +1515,11 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        final ZonedDateTime futureDateTime = ZonedDateTime.of(2012, 4, 30, 11, 30, 0, 0, ZoneId.systemDefault());
+        final DateTime futureDateTime = new DateTime(2012, 4, 30, 11, 30, 0, DateTimeZone.getDefault());
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                futureDateTime,
-                                                                                futureDateTime,
+                                                                                toJavaZonedDateTime(futureDateTime),
+                                                                                toJavaZonedDateTime(futureDateTime),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -1530,8 +1529,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING); // Still PENDING since creationDate is not reached
-        Assert.assertEquals(entitlementJson.getBillingStartDate().compareTo(futureDateTime), 0);
-        Assert.assertEquals(entitlementJson.getStartDate().compareTo(futureDateTime), 0);
+        Assert.assertEquals(toJodaDateTime(entitlementJson.getBillingStartDate()).toInstant(), futureDateTime.toInstant());
+        Assert.assertEquals(toJodaDateTime(entitlementJson.getStartDate()).toInstant(), futureDateTime.toInstant());
 
         clock.setTime(futureDateTime);
 
@@ -1542,7 +1541,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDateTimeDifferentDatesForBillingAndEntitlement() throws Exception {
-        final ZonedDateTime initialDateTime = ZonedDateTime.of(2012, 4, 25, 10, 30, 0, 0, ZoneId.systemDefault());
+        final DateTime initialDateTime = new DateTime(2012, 4, 25, 10, 30, 0, DateTimeZone.getDefault());
         clock.setTime(initialDateTime);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1554,12 +1553,12 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        final ZonedDateTime billingDateTime = ZonedDateTime.of(2012, 4, 28, 11, 30, 0, 0, ZoneId.systemDefault());
-        final ZonedDateTime entitlementDateTime = ZonedDateTime.of(2012, 4, 30, 8, 45, 0, 0, ZoneId.systemDefault());
+        final DateTime billingDateTime = new DateTime(2012, 4, 28, 11, 30, 0, DateTimeZone.getDefault());
+        final DateTime entitlementDateTime = new DateTime(2012, 4, 30, 8, 45, 0, DateTimeZone.getDefault());
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                entitlementDateTime,
-                                                                                billingDateTime,
+                                                                                toJavaZonedDateTime(entitlementDateTime),
+                                                                                toJavaZonedDateTime(billingDateTime),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -1569,8 +1568,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING); // Still PENDING since entitlementDateTime is not reached
-        Assert.assertEquals(entitlementJson.getBillingStartDate().compareTo(billingDateTime), 0);
-        Assert.assertEquals(entitlementJson.getStartDate().compareTo(entitlementDateTime), 0);
+        Assert.assertEquals(toJodaDateTime(entitlementJson.getBillingStartDate()).toInstant(), billingDateTime.toInstant());
+        Assert.assertEquals(toJodaDateTime(entitlementJson.getStartDate()).toInstant(), entitlementDateTime.toInstant());
 
         clock.setTime(billingDateTime);
 
@@ -1586,7 +1585,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCancelSubscriptionWithDate() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1598,7 +1597,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList("notrial");
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate,
+                                                                                toJavaLocalDate(initialDate),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1612,10 +1611,10 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final LocalDate cancelDate = clock.getUTCToday().plusDays(5);
+        final org.joda.time.LocalDate cancelDate = clock.getUTCToday().plusDays(5);
 
-        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), cancelDate, null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // useRequestedDateForBilling defaults to false, so billing will be cancelled as per the default billing policy in the catalog
-        //subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), cancelDate, false, null, null, null, true, NULL_PLUGIN_PROPERTIES, requestOptions); // use this to set useRequestedDateForBilling=true
+        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), toJavaLocalDate(cancelDate), null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // useRequestedDateForBilling defaults to false, so billing will be cancelled as per the default billing policy in the catalog
+        //subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), toJavaLocalDate(cancelDate), false, null, null, null, true, NULL_PLUGIN_PROPERTIES, requestOptions); // use this to set useRequestedDateForBilling=true
 
         // Retrieves with GET
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
@@ -1632,7 +1631,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCancelSubscriptionWithDateTime() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1644,7 +1643,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList("notrial");
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate,
+                                                                                toJavaLocalDate(initialDate),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1658,9 +1657,9 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final ZonedDateTime cancelDateTime = ZonedDateTime.of(2012, 4, 30, 11, 30, 0, 0, ZoneId.systemDefault());
+        final DateTime cancelDateTime = new DateTime(2012, 4, 30, 11, 30, 0, DateTimeZone.getDefault());
 
-        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), cancelDateTime, null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // Unlike cancelWithDate, in this case, the cancelDateTime is used for both entitlement and billing
+        subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), toJavaZonedDateTime(cancelDateTime), null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // Unlike cancelWithDate, in this case, the cancelDateTime is used for both entitlement and billing
 
         // Retrieves with GET
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
@@ -1672,13 +1671,13 @@ public class TestEntitlement extends TestJaxrsBase {
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
 
         Assert.assertEquals(subscription.getState(), EntitlementState.CANCELLED);
-        Assert.assertEquals(subscription.getCancelledDate().compareTo(cancelDateTime), 0);
-        Assert.assertEquals(subscription.getBillingEndDate().compareTo(cancelDateTime), 0);
+        Assert.assertEquals(toJodaDateTime(subscription.getCancelledDate()).toInstant(), cancelDateTime.toInstant());
+        Assert.assertEquals(toJodaDateTime(subscription.getBillingEndDate()).toInstant(), cancelDateTime.toInstant());
     }
 
     @Test(groups = "slow")
     public void testChangeSubscriptionPlanWithDate() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1690,7 +1689,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate,
+                                                                                toJavaLocalDate(initialDate),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1705,13 +1704,13 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
 
-        final LocalDate changeDate = clock.getUTCToday().plusDays(5);
+        final org.joda.time.LocalDate changeDate = clock.getUTCToday().plusDays(5);
 
         final Subscription newSubscriptionPlan = new Subscription();
         newSubscriptionPlan.setSubscriptionId(entitlementJson.getSubscriptionId());
         newSubscriptionPlan.setPlanName("pistol-monthly");
 
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newSubscriptionPlan, changeDate, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newSubscriptionPlan, toJavaLocalDate(changeDate), true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, null, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // Retrieves with GET
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
@@ -1733,7 +1732,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testChangeSubscriptionPlanWithDateTime() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1745,7 +1744,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate,
+                                                                                toJavaLocalDate(initialDate),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1760,13 +1759,13 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
 
-        final ZonedDateTime changeDateTime = ZonedDateTime.of(2012, 4, 25, 10, 50, 0, 0, ZoneId.systemDefault());
+        final DateTime changeDateTime = new DateTime(2012, 4, 25, 10, 50, 0, DateTimeZone.getDefault());
 
         final Subscription newSubscriptionPlan = new Subscription();
         newSubscriptionPlan.setSubscriptionId(entitlementJson.getSubscriptionId());
         newSubscriptionPlan.setPlanName("pistol-monthly");
 
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newSubscriptionPlan, changeDateTime, true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newSubscriptionPlan, toJavaZonedDateTime(changeDateTime), true, DEFAULT_WAIT_COMPLETION_TIMEOUT_SEC, null, NULL_PLUGIN_PROPERTIES, requestOptions);
 
         // Retrieves with GET
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
@@ -1782,14 +1781,13 @@ public class TestEntitlement extends TestJaxrsBase {
         assertEquals(events.get(0).getEventType(), SubscriptionEventType.START_ENTITLEMENT);
         assertEquals(events.get(1).getEventType(), SubscriptionEventType.START_BILLING);
         assertEquals(events.get(2).getEventType(), SubscriptionEventType.CHANGE);
-        assertEquals(events.get(2).getEffectiveDate().compareTo(changeDateTime), 0);  
+        assertEquals(toJodaDateTime(events.get(2).getEffectiveDate()).toInstant(), changeDateTime.toInstant());  
     }
 
     @Test(groups = "slow")
     public void testBlockBundleWithDate() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
-        // Convert Java Time LocalDate to Joda Time LocalDate for ClockMock.setDay()
-        clock.setDay(new org.joda.time.LocalDate(initialDate.getYear(), initialDate.getMonthValue(), initialDate.getDayOfMonth()));
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
+        clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1800,7 +1798,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate,
+                                                                                toJavaLocalDate(initialDate),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1814,7 +1812,7 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final LocalDate blockDate = clock.getUTCToday().plusDays(5);
+        final org.joda.time.LocalDate blockDate = clock.getUTCToday().plusDays(5);
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -1822,7 +1820,7 @@ public class TestEntitlement extends TestJaxrsBase {
         state.setIsBlockEntitlement(true);
         state.setService("service1");
         state.setStateName("STATE1");
-        bundleApi.addBundleBlockingState(entitlementJson.getBundleId(), state, blockDate, NULL_PLUGIN_PROPERTIES, requestOptions);
+        bundleApi.addBundleBlockingState(entitlementJson.getBundleId(), state, toJavaLocalDate(blockDate), NULL_PLUGIN_PROPERTIES, requestOptions);
 
         //Retrieve account blocking states
         final BlockingStates blockingStates = accountApi.getBlockingStates(accountJson.getAccountId(),
@@ -1835,7 +1833,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
         state = blockingStates.iterator().next();
         Assert.assertEquals(state.getStateName(), "STATE1");
-        Assert.assertEquals(internalCallContext.toLocalDate(state.getEffectiveDate()), blockDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate())), blockDate);
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //state still ACTIVE since blockDate is not reached
@@ -1851,7 +1849,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testBlockBundleWithDateTime() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1863,7 +1861,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate,
+                                                                                toJavaLocalDate(initialDate),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1877,7 +1875,7 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final ZonedDateTime blockDateTime = ZonedDateTime.of(2012, 4, 30, 11, 45, 0, 0, ZoneId.systemDefault());
+        final DateTime blockDateTime = new DateTime(2012, 4, 30, 11, 45, 0, DateTimeZone.getDefault());
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -1885,7 +1883,7 @@ public class TestEntitlement extends TestJaxrsBase {
         state.setIsBlockEntitlement(true);
         state.setService("service1");
         state.setStateName("STATE1");
-        bundleApi.addBundleBlockingState(entitlementJson.getBundleId(), state, blockDateTime, NULL_PLUGIN_PROPERTIES, requestOptions);
+        bundleApi.addBundleBlockingState(entitlementJson.getBundleId(), state, toJavaZonedDateTime(blockDateTime), NULL_PLUGIN_PROPERTIES, requestOptions);
 
         //Retrieve account blocking states
         final BlockingStates blockingStates = accountApi.getBlockingStates(accountJson.getAccountId(),
@@ -1898,7 +1896,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
         state = blockingStates.iterator().next();
         Assert.assertEquals(state.getStateName(), "STATE1");
-        Assert.assertEquals(state.getEffectiveDate().compareTo(blockDateTime), 0);
+        Assert.assertEquals(toJodaDateTime(state.getEffectiveDate()).toInstant(), blockDateTime.toInstant());
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //state still ACTIVE since blockDateTime is not reached
@@ -1912,7 +1910,7 @@ public class TestEntitlement extends TestJaxrsBase {
     
     @Test(groups = "slow")
     public void testBlockSubscriptionWithDate() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1924,7 +1922,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate,
+                                                                                toJavaLocalDate(initialDate),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -1938,7 +1936,7 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final LocalDate blockDate = clock.getUTCToday().plusDays(5);
+        final org.joda.time.LocalDate blockDate = clock.getUTCToday().plusDays(5);
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -1946,7 +1944,7 @@ public class TestEntitlement extends TestJaxrsBase {
         state.setIsBlockEntitlement(true);
         state.setService("service1");
         state.setStateName("STATE1");
-        subscriptionApi.addSubscriptionBlockingState(entitlementJson.getSubscriptionId(), state, blockDate, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.addSubscriptionBlockingState(entitlementJson.getSubscriptionId(), state, toJavaLocalDate(blockDate), NULL_PLUGIN_PROPERTIES, requestOptions);
 
         //Retrieve account blocking states
         final BlockingStates blockingStates = accountApi.getBlockingStates(accountJson.getAccountId(),
@@ -1956,16 +1954,16 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                            requestOptions);
         assertNotNull(blockingStates);
         Assert.assertEquals(blockingStates.size(), 2);
-        
+
         Iterator<BlockingState> itr = blockingStates.iterator();
 
         state = itr.next();
         Assert.assertEquals(state.getStateName(), "ENT_STARTED");
-        Assert.assertEquals(internalCallContext.toLocalDate(state.getEffectiveDate()), initialDate);
-        
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate())), initialDate);
+
         state = itr.next();
         Assert.assertEquals(state.getStateName(), "STATE1");
-        Assert.assertEquals(internalCallContext.toLocalDate(state.getEffectiveDate()), blockDate);        
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate())), blockDate);        
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //state still ACTIVE since blockDate is not reached
@@ -1979,7 +1977,7 @@ public class TestEntitlement extends TestJaxrsBase {
     
     @Test(groups = "slow")
     public void testBlockSubscriptionWithDateTime() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1991,7 +1989,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
-                                                                                initialDate,
+                                                                                toJavaLocalDate(initialDate),
                                                                                 null,
                                                                                 false,
                                                                                 false,
@@ -2005,7 +2003,7 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
         Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final ZonedDateTime blockDateTime = ZonedDateTime.of(2012, 4, 30, 11, 45, 0, 0, ZoneId.systemDefault());
+        final DateTime blockDateTime = new DateTime(2012, 4, 30, 11, 45, 0, DateTimeZone.getDefault());
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -2013,7 +2011,7 @@ public class TestEntitlement extends TestJaxrsBase {
         state.setIsBlockEntitlement(true);
         state.setService("service1");
         state.setStateName("STATE1");
-        subscriptionApi.addSubscriptionBlockingState(entitlementJson.getSubscriptionId(), state, blockDateTime, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.addSubscriptionBlockingState(entitlementJson.getSubscriptionId(), state, toJavaZonedDateTime(blockDateTime), NULL_PLUGIN_PROPERTIES, requestOptions);
 
         //Retrieve account blocking states
         final BlockingStates blockingStates = accountApi.getBlockingStates(accountJson.getAccountId(),
@@ -2023,16 +2021,16 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                            requestOptions);
         assertNotNull(blockingStates);
         Assert.assertEquals(blockingStates.size(), 2);
-        
+
         Iterator<BlockingState> itr = blockingStates.iterator();
 
         state = itr.next();
         Assert.assertEquals(state.getStateName(), "ENT_STARTED");
-        Assert.assertEquals(internalCallContext.toLocalDate(state.getEffectiveDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(state.getEffectiveDate())), initialDate);
         
         state = itr.next();
         Assert.assertEquals(state.getStateName(), "STATE1");
-        Assert.assertEquals(state.getEffectiveDate().compareTo(blockDateTime), 0);        
+        Assert.assertEquals(toJodaDateTime(state.getEffectiveDate()).toInstant(), blockDateTime.toInstant());        
 
         Subscription subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         Assert.assertEquals(subscription.getState(), EntitlementState.ACTIVE); //state still ACTIVE since blockDate is not reached
@@ -2044,7 +2042,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     }        
 
-    private void verifyChargedThroughDate(final UUID subscriptionId, final LocalDate ctd) {
+    private void verifyChargedThroughDate(final UUID subscriptionId, final java.time.LocalDate ctd) {
         // The call completion may return after the INVOICE event was received and prior the CTD was updated as it
         // done outside and after the transaction: See https://github.com/killbill/killbill/blob/killbill-0.22.27/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java#L686
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(new Callable<Boolean>() {
@@ -2058,7 +2056,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithEmptyOverrides() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -2080,7 +2078,7 @@ public class TestEntitlement extends TestJaxrsBase {
                                                ExtBusEventType.SUBSCRIPTION_CREATION);
             final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                     null,
-                                                                                    (LocalDate) null,
+                                                                                    (java.time.LocalDate) null,
                                                                                     NULL_PLUGIN_PROPERTIES,
                                                                                     requestOptions);
             callbackServlet.assertListenerStatus();
@@ -2093,7 +2091,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithOnlyUsageOverrides() throws Exception {
-        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        final org.joda.time.LocalDate initialDate = new org.joda.time.LocalDate(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -2140,7 +2138,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 null,
-                                                                                (LocalDate) null,
+                                                                                (java.time.LocalDate) null,
                                                                                 NULL_PLUGIN_PROPERTIES,
                                                                                 requestOptions);
         callbackServlet.assertListenerStatus();

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestEntitlement.java
@@ -28,9 +28,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.awaitility.Awaitility;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
-import org.joda.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.killbill.billing.catalog.DefaultPriceListSet;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.BillingPeriod;
@@ -76,8 +76,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can change plan and cancel a subscription")
     public void testEntitlementInTrialOk() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -135,7 +135,9 @@ public class TestEntitlement extends TestJaxrsBase {
         // Retrieves to check EndDate
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         assertNotNull(subscription.getCancelledDate());
-        assertEquals(internalCallContext.toLocalDate(subscription.getCancelledDate()).compareTo(new LocalDate(clock.getUTCNow())), 0);
+        // Convert ZonedDateTime to Joda DateTime for toLocalDate() method
+        final org.joda.time.DateTime cancelledDateTime = new org.joda.time.DateTime(subscription.getCancelledDate().toInstant().toEpochMilli());
+        assertEquals(internalCallContext.toLocalDate(cancelledDateTime).compareTo(LocalDate.now()), 0);
 
         final Bundles accountBundles = accountApi.getAccountBundles(accountJson.getAccountId(), null, null, requestOptions);
         assertEquals(accountBundles.size(), 1);
@@ -155,8 +157,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can cancel and uncancel a subscription")
     public void testEntitlementUncancel() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -239,8 +241,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can override billing policy on change")
     public void testOverridePolicy() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -275,8 +277,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can override a price when creating a subscription")
     public void testOverridePrice() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -380,8 +382,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create a base entitlement and also addOns entitlements under the same bundle")
     public void testEntitlementWithAddOnsWithWRITTEN_OFF() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final String bundleExternalKey = "bundleKey12346542";
 
@@ -466,8 +468,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create a bulk of base entitlement and addOns under the same transaction")
     public void testCreateEntitlementsWithAddOnsThenCloseAccountWithItemAdjustment() throws Exception { //TODO_1739 - Test disabled due to behavior change, revisit
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccount();
 
@@ -582,8 +584,8 @@ public class TestEntitlement extends TestJaxrsBase {
     @Test(groups = "slow", description = "Create a bulk of base entitlements and addOns under the same transaction",
             expectedExceptions = KillBillClientException.class, expectedExceptionsMessageRegExp = "SubscriptionJson productName needs to be set when no planName is specified")
     public void testCreateSubscriptionsWithoutBase() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -635,8 +637,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Create addOns in a bundle where BP subscription already exist")
     public void testEntitlementsWithAddOnsAndAlreadyExistingBP() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -686,8 +688,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a future entitlement date")
     public void testCreateSubscriptionEntitlementInTheFuture() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -711,8 +713,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING);
         Assert.assertEquals(entitlementJson.getChargedThroughDate(), initialDate.plusMonths(1).toLocalDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate.toLocalDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate.toLocalDate().plusMonths(1));
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate());
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate().plusMonths(1));
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
         Assert.assertEquals(entitlementJson.getProductCategory(), input.getProductCategory());
         Assert.assertEquals(entitlementJson.getBillingPeriod(), input.getBillingPeriod());
@@ -732,8 +734,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a future billing date")
     public void testCreateSubscriptionBillingInTheFuture() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -757,8 +759,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
         Assert.assertNull(entitlementJson.getChargedThroughDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate.toLocalDate().plusMonths(1));
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate.toLocalDate());
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate().plusMonths(1));
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate());
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
         Assert.assertEquals(entitlementJson.getProductCategory(), input.getProductCategory());
         Assert.assertEquals(entitlementJson.getBillingPeriod(), input.getBillingPeriod());
@@ -779,13 +781,13 @@ public class TestEntitlement extends TestJaxrsBase {
     @Test(groups = "slow", description = "Can create an entitlement with a future billing date v2 -- see https://github.com/killbill/killbill/pull/1234#discussion_r332148759")
     public void testCreateSubscriptionBillingInTheFutureV2() throws Exception {
         // 2012-04-25T00:03:42.000Z
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
         // Move clock back to 2012-04-25T00:01:42.000Z (we want a reference time in the future)
-        clock.setTime(new DateTime(2012, 4, 25, 0, 1, 42, 0));
+        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 1, 42, 0, ZoneId.systemDefault()));
 
         final Subscription input = new Subscription();
         input.setAccountId(accountJson.getAccountId());
@@ -796,7 +798,7 @@ public class TestEntitlement extends TestJaxrsBase {
         // Verify callCompletion works (related to https://github.com/killbill/killbill/issues/1193)
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 null,
-                                                                                new LocalDate(2012, 4, 25),
+                                                                                LocalDate.of(2012, 4, 25),
                                                                                 false,
                                                                                 false,
                                                                                 false,
@@ -807,8 +809,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
         Assert.assertNull(entitlementJson.getChargedThroughDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate.toLocalDate());
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate.toLocalDate());
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate());
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate());
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
         Assert.assertEquals(entitlementJson.getProductCategory(), input.getProductCategory());
         Assert.assertEquals(entitlementJson.getBillingPeriod(), input.getBillingPeriod());
@@ -830,8 +832,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an entitlement with a past billing date")
     public void testCreateSubscriptionBillingInThePast() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -855,9 +857,9 @@ public class TestEntitlement extends TestJaxrsBase {
 
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        verifyChargedThroughDate(entitlementJson.getSubscriptionId(), new LocalDate("2012-05-24"));
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate.toLocalDate().minusMonths(1));
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate.toLocalDate());
+        verifyChargedThroughDate(entitlementJson.getSubscriptionId(), LocalDate.parse("2012-05-24"));
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate.toLocalDate().minusMonths(1));
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate.toLocalDate());
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
         Assert.assertEquals(entitlementJson.getProductCategory(), input.getProductCategory());
         Assert.assertEquals(entitlementJson.getBillingPeriod(), input.getBillingPeriod());
@@ -1157,8 +1159,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription")
     public void testOverwriteEntitlementBCDOnCreate() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1185,8 +1187,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription when changing plan")
     public void testOverwriteEntitlementBCDOnChange() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1215,20 +1217,20 @@ public class TestEntitlement extends TestJaxrsBase {
         newInput.setBillCycleDayLocal(28);
 
         callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CHANGE,  ExtBusEventType.SUBSCRIPTION_CHANGE, ExtBusEventType.SUBSCRIPTION_BCD_CHANGE, ExtBusEventType.INVOICE_CREATION);
-        subscriptionApi.changeSubscriptionPlan(subscription.getSubscriptionId(), newInput, new LocalDate(2012, 5, 28), null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(subscription.getSubscriptionId(), newInput, LocalDate.of(2012, 5, 28), null, NULL_PLUGIN_PROPERTIES, requestOptions);
         callbackServlet.assertListenerStatus();
 
         Subscription refreshedSubscription = subscriptionApi.getSubscription(subscription.getSubscriptionId(), requestOptions);
         Assert.assertNotNull(refreshedSubscription);
 
         // We charged a full period 2012-05-28 - 2012-06-28 based on the new BCD
-        verifyChargedThroughDate(refreshedSubscription.getSubscriptionId(), new LocalDate(2012, 6, 28));
+        verifyChargedThroughDate(refreshedSubscription.getSubscriptionId(), LocalDate.of(2012, 6, 28));
     }
 
     @Test(groups = "slow", description = "Verify we can move the BCD associated with the subscription")
     public void testMoveEntitlementBCD() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1264,8 +1266,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Verify we can update the quantity associated with the subscription")
     public void testUpdateEntitlementQuantity() throws Exception {
-        final DateTime initialDate = new DateTime(2022, 11, 28, 15, 7, 00, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2022, 11, 28, 15, 7, 00, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1290,8 +1292,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create subscription and change plan using planName")
     public void testEntitlementUsingPlanName() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1329,8 +1331,8 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can changePlan and undo changePlan on a subscription")
     public void testEntitlementUndoChangePlan() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1352,7 +1354,7 @@ public class TestEntitlement extends TestJaxrsBase {
         newInput.setPriceList(entitlementJson.getPriceList());
 
         callbackServlet.pushExpectedEvents(ExtBusEventType.SUBSCRIPTION_CHANGE);
-        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newInput, new LocalDate(2012, 4, 28), null, NULL_PLUGIN_PROPERTIES, requestOptions);
+        subscriptionApi.changeSubscriptionPlan(entitlementJson.getSubscriptionId(), newInput, LocalDate.of(2012, 4, 28), null, NULL_PLUGIN_PROPERTIES, requestOptions);
         Subscription refreshedSubscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
         callbackServlet.assertListenerStatus();
         Assert.assertNotNull(refreshedSubscription);
@@ -1402,8 +1404,8 @@ public class TestEntitlement extends TestJaxrsBase {
         Assert.assertNotNull(catalog2);
 
 
-        final DateTime initialDate = new DateTime(2014, 1, 2, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2014, 1, 2, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1464,7 +1466,7 @@ public class TestEntitlement extends TestJaxrsBase {
     
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDate() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1490,8 +1492,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.PENDING); // Still PENDING since creationDate is not reached
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), creationDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), creationDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), creationDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), creationDate);
 
         clock.setDay(creationDate);
 
@@ -1502,7 +1504,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDateTime() throws Exception {
-        final DateTime initialDateTime = new DateTime(2012, 4, 25, 10, 30);
+        final ZonedDateTime initialDateTime = ZonedDateTime.of(2012, 4, 25, 10, 30, 0, 0, ZoneId.systemDefault());
         clock.setTime(initialDateTime);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1514,7 +1516,7 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        final DateTime futureDateTime = new DateTime(2012, 4, 30, 11, 30);
+        final ZonedDateTime futureDateTime = ZonedDateTime.of(2012, 4, 30, 11, 30, 0, 0, ZoneId.systemDefault());
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 futureDateTime,
@@ -1540,7 +1542,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithDateTimeDifferentDatesForBillingAndEntitlement() throws Exception {
-        final DateTime initialDateTime = new DateTime(2012, 4, 25, 10, 30);
+        final ZonedDateTime initialDateTime = ZonedDateTime.of(2012, 4, 25, 10, 30, 0, 0, ZoneId.systemDefault());
         clock.setTime(initialDateTime);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1552,8 +1554,8 @@ public class TestEntitlement extends TestJaxrsBase {
         input.setBillingPeriod(BillingPeriod.MONTHLY);
         input.setPriceList(PriceListSet.DEFAULT_PRICELIST_NAME);
 
-        final DateTime billingDateTime = new DateTime(2012, 4, 28, 11, 30);
-        final DateTime entitlementDateTime = new DateTime(2012, 4, 30, 8, 45);
+        final ZonedDateTime billingDateTime = ZonedDateTime.of(2012, 4, 28, 11, 30, 0, 0, ZoneId.systemDefault());
+        final ZonedDateTime entitlementDateTime = ZonedDateTime.of(2012, 4, 30, 8, 45, 0, 0, ZoneId.systemDefault());
 
         final Subscription entitlementJson = subscriptionApi.createSubscription(input,
                                                                                 entitlementDateTime,
@@ -1584,7 +1586,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCancelSubscriptionWithDate() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1607,8 +1609,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
         final LocalDate cancelDate = clock.getUTCToday().plusDays(5);
 
@@ -1624,13 +1626,13 @@ public class TestEntitlement extends TestJaxrsBase {
         subscription = subscriptionApi.getSubscription(entitlementJson.getSubscriptionId(), requestOptions);
 
         Assert.assertEquals(subscription.getState(), EntitlementState.CANCELLED);
-        Assert.assertEquals(internalCallContext.toLocalDate(subscription.getCancelledDate()), cancelDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(subscription.getBillingEndDate()), initialDate.plusMonths(1));  //since default billing policy is EOT, billing end date is 1 month from start date
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(subscription.getCancelledDate())), cancelDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(subscription.getBillingEndDate())), initialDate.plusMonths(1));  //since default billing policy is EOT, billing end date is 1 month from start date
     }
 
     @Test(groups = "slow")
     public void testCancelSubscriptionWithDateTime() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1653,10 +1655,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final DateTime cancelDateTime = new DateTime(2012, 4, 30, 11, 30);
+        final ZonedDateTime cancelDateTime = ZonedDateTime.of(2012, 4, 30, 11, 30, 0, 0, ZoneId.systemDefault());
 
         subscriptionApi.cancelSubscriptionPlan(entitlementJson.getSubscriptionId(), cancelDateTime, null, null, NULL_PLUGIN_PROPERTIES, requestOptions); // Unlike cancelWithDate, in this case, the cancelDateTime is used for both entitlement and billing
 
@@ -1676,7 +1678,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testChangeSubscriptionPlanWithDate() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1699,8 +1701,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
 
         final LocalDate changeDate = clock.getUTCToday().plusDays(5);
@@ -1725,13 +1727,13 @@ public class TestEntitlement extends TestJaxrsBase {
         assertEquals(events.get(0).getEventType(), SubscriptionEventType.START_ENTITLEMENT);
         assertEquals(events.get(1).getEventType(), SubscriptionEventType.START_BILLING);
         assertEquals(events.get(2).getEventType(), SubscriptionEventType.CHANGE);
-        assertEquals(internalCallContext.toLocalDate(events.get(2).getEffectiveDate()), changeDate);  
+        assertEquals(internalCallContext.toLocalDate(toJodaDateTime(events.get(2).getEffectiveDate())), changeDate);  
         
     }
 
     @Test(groups = "slow")
     public void testChangeSubscriptionPlanWithDateTime() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1754,11 +1756,11 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
         Assert.assertEquals(entitlementJson.getProductName(), input.getProductName());
 
-        final DateTime changeDateTime = new DateTime(2012, 4, 25, 10, 50);
+        final ZonedDateTime changeDateTime = ZonedDateTime.of(2012, 4, 25, 10, 50, 0, 0, ZoneId.systemDefault());
 
         final Subscription newSubscriptionPlan = new Subscription();
         newSubscriptionPlan.setSubscriptionId(entitlementJson.getSubscriptionId());
@@ -1785,8 +1787,9 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testBlockBundleWithDate() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
-        clock.setDay(initialDate);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
+        // Convert Java Time LocalDate to Joda Time LocalDate for ClockMock.setDay()
+        clock.setDay(new org.joda.time.LocalDate(initialDate.getYear(), initialDate.getMonthValue(), initialDate.getDayOfMonth()));
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
 
@@ -1808,8 +1811,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
         final LocalDate blockDate = clock.getUTCToday().plusDays(5);
 
@@ -1848,7 +1851,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testBlockBundleWithDateTime() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1871,10 +1874,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final DateTime blockDateTime = new DateTime(2012, 4, 30, 11, 45);
+        final ZonedDateTime blockDateTime = ZonedDateTime.of(2012, 4, 30, 11, 45, 0, 0, ZoneId.systemDefault());
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -1909,7 +1912,7 @@ public class TestEntitlement extends TestJaxrsBase {
     
     @Test(groups = "slow")
     public void testBlockSubscriptionWithDate() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1932,8 +1935,8 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
         final LocalDate blockDate = clock.getUTCToday().plusDays(5);
 
@@ -1976,7 +1979,7 @@ public class TestEntitlement extends TestJaxrsBase {
     
     @Test(groups = "slow")
     public void testBlockSubscriptionWithDateTime() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -1999,10 +2002,10 @@ public class TestEntitlement extends TestJaxrsBase {
                                                                                 requestOptions);
 
         Assert.assertEquals(entitlementJson.getState(), EntitlementState.ACTIVE);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getBillingStartDate()), initialDate);
-        Assert.assertEquals(internalCallContext.toLocalDate(entitlementJson.getStartDate()), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getBillingStartDate())), initialDate);
+        Assert.assertEquals(internalCallContext.toLocalDate(toJodaDateTime(entitlementJson.getStartDate())), initialDate);
 
-        final DateTime blockDateTime = new DateTime(2012, 4, 30, 11, 45);
+        final ZonedDateTime blockDateTime = ZonedDateTime.of(2012, 4, 30, 11, 45, 0, 0, ZoneId.systemDefault());
 
         BlockingState state = new BlockingState();
         state.setIsBlockBilling(true);
@@ -2055,7 +2058,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithEmptyOverrides() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -2090,7 +2093,7 @@ public class TestEntitlement extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testCreateSubscriptionWithOnlyUsageOverrides() throws Exception {
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account accountJson = createAccountWithDefaultPaymentMethod();

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestExternalRefund.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestExternalRefund.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoicePayments;
 import org.killbill.billing.client.model.Invoices;
@@ -48,8 +48,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 0 - Can refund an automatic payment. This is a test to validate the correct behaviour.")
     public void testAutomaticPaymentAndRefund() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         final Payments paymentsForAccount = accountApi.getPaymentsForAccount(accountJson.getAccountId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -72,8 +72,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 0 - Can refund an automatic payment over item adjustments. This is a test to validate the correct behaviour.")
     public void testAutomaticPaymentAndRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         final Payments paymentsForAccount = accountApi.getPaymentsForAccount(accountJson.getAccountId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -100,8 +100,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 1 - Can refund a manual payment though an external refund")
     public void testManualPaymentAndExternalRefund() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithExternalPMBundleAndSubscriptionAndManualPayTagAndWaitForFirstInvoice();
 
@@ -134,8 +134,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 1 - Can refund a manual payment though an external refund over item adjustments")
     public void testManualPaymentAndExternalRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithExternalPMBundleAndSubscriptionAndManualPayTagAndWaitForFirstInvoice();
 
@@ -170,8 +170,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2a - Can refund an automatic payment though an external refund")
     public void testAutomaticPaymentAndExternalRefund() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         // delete PM
@@ -195,8 +195,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2a - Can refund an automatic payment though an external refund over item adjustments")
     public void testAutomaticPaymentAndExternalRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         // delete PM
@@ -226,8 +226,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2b - Can refund an automatic payment though another existing payment method")
     public void testAutomaticPaymentAndExternalRefundWithDifferentPM() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestExternalRefund.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestExternalRefund.java
@@ -22,7 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import java.time.ZonedDateTime;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoicePayments;
 import org.killbill.billing.client.model.Invoices;
@@ -48,8 +49,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 0 - Can refund an automatic payment. This is a test to validate the correct behaviour.")
     public void testAutomaticPaymentAndRefund() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         final Payments paymentsForAccount = accountApi.getPaymentsForAccount(accountJson.getAccountId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -72,8 +73,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 0 - Can refund an automatic payment over item adjustments. This is a test to validate the correct behaviour.")
     public void testAutomaticPaymentAndRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         final Payments paymentsForAccount = accountApi.getPaymentsForAccount(accountJson.getAccountId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -100,8 +101,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 1 - Can refund a manual payment though an external refund")
     public void testManualPaymentAndExternalRefund() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithExternalPMBundleAndSubscriptionAndManualPayTagAndWaitForFirstInvoice();
 
@@ -134,8 +135,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 1 - Can refund a manual payment though an external refund over item adjustments")
     public void testManualPaymentAndExternalRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithExternalPMBundleAndSubscriptionAndManualPayTagAndWaitForFirstInvoice();
 
@@ -170,8 +171,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2a - Can refund an automatic payment though an external refund")
     public void testAutomaticPaymentAndExternalRefund() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         // delete PM
@@ -195,8 +196,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2a - Can refund an automatic payment though an external refund over item adjustments")
     public void testAutomaticPaymentAndExternalRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         // delete PM
@@ -226,8 +227,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2b - Can refund an automatic payment though another existing payment method")
     public void testAutomaticPaymentAndExternalRefundWithDifferentPM() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestExternalRefund.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestExternalRefund.java
@@ -18,12 +18,12 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.model.InvoicePayments;
 import org.killbill.billing.client.model.Invoices;
@@ -49,8 +49,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 0 - Can refund an automatic payment. This is a test to validate the correct behaviour.")
     public void testAutomaticPaymentAndRefund() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         final Payments paymentsForAccount = accountApi.getPaymentsForAccount(accountJson.getAccountId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -73,8 +73,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 0 - Can refund an automatic payment over item adjustments. This is a test to validate the correct behaviour.")
     public void testAutomaticPaymentAndRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         final Payments paymentsForAccount = accountApi.getPaymentsForAccount(accountJson.getAccountId(), NULL_PLUGIN_PROPERTIES, requestOptions);
@@ -101,8 +101,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 1 - Can refund a manual payment though an external refund")
     public void testManualPaymentAndExternalRefund() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithExternalPMBundleAndSubscriptionAndManualPayTagAndWaitForFirstInvoice();
 
@@ -135,8 +135,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 1 - Can refund a manual payment though an external refund over item adjustments")
     public void testManualPaymentAndExternalRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithExternalPMBundleAndSubscriptionAndManualPayTagAndWaitForFirstInvoice();
 
@@ -171,8 +171,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2a - Can refund an automatic payment though an external refund")
     public void testAutomaticPaymentAndExternalRefund() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         // delete PM
@@ -196,8 +196,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2a - Can refund an automatic payment though an external refund over item adjustments")
     public void testAutomaticPaymentAndExternalRefundWithAdjustments() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
         // delete PM
@@ -227,8 +227,8 @@ public class TestExternalRefund extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "#255 - Scenario 2b - Can refund an automatic payment though another existing payment method")
     public void testAutomaticPaymentAndExternalRefundWithDifferentPM() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
@@ -29,10 +29,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDate;
-import org.joda.time.format.ISODateTimeFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.JaxrsResource;
@@ -72,8 +72,8 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can search and retrieve invoices with and without items")
     public void testInvoiceOk() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -102,7 +102,7 @@ public class TestInvoice extends TestJaxrsBase {
         assertEquals(invoiceItem.getPrettyPhaseName(), "shotgun-monthly-trial");
 
         // Check item is correctly returned with catalog effective date
-        assertEquals(invoiceItem.getCatalogEffectiveDate().compareTo(ISODateTimeFormat.dateTimeParser().parseDateTime("2011-01-01T00:00:00+00:00")), 0);
+        assertEquals(invoiceItem.getCatalogEffectiveDate().compareTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse("2011-01-01T00:00:00+00:00", java.time.temporal.TemporalAccessor::from)), 0);
 
         assertEquals(invoiceApi.getInvoice(invoiceJson.getInvoiceId(), Boolean.TRUE, AuditLevel.NONE, requestOptions).getItems().size(), invoiceJson.getItems().size());
         assertEquals(invoiceApi.getInvoiceByNumber(Integer.valueOf(invoiceJson.getInvoiceNumber()), Boolean.FALSE, AuditLevel.NONE, requestOptions).getItems().size(), invoiceJson.getItems().size());
@@ -211,10 +211,10 @@ public class TestInvoice extends TestJaxrsBase {
 
         final Invoice dryRunInvoice = invoiceApi.generateDryRunInvoice(dryRunArg, accountJson.getAccountId(), null, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(dryRunInvoice.getBalance(), new BigDecimal("249.95"));
-        assertEquals(dryRunInvoice.getTargetDate(), new LocalDate(2012, 6, 25));
+        assertEquals(dryRunInvoice.getTargetDate(), LocalDate.of(2012, 6, 25));
         assertEquals(dryRunInvoice.getItems().size(), 1);
-        assertEquals(dryRunInvoice.getItems().get(0).getStartDate(), new LocalDate(2012, 6, 25));
-        assertEquals(dryRunInvoice.getItems().get(0).getEndDate(), new LocalDate(2012, 7, 25));
+        assertEquals(dryRunInvoice.getItems().get(0).getStartDate(), LocalDate.of(2012, 6, 25));
+        assertEquals(dryRunInvoice.getItems().get(0).getEndDate(), LocalDate.of(2012, 7, 25));
         assertEquals(dryRunInvoice.getItems().get(0).getAmount(), new BigDecimal("249.95"));
 
         final LocalDate futureDate = dryRunInvoice.getTargetDate();
@@ -228,8 +228,8 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow")
     public void testGetInvoicesWithFilters() throws Exception {
-        final DateTime initialDate = new DateTime(2021, 4, 18, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2021, 4, 18, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -240,19 +240,19 @@ public class TestInvoice extends TestJaxrsBase {
         final String invoiceId2 = invoices.get(1).getInvoiceId().toString();
 
         // Filter on dates only
-        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), new LocalDate(2021, 4, 18), new LocalDate(2021, 5, 18), false, false, false, true, null, AuditLevel.FULL, requestOptions);
+        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), LocalDate.of(2021, 4, 18), LocalDate.of(2021, 5, 18), false, false, false, true, null, AuditLevel.FULL, requestOptions);
         assertEquals(invoices.size(), 2);
 
-        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), new LocalDate(2021, 4, 18), new LocalDate(2021, 5, 17), false, false, false, true, null, AuditLevel.FULL, requestOptions);
+        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), LocalDate.of(2021, 4, 18), LocalDate.of(2021, 5, 17), false, false, false, true, null, AuditLevel.FULL, requestOptions);
         assertEquals(invoices.size(), 1);
 
-        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), new LocalDate(2021, 4, 19), new LocalDate(2021, 5, 18), false, false, false, true, null, AuditLevel.FULL, requestOptions);
+        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), LocalDate.of(2021, 4, 19), LocalDate.of(2021, 5, 18), false, false, false, true, null, AuditLevel.FULL, requestOptions);
         assertEquals(invoices.size(), 1);
 
-        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), new LocalDate(2021, 4, 19), new LocalDate(2021, 5, 17), false, false, false, true, null, AuditLevel.FULL, requestOptions);
+        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), LocalDate.of(2021, 4, 19), LocalDate.of(2021, 5, 17), false, false, false, true, null, AuditLevel.FULL, requestOptions);
         assertEquals(invoices.size(), 0);
 
-        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), new LocalDate(2021, 4, 19), new LocalDate(2021, 5, 17), false, false, false, true, null, AuditLevel.FULL, requestOptions);
+        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), LocalDate.of(2021, 4, 19), LocalDate.of(2021, 5, 17), false, false, false, true, null, AuditLevel.FULL, requestOptions);
         assertEquals(invoices.size(), 0);
 
         // Filter on invoiceIds only
@@ -266,15 +266,15 @@ public class TestInvoice extends TestJaxrsBase {
 
         // Dates and id filter
         idFilter = Strings.join(",", new String[]{invoiceId1, invoiceId2});
-        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), new LocalDate(2021, 4, 18), new LocalDate(2021, 5, 17), false, false, false, true, idFilter, AuditLevel.FULL, requestOptions);
+        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), LocalDate.of(2021, 4, 18), LocalDate.of(2021, 5, 17), false, false, false, true, idFilter, AuditLevel.FULL, requestOptions);
         assertEquals(invoices.size(), 1);
 
         idFilter = invoiceId1;
-        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), new LocalDate(2021, 4, 18), new LocalDate(2021, 5, 17), false, false, false, true, idFilter, AuditLevel.FULL, requestOptions);
+        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), LocalDate.of(2021, 4, 18), LocalDate.of(2021, 5, 17), false, false, false, true, idFilter, AuditLevel.FULL, requestOptions);
         assertEquals(invoices.size(), 1);
 
         idFilter = invoiceId2;
-        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), new LocalDate(2021, 4, 18), new LocalDate(2021, 5, 17), false, false, false, true, idFilter, AuditLevel.FULL, requestOptions);
+        invoices = accountApi.getInvoicesForAccount(accountJson.getAccountId(), LocalDate.of(2021, 4, 18), LocalDate.of(2021, 5, 17), false, false, false, true, idFilter, AuditLevel.FULL, requestOptions);
         assertEquals(invoices.size(), 0);
 
 
@@ -282,12 +282,12 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create a subscription in dryRun mode and get an invoice back")
     public void testDryRunSubscriptionCreate() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         // "Assault-Rifle", BillingPeriod.ANNUAL, "rescue", BillingActionPolicy.IMMEDIATE,
         final Account accountJson = createAccountWithDefaultPaymentMethod();
-        final LocalDate effDt = new LocalDate(initialDate, DateTimeZone.forID(accountJson.getTimeZone()));
+        final LocalDate effDt = initialDate.withZoneSameInstant(ZoneId.of(accountJson.getTimeZone())).toLocalDate();
         final InvoiceDryRun dryRunArg = new InvoiceDryRun(DryRunType.SUBSCRIPTION_ACTION, SubscriptionEventType.START_BILLING,
                                                           null, "Assault-Rifle", ProductCategory.BASE, BillingPeriod.ANNUAL, null, null, null, effDt, null, null, null);
 
@@ -304,7 +304,7 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can retrieve invoice payments")
     public void testInvoicePayments() throws Exception {
-        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, 0));
+        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -324,7 +324,7 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an insta-payment")
     public void testInvoiceCreatePayment() throws Exception {
-        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, 0));
+        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
 
         // STEPH MISSING SET ACCOUNT AUTO_PAY_OFF
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
@@ -728,7 +728,7 @@ public class TestInvoice extends TestJaxrsBase {
         // Migrate an invoice with one external charge
         final BigDecimal chargeAmount = BigDecimal.TEN;
         final InvoiceItem externalCharge = new InvoiceItem();
-        externalCharge.setStartDate(new LocalDate());
+        externalCharge.setStartDate(LocalDate.now());
         externalCharge.setAccountId(accountJson.getAccountId());
         externalCharge.setAmount(chargeAmount);
         externalCharge.setItemType(InvoiceItemType.EXTERNAL_CHARGE);
@@ -812,8 +812,8 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can search and retrieve parent and children invoices with and without children items")
     public void testParentInvoiceWithChildItems() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());
@@ -927,8 +927,8 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Test invoice grouping api")
     public void testInvoiceGroupApi() throws Exception {
-        final DateTime initialDate = new DateTime(2022, 5, 5, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2022, 5, 5, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -937,7 +937,7 @@ public class TestInvoice extends TestJaxrsBase {
 
         // Follow location to return the list of invoices
         final Invoices invoices2 = invoiceApi.createFutureInvoiceGroup(accountJson.getAccountId(),
-                                                                       new LocalDate(2022, 7, 4),
+                                                                       LocalDate.of(2022, 7, 4),
                                                                        NULL_PLUGIN_PROPERTIES,
                                                                        requestOptions.extend()
                                                                                      .withQueryParamsForFollow(Map.of(JaxrsResource.QUERY_ACCOUNT_ID, List.of(accountJson.getAccountId().toString())))
@@ -946,7 +946,7 @@ public class TestInvoice extends TestJaxrsBase {
         assertEquals(invoices2.size(), 1);
 
         // Do it again for following month but without any follow up
-        invoiceApi.createFutureInvoiceGroup(accountJson.getAccountId(), new LocalDate(2022, 8, 4), NULL_PLUGIN_PROPERTIES, requestOptions);
+        invoiceApi.createFutureInvoiceGroup(accountJson.getAccountId(), LocalDate.of(2022, 8, 4), NULL_PLUGIN_PROPERTIES, requestOptions);
 
         final Invoices accountInvoices2 = accountApi.getInvoicesForAccount(accountJson.getAccountId(), null, null, false, false, false, true, null, AuditLevel.FULL, requestOptions);
         assertEquals(accountInvoices2.size(), 4);
@@ -1195,7 +1195,7 @@ public class TestInvoice extends TestJaxrsBase {
     @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/1340")
     public void testInvoiceDryRunStopBilling() throws Exception {
 
-        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        final LocalDate initialDate = LocalDate.of(2012, 4, 25);
         clock.setDay(initialDate);
 
         final Account account = createAccountNoPMBundleAndSubscription(); // create account with subscription to shotgun-monthly plan

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
@@ -73,7 +73,7 @@ public class TestInvoice extends TestJaxrsBase {
     @Test(groups = "slow", description = "Can search and retrieve invoices with and without items")
     public void testInvoiceOk() throws Exception {
         final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -102,7 +102,7 @@ public class TestInvoice extends TestJaxrsBase {
         assertEquals(invoiceItem.getPrettyPhaseName(), "shotgun-monthly-trial");
 
         // Check item is correctly returned with catalog effective date
-        assertEquals(invoiceItem.getCatalogEffectiveDate().compareTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse("2011-01-01T00:00:00+00:00", java.time.temporal.TemporalAccessor::from)), 0);
+        assertEquals(invoiceItem.getCatalogEffectiveDate().toInstant(), java.time.Instant.parse("2011-01-01T00:00:00Z"));
 
         assertEquals(invoiceApi.getInvoice(invoiceJson.getInvoiceId(), Boolean.TRUE, AuditLevel.NONE, requestOptions).getItems().size(), invoiceJson.getItems().size());
         assertEquals(invoiceApi.getInvoiceByNumber(Integer.valueOf(invoiceJson.getInvoiceNumber()), Boolean.FALSE, AuditLevel.NONE, requestOptions).getItems().size(), invoiceJson.getItems().size());
@@ -229,7 +229,7 @@ public class TestInvoice extends TestJaxrsBase {
     @Test(groups = "slow")
     public void testGetInvoicesWithFilters() throws Exception {
         final ZonedDateTime initialDate = ZonedDateTime.of(2021, 4, 18, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -283,7 +283,7 @@ public class TestInvoice extends TestJaxrsBase {
     @Test(groups = "slow", description = "Can create a subscription in dryRun mode and get an invoice back")
     public void testDryRunSubscriptionCreate() throws Exception {
         final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         // "Assault-Rifle", BillingPeriod.ANNUAL, "rescue", BillingActionPolicy.IMMEDIATE,
         final Account accountJson = createAccountWithDefaultPaymentMethod();
@@ -304,7 +304,7 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can retrieve invoice payments")
     public void testInvoicePayments() throws Exception {
-        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
+        clock.setTime(new org.joda.time.DateTime(2012, 4, 25, 0, 3, 42, org.joda.time.DateTimeZone.getDefault()));
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -324,7 +324,7 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an insta-payment")
     public void testInvoiceCreatePayment() throws Exception {
-        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
+        clock.setTime(new org.joda.time.DateTime(2012, 4, 25, 0, 3, 42, org.joda.time.DateTimeZone.getDefault()));
 
         // STEPH MISSING SET ACCOUNT AUTO_PAY_OFF
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
@@ -509,7 +509,7 @@ public class TestInvoice extends TestJaxrsBase {
         externalCharge.setItemDetails("Item Details");
         externalCharge.setLinkedInvoiceItemId(firstInvoiceItemId);
 
-        final LocalDate startDate = clock.getUTCToday();
+        final LocalDate startDate = toJavaLocalDate(clock.getUTCToday());
         externalCharge.setStartDate(startDate);
         final LocalDate endDate = startDate.plusDays(10);
         externalCharge.setEndDate(endDate);
@@ -517,7 +517,7 @@ public class TestInvoice extends TestJaxrsBase {
         final InvoiceItems itemsForCharge = new InvoiceItems();
         itemsForCharge.add(externalCharge);
 
-        final List<InvoiceItem> createdExternalCharges = invoiceApi.createExternalCharges(accountJson.getAccountId(), itemsForCharge, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final List<InvoiceItem> createdExternalCharges = invoiceApi.createExternalCharges(accountJson.getAccountId(), itemsForCharge, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(createdExternalCharges.size(), 1);
         final Invoice invoiceWithItems = invoiceApi.getInvoice(createdExternalCharges.get(0).getInvoiceId(), false, AuditLevel.NONE, requestOptions);
         assertEquals(invoiceWithItems.getBalance().compareTo(chargeAmount), 0);
@@ -561,7 +561,7 @@ public class TestInvoice extends TestJaxrsBase {
         externalCharge2.setDescription(UUID.randomUUID().toString());
         externalCharges.add(externalCharge2);
 
-        final List<InvoiceItem> createdExternalCharges = invoiceApi.createExternalCharges(accountJson.getAccountId(), externalCharges, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final List<InvoiceItem> createdExternalCharges = invoiceApi.createExternalCharges(accountJson.getAccountId(), externalCharges, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(createdExternalCharges.size(), 2);
         assertEquals(createdExternalCharges.get(0).getCurrency(), accountJson.getCurrency());
         assertEquals(createdExternalCharges.get(1).getCurrency(), accountJson.getCurrency());
@@ -596,7 +596,7 @@ public class TestInvoice extends TestJaxrsBase {
         externalCharge2.setDescription(UUID.randomUUID().toString());
         externalCharges.add(externalCharge2);
 
-        final List<InvoiceItem> createdExternalCharges = invoiceApi.createExternalCharges(accountJson.getAccountId(), externalCharges, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final List<InvoiceItem> createdExternalCharges = invoiceApi.createExternalCharges(accountJson.getAccountId(), externalCharges, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(createdExternalCharges.size(), 2);
         assertEquals(createdExternalCharges.get(0).getCurrency(), accountJson.getCurrency());
         assertEquals(createdExternalCharges.get(1).getCurrency(), accountJson.getCurrency());
@@ -619,7 +619,7 @@ public class TestInvoice extends TestJaxrsBase {
         externalCharge.setBundleId(bundleId);
         final InvoiceItems input = new InvoiceItems();
         input.add(externalCharge);
-        final List<InvoiceItem> createdExternalCharges = invoiceApi.createExternalCharges(accountJson.getAccountId(), input, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final List<InvoiceItem> createdExternalCharges = invoiceApi.createExternalCharges(accountJson.getAccountId(), input, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(createdExternalCharges.size(), 1);
         final Invoice invoiceWithItems = invoiceApi.getInvoice(createdExternalCharges.get(0).getInvoiceId(), null, AuditLevel.NONE, requestOptions);
         assertEquals(invoiceWithItems.getBalance().compareTo(chargeAmount), 0);
@@ -647,7 +647,7 @@ public class TestInvoice extends TestJaxrsBase {
         taxItem.setBundleId(bundleId);
         final InvoiceItems input = new InvoiceItems();
         input.add(taxItem);
-        final List<InvoiceItem> createdTaxItems = invoiceApi.createTaxItems(accountJson.getAccountId(), input, true, clock.getUTCToday(), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final List<InvoiceItem> createdTaxItems = invoiceApi.createTaxItems(accountJson.getAccountId(), input, true, toJavaLocalDate(clock.getUTCToday()), NULL_PLUGIN_PROPERTIES, requestOptions);
         assertEquals(createdTaxItems.size(), 1);
         final Invoice invoiceWithItems = invoiceApi.getInvoice(createdTaxItems.get(0).getInvoiceId(), null, AuditLevel.NONE, requestOptions);
         assertEquals(invoiceWithItems.getBalance().compareTo(taxAmount), 0);
@@ -812,8 +812,8 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can search and retrieve parent and children invoices with and without children items")
     public void testParentInvoiceWithChildItems() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final org.joda.time.DateTime initialDate = new org.joda.time.DateTime(2012, 4, 25, 0, 3, 42, org.joda.time.DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());
@@ -928,7 +928,7 @@ public class TestInvoice extends TestJaxrsBase {
     @Test(groups = "slow", description = "Test invoice grouping api")
     public void testInvoiceGroupApi() throws Exception {
         final ZonedDateTime initialDate = ZonedDateTime.of(2022, 5, 5, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -1001,7 +1001,7 @@ public class TestInvoice extends TestJaxrsBase {
         assertNotNull(subscriptionJson);
         callbackServlet.assertListenerStatus();
 
-        final LocalDate futureDate = clock.getUTCToday();
+        final LocalDate futureDate = toJavaLocalDate(clock.getUTCToday());
         final Map<String, String> properties = new HashMap<>();
         properties.put("KB_REUSE_DRAFT_INVOICING_ID", invoiceId.toString());
 
@@ -1196,7 +1196,7 @@ public class TestInvoice extends TestJaxrsBase {
     public void testInvoiceDryRunStopBilling() throws Exception {
 
         final LocalDate initialDate = LocalDate.of(2012, 4, 25);
-        clock.setDay(initialDate);
+        clock.setDay(new org.joda.time.LocalDate(initialDate.getYear(), initialDate.getMonthValue(), initialDate.getDayOfMonth()));
 
         final Account account = createAccountNoPMBundleAndSubscription(); // create account with subscription to shotgun-monthly plan
         final Subscription subscription = accountApi.getAccountBundles(account.getAccountId(), null, null, requestOptions).get(0).getSubscriptions().get(0);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
@@ -304,7 +304,7 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can retrieve invoice payments")
     public void testInvoicePayments() throws Exception {
-        clock.setTime(new org.joda.time.DateTime(2012, 4, 25, 0, 3, 42, org.joda.time.DateTimeZone.getDefault()));
+        clock.setTime(toJodaDateTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault())));
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
 
@@ -324,7 +324,7 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can create an insta-payment")
     public void testInvoiceCreatePayment() throws Exception {
-        clock.setTime(new org.joda.time.DateTime(2012, 4, 25, 0, 3, 42, org.joda.time.DateTimeZone.getDefault()));
+        clock.setTime(toJodaDateTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault())));
 
         // STEPH MISSING SET ACCOUNT AUTO_PAY_OFF
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice();
@@ -812,8 +812,8 @@ public class TestInvoice extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can search and retrieve parent and children invoices with and without children items")
     public void testParentInvoiceWithChildItems() throws Exception {
-        final org.joda.time.DateTime initialDate = new org.joda.time.DateTime(2012, 4, 25, 0, 3, 42, org.joda.time.DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());
@@ -1196,7 +1196,7 @@ public class TestInvoice extends TestJaxrsBase {
     public void testInvoiceDryRunStopBilling() throws Exception {
 
         final LocalDate initialDate = LocalDate.of(2012, 4, 25);
-        clock.setDay(new org.joda.time.LocalDate(initialDate.getYear(), initialDate.getMonthValue(), initialDate.getDayOfMonth()));
+        clock.setDay(toJodaLocalDate(initialDate));
 
         final Account account = createAccountNoPMBundleAndSubscription(); // create account with subscription to shotgun-monthly plan
         final Subscription subscription = accountApi.getAccountBundles(account.getAccountId(), null, null, requestOptions).get(0).getSubscriptions().get(0);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
@@ -705,7 +705,7 @@ public class TestInvoice extends TestJaxrsBase {
 
         InvoiceItems credits = new InvoiceItems();
         credits.add(credit);
-        final List<InvoiceItem> creditJsons = creditApi.createCredits(credits, clock.getUTCToday(), false, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final List<InvoiceItem> creditJsons = creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), false, NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(creditJsons.size(), 1);
 
         Invoice invoice = invoiceApi.getInvoice(creditJsons.get(0).getInvoiceId(), requestOptions);
@@ -767,7 +767,7 @@ public class TestInvoice extends TestJaxrsBase {
         // insert credit to child account
         InvoiceItems credits = new InvoiceItems();
         credits.add(credit);
-        final List<InvoiceItem> creditJsons = creditApi.createCredits(credits, clock.getUTCToday(), true, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final List<InvoiceItem> creditJsons = creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), true, NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(creditJsons.size(), 1);
 
         Invoices childInvoices = accountApi.getInvoicesForAccount(childAccount.getAccountId(), null, null, false, false, false, true, null, AuditLevel.NONE, requestOptions);
@@ -972,7 +972,7 @@ public class TestInvoice extends TestJaxrsBase {
 
         InvoiceItems credits = new InvoiceItems();
         credits.add(credit);
-        final List<InvoiceItem> creditJsons = creditApi.createCredits(credits, clock.getUTCToday(), false, NULL_PLUGIN_PROPERTIES, requestOptions);
+        final List<InvoiceItem> creditJsons = creditApi.createCredits(credits, toJavaLocalDate(clock.getUTCToday()), false, NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(creditJsons.size(), 1);
         final UUID invoiceId = creditJsons.get(0).getInvoiceId();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoicePayment.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoicePayment.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.KillBillClientException;
@@ -77,7 +77,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
     }
     @Test(groups = "slow", description = "Trigger payments for account with no unpaid invoices")
     public void testPayZeroInvoice() throws Exception {
-        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, 0));
+        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
         // No payment method
         final Account accountJson = createAccountWithExternalPaymentMethod();
         // Pay all invoices - nothing to pay
@@ -87,7 +87,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can pay invoices")
     public void testPayAllInvoices() throws Exception {
-        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, 0));
+        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
 
         // No payment method
         final Account accountJson = createAccountNoPMBundleAndSubscriptionAndWaitForFirstInvoice();
@@ -318,8 +318,8 @@ public class TestInvoicePayment extends TestJaxrsBase {
 
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
 
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoicePayment.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoicePayment.java
@@ -20,14 +20,14 @@ package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import javax.inject.Inject;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.KillBillClientException;
@@ -76,9 +76,12 @@ public class TestInvoicePayment extends TestJaxrsBase {
         super.beforeMethod();
         mockPaymentProviderPlugin = (MockPaymentProviderPlugin) registry.getServiceForName(PLUGIN_NAME);
     }
+
     @Test(groups = "slow", description = "Trigger payments for account with no unpaid invoices")
     public void testPayZeroInvoice() throws Exception {
-        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault()));
+        final ZonedDateTime newTime = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setTime(toJodaDateTime(newTime));
+
         // No payment method
         final Account accountJson = createAccountWithExternalPaymentMethod();
         // Pay all invoices - nothing to pay
@@ -88,7 +91,8 @@ public class TestInvoicePayment extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can pay invoices")
     public void testPayAllInvoices() throws Exception {
-        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault()));
+        final ZonedDateTime newTime = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setTime(toJodaDateTime(newTime));
 
         // No payment method
         final Account accountJson = createAccountNoPMBundleAndSubscriptionAndWaitForFirstInvoice();
@@ -318,9 +322,8 @@ public class TestInvoicePayment extends TestJaxrsBase {
     public void testWithFailedInvoicePayment() throws Exception {
 
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
-
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoicePayment.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoicePayment.java
@@ -26,7 +26,8 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
-import java.time.ZonedDateTime;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.KillBillClientException;
@@ -77,7 +78,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
     }
     @Test(groups = "slow", description = "Trigger payments for account with no unpaid invoices")
     public void testPayZeroInvoice() throws Exception {
-        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
+        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault()));
         // No payment method
         final Account accountJson = createAccountWithExternalPaymentMethod();
         // Pay all invoices - nothing to pay
@@ -87,7 +88,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can pay invoices")
     public void testPayAllInvoices() throws Exception {
-        clock.setTime(ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault()));
+        clock.setTime(new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault()));
 
         // No payment method
         final Account accountJson = createAccountNoPMBundleAndSubscriptionAndWaitForFirstInvoice();
@@ -318,8 +319,8 @@ public class TestInvoicePayment extends TestJaxrsBase {
 
         mockPaymentProviderPlugin.makeNextPaymentFailWithError();
 
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account accountJson = createAccountWithPMBundleAndSubscriptionAndWaitForFirstInvoice(false);
 
@@ -436,7 +437,7 @@ public class TestInvoicePayment extends TestJaxrsBase {
         Assert.assertEquals(refund.getCurrency(), DEFAULT_CURRENCY);
         Assert.assertEquals(refund.getStatus(), TransactionStatus.SUCCESS);
         Assert.assertEquals(refund.getEffectiveDate().getYear(), clock.getUTCNow().getYear());
-        Assert.assertEquals(refund.getEffectiveDate().getMonthOfYear(), clock.getUTCNow().getMonthOfYear());
+        Assert.assertEquals(refund.getEffectiveDate().getMonthValue(), clock.getUTCNow().getMonthOfYear());
         Assert.assertEquals(refund.getEffectiveDate().getDayOfMonth(), clock.getUTCNow().getDayOfMonth());
 
         // Verify the refund via the payment API

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceVoid.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceVoid.java
@@ -23,9 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import java.time.ZonedDateTime;
-import java.time.ZoneId;
-import java.time.LocalDate;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.KillBillClientException;
@@ -88,7 +87,7 @@ public class TestInvoiceVoid extends TestJaxrsBase {
         // After invoice was voided verify the subscription is re-invoiced on a new invoice
         // trigger an invoice generation
         callbackServlet.pushExpectedEvent(ExtBusEventType.INVOICE_CREATION);
-        invoiceApi.createFutureInvoice(accountJson.getAccountId(), clock.getToday(ZoneId.of(accountJson.getTimeZone())), NULL_PLUGIN_PROPERTIES, requestOptions);
+        invoiceApi.createFutureInvoice(accountJson.getAccountId(), toJavaLocalDate(clock.getToday(DateTimeZone.forID(accountJson.getTimeZone()))), NULL_PLUGIN_PROPERTIES, requestOptions);
         callbackServlet.assertListenerStatus();
 
         // Get the invoices excluding voided
@@ -151,9 +150,9 @@ public class TestInvoiceVoid extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Void a child invoice")
     public void testChildVoidInvoice() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        final LocalDate triggeredDate = LocalDate.of(2012, 5, 26);
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        final java.time.LocalDate triggeredDate = java.time.LocalDate.of(2012, 5, 26);
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());
@@ -203,9 +202,9 @@ public class TestInvoiceVoid extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Void a parent invoice")
     public void testParentVoidInvoice() throws Exception {
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        final LocalDate triggeredDate = LocalDate.of(2012, 5, 26);
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        final java.time.LocalDate triggeredDate = java.time.LocalDate.of(2012, 5, 26);
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceVoid.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceVoid.java
@@ -23,9 +23,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.LocalDate;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.KillBillClientException;
@@ -88,7 +88,7 @@ public class TestInvoiceVoid extends TestJaxrsBase {
         // After invoice was voided verify the subscription is re-invoiced on a new invoice
         // trigger an invoice generation
         callbackServlet.pushExpectedEvent(ExtBusEventType.INVOICE_CREATION);
-        invoiceApi.createFutureInvoice(accountJson.getAccountId(), clock.getToday(DateTimeZone.forID(accountJson.getTimeZone())), NULL_PLUGIN_PROPERTIES, requestOptions);
+        invoiceApi.createFutureInvoice(accountJson.getAccountId(), clock.getToday(ZoneId.of(accountJson.getTimeZone())), NULL_PLUGIN_PROPERTIES, requestOptions);
         callbackServlet.assertListenerStatus();
 
         // Get the invoices excluding voided
@@ -151,9 +151,9 @@ public class TestInvoiceVoid extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Void a child invoice")
     public void testChildVoidInvoice() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        final LocalDate triggeredDate = new LocalDate(2012, 5, 26);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        final LocalDate triggeredDate = LocalDate.of(2012, 5, 26);
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());
@@ -203,9 +203,9 @@ public class TestInvoiceVoid extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Void a parent invoice")
     public void testParentVoidInvoice() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        final LocalDate triggeredDate = new LocalDate(2012, 5, 26);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        final LocalDate triggeredDate = LocalDate.of(2012, 5, 26);
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceVoid.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoiceVoid.java
@@ -19,12 +19,12 @@
 package org.killbill.billing.jaxrs;
 
 import java.math.BigDecimal;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
 import org.killbill.billing.client.KillBillClientException;
@@ -87,7 +87,8 @@ public class TestInvoiceVoid extends TestJaxrsBase {
         // After invoice was voided verify the subscription is re-invoiced on a new invoice
         // trigger an invoice generation
         callbackServlet.pushExpectedEvent(ExtBusEventType.INVOICE_CREATION);
-        invoiceApi.createFutureInvoice(accountJson.getAccountId(), toJavaLocalDate(clock.getToday(DateTimeZone.forID(accountJson.getTimeZone()))), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final var today = clockGetToday(accountJson.getTimeZone());
+        invoiceApi.createFutureInvoice(accountJson.getAccountId(), toJavaLocalDate(today), NULL_PLUGIN_PROPERTIES, requestOptions);
         callbackServlet.assertListenerStatus();
 
         // Get the invoices excluding voided
@@ -150,9 +151,9 @@ public class TestInvoiceVoid extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Void a child invoice")
     public void testChildVoidInvoice() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
         final java.time.LocalDate triggeredDate = java.time.LocalDate.of(2012, 5, 26);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());
@@ -202,9 +203,9 @@ public class TestInvoiceVoid extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Void a parent invoice")
     public void testParentVoidInvoice() throws Exception {
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
         final java.time.LocalDate triggeredDate = java.time.LocalDate.of(2012, 5, 26);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account parentAccount = createAccount();
         final Account childAccount1 = createAccount(parentAccount.getAccountId());

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
@@ -27,6 +27,9 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.EventListener;
 import java.util.Iterator;
@@ -43,7 +46,6 @@ import javax.sql.DataSource;
 
 import org.apache.shiro.web.servlet.ShiroFilter;
 import org.eclipse.jetty.servlet.FilterHolder;
-import java.time.LocalDate;
 import org.killbill.billing.GuicyKillbillTestWithEmbeddedDBModule;
 import org.killbill.billing.api.TestApiListener;
 import org.killbill.billing.beatrix.integration.db.TestDBRouterAPI;
@@ -467,25 +469,43 @@ public class TestJaxrsBase extends KillbillClient {
     /**
      * Helper method to convert Java Time ZonedDateTime to Joda Time DateTime for use with InternalCallContext.toLocalDate()
      */
-    protected org.joda.time.DateTime toJodaDateTime(final java.time.ZonedDateTime zonedDateTime) {
+    protected org.joda.time.DateTime toJodaDateTime(final ZonedDateTime zonedDateTime) {
         if (zonedDateTime == null) {
             return null;
         }
         return new org.joda.time.DateTime(zonedDateTime.toInstant().toEpochMilli());
     }
 
-    protected java.time.ZonedDateTime toJavaZonedDateTime(final org.joda.time.DateTime jodaDateTime) {
+    protected org.joda.time.LocalDate toJodaLocalDate(final LocalDate localDate) {
+        if (localDate == null) {
+            return null;
+        }
+        return new org.joda.time.LocalDate(localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth());
+    }
+
+    protected ZonedDateTime toJavaZonedDateTime(final org.joda.time.DateTime jodaDateTime) {
         if (jodaDateTime == null) {
             return null;
         }
         final int offsetSeconds = jodaDateTime.getZone().getOffset(jodaDateTime.getMillis()) / 1000;
-        return java.time.Instant.ofEpochMilli(jodaDateTime.getMillis()).atZone(java.time.ZoneOffset.ofTotalSeconds(offsetSeconds));
+        return Instant.ofEpochMilli(jodaDateTime.getMillis()).atZone(java.time.ZoneOffset.ofTotalSeconds(offsetSeconds));
     }
 
-    protected java.time.LocalDate toJavaLocalDate(final org.joda.time.LocalDate jodaDate) {
+    protected LocalDate toJavaLocalDate(final org.joda.time.LocalDate jodaDate) {
         if (jodaDate == null) {
             return null;
         }
-        return java.time.LocalDate.of(jodaDate.getYear(), jodaDate.getMonthOfYear(), jodaDate.getDayOfMonth());
+        return LocalDate.of(jodaDate.getYear(), jodaDate.getMonthOfYear(), jodaDate.getDayOfMonth());
+    }
+
+    protected java.time.LocalDate toJavaLocalDate(final org.joda.time.DateTime jodaDateTime) {
+        if (jodaDateTime == null) {
+            return null;
+        }
+        return LocalDate.of(jodaDateTime.getYear(), jodaDateTime.getMonthOfYear(), jodaDateTime.getDayOfMonth());
+    }
+
+    protected org.joda.time.LocalDate clockGetToday(final String timezone) {
+        return clock.getToday(org.joda.time.DateTimeZone.forID(timezone));
     }
 }

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
@@ -473,4 +473,18 @@ public class TestJaxrsBase extends KillbillClient {
         }
         return new org.joda.time.DateTime(zonedDateTime.toInstant().toEpochMilli());
     }
+
+    protected java.time.ZonedDateTime toJavaZonedDateTime(final org.joda.time.DateTime jodaDateTime) {
+        if (jodaDateTime == null) {
+            return null;
+        }
+        return java.time.Instant.ofEpochMilli(jodaDateTime.getMillis()).atZone(java.time.ZoneId.of(jodaDateTime.getZone().getID()));
+    }
+
+    protected java.time.LocalDate toJavaLocalDate(final org.joda.time.LocalDate jodaDate) {
+        if (jodaDate == null) {
+            return null;
+        }
+        return java.time.LocalDate.of(jodaDate.getYear(), jodaDate.getMonthOfYear(), jodaDate.getDayOfMonth());
+    }
 }

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
@@ -43,7 +43,7 @@ import javax.sql.DataSource;
 
 import org.apache.shiro.web.servlet.ShiroFilter;
 import org.eclipse.jetty.servlet.FilterHolder;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.killbill.billing.GuicyKillbillTestWithEmbeddedDBModule;
 import org.killbill.billing.api.TestApiListener;
 import org.killbill.billing.beatrix.integration.db.TestDBRouterAPI;
@@ -284,7 +284,8 @@ public class TestJaxrsBase extends KillbillClient {
         callbackServlet.reset();
 
         clock.resetDeltaFromReality();
-        clock.setDay(new LocalDate(2012, 8, 25));
+        // Convert Java Time LocalDate to Joda Time LocalDate for ClockMock
+        clock.setDay(new org.joda.time.LocalDate(2012, 8, 25));
 
         // Make sure to re-generate the api key and secret (could be cached by Shiro)
         DEFAULT_API_KEY = UUID.randomUUID().toString();
@@ -461,5 +462,15 @@ public class TestJaxrsBase extends KillbillClient {
             dump.append("\n\n");
         }
         log.warn(dump.toString());
+    }
+
+    /**
+     * Helper method to convert Java Time ZonedDateTime to Joda Time DateTime for use with InternalCallContext.toLocalDate()
+     */
+    protected org.joda.time.DateTime toJodaDateTime(final java.time.ZonedDateTime zonedDateTime) {
+        if (zonedDateTime == null) {
+            return null;
+        }
+        return new org.joda.time.DateTime(zonedDateTime.toInstant().toEpochMilli());
     }
 }

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestJaxrsBase.java
@@ -478,7 +478,8 @@ public class TestJaxrsBase extends KillbillClient {
         if (jodaDateTime == null) {
             return null;
         }
-        return java.time.Instant.ofEpochMilli(jodaDateTime.getMillis()).atZone(java.time.ZoneId.of(jodaDateTime.getZone().getID()));
+        final int offsetSeconds = jodaDateTime.getZone().getOffset(jodaDateTime.getMillis()) / 1000;
+        return java.time.Instant.ofEpochMilli(jodaDateTime.getMillis()).atZone(java.time.ZoneOffset.ofTotalSeconds(offsetSeconds));
     }
 
     protected java.time.LocalDate toJavaLocalDate(final org.joda.time.LocalDate jodaDate) {

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPayment.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPayment.java
@@ -31,7 +31,8 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.client.KillBillClientException;
 import org.killbill.billing.client.RequestOptions;
@@ -124,7 +125,7 @@ public class TestPayment extends TestJaxrsBase {
         authTransaction.setAmount(BigDecimal.ONE);
         authTransaction.setCurrency(account.getCurrency());
         authTransaction.setTransactionType(TransactionType.AUTHORIZE);
-        final DateTime effectiveDate = new DateTime(2018, 9, 4, 3, 5, 35);
+        final ZonedDateTime effectiveDate = ZonedDateTime.of(2018, 9, 4, 3, 5, 35, 0, ZoneId.systemDefault());
         authTransaction.setEffectiveDate(effectiveDate);
 
         final Payment payment = accountApi.processPayment(account.getAccountId(), authTransaction, account.getPaymentMethodId(),

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPayment.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPayment.java
@@ -131,7 +131,7 @@ public class TestPayment extends TestJaxrsBase {
         final Payment payment = accountApi.processPayment(account.getAccountId(), authTransaction, account.getPaymentMethodId(),
                                                           NULL_PLUGIN_NAMES, NULL_PLUGIN_PROPERTIES, requestOptions);
         final PaymentTransaction paymentTransaction = payment.getTransactions().get(0);
-        assertEquals(paymentTransaction.getEffectiveDate().compareTo(effectiveDate), 0);
+        assertEquals(paymentTransaction.getEffectiveDate().toInstant(), effectiveDate.toInstant());
     }
 
     @Test(groups = "slow")

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPushNotification.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPushNotification.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.awaitility.Awaitility;
-import java.time.ZonedDateTime;
+import org.joda.time.DateTime;
 import org.killbill.CreatorName;
 import org.killbill.billing.notification.plugin.api.ExtBusEventType;
 import org.killbill.billing.platform.api.KillbillService.KILLBILL_SERVICES;

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPushNotification.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPushNotification.java
@@ -24,11 +24,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.awaitility.Awaitility;
-import org.joda.time.DateTime;
 import org.killbill.CreatorName;
 import org.killbill.billing.notification.plugin.api.ExtBusEventType;
 import org.killbill.billing.platform.api.KillbillService.KILLBILL_SERVICES;
-import org.killbill.billing.server.DefaultServerService;
 import org.killbill.billing.server.notifications.PushNotificationKey;
 import org.killbill.notificationq.NotificationQueueDispatcher;
 import org.killbill.notificationq.api.NotificationEvent;
@@ -73,7 +71,7 @@ public class TestPushNotification extends TestJaxrsBase {
                                                                                                      "testVerify726Backport",
                                                                                                      new NotificationQueueHandler() {
                                                                                                          @Override
-                                                                                                         public void handleReadyNotification(final NotificationEvent notificationKey, final DateTime eventDateTime, final UUID userToken, final Long accountRecordId, final Long tenantRecordId) {
+                                                                                                         public void handleReadyNotification(final NotificationEvent notificationKey, final org.joda.time.DateTime eventDateTime, final UUID userToken, final Long accountRecordId, final Long tenantRecordId) {
                                                                                                              if (!(notificationKey instanceof PushNotificationKey)) {
                                                                                                                  Assert.fail();
                                                                                                                  return;

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPushNotification.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestPushNotification.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.awaitility.Awaitility;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.killbill.CreatorName;
 import org.killbill.billing.notification.plugin.api.ExtBusEventType;
 import org.killbill.billing.platform.api.KillbillService.KILLBILL_SERVICES;

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
@@ -19,14 +19,15 @@
 
 package org.killbill.billing.jaxrs;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
@@ -106,9 +107,8 @@ public class TestTag extends TestJaxrsBase {
 
     @Test(groups = "slow", description = "Can search all tags for an account")
     public void testGetAllTagsByType() throws Exception {
-
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final ZonedDateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().getMillis());
 
         final Account account = createAccountWithDefaultPaymentMethod();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
@@ -106,8 +106,8 @@ public class TestTag extends TestJaxrsBase {
     @Test(groups = "slow", description = "Can search all tags for an account")
     public void testGetAllTagsByType() throws Exception {
 
-        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, 0);
-        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
+        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
+        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
 
         final Account account = createAccountWithDefaultPaymentMethod();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestTag.java
@@ -25,7 +25,8 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import java.time.ZonedDateTime;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.ProductCategory;
@@ -106,8 +107,8 @@ public class TestTag extends TestJaxrsBase {
     @Test(groups = "slow", description = "Can search all tags for an account")
     public void testGetAllTagsByType() throws Exception {
 
-        final DateTime initialDate = ZonedDateTime.of(2012, 4, 25, 0, 3, 42, 0, ZoneId.systemDefault());
-        clock.setDeltaFromReality(initialDate.toInstant().toEpochMilli() - clock.getUTCNow().toInstant().toEpochMilli());
+        final DateTime initialDate = new DateTime(2012, 4, 25, 0, 3, 42, DateTimeZone.getDefault());
+        clock.setDeltaFromReality(initialDate.getMillis() - clock.getUTCNow().getMillis());
 
         final Account account = createAccountWithDefaultPaymentMethod();
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestUsage.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestUsage.java
@@ -21,7 +21,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.PriceListSet;

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestUsage.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestUsage.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.catalog.api.BillingPeriod;
 import org.killbill.billing.catalog.api.PriceListSet;
@@ -102,33 +103,33 @@ public class TestUsage extends TestJaxrsBase {
 
         clock.addDays(1);
 
-        final UsageRecord usageRecord1 = new UsageRecord(clock.getUTCNow().minusDays(1), BigDecimal.TEN);
-        final UsageRecord usageRecord2 = new UsageRecord(clock.getUTCNow(), new BigDecimal("5"));
+        final UsageRecord usageRecord1 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow().minusDays(1)), BigDecimal.TEN);
+        final UsageRecord usageRecord2 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow()), new BigDecimal("5"));
         final UnitUsageRecord unitUsageRecord = new UnitUsageRecord("bullets", List.of(usageRecord1, usageRecord2));
         final SubscriptionUsageRecord usage = new SubscriptionUsageRecord(addOnSubscriptionId, null, List.of(unitUsageRecord));
 
         usageApi.recordUsage(usage, requestOptions);
         callbackServlet.assertListenerStatus();
-        final RolledUpUsage retrievedUsage1 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday().minusDays(1), clock.getUTCToday(), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage1 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday().minusDays(1)), toJavaLocalDate(clock.getUTCToday()), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(retrievedUsage1.getSubscriptionId(), usage.getSubscriptionId());
         Assert.assertEquals(retrievedUsage1.getRolledUpUnits().size(), 1);
         Assert.assertEquals(retrievedUsage1.getRolledUpUnits().get(0).getUnitType(), unitUsageRecord.getUnitType());
         // endDate is excluded
         Assert.assertEquals(BigDecimal.TEN.compareTo(retrievedUsage1.getRolledUpUnits().get(0).getAmount()), 0);
 
-        final RolledUpUsage retrievedUsage2 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday().minusDays(1), clock.getUTCToday().plusDays(1), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage2 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday().minusDays(1)), toJavaLocalDate(clock.getUTCToday().plusDays(1)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(retrievedUsage2.getSubscriptionId(), usage.getSubscriptionId());
         Assert.assertEquals(retrievedUsage2.getRolledUpUnits().size(), 1);
         Assert.assertEquals(retrievedUsage2.getRolledUpUnits().get(0).getUnitType(), unitUsageRecord.getUnitType());
         Assert.assertEquals(new BigDecimal("15").compareTo(retrievedUsage2.getRolledUpUnits().get(0).getAmount()), 0);
 
-        final RolledUpUsage retrievedUsage3 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday(), clock.getUTCToday().plusDays(1), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage3 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday()), toJavaLocalDate(clock.getUTCToday().plusDays(1)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(retrievedUsage3.getSubscriptionId(), usage.getSubscriptionId());
         Assert.assertEquals(retrievedUsage3.getRolledUpUnits().size(), 1);
         Assert.assertEquals(retrievedUsage3.getRolledUpUnits().get(0).getUnitType(), unitUsageRecord.getUnitType());
         Assert.assertEquals(new BigDecimal("5").compareTo(retrievedUsage3.getRolledUpUnits().get(0).getAmount()), 0);
 
-        final RolledUpUsage retrievedUsage4 = usageApi.getAllUsage(addOnSubscriptionId, clock.getUTCToday(), clock.getUTCToday().plusDays(1), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage4 = usageApi.getAllUsage(addOnSubscriptionId, toJavaLocalDate(clock.getUTCToday()), toJavaLocalDate(clock.getUTCToday().plusDays(1)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(retrievedUsage4.getSubscriptionId(), usage.getSubscriptionId());
         Assert.assertEquals(retrievedUsage4.getRolledUpUnits().size(), 1);
         Assert.assertEquals(retrievedUsage4.getRolledUpUnits().get(0).getUnitType(), "bullets");
@@ -163,7 +164,7 @@ public class TestUsage extends TestJaxrsBase {
         final Bundle bundle = subscriptionApi.createSubscriptionWithAddOns(body, (LocalDate) null, (LocalDate) null, NULL_PLUGIN_PROPERTIES, requestOptions);
         final UUID addOnSubscriptionId = findSubscriptionIdByProductCategory(bundle.getSubscriptions(), ProductCategory.ADD_ON);
 
-        final UsageRecord usageRecord1 = new UsageRecord(clock.getUTCNow().minusDays(1), BigDecimal.TEN);
+        final UsageRecord usageRecord1 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow().minusDays(1)), BigDecimal.TEN);
         final UnitUsageRecord unitUsageRecord = new UnitUsageRecord("bullets", List.of(usageRecord1));
         final SubscriptionUsageRecord usage = new SubscriptionUsageRecord(addOnSubscriptionId,
                                                                           UUID.randomUUID().toString(),
@@ -188,22 +189,22 @@ public class TestUsage extends TestJaxrsBase {
 
         clock.addDays(2);
 
-        final UsageRecord record1 = new UsageRecord(clock.getUTCNow().minusDays(1), new BigDecimal("4.75"));
-        final UsageRecord record2 = new UsageRecord(clock.getUTCNow(), new BigDecimal("6.25"));
-        final UsageRecord record3 = new UsageRecord(clock.getUTCNow().plusDays(1), new BigDecimal("8.5"));
+        final UsageRecord record1 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow().minusDays(1)), new BigDecimal("4.75"));
+        final UsageRecord record2 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow()), new BigDecimal("6.25"));
+        final UsageRecord record3 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow().plusDays(1)), new BigDecimal("8.5"));
 
         final UnitUsageRecord unitUsageRecord = new UnitUsageRecord("bullets", List.of(record1, record2, record3));
         final SubscriptionUsageRecord usage = new SubscriptionUsageRecord(addOnSubscriptionId, null, List.of(unitUsageRecord));
 
         usageApi.recordUsage(usage, requestOptions);
 
-        final RolledUpUsage retrievedUsage1 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday().minusDays(1), clock.getUTCToday().plusDays(1), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage1 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday().minusDays(1)), toJavaLocalDate(clock.getUTCToday().plusDays(1)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(new BigDecimal("11").compareTo(retrievedUsage1.getRolledUpUnits().get(0).getAmount()), 0);
 
-        final RolledUpUsage retrievedUsage2 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday().minusDays(1), clock.getUTCToday().plusDays(2), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage2 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday().minusDays(1)), toJavaLocalDate(clock.getUTCToday().plusDays(2)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(new BigDecimal("19.5").compareTo(retrievedUsage2.getRolledUpUnits().get(0).getAmount()), 0);
 
-        final RolledUpUsage retrievedUsage3 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday(), clock.getUTCToday().plusDays(2), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage3 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday()), toJavaLocalDate(clock.getUTCToday().plusDays(2)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(new BigDecimal("14.75").compareTo(retrievedUsage3.getRolledUpUnits().get(0).getAmount()), 0);
     }
 
@@ -216,22 +217,22 @@ public class TestUsage extends TestJaxrsBase {
 
         clock.addDays(2);
 
-        final UsageRecord record1 = new UsageRecord(clock.getUTCNow().minusDays(1), new BigDecimal("111111111.111111111"));
-        final UsageRecord record2 = new UsageRecord(clock.getUTCNow(), new BigDecimal("222222222.222222222"));
-        final UsageRecord record3 = new UsageRecord(clock.getUTCNow().plusDays(1), new BigDecimal("333333333.333333333"));
+        final UsageRecord record1 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow().minusDays(1)), new BigDecimal("111111111.111111111"));
+        final UsageRecord record2 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow()), new BigDecimal("222222222.222222222"));
+        final UsageRecord record3 = new UsageRecord(toJavaZonedDateTime(clock.getUTCNow().plusDays(1)), new BigDecimal("333333333.333333333"));
 
         final UnitUsageRecord unitUsageRecord = new UnitUsageRecord("bullets", List.of(record1, record2, record3));
         final SubscriptionUsageRecord usage = new SubscriptionUsageRecord(addOnSubscriptionId, null, List.of(unitUsageRecord));
 
         usageApi.recordUsage(usage, requestOptions);
 
-        final RolledUpUsage retrievedUsage1 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday().minusDays(1), clock.getUTCToday().plusDays(1), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage1 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday().minusDays(1)), toJavaLocalDate(clock.getUTCToday().plusDays(1)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(new BigDecimal("333333333.333333333").compareTo(retrievedUsage1.getRolledUpUnits().get(0).getAmount()), 0);
 
-        final RolledUpUsage retrievedUsage2 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday().minusDays(1), clock.getUTCToday().plusDays(2), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage2 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday().minusDays(1)), toJavaLocalDate(clock.getUTCToday().plusDays(2)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(new BigDecimal("666666666.666666666").compareTo(retrievedUsage2.getRolledUpUnits().get(0).getAmount()), 0);
 
-        final RolledUpUsage retrievedUsage3 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), clock.getUTCToday(), clock.getUTCToday().plusDays(2), NULL_PLUGIN_PROPERTIES, requestOptions);
+        final RolledUpUsage retrievedUsage3 = usageApi.getUsage(addOnSubscriptionId, unitUsageRecord.getUnitType(), toJavaLocalDate(clock.getUTCToday()), toJavaLocalDate(clock.getUTCToday().plusDays(2)), NULL_PLUGIN_PROPERTIES, requestOptions);
         Assert.assertEquals(new BigDecimal("555555555.555555555").compareTo(retrievedUsage3.getRolledUpUnits().get(0).getAmount()), 0);
     }
 }

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/resources/TestDBRouterResource.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/resources/TestDBRouterResource.java
@@ -25,8 +25,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.killbill.billing.GuicyKillbillTestSuite;
 import org.killbill.billing.beatrix.integration.db.TestDBRouterAPI;
 import org.killbill.billing.callcontext.MutableCallContext;
@@ -40,17 +38,17 @@ public class TestDBRouterResource implements JaxrsResource {
 
     private final MutableInternalCallContext internalCallContext = new MutableInternalCallContext(InternalCallContextFactory.INTERNAL_TENANT_RECORD_ID,
                                                                                                   1687L,
-                                                                                                  DateTimeZone.UTC,
-                                                                                                  DateTimeZone.UTC,
-                                                                                                  new DateTime(DateTimeZone.UTC),
+                                                                                                  org.joda.time.DateTimeZone.UTC,
+                                                                                                  org.joda.time.DateTimeZone.UTC,
+                                                                                                  new org.joda.time.DateTime(org.joda.time.DateTimeZone.UTC),
                                                                                                   UUID.randomUUID(),
                                                                                                   UUID.randomUUID().toString(),
                                                                                                   CallOrigin.TEST,
                                                                                                   UserType.TEST,
                                                                                                   "Testing",
                                                                                                   "This is a test",
-                                                                                                  new DateTime(DateTimeZone.UTC),
-                                                                                                  new DateTime(DateTimeZone.UTC));
+                                                                                                  new org.joda.time.DateTime(org.joda.time.DateTimeZone.UTC),
+                                                                                                  new org.joda.time.DateTime(org.joda.time.DateTimeZone.UTC));
 
     private final MutableCallContext callContext = new MutableCallContext(internalCallContext);
 


### PR DESCRIPTION
This work is take over from https://github.com/killbill/killbill/pull/2181 : 
- Rebased from latest `master` branch. Complete commit history could be tracked here: https://github.com/killbill/killbill/commits/joda-removal-latest/
- Use `killbill-oss-parent:0.146.78` that contains `killbill-client-java:1.4.0`
- [Additional commit](https://github.com/killbill/killbill/pull/2225/changes/e8780ccb13a8fa0b2d9154004cf135022ef3049c) : convert `clock.getUTCToday()` to Java API LocalDate

If this approved, then we can close and delete original PR.
