### PR TITLE
Fix incorrect CBA_ADJ invoice item date (#2202)

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java
@@ -99,7 +99,7 @@ public class TestSubscription extends TestIntegrationBase {
         toBeChecked = List.of(
                 new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 11), new LocalDate(2012, 6, 1), InvoiceItemType.RECURRING, new BigDecimal("169.32")),
                 new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 11), new LocalDate(2013, 5, 1), InvoiceItemType.REPAIR_ADJ, new BigDecimal("-2334.20")),
-                new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 11), new LocalDate(2012, 5, 11), InvoiceItemType.CBA_ADJ, new BigDecimal("2164.88"), false /* Issue with test where created date for context is wrong*/));
+                new ExpectedInvoiceItemCheck(new LocalDate(2012, 5, 11), new LocalDate(2012, 5, 11), InvoiceItemType.CBA_ADJ, new BigDecimal("2164.88")));
 
         final TestDryRunArguments dryRun = new TestDryRunArguments(DryRunType.SUBSCRIPTION_ACTION, productName, ProductCategory.BASE, BillingPeriod.MONTHLY, null, null,
                                                                    SubscriptionEventType.CHANGE, bpEntitlement.getId(), bpEntitlement.getBundleId(), null, BillingActionPolicy.IMMEDIATE);

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import org.joda.time.LocalDate;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.entity.EntityPersistenceException;
@@ -243,9 +244,15 @@ public class CBADao {
     private InvoiceItemModelDao buildCBAItem(final InvoiceModelDao invoice,
                                              final BigDecimal amount,
                                              final InternalCallContext context) {
+        // Use the invoice's target date (effective date) so that the CBA_ADJ item date is consistent
+        // with the corresponding CREDIT_ADJ or other invoice items. Fall back to invoiceDate for
+        // parent invoices where targetDate is null, and finally to context createdDate as last resort.
+        final LocalDate cbaDate = invoice.getTargetDate() != null ? invoice.getTargetDate() :
+                                  (invoice.getInvoiceDate() != null ? invoice.getInvoiceDate() :
+                                   context.getCreatedDate().toLocalDate());
         return new InvoiceItemModelDao(new CreditBalanceAdjInvoiceItem(invoice.getId(),
                                                                        invoice.getAccountId(),
-                                                                       context.getCreatedDate().toLocalDate(),
+                                                                       cbaDate,
                                                                        amount.negate(),
                                                                        invoice.getCurrency()));
     }


### PR DESCRIPTION
## Summary

Fixes #2202 - CBA_ADJ invoice item uses today's date instead of the user-specified effectiveDate when creating credits via the API.

## Root Cause

`CBADao.buildCBAItem()` was using `context.getCreatedDate().toLocalDate()` (the API call timestamp) as the CBA item date, instead of the invoice's target date which holds the user-specified effective date.

## Fix

Changed `buildCBAItem()` to use `invoice.getTargetDate()` as the CBA item date, with fallbacks:
1. `invoice.getTargetDate()` — the user-specified effective date (normal case)
2. `invoice.getInvoiceDate()` — for parent invoices where targetDate is null
3. `context.getCreatedDate().toLocalDate()` — last resort fallback

## Files Changed

- `invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java` — core fix
- `beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java` — enabled date verification that was previously skipped due to this bug

## Why the previously suggested fix caused CI failures

The issue author's initial fix (`invoice.getTargetDate()` directly) caused NPE because parent invoices are created with `targetDate = null`. The three-level fallback handles this edge case.
