### PR TITLE
[Experiment / arm a (no graph)] Fix #2127: type-aware binding for date columns in advanced search (issue #2127)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,91 @@
+# Fix Report — Kill Bill issue #2127
+
+## Root cause
+
+`SearchQuery` (`util/src/main/java/org/killbill/billing/util/entity/dao/SearchQuery.java`) is responsible for parsing the
+`_q=1&col[op]=value` advanced-search syntax into a JDBI bind map. The constructor only knew how to convert string values
+for `Boolean`, `Integer`, `Long` and `Double` column types; everything else, including date columns, fell through to the
+default branch and was bound as a raw `String`.
+
+`DefaultInvoiceDao.searchInvoices` (`invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java`) then
+fed that bind map straight into the JDBI `search` / `getSearchCount` queries declared on `EntitySqlDao`. With the value
+left as a `String`, the generated SQL effectively becomes `t.target_date <= '2025-08-28'`. MySQL silently coerces the
+string to a date, but PostgreSQL is strict about types and rejects it with:
+
+```
+ERROR: operator does not exist: date <= character varying
+```
+
+The same issue applied to `invoice_date`, `created_date` and `updated_date`.
+
+## Change summary
+
+- `util/src/main/java/org/killbill/billing/util/entity/dao/SearchQuery.java`
+  - Added `LocalDate.class` and `DateTime.class` branches to the type-aware value conversion in the constructor.
+  - Added small `convertToLocalDate` / `convertToDateTime` helpers that parse ISO-8601 strings and fall back to the raw
+    string when the input does not parse (matching the existing numeric-fallback behaviour).
+- `invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java`
+  - Declared the column types of `invoice_date` and `target_date` as `LocalDate.class` and of `created_date` /
+    `updated_date` as `DateTime.class` in the `searchInvoices` `columnTypes` map. `LocalDate` / `DateTime` were already
+    imported in this file.
+- `util/src/test/java/org/killbill/billing/util/entity/dao/TestSearchQuery.java` (new, fast)
+  - Unit tests covering: a `LocalDate` column produces a `LocalDate` binding, a `DateTime` column produces a `DateTime`
+    binding, an unparseable date falls back to the raw string, and an untyped column is unchanged.
+- `profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java`
+  - Added the integration test `testInvoiceSearchByDate` (slow, JAX-RS) replicating the reporter's reproducer: searches
+    on `target_date=...` and `target_date[lte]=...` are expected to succeed on PostgreSQL and MySQL.
+
+## How the tests exercise the fix
+
+- `TestSearchQuery#testLocalDateColumnTypeIsParsed` builds the exact query string from the issue
+  (`_q=1&target_date[lte]=2025-08-28`) with `target_date` typed as `LocalDate.class` and asserts the bound value is a
+  `LocalDate(2025, 8, 28)` rather than the string `"2025-08-28"`. Before the fix this test would fail because the value
+  bound was a `String`.
+- `TestSearchQuery#testDateTimeColumnTypeIsParsed` covers the parallel `DateTime` path used for `created_date` /
+  `updated_date`.
+- `TestSearchQuery#testUnparseableDateFallsBackToString` documents the fallback contract (an invalid value still flows
+  through, surfacing as a JDBC-level type error rather than a parse exception inside the search machinery).
+- `TestInvoice#testInvoiceSearchByDate` (slow) goes end-to-end through the REST endpoint and exercises both
+  `target_date=...` and `target_date[lte]=...`. With the fix in place, the JDBC layer binds a real `DATE` value and
+  PostgreSQL no longer rejects the comparison.
+
+## Build status
+
+`mvn -pl util,invoice -am -DskipTests compile`:
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO] killbill ........................................... SUCCESS [  0.217 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.772 s]
+[INFO] killbill-util ...................................... SUCCESS [  1.630 s]
+[INFO] killbill-tenant .................................... SUCCESS [  0.693 s]
+[INFO] killbill-account ................................... SUCCESS [  0.719 s]
+[INFO] killbill-catalog ................................... SUCCESS [  0.956 s]
+[INFO] killbill-subscription .............................. SUCCESS [  0.993 s]
+[INFO] killbill-entitlement ............................... SUCCESS [  0.911 s]
+[INFO] killbill-junction .................................. SUCCESS [  0.603 s]
+[INFO] killbill-usage ..................................... SUCCESS [  0.582 s]
+[INFO] killbill-invoice ................................... SUCCESS [  1.281 s]
+[INFO] BUILD SUCCESS
+```
+
+`mvn -pl profiles/killbill -am -DskipTests test-compile` also passes (all of `killbill-util`, `killbill-invoice`,
+`killbill-jaxrs`, `killbill-profiles-killbill` etc. SUCCESS), confirming the new TestNG sources compile.
+
+`mvn -pl util test -Dtest=TestSearchQuery -Dgroups=fast`:
+
+```
+Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+## Confidence
+
+**High.** The new unit tests prove the bind map now contains a `LocalDate` / `DateTime` instead of a `String`, which
+directly resolves the `operator does not exist: date <= character varying` PostgreSQL error. JDBI's killbill-commons
+argument factories (`LocalDateArgumentFactory`, `DateTimeArgumentFactory`) already know how to bind these Joda types as
+proper SQL `DATE` / `TIMESTAMP` parameters, so no further plumbing is required. The change is narrowly scoped: it only
+adds new branches to type-aware parsing and a new entry in `DefaultInvoiceDao`'s `columnTypes` map; no existing
+behaviour is altered. The integration test from the issue reporter is reproduced verbatim against the JAX-RS endpoint.
+The compile-clean bar is met; the slow integration test was not executed locally because the embedded MySQL ARM archive
+is unavailable in this environment (per task constraints).

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -680,7 +680,11 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                                  "created_date",
                                                  "updated_by",
                                                  "updated_date"),
