### PR TITLE
[Experiment / arm a (no graph)] Fix #2208: Park accounts on unrecoverable invoice processing failures (issue #2208)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,140 @@
+# Fix Report — Issue #2208 (Park accounts on unrecoverable invoice processing failures)
+
+## Root cause / design summary
+
+This is an enhancement, not a bug. Before this change, `org.killbill.billing.invoice.InvoiceDispatcher`
+and `org.killbill.billing.invoice.InvoiceListener` only parked an account in two situations:
+when the invoicing system was disabled (`processAccountFromNotificationOrBusEvent`) and when an
+`InvoiceApiException` with `UNEXPECTED_ERROR` was thrown inside `processAccountInternal`. Other
+unrecoverable failure paths — lock-rescheduling not configured, `CatalogApiException` /
+`AccountApiException` / `SubscriptionBaseApiException` in `processAccountInternal`, every
+`InvoiceApiException` / `AccountApiException` / `RuntimeException` caught in the bus subscriber
+actions of `InvoiceListener` — only logged at `WARN` and silently dropped the work, leaving the
+account in a state where invoicing would never make progress with no human-visible signal.
+
+## Change summary (by file)
+
+- **`util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java`** — added
+  `isParkAccountsOnAllExceptions()` (both per-tenant and global), default `true`, configured by
+  `org.killbill.invoice.parkAccountsOnAllExceptions` (per @sbrossie's request in the issue).
+
+- **`invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java`** —
+  implemented the new `isParkAccountsOnAllExceptions` overrides so per-tenant overrides work.
+
+- **`invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java`**:
+  - `processAccount()`: when `rescheduleProcessAccount()` returns `false` (no retry periods
+    configured and we hit `LockFailedException` from a notification path), now parks the account.
+    Updated WARN message to include the `parking account` marker.
+  - `processAccountInternal()`: `CatalogApiException`, `AccountApiException`, and
+    `SubscriptionBaseApiException` catch blocks now park the account when not in dry-run mode and
+    the new config flag is true. Same `parking account` marker as the existing
+    `UNEXPECTED_ERROR` branch.
+
+- **`invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java`**:
+  - Constructor now injects `ParkedAccountsManager` and `InvoiceConfig`; field `accountApi` is
+    promoted so the new helper can use it.
+  - New public helper `handleFailedInvoiceDispatch(String, Long, Long, UUID, Exception)` — looks
+    up the account by record id and parks it, swallowing everything (`AccountApiException`,
+    `TagApiException`, `RuntimeException`) so it cannot escape a bus subscriber. When the new
+    config flag is `false` it just logs.
+  - Every bus subscriber `run()` block (`EffectiveSubscriptionInternalEvent`,
+    `BlockingTransitionInternalEvent`, `InvoiceCreationInternalEvent`,
+    `DefaultInvoiceAdjustmentEvent`, `RequestedSubscriptionInternalEvent`,
+    `AccountChangeInternalEvent`) now routes its catch blocks through the helper and adds an
+    outer `catch (RuntimeException)` so propagated runtime exceptions can no longer be silently
+    dropped by the event bus.
+  - `handleNextBillingDateEvent` and `handleEventForInvoiceNotification` also route through the
+    helper. The public visibility of `handleFailedInvoiceDispatch` matches the issue's design so
+    sibling components (e.g. `DefaultNextBillingDateNotifier`) can delegate to it once the
+    `onRetriesExhausted` hook lands in killbill-commons.
+
+- **`invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java`** —
+  updated the test subclass to thread through the new constructor parameters.
+
+- **`beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java`** —
+  the inner `ConfigurableInvoiceConfig` test stub now overrides the new
+  `isParkAccountsOnAllExceptions` methods (otherwise integration test compile breaks).
+
+### What I deliberately did **not** do
+
+Parts **B** and **D** of the proposal (`onRetriesExhausted` hook on `RetryableService`, override
+in `DefaultNextBillingDateNotifier`) require modifying `killbill-commons`, which is a separate
+repository. The issue itself flags this as a coordinated release. The `InvoiceListener` helper is
+intentionally `public` and shaped to match the proposed override signature so a follow-up PR can
+wire the upstream hook through without any further refactor here.
+
+## How the test exercises the new behaviour
+
+`invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceListenerParking.java` is a new
+Mockito-based fast test that constructs an `InvoiceListener` with mocked collaborators and
+exercises `handleFailedInvoiceDispatch` directly:
+
+1. **`testHandleFailedInvoiceDispatchParksAccountWhenConfigEnabled`** — sets
+   `isParkAccountsOnAllExceptions` to `true`, fires a failed dispatch, and verifies
+   `parkedAccountsManager.parkAccount(accountId, ...)` is invoked exactly once.
+2. **`testHandleFailedInvoiceDispatchDoesNotParkWhenConfigDisabled`** — sets the config to
+   `false` and verifies `parkAccount` is **never** called, proving the kill-switch works.
+3. **`testHandleFailedInvoiceDispatchSurvivesAccountLookupFailure`** — makes
+   `AccountInternalApi.getByRecordId` throw an `AccountApiException` and asserts the helper does
+   not propagate any exception (subscriber actions must never re-throw).
+
+The tests use `MockMakers.SUBCLASS` because Mockito's default inline mock maker fails to redefine
+some bootstrap classes on Java 21+ (the JVM available in this sandbox is OpenJDK 25).
+
+## Build status
+
+`mvn -DskipTests -Dcheck.skip-spotbugs=true compile` — every module passes:
+
+```
+[INFO] killbill-util ...................................... SUCCESS
+[INFO] killbill-tenant .................................... SUCCESS
+[INFO] killbill-account ................................... SUCCESS
+[INFO] killbill-catalog ................................... SUCCESS
+[INFO] killbill-currency .................................. SUCCESS
+[INFO] killbill-subscription .............................. SUCCESS
+[INFO] killbill-entitlement ............................... SUCCESS
+[INFO] killbill-junction .................................. SUCCESS
+[INFO] killbill-usage ..................................... SUCCESS
+[INFO] killbill-invoice ................................... SUCCESS
+[INFO] killbill-overdue ................................... SUCCESS
+[INFO] killbill-payment ................................... SUCCESS
+[INFO] killbill-beatrix ................................... SUCCESS
+[INFO] killbill-jaxrs ..................................... SUCCESS
+[INFO] killbill-profiles-killbill ......................... SUCCESS
+[INFO] killbill-profiles-killpay .......................... SUCCESS
+[INFO] BUILD SUCCESS
+```
+
+`mvn -pl invoice -Dtest=TestInvoiceListenerParking -Dgroups=fast -Dcheck.skip-spotbugs=true test`:
+
+```
+[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
+[INFO] BUILD SUCCESS
+```
+
+Full test-compile across the repo also succeeds (`mvn -DskipTests test-compile`).
+
+## Confidence level
+
+**Medium-high.**
+
+What I'm confident in:
+
+- Compile-clean across the whole repo, including all downstream modules (`beatrix`, `jaxrs`,
+  `profiles-*`).
+- The new fast unit tests actually execute and pass (3 / 3).
+- The parking call sites match the design proposed in the issue, including the @sbrossie config
+  switch and the consistent `parking account` log marker.
+- Existing parking semantics are preserved (UNEXPECTED_ERROR still parks; dry-run never parks;
+  parking is idempotent via `ParkedAccountsManager`).
+
+Reasons it isn't "high":
+
+- The slow integration tests (`TestInvoiceDispatcher`, beatrix `TestIntegration*`) require the
+  ARM MySQL binary that is not available in this environment, so I didn't end-to-end exercise the
+  `processAccountInternal` parking paths against a real DB.
+- Parts B/D of the proposal (the `RetryableService.onRetriesExhausted` hook) are intentionally
+  deferred to a coordinated killbill-commons release; the `RetryableException` retry-exhausted
+  path still drops events silently for now. The public shape of
+  `InvoiceListener.handleFailedInvoiceDispatch` is set up so the follow-up is a one-method
+  override.

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestIntegrationBase.java
@@ -1457,6 +1457,16 @@ public class TestIntegrationBase extends BeatrixTestSuiteWithEmbeddedDB implemen
         }
 
         @Override
