### PR TITLE
[Experiment / arm b (ARK graph)] Fix #2208: park accounts on unrecoverable invoice processing failures (issue #2208)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,118 @@
+# Issue #2208 — Park accounts on unrecoverable invoice processing failures
+
+## Root cause / design summary
+
+Invoice processing has multiple silent-failure paths that abandon an account without parking
+it, so the operator never finds out. The relevant sites are concentrated in:
+
+- `org.killbill.billing.invoice.InvoiceDispatcher#processAccount` — when
+  `rescheduleProcessAccount()` returns `false` (no reschedule periods configured) after a
+  `LockFailedException`, the account is logged at WARN and dropped.
+- `org.killbill.billing.invoice.InvoiceDispatcher#processAccountInternal` — when
+  `CatalogApiException` / `AccountApiException` / `SubscriptionBaseApiException` bubbles up
+  from `billingApi.getBillingEventsForAccountAndUpdateAccountBCD(...)`, the catch blocks
+  return `Collections.emptyList()` after a WARN, again losing the failure.
+- `org.killbill.billing.invoice.InvoiceListener` — the `SubscriberAction.run()` lambdas for
+  `EffectiveSubscriptionInternalEvent`, `BlockingTransitionInternalEvent`,
+  `InvoiceCreationInternalEvent`, `DefaultInvoiceAdjustmentEvent`,
+  `RequestedSubscriptionInternalEvent` and `AccountChangeInternalEvent` either WARN-and-swallow
+  the recoverable-looking checked exceptions or let `RuntimeException`s propagate to the bus
+  where they are dropped.
+
+The fix routes all of these paths through `ParkedAccountsManager.parkAccount(...)` so the
+account ends up tagged with `SystemTags.PARK_TAG_DEFINITION_ID` and the operator can find it.
+Per the reviewer comment on the issue, parking is gated by a new tenant-aware config flag
+`org.killbill.invoice.parkAccountsOnAllExceptions` (default `true`), and every park log line
+uses the shared WARN marker `parking account` so alerting can pivot on it.
+
+## Change summary
+
+| File | Change |
+| --- | --- |
+| `util/.../config/definition/InvoiceConfig.java` | New `isParkAccountsOnAllExceptions()` static and tenant-aware accessors, default `true`. |
+| `invoice/.../config/MultiTenantInvoiceConfig.java` | Implementations of both new accessors with the standard `getStringTenantConfig` fallback to the static value. |
+| `invoice/.../InvoiceDispatcher.java` | `processAccount` parks on `LockFailedException` when `rescheduleProcessAccount` returns false (Section A of the issue). `processAccountInternal` parks (non dry-run, when config enabled) on `CatalogApiException` / `AccountApiException` / `SubscriptionBaseApiException` (Section F). New `parkAccountOnRecoverableError` helper. All WARN messages now carry the `parking account` marker. |
+| `invoice/.../InvoiceListener.java` | Injects `ParkedAccountsManager` and `InvoiceConfig`; stores `accountApi` as a field. Each `SubscriberAction.run()` now also catches `RuntimeException` and routes every failure through a new private `handleFailedInvoiceDispatch(...)` helper that resolves the account from `searchKey1` and parks it (Section E). Adds a public `onRetriesExhaustedForInvoice(QueueEvent, Long, Long)` method that performs the same park; it is left non-`@Override` so it compiles before the killbill-commons `RetryableService` hook (Section B) lands. |
+| `invoice/.../notification/DefaultNextBillingDateNotifier.java` | New public `onRetriesExhaustedForInvoice(...)` that simply delegates to `InvoiceListener` (Section D), again non-`@Override` so it compiles today and snaps into place when the parent hook ships. |
+| `invoice/.../TestInvoiceNotificationQListener.java` (test) | Constructor updated to forward `ParkedAccountsManager` and `InvoiceConfig` to the new `InvoiceListener` signature. |
+| `invoice/.../TestInvoiceDispatcherParkingOnFailure.java` (test, new) | Four `groups="slow"` tests covering the three `processAccountInternal` exception paths plus the dry-run negative case. |
+
+### What is intentionally NOT done here
+
+- **Section B (`RetryableService.scheduleRetry` hook).** That class lives in the separate
+  `killbill-commons` repository (the issue explicitly notes "requires a coordinated release").
+  This branch ships the consumer side — `onRetriesExhaustedForInvoice` on both `InvoiceListener`
+  and `DefaultNextBillingDateNotifier` — so the killbill-commons PR only has to add the
+  `protected void onRetriesExhausted(QueueEvent, Long, Long)` no-op and the `scheduleRetry()`
+  callsite invocation, plus an `@Override` on the two consumer methods.
+
+## How the test exercises the new behaviour
+
+`TestInvoiceDispatcherParkingOnFailure` (in `invoice/src/test/java/org/killbill/billing/invoice/`)
+extends `InvoiceTestSuiteWithEmbeddedDB` and uses the existing Mockito-bound `BillingInternalApi`
+to make `getBillingEventsForAccountAndUpdateAccountBCD(...)` throw each of the three checked
+exception types in turn. It then drives `dispatcher.processAccountFromNotificationOrBusEvent(...)`
+and asserts via `tagUserApi.getTagsForAccount(...)` that:
+
+1. `CatalogApiException` in non-dryRun → exactly one tag, `PARK_TAG_DEFINITION_ID`.
+2. `CatalogApiException` in dryRun → no tags (regression guard for accidental side-effects).
+3. `AccountApiException` in non-dryRun → parked.
+4. `SubscriptionBaseApiException` in non-dryRun → parked.
+
+The first test would have failed before this change because `processAccountInternal` returned
+`Collections.emptyList()` without tagging anything.
+
+## Build status
+
+`mvn -pl invoice -am -DskipTests compile`:
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS
+[INFO] killbill-api ....................................... SUCCESS
+[INFO] killbill-util ...................................... SUCCESS
+[INFO] killbill-tenant .................................... SUCCESS
+[INFO] killbill-account ................................... SUCCESS
+[INFO] killbill-catalog ................................... SUCCESS
+[INFO] killbill-subscription .............................. SUCCESS
+[INFO] killbill-entitlement ............................... SUCCESS
+[INFO] killbill-junction .................................. SUCCESS
+[INFO] killbill-usage ..................................... SUCCESS
+[INFO] killbill-invoice ................................... SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+```
+
+`mvn -pl invoice -am -DskipTests test-compile`: BUILD SUCCESS (all 11 modules).
+
+Full-project `mvn -DskipTests compile`: BUILD SUCCESS across all 19 reactor modules
+(including `beatrix`, `jaxrs`, `profiles-killbill`, `profiles-killpay`).
+
+The embedded MySQL `slow` tests cannot start on this ARM host
+(`archive not found: /mysql-Mac_OS_X-aarch64.tar.gz`), which is an environment limitation
+called out by the prompt and not within the scope of this fix.
+
+## Confidence level
+
+**Medium-high.**
+
+What I am confident about:
+- The three call-sites changed in `InvoiceDispatcher` are exactly the ones the issue
+  identifies, and the new code reuses the existing `parkAccount()` helper that has been
+  battle-tested for the `UNEXPECTED_ERROR` path.
+- The `InvoiceListener` constructor change is mechanically consistent — all callers
+  (`TestInvoiceNotificationQListener`, Guice DI via `TestInvoiceModuleWithEmbeddedDb`,
+  production wiring via `InvoiceModule`) compile cleanly.
+- The new config accessor mirrors the structure of the existing `isInvoicingSystemEnabled`
+  pair, including the `MultiTenantInvoiceConfig` override.
+
+Where caveats apply:
+- `onRetriesExhaustedForInvoice` cannot become an `@Override` until the killbill-commons
+  side ships, so today those methods are dead code from the runtime's perspective. They
+  exist so the coordinated release in `killbill-commons` is a one-line annotation + caller
+  change rather than a re-design.
+- The new `slow` tests compile cleanly but could not be executed in this environment;
+  they are written against the same Mockito-bound `BillingInternalApi` pattern as the
+  long-standing `TestInvoiceDispatcher#testIllegalInvoicing`, so they should behave
+  consistently with that proven baseline.

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -333,7 +333,11 @@ public class InvoiceDispatcher {
                 throw new InvoiceApiException(e, ErrorCode.UNEXPECTED_ERROR, "Failed to generate invoice: failed to acquire lock");
             }
             if (!rescheduleProcessAccount(accountId, context)) {
-                log.warn("Failed to process invoice for accountId='{}', targetDate='{}'", accountId, targetDate, e);
+                // Issue #2208: with no reschedule periods configured, the account would otherwise be silently abandoned.
+                log.warn("Failed to generate invoice for accountId='{}', targetDate='{}', parking account", accountId, targetDate, e);
+                if (invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                    parkAccount(accountId, context);
+                }
             }
         } finally {
             if (lock != null) {
@@ -460,13 +464,16 @@ public class InvoiceDispatcher {
             printInvoiceTiming(invoiceTimings);
             return result;
         } catch (final CatalogApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}', parking account", accountId, dryRunArguments, e);
+            parkAccountOnRecoverableError(isDryRun, accountId, context);
             return Collections.emptyList();
         } catch (final AccountApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}', parking account", accountId, dryRunArguments, e);
+            parkAccountOnRecoverableError(isDryRun, accountId, context);
             return Collections.emptyList();
         } catch (final SubscriptionBaseApiException e) {
-            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to retrieve BillingEvents for accountId='{}', dryRunArguments='{}', parking account", accountId, dryRunArguments, e);
+            parkAccountOnRecoverableError(isDryRun, accountId, context);
             return Collections.emptyList();
         } catch (final InvoiceApiException e) {
             if (e.getCode() == ErrorCode.INVOICE_PLUGIN_API_ABORTED.getCode()) {
@@ -629,6 +636,19 @@ public class InvoiceDispatcher {
         } catch (final TagApiException ignored) {
             log.warn("Unable to park account", ignored);
         }
+    }
+
+    // Issue #2208: park when a recoverable-looking API exception (Catalog/Account/SubscriptionBase) has just
+    // caused us to silently drop invoice generation. Skipped in dryRun (to avoid mutating state) and when
+    // the operator has opted out via org.killbill.invoice.parkAccountsOnAllExceptions=false.
+    private void parkAccountOnRecoverableError(final boolean isDryRun, final UUID accountId, final InternalCallContext context) {
+        if (isDryRun) {
+            return;
+        }
+        if (!invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+            return;
+        }
+        parkAccount(accountId, context);
     }
 
     private Iterable<UUID> getFilteredSubscriptionIdsFor_UPCOMING_INVOICE_DryRun(@Nullable final DryRunArguments dryRunArguments, final BillingEventSet billingEvents) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -44,15 +44,18 @@ import org.killbill.billing.invoice.api.user.DefaultInvoiceAdjustmentEvent;
 import org.killbill.billing.platform.api.LifecycleHandlerType;
 import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
 import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
+import org.killbill.billing.util.api.TagApiException;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.commons.eventbus.AllowConcurrentEvents;
 import org.killbill.commons.eventbus.Subscribe;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
+import org.killbill.queue.api.QueueEvent;
 import org.killbill.queue.retry.RetryableService;
 import org.killbill.queue.retry.RetryableSubscriber;
 import org.killbill.queue.retry.RetryableSubscriber.SubscriberAction;
@@ -67,12 +70,15 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
 
     private static final Logger log = LoggerFactory.getLogger(InvoiceListener.class);
 
+    private final AccountInternalApi accountApi;
     private final InvoiceDispatcher dispatcher;
     private final InternalCallContextFactory internalCallContextFactory;
     private final InvoiceInternalApi invoiceApi;
     private final RetryableSubscriber retryableSubscriber;
     private final BusDispatcherOptimizer busDispatcherOptimizer;
     private final SubscriberQueueHandler subscriberQueueHandler;
+    private final ParkedAccountsManager parkedAccountsManager;
+    private final InvoiceConfig invoiceConfig;
 
     @Inject
     public InvoiceListener(final AccountInternalApi accountApi,
@@ -81,12 +87,17 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                            final InvoiceInternalApi invoiceApi,
                            final NotificationQueueService notificationQueueService,
                            final BusDispatcherOptimizer busDispatcherOptimizer,
+                           final ParkedAccountsManager parkedAccountsManager,
+                           final InvoiceConfig invoiceConfig,
                            final Clock clock) {
         super(notificationQueueService);
+        this.accountApi = accountApi;
         this.dispatcher = dispatcher;
         this.internalCallContextFactory = internalCallContextFactory;
         this.invoiceApi = invoiceApi;
         this.busDispatcherOptimizer = busDispatcherOptimizer;
+        this.parkedAccountsManager = parkedAccountsManager;
+        this.invoiceConfig = invoiceConfig;
         this.subscriberQueueHandler = new SubscriberQueueHandler();
 
         subscriberQueueHandler.subscribe(EffectiveSubscriptionInternalEvent.class,
@@ -103,7 +114,9 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
                                                      dispatcher.processSubscriptionForInvoiceGeneration(event, context);
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
                                                  }
                                              }
                                          });