-                                          Map.of("migrated", Boolean.class));
+                                          Map.of("migrated", Boolean.class,
+                                                 "invoice_date", LocalDate.class,
+                                                 "target_date", LocalDate.class,
+                                                 "created_date", DateTime.class,
+                                                 "updated_date", DateTime.class));
         } else {
             searchQuery = new SearchQuery(SqlOperator.OR);
             searchQuery.addSearchClause("id", SqlOperator.EQ, searchKey);

--- a/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/jaxrs/TestInvoice.java
@@ -692,6 +692,36 @@ public class TestInvoice extends TestJaxrsBase {
         Assert.assertNull(page);
     }
 
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/2127")
+    public void testInvoiceSearchByDate() throws Exception {
+        final LocalDate initialDate = new LocalDate(2012, 4, 25);
+        clock.setDay(initialDate);
+
+        final Account account = createAccountNoPMBundleAndSubscription();
+        Assert.assertNotNull(account);
+
+        Invoices invoices = accountApi.getInvoicesForAccount(account.getAccountId(), null, null, false, false, false, true, null, AuditLevel.FULL, requestOptions);
+        Assert.assertNotNull(invoices);
+        Assert.assertEquals(invoices.size(), 1);
+
+        // Non-date search clauses should keep working
+        invoices = invoiceApi.searchInvoices("_q=1&status=COMMITTED", requestOptions);
+        Assert.assertNotNull(invoices);
+        Assert.assertEquals(invoices.size(), 1);
+
+        // Equality match on a date column. Previously broken on PostgreSQL
+        // ("operator does not exist: date = character varying").
+        invoices = invoiceApi.searchInvoices("_q=1&target_date=2012-04-25", requestOptions);
+        Assert.assertNotNull(invoices);
+        Assert.assertEquals(invoices.size(), 1);
+
+        // Range match on a date column. Previously broken on PostgreSQL
+        // ("operator does not exist: date <= character varying").
+        invoices = invoiceApi.searchInvoices("_q=1&target_date%5Blte%5D=2012-04-25", requestOptions);
+        Assert.assertNotNull(invoices);
+        Assert.assertEquals(invoices.size(), 1);
+    }
+
     @Test(groups = "slow", description = "Can add a credit to a new invoice")
     public void testCreateCreditInvoiceAndMoveStatus() throws Exception {
 

--- a/util/src/main/java/org/killbill/billing/util/entity/dao/SearchQuery.java
+++ b/util/src/main/java/org/killbill/billing/util/entity/dao/SearchQuery.java
@@ -28,6 +28,9 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+
 public class SearchQuery {
 
     public static final String SEARCH_QUERY_MARKER = "_q=1&";
@@ -71,6 +74,10 @@ public class SearchQuery {
                 valueTyped = Boolean.valueOf(value);
             } else if (valueType == Integer.class || valueType == Long.class || valueType == Double.class) {
                 valueTyped = Objects.requireNonNullElse(convertToNumber(value), value);
+            } else if (valueType == LocalDate.class) {
+                valueTyped = Objects.requireNonNullElse(convertToLocalDate(value), value);
+            } else if (valueType == DateTime.class) {
+                valueTyped = Objects.requireNonNullElse(convertToDateTime(value), value);
             } else {
                 valueTyped = value;
             }
@@ -94,6 +101,28 @@ public class SearchQuery {
                 // String cannot be parsed as a number
                 return null;
             }
+        }
+    }
+
+    private static LocalDate convertToLocalDate(@Nullable final String str) {
+        if (str == null) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(str);
+        } catch (final IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static DateTime convertToDateTime(@Nullable final String str) {
+        if (str == null) {
+            return null;
+        }
+        try {
+            return DateTime.parse(str);
+        } catch (final IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/util/src/test/java/org/killbill/billing/util/entity/dao/TestSearchQuery.java
+++ b/util/src/test/java/org/killbill/billing/util/entity/dao/TestSearchQuery.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020-2024 Equinix, Inc
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.entity.dao;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestSearchQuery {
+
+    // Regression test for https://github.com/killbill/killbill/issues/2127.
+    // When the search query references a DATE column on PostgreSQL, the bound
+    // value must be a LocalDate (not a String), otherwise the database rejects
+    // the comparison with "operator does not exist: date <= character varying".
+    @Test(groups = "fast")
+    public void testLocalDateColumnTypeIsParsed() {
+        final SearchQuery searchQuery = new SearchQuery("_q=1&target_date[lte]=2025-08-28",
+                                                        Set.of("target_date"),
+                                                        Map.of("target_date", LocalDate.class));
+
+        Assert.assertEquals(searchQuery.getSearchAttributes().size(), 1);
+        final SearchAttribute attribute = searchQuery.getSearchAttributes().get(0);
+        Assert.assertEquals(attribute.getColumn(), "target_date");
+        Assert.assertEquals(attribute.getOperator(), SqlOperator.LTE);
+
+        final Object boundValue = searchQuery.getSearchKeysBindMap().get(attribute.getBindingKey());
+        Assert.assertTrue(boundValue instanceof LocalDate,
+                          "Expected LocalDate but got " + (boundValue == null ? "null" : boundValue.getClass()));
+        Assert.assertEquals(boundValue, new LocalDate(2025, 8, 28));
+    }
+
+    @Test(groups = "fast")
+    public void testDateTimeColumnTypeIsParsed() {
+        final SearchQuery searchQuery = new SearchQuery("_q=1&created_date[gte]=2025-08-28T10:15:30Z",
+                                                        Set.of("created_date"),
+                                                        Map.of("created_date", DateTime.class));
+
+        Assert.assertEquals(searchQuery.getSearchAttributes().size(), 1);
+        final SearchAttribute attribute = searchQuery.getSearchAttributes().get(0);
+        final Object boundValue = searchQuery.getSearchKeysBindMap().get(attribute.getBindingKey());
+        Assert.assertTrue(boundValue instanceof DateTime,
+                          "Expected DateTime but got " + (boundValue == null ? "null" : boundValue.getClass()));
+    }
+
+    @Test(groups = "fast")
+    public void testUnparseableDateFallsBackToString() {
+        final SearchQuery searchQuery = new SearchQuery("_q=1&target_date=not-a-date",
+                                                        Set.of("target_date"),
+                                                        Map.of("target_date", LocalDate.class));
+
+        Assert.assertEquals(searchQuery.getSearchAttributes().size(), 1);
+        final SearchAttribute attribute = searchQuery.getSearchAttributes().get(0);
+        final Object boundValue = searchQuery.getSearchKeysBindMap().get(attribute.getBindingKey());
+        // We fall back to the raw string so that the search clause still surfaces
+        // a JDBC-level type error rather than NPE'ing in the SearchQuery itself.
+        Assert.assertEquals(boundValue, "not-a-date");
+    }
+
+    @Test(groups = "fast")
+    public void testStringColumnTypeIsUnchanged() {
+        final SearchQuery searchQuery = new SearchQuery("_q=1&status=COMMITTED",
+                                                        Set.of("status"),
+                                                        Map.of());
+
+        final SearchAttribute attribute = searchQuery.getSearchAttributes().get(0);
+        final Object boundValue = searchQuery.getSearchKeysBindMap().get(attribute.getBindingKey());
+        Assert.assertEquals(boundValue, "COMMITTED");
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2127, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

Closes #2127 (proposes a fix; needs maintainer review)

## Arm a (no graph)

The advanced-search syntax (_q=1&col[op]=value) handled by SearchQuery
only converted values for Boolean, Integer, Long and Double column
types; everything else, including date columns, was bound as a raw
String. DefaultInvoiceDao.searchInvoices fed that bind map straight
into the JDBI search / getSearchCount queries, so a request like
/invoices/search/_q=1&target_date[lte]=2025-08-28 generated SQL of
the form "t.target_date <= '2025-08-28'". MySQL silently coerces the
string to a date but PostgreSQL is strict and rejects it with
"operator does not exist: date <= character varying".

This change teaches SearchQuery to convert string values to Joda
LocalDate / DateTime when the caller declares those types in the
columnTypes map (falling back to the raw string for unparseable
input, mirroring the existing numeric fallback). DefaultInvoiceDao
now declares invoice_date / target_date as LocalDate and
created_date / updated_date as DateTime, so the JDBI argument
factories already registered by killbill-commons bind a real
DATE / TIMESTAMP parameter.

Adds a fast unit test (TestSearchQuery) covering the new typed
parsing paths and the fallback contract, plus an integration test
(TestInvoice#testInvoiceSearchByDate) that replicates the
reporter's reproducer against the JAX-RS endpoint.

## Diff stat

```
 FIX_REPORT.md                                      | 91 ++++++++++++++++++++++
 .../billing/invoice/dao/DefaultInvoiceDao.java     |  6 +-
 .../org/killbill/billing/jaxrs/TestInvoice.java    | 30 +++++++
 .../billing/util/entity/dao/SearchQuery.java       | 29 +++++++
 .../billing/util/entity/dao/TestSearchQuery.java   | 88 +++++++++++++++++++++
 5 files changed, 243 insertions(+), 1 deletion(-)
```

## Compile status

[INFO] BUILD SUCCESS
```
--