+        public boolean isParkAccountsOnAllExceptions() {
+            return defaultInvoiceConfig.isParkAccountsOnAllExceptions();
+        }
+
+        @Override
+        public boolean isParkAccountsOnAllExceptions(final InternalTenantContext tenantContext) {
+            return isParkAccountsOnAllExceptions();
+        }
+
+        @Override
         public List<TimeSpan> getRescheduleIntervalOnLock() {
             return defaultInvoiceConfig.getRescheduleIntervalOnLock();
         }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -333,7 +333,10 @@ public class InvoiceDispatcher {
                 throw new InvoiceApiException(e, ErrorCode.UNEXPECTED_ERROR, "Failed to generate invoice: failed to acquire lock");
             }
             if (!rescheduleProcessAccount(accountId, context)) {
-                log.warn("Failed to process invoice for accountId='{}', targetDate='{}'", accountId, targetDate, e);
+                log.warn("Failed to process invoice for accountId='{}', targetDate='{}', parking account", accountId, targetDate, e);
+                if (invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                    parkAccount(accountId, context);
+                }
             }
         } finally {
             if (lock != null) {
@@ -460,13 +463,22 @@ public class InvoiceDispatcher {
             printInvoiceTiming(invoiceTimings);
             return result;
         } catch (final CatalogApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}', parking account", accountId, dryRunArguments, e);
+            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                parkAccount(accountId, context);
+            }
             return Collections.emptyList();
         } catch (final AccountApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}', parking account", accountId, dryRunArguments, e);