@@ -121,9 +134,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      final UUID accountId = accountApi.getByRecordId(event.getSearchKey1(), context);
                                                      dispatcher.processAccountFromNotificationOrBusEvent(accountId, null, null, false, context);
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
                                                  }
                                              }
                                          });
@@ -141,9 +156,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      }
 
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("CreateParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
                                                  }
                                              }
                                          });
@@ -160,9 +177,11 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                          dispatcher.processParentInvoiceForAdjustments(account, event.getInvoiceId(), context);
                                                      }
                                                  } catch (final InvoiceApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
                                                  } catch (final AccountApiException e) {
-                                                     log.warn("Unable to process event {}", event, e);
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("AdjustParentInvoice", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
                                                  }
                                              }
                                          });
@@ -175,23 +194,30 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                                      return;
                                                  }
 
-
-                                                 final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-                                                 dispatcher.processSubscriptionStartRequestedDate(event, context);
+                                                 try {
+                                                     final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+                                                     dispatcher.processSubscriptionStartRequestedDate(event, context);
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("SubscriptionBaseTransition", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
+                                                 }
                                              }
                                          });
         subscriberQueueHandler.subscribe(AccountChangeInternalEvent.class,
                                          new SubscriberAction<AccountChangeInternalEvent>() {
                                              @Override
                                              public void run(final AccountChangeInternalEvent event) {
-                                                 for (final ChangedField changedField : event.getChangedFields()) {
-                                                     if ("billCycleDayLocal".equals(changedField.getFieldName()) &&
-                                                         !Objects.equals(changedField.getOldValue(), changedField.getNewValue()) &&
-                                                         !"0".equals(changedField.getOldValue())) {
-                                                         final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "AccountBCDChange", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-                                                         dispatcher.processAccountBCDChange(event.getAccountId(), context);
-                                                         return;
+                                                 try {
+                                                     for (final ChangedField changedField : event.getChangedFields()) {
+                                                         if ("billCycleDayLocal".equals(changedField.getFieldName()) &&
+                                                             !Objects.equals(changedField.getOldValue(), changedField.getNewValue()) &&
+                                                             !"0".equals(changedField.getOldValue())) {
+                                                             final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "AccountBCDChange", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+                                                             dispatcher.processAccountBCDChange(event.getAccountId(), context);
+                                                             return;
+                                                         }
                                                      }
+                                                 } catch (final RuntimeException e) {
+                                                     handleFailedInvoiceDispatch("AccountBCDChange", event.getSearchKey1(), event.getSearchKey2(), event.getUserToken(), event, e);
                                                  }
                                              }
                                          });
@@ -282,6 +308,52 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
 
     private boolean isChildrenAccountAndPaymentDelegated(final Account account) {
         return account.getParentAccountId() != null && account.isPaymentDelegatedToParent();
+    }
+
+    // Issue #2208: shared park helper for subscriber action failures. We log at WARN with the
+    // shared "parking account" marker so operators can alert on it, then attempt the park-tag write.
+    private void handleFailedInvoiceDispatch(final String eventDescription,
+                                             final Long accountRecordId,
+                                             final Long tenantRecordId,
+                                             final UUID userToken,
+                                             final BusInternalEvent event,
+                                             final Exception e) {
+        try {
+            final InternalCallContext context = internalCallContextFactory.createInternalCallContext(
+                    tenantRecordId, accountRecordId, eventDescription, CallOrigin.INTERNAL, UserType.SYSTEM, userToken);
+            final UUID accountId = accountApi.getByRecordId(accountRecordId, context);
+            log.warn("Failed to generate invoice for accountId='{}', event='{}', parking account", accountId, event, e);
+            if (invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                try {
+                    parkedAccountsManager.parkAccount(accountId, context);
+                } catch (final TagApiException tagApiException) {
+                    log.warn("Unable to park account after invoice failure for accountId='{}'", accountId, tagApiException);
+                }
+            }
+        } catch (final Exception inner) {
+            log.warn("Unable to park account after invoice failure for accountRecordId='{}', event='{}'", accountRecordId, event, inner);
+        }
+    }
+
+    // Issue #2208: invoked from RetryableService.scheduleRetry() once the killbill-commons hook is
+    // released. Kept public + non-@Override so it compiles before the parent change lands; subclasses
+    // (DefaultNextBillingDateNotifier) can delegate here.
+    public void onRetriesExhaustedForInvoice(final QueueEvent event, final Long accountRecordId, final Long tenantRecordId) {
+        try {
+            final InternalCallContext context = internalCallContextFactory.createInternalCallContext(
+                    tenantRecordId, accountRecordId, "InvoiceRetryExhausted", CallOrigin.INTERNAL, UserType.SYSTEM, null);
+            final UUID accountId = accountApi.getByRecordId(accountRecordId, context);
+            log.warn("Failed to generate invoice for accountId='{}', all retries exhausted, parking account", accountId);
+            if (invoiceConfig.isParkAccountsOnAllExceptions(context)) {
+                try {
+                    parkedAccountsManager.parkAccount(accountId, context);
+                } catch (final TagApiException tagApiException) {
+                    log.warn("Unable to park account after retries exhausted for accountId='{}'", accountId, tagApiException);
+                }
+            }
+        } catch (final Exception inner) {
+            log.warn("Unable to park account after retries exhausted for accountRecordId='{}'", accountRecordId, inner);
+        }
     }
 
     public void handleParentInvoiceCommitmentEvent(final UUID invoiceId, final UUID userToken, final Long accountRecordId, final Long tenantRecordId) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -223,6 +223,20 @@ public class MultiTenantInvoiceConfig extends MultiTenantLockAwareConfigBase imp
     }
 
     @Override
+    public boolean isParkAccountsOnAllExceptions() {
+        return staticConfig.isParkAccountsOnAllExceptions();
+    }
+
+    @Override
+    public boolean isParkAccountsOnAllExceptions(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("isParkAccountsOnAllExceptions", tenantContext);
+        if (result != null) {
+            return Boolean.parseBoolean(result);
+        }
+        return isParkAccountsOnAllExceptions();
+    }
+
+    @Override
     public UsageDetailMode getItemResultBehaviorMode() {
         final UsageDetailMode mode = staticConfig.getItemResultBehaviorMode();
         if (mode == UsageDetailMode.AGGREGATE || mode == UsageDetailMode.DETAIL) {

--- a/invoice/src/main/java/org/killbill/billing/invoice/notification/DefaultNextBillingDateNotifier.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/notification/DefaultNextBillingDateNotifier.java
@@ -33,6 +33,7 @@ import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
 import org.killbill.notificationq.api.NotificationQueueService.NotificationQueueAlreadyExists;
 import org.killbill.notificationq.api.NotificationQueueService.NotificationQueueHandler;
+import org.killbill.queue.api.QueueEvent;
 import org.killbill.queue.retry.RetryableHandler;
 import org.killbill.queue.retry.RetryableService;
 import org.slf4j.Logger;
@@ -114,5 +115,11 @@ public class DefaultNextBillingDateNotifier extends RetryableService implements 
 
     private void processEventForInvoiceNotification(final DateTime eventDateTime, final UUID userToken, final Long accountRecordId, final Long tenantRecordId) {
         listener.handleEventForInvoiceNotification(eventDateTime, userToken, accountRecordId, tenantRecordId);
+    }
+
+    // Issue #2208: delegate retry-exhaustion notification to InvoiceListener (which owns the
+    // ParkedAccountsManager). Will be wired in by RetryableService once the killbill-commons hook lands.
+    public void onRetriesExhaustedForInvoice(final QueueEvent event, final Long accountRecordId, final Long tenantRecordId) {
+        listener.onRetriesExhaustedForInvoice(event, accountRecordId, tenantRecordId);
     }
 }

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcherParkingOnFailure.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcherParkingOnFailure.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014-2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.ErrorCode;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.account.api.AccountApiException;
+import org.killbill.billing.callcontext.InternalCallContext;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.invoice.TestInvoiceHelper.DryRunFutureDateArguments;
+import org.killbill.billing.invoice.api.DryRunArguments;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.subscription.api.SubscriptionBase;
+import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
+import org.killbill.billing.util.tag.Tag;
+import org.killbill.billing.util.tag.dao.SystemTags;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+// Regression test for issue #2208: when invoice generation fails with a recoverable-looking
+// API exception (Catalog/Account/SubscriptionBase) outside of dryRun, the account is parked
+// so the operator can find it instead of seeing a silent WARN log.
+public class TestInvoiceDispatcherParkingOnFailure extends InvoiceTestSuiteWithEmbeddedDB {
+
+    private Account account;
+    private SubscriptionBase subscription;
+    private InternalCallContext context;
+    private InvoiceDispatcher dispatcher;
+
+    @Override
+    @BeforeMethod(groups = "slow")
+    public void beforeMethod() throws Exception {
+        if (hasFailed()) {
+            return;
+        }
+        super.beforeMethod();
+        account = invoiceUtil.createAccount(callContext);
+        subscription = invoiceUtil.createSubscription();
+        context = internalCallContextFactory.createInternalCallContext(account.getId(), callContext);
+
+        dispatcher = new InvoiceDispatcher(generator, accountApi, billingApi, subscriptionApi, invoiceDao,
+                                           internalCallContextFactory, invoicePluginDispatcher, locker, bus,
+                                           notificationQueueService, invoiceConfig, clock, invoiceOptimizer, parkedAccountsManager);
+    }
+
+    // CatalogApiException raised while fetching billing events parks the account in non dry-run mode.
+    @Test(groups = "slow")
+    public void testCatalogApiExceptionParksAccountInNonDryRun() throws Exception {
+        final UUID accountId = account.getId();
+        final DateTime effectiveDate = clock.getUTCNow().minusDays(1);
+        final LocalDate target = internalCallContext.toLocalDate(effectiveDate);
+
+        Mockito.when(billingApi.getBillingEventsForAccountAndUpdateAccountBCD(
+                Mockito.<UUID>any(),
+                Mockito.<DryRunArguments>any(),
+                Mockito.<LocalDate>any(),
+                Mockito.<InternalCallContext>any()))
+               .thenThrow(new CatalogApiException(ErrorCode.CAT_NO_SUCH_PLAN, "missing-plan"));
+
+        Assert.assertTrue(tagUserApi.getTagsForAccount(accountId, true, callContext).isEmpty());
+
+        final List<Invoice> result = dispatcher.processAccountFromNotificationOrBusEvent(accountId, target, null, false, context);
+        Assert.assertTrue(result.isEmpty());
+
+        final List<Tag> tags = tagUserApi.getTagsForAccount(accountId, false, callContext);
+        Assert.assertEquals(tags.size(), 1, "Account should have been parked after CatalogApiException");
+        Assert.assertEquals(tags.get(0).getTagDefinitionId(), SystemTags.PARK_TAG_DEFINITION_ID);
+    }
+
+    // Dry-run path remains side-effect-free even when the same failure occurs.
+    @Test(groups = "slow")
+    public void testCatalogApiExceptionDoesNotParkAccountInDryRun() throws Exception {
+        final UUID accountId = account.getId();
+        final DateTime effectiveDate = clock.getUTCNow().minusDays(1);
+        final LocalDate target = internalCallContext.toLocalDate(effectiveDate);
+
+        Mockito.when(billingApi.getBillingEventsForAccountAndUpdateAccountBCD(
+                Mockito.<UUID>any(),
+                Mockito.<DryRunArguments>any(),
+                Mockito.<LocalDate>any(),
+                Mockito.<InternalCallContext>any()))
+               .thenThrow(new CatalogApiException(ErrorCode.CAT_NO_SUCH_PLAN, "missing-plan"));
+
+        Assert.assertTrue(tagUserApi.getTagsForAccount(accountId, true, callContext).isEmpty());
+
+        final List<Invoice> result = dispatcher.processAccountFromNotificationOrBusEvent(accountId, target, new DryRunFutureDateArguments(), false, context);
+        Assert.assertTrue(result.isEmpty());
+
+        // Dry-run must NOT have side effects on tags.
+        Assert.assertTrue(tagUserApi.getTagsForAccount(accountId, true, callContext).isEmpty(),
+                          "Account must not be parked from a dry-run failure");
+    }
+
+    // AccountApiException also triggers parking on the non dry-run path.
+    @Test(groups = "slow")
+    public void testAccountApiExceptionParksAccountInNonDryRun() throws Exception {
+        final UUID accountId = account.getId();
+        final DateTime effectiveDate = clock.getUTCNow().minusDays(1);
+        final LocalDate target = internalCallContext.toLocalDate(effectiveDate);
+
+        Mockito.when(billingApi.getBillingEventsForAccountAndUpdateAccountBCD(
+                Mockito.<UUID>any(),
+                Mockito.<DryRunArguments>any(),
+                Mockito.<LocalDate>any(),
+                Mockito.<InternalCallContext>any()))
+               .thenThrow(new AccountApiException(ErrorCode.ACCOUNT_DOES_NOT_EXIST_FOR_ID, accountId));
+
+        Assert.assertTrue(tagUserApi.getTagsForAccount(accountId, true, callContext).isEmpty());
+
+        final List<Invoice> result = dispatcher.processAccountFromNotificationOrBusEvent(accountId, target, null, false, context);
+        Assert.assertTrue(result.isEmpty());
+
+        final List<Tag> tags = tagUserApi.getTagsForAccount(accountId, false, callContext);
+        Assert.assertEquals(tags.size(), 1, "Account should have been parked after AccountApiException");
+        Assert.assertEquals(tags.get(0).getTagDefinitionId(), SystemTags.PARK_TAG_DEFINITION_ID);
+    }
+
+    // SubscriptionBaseApiException also triggers parking on the non dry-run path.
+    @Test(groups = "slow")
+    public void testSubscriptionBaseApiExceptionParksAccountInNonDryRun() throws Exception {
+        final UUID accountId = account.getId();
+        final DateTime effectiveDate = clock.getUTCNow().minusDays(1);
+        final LocalDate target = internalCallContext.toLocalDate(effectiveDate);
+
+        Mockito.when(billingApi.getBillingEventsForAccountAndUpdateAccountBCD(
+                Mockito.<UUID>any(),
+                Mockito.<DryRunArguments>any(),
+                Mockito.<LocalDate>any(),
+                Mockito.<InternalCallContext>any()))
+               .thenThrow(new SubscriptionBaseApiException(ErrorCode.SUB_INVALID_REQUESTED_DATE, "any-id", "any-date"));
+
+        Assert.assertTrue(tagUserApi.getTagsForAccount(accountId, true, callContext).isEmpty());
+
+        final List<Invoice> result = dispatcher.processAccountFromNotificationOrBusEvent(accountId, target, null, false, context);
+        Assert.assertTrue(result.isEmpty());
+
+        final List<Tag> tags = tagUserApi.getTagsForAccount(accountId, false, callContext);
+        Assert.assertEquals(tags.size(), 1, "Account should have been parked after SubscriptionBaseApiException");
+        Assert.assertEquals(tags.get(0).getTagDefinitionId(), SystemTags.PARK_TAG_DEFINITION_ID);
+    }
+}

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.invoice.api.InvoiceInternalApi;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
@@ -42,8 +43,10 @@ public class TestInvoiceNotificationQListener extends InvoiceListener {
                                             final InvoiceDispatcher dispatcher,
                                             final InvoiceInternalApi invoiceApi,
                                             final BusDispatcherOptimizer busOptimizer,
+                                            final ParkedAccountsManager parkedAccountsManager,
+                                            final InvoiceConfig invoiceConfig,
                                             final NotificationQueueService notificationQueueService) {
-        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, notificationQueueService, busOptimizer, clock);
+        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, notificationQueueService, busOptimizer, parkedAccountsManager, invoiceConfig, clock);
     }
 
     @Override

