### PR TITLE
[Experiment / arm a (no graph)] Fix #2207: tighten lock-failure retry handling in InvoiceDispatcher (issue #2207)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,109 @@
+# Fix Report — Kill Bill issue #2207
+
+## Root cause / design summary
+
+In `invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java`, two
+methods participate in the billing-date notification-queue lock-failure path:
+`processAccount(...)` (the catch-`LockFailedException` site) and the private helper
+`rescheduleProcessAccount(UUID, InternalCallContext)`. The path had two operational
+gaps relative to the bus-event paths that throw `QueueRetryException`:
+
+1. `rescheduleProcessAccount` logged at `INFO` without the `accountId`, so a successful
+   one-shot reschedule was indistinguishable across accounts in the log stream.
+2. When `getRescheduleIntervalOnLock` was not configured, `rescheduleProcessAccount`
+   returned `false` and the caller only emitted a `WARN`. No further notification was
+   ever enqueued, silently abandoning the account.
+
+The asymmetry of the *mechanism* (notification reschedule vs. `QueueRetryException`)
+is intentional — see the proposal in the issue — so the fix tightens the
+notification-queue path without unifying it with the bus-event path.
+
+## Change summary
+
+- `invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java`
+  - `rescheduleProcessAccount(...)`: added the `accountId` and `nextRescheduleDt` to
+    the success log (`"Failed to acquire lock, rescheduling invoice for accountId='{}' at '{}'"`),
+    and replaced the prior single-line "we only look at the first value" comment with
+    a longer explanation of *why* this path does single-reschedule (no attempt count
+    can be tracked across notification reschedules, unlike the
+    `RetryableService`-backed `QueueRetryException` path).
+  - `processAccount(...)` — `catch (LockFailedException)` branch: when
+    `rescheduleProcessAccount(...)` returns `false` (empty schedule), the warn message
+    now mentions parking, and the account is parked via the existing `parkAccount(...)`
+    helper so the failure is surfaced (matching the proposed implementation #3 in the
+    issue).
+
+- `invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcherLockHandling.java`
+  *(new)* — three `groups = "fast"` unit tests, pure Mockito, no embedded DB.
+
+## How the test exercises the fix / new behaviour
+
+`TestInvoiceDispatcherLockHandling` builds an `InvoiceDispatcher` with a mocked
+`GlobalLocker` whose `lockWithNumberOfTries(...)` always throws `LockFailedException`,
+a mocked `InvoiceConfig`, a real `ParkedAccountsManager` backed by a mocked
+`TagInternalApi`, a mocked `InvoiceDao`, and a fixed-`Clock`:
+
+- `testLockFailureWithRescheduleConfiguredCallsRescheduleAndDoesNotPark` — with a
+  non-empty `getRescheduleIntervalOnLock` schedule (single `5m` period), it asserts
+  that `invoiceDao.rescheduleInvoiceNotification(...)` is called exactly once with
+  `accountId` and `clock + 5m`, and that `tagApi.addTag(PARK_TAG_DEFINITION_ID, ...)`
+  is **never** called.
+- `testLockFailureWithEmptyRescheduleParksTheAccount` — with an empty schedule it
+  asserts the inverse: no reschedule, and `tagApi.addTag(accountId, ACCOUNT,
+  PARK_TAG_DEFINITION_ID, ctx)` is called exactly once. This is the regression
+  test for the new behaviour described in issue #2207 §3 ("Park when lock
+  rescheduling is not configured").
+- `testLockFailureOnApiCallStillThrowsInvoiceApiException` — with `isApiCall=true`,
+  the dispatcher must rethrow as `InvoiceApiException` and must not reschedule
+  or park; this guards the unchanged API semantics from regressing.
+
+Captured log line during the test run confirms the new format:
+
+```
+INFO  o.k.b.i.InvoiceDispatcher - Failed to acquire lock, rescheduling invoice for
+  accountId='456e1be1-0b6f-4488-9bea-6dfb736ce00e' at '2026-01-01T00:05:00.000Z'
+```
+
+## Build status
+
+`mvn -pl invoice -am -DskipTests compile`:
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.216 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.203 s]
+[INFO] killbill-util ...................................... SUCCESS [  0.429 s]
+[INFO] killbill-tenant .................................... SUCCESS [  0.205 s]
+[INFO] killbill-account ................................... SUCCESS [  0.215 s]
+[INFO] killbill-catalog ................................... SUCCESS [  0.181 s]
+[INFO] killbill-subscription .............................. SUCCESS [  0.183 s]
+[INFO] killbill-entitlement ............................... SUCCESS [  0.177 s]
+[INFO] killbill-junction .................................. SUCCESS [  0.174 s]
+[INFO] killbill-usage ..................................... SUCCESS [  0.162 s]
+[INFO] killbill-invoice ................................... SUCCESS [  0.166 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+`mvn -pl invoice test -Dtest=TestInvoiceDispatcherLockHandling`:
+
+```
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.563 s
+  -- in org.killbill.billing.invoice.TestInvoiceDispatcherLockHandling
+[INFO] Results:
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
+[INFO] BUILD SUCCESS
+```
+
+## Confidence level
+
+**High.** The change is small and confined to one method body plus one helper signature
+log line in `InvoiceDispatcher`. It exactly matches the implementation proposed in the
+issue (items 1–4). The new unit test exercises both the "reschedule" and "park" branches
+of the catch block as well as the unchanged API-caller behaviour, and runs in the `fast`
+group without the embedded MySQL dependency.
+
+The mechanism asymmetry between Path A (notification queue) and Paths B / C (bus events
+via `QueueRetryException`) is preserved by design, as confirmed in the issue body.

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -333,7 +333,12 @@ public class InvoiceDispatcher {
                 throw new InvoiceApiException(e, ErrorCode.UNEXPECTED_ERROR, "Failed to generate invoice: failed to acquire lock");
             }
             if (!rescheduleProcessAccount(accountId, context)) {
-                log.warn("Failed to process invoice for accountId='{}', targetDate='{}'", accountId, targetDate, e);
+                // No rescheduleIntervalOnLock is configured, so we cannot put a follow-up
+                // notification on the bus. The next billing-date notification for this account
+                // would otherwise never be issued, silently abandoning the account. Park it
+                // instead so the failure surfaces and an operator can recover invoicing.
+                log.warn("Failed to process invoice for accountId='{}', targetDate='{}', parking account (no rescheduleIntervalOnLock configured)", accountId, targetDate, e);
+                parkAccount(accountId, context);
             }
         } finally {
             if (lock != null) {
@@ -350,9 +355,14 @@ public class InvoiceDispatcher {
         if (periods.size() == 0) {
             return false;
         }
-        // Since we can't keep track of attempts, we only look at the first value
+        // Unlike the QueueRetryException path used by the bus-event handlers (which is driven
+        // by RetryableService and tracks attempt counts), the billing-date notification queue
+        // path used here cannot track retries across reschedules: the rescheduled notification
+        // is indistinguishable from a fresh one. We therefore always issue exactly one reschedule
+        // using the first configured period; subsequent lock failures will be reschedule-once as
+        // well. If even that single retry fails repeatedly, no further retries are attempted.
         final DateTime nextRescheduleDt = clock.getUTCNow().plus(periods.get(0));
-        log.info("Rescheduling invoice call at time {}", nextRescheduleDt);
+        log.info("Failed to acquire lock, rescheduling invoice for accountId='{}' at '{}'", accountId, nextRescheduleDt);
         invoiceDao.rescheduleInvoiceNotification(accountId, nextRescheduleDt, context);
         return true;
     }

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcherLockHandling.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcherLockHandling.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.callcontext.InternalCallContext;
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.invoice.api.InvoiceApiException;
+import org.killbill.billing.invoice.dao.InvoiceDao;
+import org.killbill.billing.tag.TagInternalApi;
+import org.killbill.billing.util.callcontext.CallOrigin;
+import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
+import org.killbill.billing.util.tag.dao.SystemTags;
+import org.killbill.clock.Clock;
+import org.killbill.commons.locker.GlobalLocker;
+import org.killbill.commons.locker.LockFailedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit test for {@link InvoiceDispatcher} lock-failure handling — verifies the behaviour
+ * described in issue #2207:
+ *
+ *   - When the lock fails on a non-API (notification-queue) call and
+ *     {@code getRescheduleIntervalOnLock} yields a non-empty schedule, the dispatcher
+ *     reschedules the invoice notification.
+ *   - When the schedule is empty, the dispatcher parks the account so the failure is
+ *     not silently dropped.
+ *   - When the call originates from an API request, the dispatcher still rethrows as
+ *     {@link InvoiceApiException} regardless of the reschedule configuration.
+ *
+ * Uses pure Mockito mocks (no embedded DB / Guice wiring) so it runs on machines where
+ * the embedded MySQL ARM build is unavailable.
+ */
+public class TestInvoiceDispatcherLockHandling {
+
+    private InvoiceDao invoiceDao;
+    private GlobalLocker locker;
+    private InvoiceConfig invoiceConfig;
+    private Clock clock;
+    private TagInternalApi tagApi;
+    private ParkedAccountsManager parkedAccountsManager;
+    private InternalCallContext context;
+    private InvoiceDispatcher dispatcher;
+
+    @BeforeMethod(groups = "fast")
+    public void setUp() throws Exception {
+        invoiceDao = Mockito.mock(InvoiceDao.class);
+        locker = Mockito.mock(GlobalLocker.class);
+        invoiceConfig = Mockito.mock(InvoiceConfig.class);
+        clock = Mockito.mock(Clock.class);
+        // Use a real ParkedAccountsManager driven by a mocked TagInternalApi — observing
+        // the dispatcher's "park the account" decision boils down to observing
+        // tagApi.addTag(PARK_TAG_DEFINITION_ID).
+        tagApi = Mockito.mock(TagInternalApi.class);
+        Mockito.when(tagApi.getTagsForAccountType(any(ObjectType.class),
+                                                  Mockito.anyBoolean(),
+                                                  any(InternalTenantContext.class)))
+               .thenReturn(Collections.emptyList());
+        parkedAccountsManager = new ParkedAccountsManager(tagApi);
+        // Mockito cannot inline-mock InternalCallContext on Java 25, so construct a real one.
+        context = new InternalCallContext(1L, 1L, null, null, null,
+                                          UUID.randomUUID(), "test", CallOrigin.INTERNAL, UserType.TEST,
+                                          null, null,
+                                          new DateTime(2026, 1, 1, 0, 0, DateTimeZone.UTC),
+                                          new DateTime(2026, 1, 1, 0, 0, DateTimeZone.UTC));
+
+        // Always say the invoicing system is enabled, otherwise processAccountFromNotificationOrBusEvent
+        // short-circuits before reaching the lock acquisition path.
+        Mockito.when(invoiceConfig.isInvoicingSystemEnabled(any(InternalTenantContext.class))).thenReturn(true);
+        Mockito.when(invoiceConfig.getMaxGlobalLockRetries()).thenReturn(1);
+
+        Mockito.when(clock.getUTCNow()).thenReturn(new DateTime(2026, 1, 1, 0, 0, DateTimeZone.UTC));
+
+        // Force every lock acquisition to fail to exercise the catch (LockFailedException) branch.
+        Mockito.when(locker.lockWithNumberOfTries(anyString(), anyString(), anyInt()))
+               .thenThrow(new LockFailedException());
+
+        // The constructor only assigns fields. None of the LockFailedException-handling code
+        // paths exercised below touch the generator, account/billing/subscription APIs,
+        // plugin dispatcher, bus, notification queue, optimizer, or context factory — so we
+        // pass null for those. (Mockito on Java 25 cannot inline-mock several of these
+        // concrete classes.)
+        dispatcher = new InvoiceDispatcher(null,
+                                           null,
+                                           null,
+                                           null,
+                                           invoiceDao,
+                                           null,
+                                           null,
+                                           locker,
+                                           null,
+                                           null,
+                                           invoiceConfig,
+                                           clock,
+                                           null,
+                                           parkedAccountsManager);
+    }
+
+    @Test(groups = "fast")
+    public void testLockFailureWithRescheduleConfiguredCallsRescheduleAndDoesNotPark() throws Exception {
+        // Configure a non-empty schedule — a single 5-minute period is enough.
+        final List<org.skife.config.TimeSpan> periods = Collections.singletonList(
+                new org.skife.config.TimeSpan("5m"));
+        Mockito.when(invoiceConfig.getRescheduleIntervalOnLock(any(InternalCallContext.class))).thenReturn(periods);
+
+        final UUID accountId = UUID.randomUUID();
+
+        // Should swallow the LockFailedException and reschedule (non-API code path).
+        dispatcher.processAccountFromNotificationOrBusEvent(accountId, null, null, false, context);
+
+        // rescheduleInvoiceNotification was called once with the account id and a future
+        // DateTime computed from clock + first period.
+        final ArgumentCaptor<DateTime> when = ArgumentCaptor.forClass(DateTime.class);
+        Mockito.verify(invoiceDao, Mockito.times(1)).rescheduleInvoiceNotification(eq(accountId),
+                                                                                   when.capture(),
+                                                                                   eq(context));
+        final DateTime expected = new DateTime(2026, 1, 1, 0, 5, DateTimeZone.UTC);
+        assertEquals(when.getValue(), expected, "Reschedule time should equal clock + first period");
+
+        // The account must NOT be parked when a reschedule was issued.
+        Mockito.verify(tagApi, Mockito.never()).addTag(any(UUID.class),
+                                                       any(ObjectType.class),
+                                                       any(UUID.class),
+                                                       any(InternalCallContext.class));
+    }
+
+    @Test(groups = "fast")
+    public void testLockFailureWithEmptyRescheduleParksTheAccount() throws Exception {
+        // Empty schedule simulates rescheduleIntervalOnLock not being configured.
+        Mockito.when(invoiceConfig.getRescheduleIntervalOnLock(any(InternalCallContext.class)))
+               .thenReturn(Collections.emptyList());
+
+        final UUID accountId = UUID.randomUUID();
+
+        // Should swallow the LockFailedException and park the account.
+        dispatcher.processAccountFromNotificationOrBusEvent(accountId, null, null, false, context);
+
+        // Nothing should be rescheduled.
+        Mockito.verify(invoiceDao, Mockito.never()).rescheduleInvoiceNotification(any(UUID.class),
+                                                                                  any(DateTime.class),
+                                                                                  any(InternalCallContext.class));
+
+        // The account must be parked — this is the behavioural change for #2207.
+        // ParkedAccountsManager delegates to tagApi.addTag(accountId, ACCOUNT, PARK_TAG_DEFINITION_ID, ctx).
+        Mockito.verify(tagApi, Mockito.times(1)).addTag(eq(accountId),
+                                                        eq(ObjectType.ACCOUNT),
+                                                        eq(SystemTags.PARK_TAG_DEFINITION_ID),
+                                                        eq(context));
+    }
+
+    @Test(groups = "fast")
+    public void testLockFailureOnApiCallStillThrowsInvoiceApiException() throws Exception {
+        // Even when rescheduling is configured, API callers must surface the failure
+        // rather than silently rescheduling — this preserves the original Path A
+        // semantics for API callers.
+        final List<org.skife.config.TimeSpan> periods = Collections.singletonList(
+                new org.skife.config.TimeSpan("5m"));
+        Mockito.when(invoiceConfig.getRescheduleIntervalOnLock(any(InternalCallContext.class))).thenReturn(periods);
+
+        final UUID accountId = UUID.randomUUID();
+        boolean threw = false;
+        try {
+            dispatcher.processAccount(true, accountId, null, null, false, true, Collections.emptyList(), context);
+        } catch (final InvoiceApiException e) {
+            threw = true;
+        }
+        assertTrue(threw, "API call should rethrow as InvoiceApiException on lock failure");
+        Mockito.verify(invoiceDao, Mockito.never()).rescheduleInvoiceNotification(any(UUID.class),
+                                                                                  any(DateTime.class),
+                                                                                  any(InternalCallContext.class));
+        Mockito.verify(tagApi, Mockito.never()).addTag(any(UUID.class),
+                                                       any(ObjectType.class),
+                                                       any(UUID.class),
+                                                       any(InternalCallContext.class));
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2207, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

Closes #2207 (proposes a fix; needs maintainer review)

## Arm a (no graph)

Two operational gaps in the billing-date notification-queue lock-failure
path (Path A) in InvoiceDispatcher.processAccount / rescheduleProcessAccount:

  1. The reschedule success path logged at INFO without the accountId, so
     a one-shot reschedule could not be attributed to a specific account
     in the log stream.

  2. When org.killbill.invoice.rescheduleIntervalOnLock was not configured,
     rescheduleProcessAccount returned false and the caller only emitted a
     WARN. No follow-up notification was ever enqueued and the account was
     silently abandoned for invoicing.

Changes (issue proposal items 1-3):

  * rescheduleProcessAccount: log line now includes accountId and the
    reschedule time. Long-form comment added explaining why this path
    can only ever reschedule once (no attempt-count tracking across
    notification reschedules, unlike the QueueRetryException path).

  * processAccount catch (LockFailedException): when rescheduleProcessAccount
    returns false, the WARN message now mentions the parking action and the
    account is parked via the existing parkAccount(...) helper so the
    failure surfaces to operators.

Paths B and C (processSubscriptionStartRequestedDate,
processParentInvoiceForInvoiceGeneration, processParentInvoiceForAdjustments)
are intentionally left as-is: they go through QueueRetryException /
RetryableService, which already tracks attempt counts against the full
configured schedule.

A new unit test, TestInvoiceDispatcherLockHandling (groups = "fast", pure
Mockito, no embedded DB), covers all three branches: reschedule-with-schedule,
park-on-empty-schedule, and the unchanged API-caller behaviour.

## Diff stat

```
 FIX_REPORT.md                                      | 109 +++++++++++
 .../billing/invoice/InvoiceDispatcher.java         |  16 +-
 .../invoice/TestInvoiceDispatcherLockHandling.java | 207 +++++++++++++++++++++
 3 files changed, 329 insertions(+), 3 deletions(-)
```

## Compile status

[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
--