+            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                parkAccount(accountId, context);
+            }
             return Collections.emptyList();
         } catch (final SubscriptionBaseApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}', parking account", accountId, dryRunArguments, e);
+            if (!isDryRun && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                parkAccount(accountId, context);
+            }
             return Collections.emptyList();
         } catch (final InvoiceApiException e) {
             if (e.getCode() == ErrorCode.INVOICE_PLUGIN_API_ABORTED.getCode()) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -44,9 +44,11 @@ import org.killbill.billing.invoice.api.user.DefaultInvoiceAdjustmentEvent;
 import org.killbill.billing.platform.api.LifecycleHandlerType;
 import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
 import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
+import org.killbill.billing.util.api.TagApiException;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.commons.eventbus.AllowConcurrentEvents;
@@ -67,12 +69,15 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
 
     private static final Logger log = LoggerFactory.getLogger(InvoiceListener.class);
 
+    private final AccountInternalApi accountApi;
     private final InvoiceDispatcher dispatcher;
     private final InternalCallContextFactory internalCallContextFactory;
     private final InvoiceInternalApi invoiceApi;
     private final RetryableSubscriber retryableSubscriber;
     private final BusDispatcherOptimizer busDispatcherOptimizer;
     private final SubscriberQueueHandler subscriberQueueHandler;
+    private final ParkedAccountsManager parkedAccountsManager;
+    private final InvoiceConfig invoiceConfig;
 
     @Inject
     public InvoiceListener(final AccountInternalApi accountApi,
@@ -81,12 +86,17 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                            final InvoiceInternalApi invoiceApi,
                            final NotificationQueueService notificationQueueService,
                            final BusDispatcherOptimizer busDispatcherOptimizer,
+                           final ParkedAccountsManager parkedAccountsManager,
+                           final InvoiceConfig invoiceConfig,
                            final Clock clock) {
         super(notificationQueueService);
+        this.accountApi = accountApi;
         this.dispatcher = dispatcher;
         this.internalCallContextFactory = internalCallContextFactory;
         this.invoiceApi = invoiceApi;
         this.busDispatcherOptimizer = busDispatcherOptimizer;
+        this.parkedAccountsManager = parkedAccountsManager;
+        this.invoiceConfig = invoiceConfig;
         this.subscriberQueueHandler = new SubscriberQueueHandler();
 
         subscriberQueueHandler.subscribe(EffectiveSubscriptionInternalEvent.class,
@@ -103,7 +113,9 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
                                                      dispatcher.processSubscriptionForInvoiceGeneration(event, context);
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  }
                                              }
                                          });