--- a/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/InvoiceConfig.java
@@ -171,6 +171,16 @@ public interface InvoiceConfig extends LockAwareConfig {
     @Description("Whether the invoicing system is enabled")
     boolean isInvoicingSystemEnabled(@Param("dummy") final InternalTenantContext tenantContext);
 
+    @Config("org.killbill.invoice.parkAccountsOnAllExceptions")
+    @Default("true")
+    @Description("Park accounts on any unrecoverable invoice processing failure (lock retry exhausted, retries exhausted, non-UNEXPECTED_ERROR exceptions, runtime exceptions in subscribers)")
+    boolean isParkAccountsOnAllExceptions();
+
+    @Config("org.killbill.invoice.parkAccountsOnAllExceptions")
+    @Default("true")
+    @Description("Park accounts on any unrecoverable invoice processing failure (lock retry exhausted, retries exhausted, non-UNEXPECTED_ERROR exceptions, runtime exceptions in subscribers)")
+    boolean isParkAccountsOnAllExceptions(@Param("dummy") final InternalTenantContext tenantContext);
+
     @Config("org.killbill.invoice.item.result.behavior.mode")
     @Default("AGGREGATE")
     @Description("How the result for an item will be reported (aggregate mode or detail mode). ")


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2208, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

Closes #2208 (proposes a fix; needs maintainer review)

## Arm b (ARK graph)

Today, several invoice-processing failure paths abandon an account with
just a WARN log so the operator has no way to find it. This change
routes them through ParkedAccountsManager.parkAccount() so the account
ends up tagged and surfaces in operator tooling.

Specifically:

- InvoiceDispatcher#processAccount parks when rescheduleProcessAccount()
  returns false after a LockFailedException (Section A of the issue).
- InvoiceDispatcher#processAccountInternal parks (non-dryRun) on
  CatalogApiException, AccountApiException, and SubscriptionBaseApiException
  raised from getBillingEventsForAccountAndUpdateAccountBCD (Section F).
- InvoiceListener now injects ParkedAccountsManager + InvoiceConfig and
  routes every subscriber-action catch (including a new RuntimeException
  catch on each run() method) through a shared handleFailedInvoiceDispatch
  helper that parks the account (Section E).
- A new public onRetriesExhaustedForInvoice(QueueEvent, Long, Long) hook
  is added on InvoiceListener and delegated to from DefaultNextBillingDateNotifier
  (Sections C+D). It is intentionally non-@Override so it compiles today;
  the matching protected hook in killbill-commons' RetryableService (Section B)
  is a coordinated release per the issue.

Per sbrossie's review comment, parking is gated by a new tenant-aware
config flag org.killbill.invoice.parkAccountsOnAllExceptions (default true)
and every park-related WARN now carries the shared "parking account"
marker for alerting.

New regression test TestInvoiceDispatcherParkingOnFailure covers each of
the three checked-exception parking paths plus the dry-run negative case.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Diff stat

```
 FIX_REPORT.md                                      | 118 +++++++++++++++
 .../billing/invoice/InvoiceDispatcher.java         |  28 +++-
 .../killbill/billing/invoice/InvoiceListener.java  | 106 +++++++++++---
 .../invoice/config/MultiTenantInvoiceConfig.java   |  14 ++
 .../DefaultNextBillingDateNotifier.java            |   7 +
 .../TestInvoiceDispatcherParkingOnFailure.java     | 162 +++++++++++++++++++++
 .../invoice/TestInvoiceNotificationQListener.java  |   5 +-
 .../util/config/definition/InvoiceConfig.java      |  10 ++
 8 files changed, 428 insertions(+), 22 deletions(-)
```

## Compile status

[INFO] BUILD SUCCESS
```
--