@@ -121,9 +133,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      final UUID accountId = accountApi.getByRecordId(event.getSearchKey1(), context);
                                                      dispatcher.processAccountFromNotificationOrBusEvent(accountId, null, null, false, context);
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("BlockingTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("BlockingTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("BlockingTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  }
                                              }
                                          });
@@ -141,9 +155,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      }
 
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  }
                                              }
                                          });
@@ -160,9 +176,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                          dispatcher.processParentInvoiceForAdjustments(account, event.getInvoiceId(), context);
                                                      }
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  }
                                              }
                                          });
@@ -175,23 +193,30 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      return;
                                                  }
 
-
-                                                 final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-                                                 dispatcher.processSubscriptionStartRequestedDate(event, context);
+                                                 try {
+                                                     final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+                                                     dispatcher.processSubscriptionStartRequestedDate(event, context);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
+                                                 }
                                              }
                                          });
         subscriberQueueHandler.subscribe(AccountChangeInternalEvent.class,
                                          new SubscriberAction<AccountChangeInternalEvent>() {
                                              @Override
                                              public void run(final AccountChangeInternalEvent event) {
-                                                 for (final ChangedField changedField : event.getChangedFields()) {
-                                                     if ("billCycleDayLocal".equals(changedField.getFieldName()) &&
-                                                         !Objects.equals(changedField.getOldValue(), changedField.getNewValue()) &&
-                                                         !"0".equals(changedField.getOldValue())) {
-                                                         final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "AccountBCDChange", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-                                                         dispatcher.processAccountBCDChange(event.getAccountId(), context);
-                                                         return;
+                                                 try {
+                                                     for (final ChangedField changedField : event.getChangedFields()) {
+                                                         if ("billCycleDayLocal".equals(changedField.getFieldName()) &&
+                                                             !Objects.equals(changedField.getOldValue(), changedField.getNewValue()) &&
+                                                             !"0".equals(changedField.getOldValue())) {
+                                                             final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "AccountBCDChange", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+                                                             dispatcher.processAccountBCDChange(event.getAccountId(), context);
+                                                             return;
+                                                         }
                                                      }
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("AccountBCDChange", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), e);
                                                  }
                                              }
                                          });
@@ -261,7 +286,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         try {
             dispatcher.processSubscriptionForInvoiceGeneration(context.toLocalDate(eventDateTime), isRescheduled, context);
         } catch (final InvoiceApiException e) {
-            log.warn("Unable to process next billing date event, eventDateTime='{}'", eventDateTime, e);
+            handleFailedInvoiceDispatch("Next Billing Date", accountRecordId, tenantRecordId, userToken, e);
         }
     }
 
@@ -270,7 +295,39 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         try {
             dispatcher.processSubscriptionForInvoiceNotification(context.toLocalDate(eventDateTime), context);
         } catch (final InvoiceApiException e) {
-            log.warn("Unable to process event for invoice notification eventDateTime='{}'", eventDateTime, e);
+            handleFailedInvoiceDispatch("Next Billing Date Notification", accountRecordId, tenantRecordId, userToken, e);
+        }
+    }
+
+    /**
+     * Park the account associated with a failed invoice dispatch so a human can investigate.
+     *
+     * @param eventDescription human-readable description of the dispatch context (used for call context tracing)
+     * @param accountRecordId  account record id (searchKey1)
+     * @param tenantRecordId   tenant record id (searchKey2)
+     * @param userToken        propagated user token
+     * @param e                the exception that caused the failure
+     */
+    public void handleFailedInvoiceDispatch(final String eventDescription,
+                                            final Long accountRecordId,
+                                            final Long tenantRecordId,
+                                            final UUID userToken,
+                                            final Exception e) {
+        try {
+            final InternalCallContext context = internalCallContextFactory.createInternalCallContext(tenantRecordId, accountRecordId, eventDescription, CallOrigin.INTERNAL, UserType.SYSTEM, userToken);
+            if (!invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                log.warn("Failed to generate invoice, event='{}', accountRecordId='{}'", eventDescription, accountRecordId, e);
+                return;
+            }
+            final UUID accountId = accountApi.getByRecordId(accountRecordId, context);
+            log.warn("Failed to generate invoice for accountId='{}', event='{}', parking account", accountId, eventDescription, e);
+            parkedAccountsManager.parkAccount(accountId, context);
+        } catch (final AccountApiException inner) {
+            log.warn("Unable to park account after invoice failure for accountRecordId='{}'", accountRecordId, inner);
+        } catch (final TagApiException inner) {
+            log.warn("Unable to park account after invoice failure for accountRecordId='{}'", accountRecordId, inner);
+        } catch (final RuntimeException inner) {
+            log.warn("Unable to park account after invoice failure for accountRecordId='{}'", accountRecordId, inner);
         }
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -295,6 +295,20 @@ public class MultiTenantInvoiceConfig extends MultiTenantLockAwareConfigBase imp
     }
 
     @Override
+    public boolean isParkAccountsOnAllExceptions() {
+        return staticConfig.isParkAccountsOnAllExceptions();
+    }
+
+    @Override
+    public boolean isParkAccountsOnAllExceptions(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("isParkAccountsOnAllExceptions", tenantContext);
+        if (result != null) {
+            return Boolean.parseBoolean(result);
+        }
+        return isParkAccountsOnAllExceptions();
+    }
+
+    @Override
     protected Class<? extends KillbillConfig> getConfigClass() {
         return InvoiceConfig.class;
     }

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceListenerParking.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceListenerParking.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice;
+
+import java.util.UUID;
+
+import org.killbill.billing.ErrorCode;
+import org.killbill.billing.account.api.AccountInternalApi;
+import org.killbill.billing.account.api.AccountApiException;
+import org.killbill.billing.callcontext.InternalCallContext;
+import org.killbill.billing.invoice.api.InvoiceApiException;
+import org.killbill.billing.invoice.api.InvoiceInternalApi;
+import org.killbill.billing.util.callcontext.CallOrigin;
+import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
+import org.killbill.clock.ClockMock;
+import org.killbill.notificationq.api.NotificationQueueService;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockMakers;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Regression tests for issue #2208: invoice dispatch failures must park the account so a human can investigate.
+ *
+ * These tests intentionally avoid the embedded DB to remain portable across environments — they exercise the
+ * {@link InvoiceListener#handleFailedInvoiceDispatch(String, Long, Long, UUID, Exception)} hook in isolation.
+ */
+public class TestInvoiceListenerParking {
+
+    private AccountInternalApi accountApi;
+    private InternalCallContextFactory internalCallContextFactory;
+    private InvoiceDispatcher dispatcher;
+    private InvoiceInternalApi invoiceApi;
+    private NotificationQueueService notificationQueueService;
+    private BusDispatcherOptimizer busDispatcherOptimizer;
+    private ParkedAccountsManager parkedAccountsManager;
+    private InvoiceConfig invoiceConfig;
+    private ClockMock clock;
+    private InternalCallContext callContext;
+
+    private final Long accountRecordId = 11L;
+    private final Long tenantRecordId = 22L;
+    private final UUID userToken = UUID.randomUUID();
+    private final UUID accountId = UUID.randomUUID();
+
+    @BeforeMethod(groups = "fast")
+    public void beforeMethod() throws Exception {
+        // Use subclass mock-maker to avoid inline-mock issues on newer JVMs (Mockito cannot bytecode-rewrite
+        // some bootstrap classes under Java 21+).
+        accountApi = Mockito.mock(AccountInternalApi.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        internalCallContextFactory = Mockito.mock(InternalCallContextFactory.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        dispatcher = Mockito.mock(InvoiceDispatcher.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        invoiceApi = Mockito.mock(InvoiceInternalApi.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        notificationQueueService = Mockito.mock(NotificationQueueService.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        busDispatcherOptimizer = Mockito.mock(BusDispatcherOptimizer.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        parkedAccountsManager = Mockito.mock(ParkedAccountsManager.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        invoiceConfig = Mockito.mock(InvoiceConfig.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+        clock = new ClockMock();
+        callContext = Mockito.mock(InternalCallContext.class, Mockito.withSettings().mockMaker(MockMakers.SUBCLASS));
+
+        Mockito.when(internalCallContextFactory.createInternalCallContext(
+                ArgumentMatchers.eq(tenantRecordId),
+                ArgumentMatchers.eq(accountRecordId),
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.eq(CallOrigin.INTERNAL),
+                ArgumentMatchers.eq(UserType.SYSTEM),
+                ArgumentMatchers.any())).thenReturn(callContext);
+
+        Mockito.when(accountApi.getByRecordId(ArgumentMatchers.eq(accountRecordId), ArgumentMatchers.any(InternalCallContext.class))).thenReturn(accountId);
+    }
+
+    private InvoiceListener newListener() {
+        return new InvoiceListener(accountApi, internalCallContextFactory, dispatcher, invoiceApi,
+                                   notificationQueueService, busDispatcherOptimizer,
+                                   parkedAccountsManager, invoiceConfig, clock);
+    }
+
+    @Test(groups = "fast")
+    public void testHandleFailedInvoiceDispatchParksAccountWhenConfigEnabled() throws Exception {
+        Mockito.when(invoiceConfig.isParkAccountsOnAllExceptions(ArgumentMatchers.any(org.killbill.billing.callcontext.InternalTenantContext.class))).thenReturn(true);
+
+        final InvoiceListener listener = newListener();
+        final InvoiceApiException ex = new InvoiceApiException(ErrorCode.INVOICE_NOT_FOUND, accountId);
+        listener.handleFailedInvoiceDispatch("SubscriptionBaseTransition", accountRecordId, tenantRecordId, userToken, ex);
+
+        Mockito.verify(parkedAccountsManager, Mockito.times(1)).parkAccount(ArgumentMatchers.eq(accountId), ArgumentMatchers.any(InternalCallContext.class));
+    }
+
+    @Test(groups = "fast")
+    public void testHandleFailedInvoiceDispatchDoesNotParkWhenConfigDisabled() throws Exception {
+        Mockito.when(invoiceConfig.isParkAccountsOnAllExceptions(ArgumentMatchers.any(org.killbill.billing.callcontext.InternalTenantContext.class))).thenReturn(false);
+
+        final InvoiceListener listener = newListener();
+        final InvoiceApiException ex = new InvoiceApiException(ErrorCode.INVOICE_NOT_FOUND, accountId);
+        listener.handleFailedInvoiceDispatch("SubscriptionBaseTransition", accountRecordId, tenantRecordId, userToken, ex);
+
+        Mockito.verify(parkedAccountsManager, Mockito.never()).parkAccount(ArgumentMatchers.any(UUID.class), ArgumentMatchers.any(InternalCallContext.class));
+    }
+
+    @Test(groups = "fast")
+    public void testHandleFailedInvoiceDispatchSurvivesAccountLookupFailure() throws Exception {
+        Mockito.when(invoiceConfig.isParkAccountsOnAllExceptions(ArgumentMatchers.any(org.killbill.billing.callcontext.InternalTenantContext.class))).thenReturn(true);
+        Mockito.when(accountApi.getByRecordId(ArgumentMatchers.eq(accountRecordId), ArgumentMatchers.any(InternalCallContext.class)))
+               .thenThrow(new AccountApiException(ErrorCode.ACCOUNT_DOES_NOT_EXIST_FOR_RECORD_ID, accountRecordId));
+
+        final InvoiceListener listener = newListener();
+        final RuntimeException ex = new RuntimeException("boom");
+        // Must not propagate: the bus subscriber callers must never re-throw.
+        try {
+            listener.handleFailedInvoiceDispatch("AccountBCDChange", accountRecordId, tenantRecordId, userToken, ex);
+        } catch (final Throwable t) {
+            Assert.fail("handleFailedInvoiceDispatch must swallow exceptions, got: " + t);
+        }
+
+        Mockito.verify(parkedAccountsManager, Mockito.never()).parkAccount(ArgumentMatchers.any(UUID.class), ArgumentMatchers.any(InternalCallContext.class));
+    }
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.invoice.api.InvoiceInternalApi;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
@@ -42,8 +43,10 @@ public class TestInvoiceNotificationQListener extends InvoiceListener {
                                             final InvoiceDispatcher dispatcher,
                                             final InvoiceInternalApi invoiceApi,
                                             final BusDispatcherOptimizer busOptimizer,
+                                            final ParkedAccountsManager parkedAccountsManager,
+                                            final InvoiceConfig invoiceConfig,
                                             final NotificationQueueService notificationQueueService) {
-        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, notificationQueueService, busOptimizer, clock);
+        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, notificationQueueService, busOptimizer, parkedAccountsManager, invoiceConfig, clock);
     }
 
     @Override

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -212,6 +212,16 @@ public interface InvoiceConfig extends LockAwareConfig {
     @Description("Whether to park accounts when usage data is recorded but not defined in the catalog")
     boolean shouldParkAccountsWithUnknownUsage(@Param("dummy") final InternalTenantContext tenantContext);
 
+    @Config("org.killbill.invoice.parkAccountsOnAllExceptions")
+    @Default("true")
+    @Description("Whether to park accounts on any unrecoverable invoice processing failure (in addition to UNEXPECTED_ERROR)")
+    boolean isParkAccountsOnAllExceptions();
+
+    @Config("org.killbill.invoice.parkAccountsOnAllExceptions")
+    @Default("true")
+    @Description("Whether to park accounts on any unrecoverable invoice processing failure (in addition to UNEXPECTED_ERROR)")
+    boolean isParkAccountsOnAllExceptions(@Param("dummy") final InternalTenantContext tenantContext);
+
     @Config("org.killbill.invoice.maxInvoiceLimit")
     @Default(DEFAULT_NULL_PERIOD)
     @Description("How far back in time should invoice generation look at")


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2208, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

Closes #2208 (proposes a fix; needs maintainer review)

## Arm a (no graph)

Until now, only two paths in invoice processing parked the account: the
"invoicing system disabled" check in
InvoiceDispatcher.processAccountFromNotificationOrBusEvent, and
UNEXPECTED_ERROR InvoiceApiExceptions in processAccountInternal. Every
other failure mode (lock-reschedule not configured, CatalogApiException /
AccountApiException / SubscriptionBaseApiException in
processAccountInternal, every InvoiceApiException /
AccountApiException / RuntimeException caught in InvoiceListener bus
subscriber actions, and the implicit RuntimeException drop on
RequestedSubscriptionInternalEvent / AccountChangeInternalEvent) merely
logged a WARN and silently abandoned the work, leaving accounts that
would never invoice again with no visible signal.

This change wires parkAccount through all of those paths. Parking is
gated by a new InvoiceConfig flag
org.killbill.invoice.parkAccountsOnAllExceptions (default true,
per-tenant overridable, as requested by sbrossie on the issue) so it
can be turned off if it turns out to be too aggressive. All WARN logs
that trigger parking now include the literal "parking account" marker
so operators can alert on it consistently.

InvoiceListener gains a public handleFailedInvoiceDispatch helper that
resolves the account from the search keys, parks it, and swallows
AccountApiException / TagApiException / RuntimeException so bus
subscriber actions cannot re-throw. Public visibility is intentional:
when the upstream killbill-commons onRetriesExhausted hook lands (parts
B/D of the issue, which require a coordinated commons release),
DefaultNextBillingDateNotifier can delegate to this helper directly.

Adds a Mockito-based fast regression test
(TestInvoiceListenerParking) covering the on/off config flag and the
account-lookup-failure path.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Diff stat

```
 FIX_REPORT.md                                      | 140 +++++++++++++++++++++
 .../beatrix/integration/TestIntegrationBase.java   |  10 ++
 .../billing/invoice/InvoiceDispatcher.java         |  20 ++-
 .../killbill/billing/invoice/InvoiceListener.java  |  95 +++++++++++---
 .../invoice/config/MultiTenantInvoiceConfig.java   |  14 +++
 .../invoice/TestInvoiceListenerParking.java        | 136 ++++++++++++++++++++
 .../invoice/TestInvoiceNotificationQListener.java  |   5 +-
 .../util/config/definition/InvoiceConfig.java      |  10 ++
 8 files changed, 406 insertions(+), 24 deletions(-)
```

## Compile status

[INFO] BUILD SUCCESS
```
--
