### PR TITLE
[Experiment / arm a (no graph)] Fix #2224: include BCD_UPDATE in subscription event list (issue #2224)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,104 @@
+# Fix report — issue #2224: BCD_UPDATE event is not returned from subscription events
+
+## Root cause / design summary
+
+When the entitlement layer translates lower-level subscription-base transitions
+into the public `SubscriptionEvent` list returned by the API, it routes each
+`SubscriptionBaseTransitionType` through
+`SubscriptionEventOrdering.toEventTypes` (in
+`entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java`).
+That `switch` handles `CREATE`/`TRANSFER`, `CHANGE`, `CANCEL`/`EXPIRED`, and
+`PHASE`, but `BCD_CHANGE` (produced by `SubscriptionBaseTransitionData.toSubscriptionTransitionType`
+when the underlying event is of type `BCD_UPDATE`) falls through to the default
+branch and is mapped to `Collections.emptyList()`. The transition is therefore
+silently dropped before reaching `DefaultSubscriptionBundleTimeline` /
+`SubscriptionJson`, which is why the BCD update is absent from the `events`
+field of the REST response (issue #2224). The transition itself is correctly
+created in `DefaultSubscriptionBase.rebuildTransitionsInternal` — the bug is
+purely in the entitlement-level translation.
+
+The omission appears to be unintentional: there is no semantic reason to hide
+the event, and the public `SubscriptionEventType` enum (`killbill-api`) does not
+expose a dedicated `BCD_CHANGE` value, so the closest matching event type that
+the API can express is `CHANGE`. The fix maps `BCD_CHANGE` → `CHANGE`.
+
+## Change summary
+
+- `entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java`
+  — added a `case BCD_CHANGE:` that falls through to the existing `CHANGE`
+  arm, returning `List.of(SubscriptionEventType.CHANGE)`. A short comment
+  documents why BCD updates surface as `CHANGE` (no dedicated enum value in
+  killbill-api 0.54.0).
+- `entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultSubscriptionBundleTimeline.java`
+  — added `testBCDUpdateEventIsIncludedInTimeline`, a fast unit test that
+  builds an entitlement timeline containing CREATE → PHASE → BCD_UPDATE
+  base transitions, then asserts the resulting `SubscriptionEvent` list
+  contains four events (`START_ENTITLEMENT`, `START_BILLING`, `PHASE`,
+  `CHANGE`) and that the trailing `CHANGE` event carries the id and
+  effective date of the BCD transition.
+
+## How the test exercises the fix / new behaviour
+
+The test mocks an entitlement whose `SubscriptionBase` returns a list of
+transitions including a `BCD_UPDATE` event (which maps to a `BCD_CHANGE`
+transition). It then constructs a `DefaultSubscriptionBundleTimeline` (the same
+code path used by the JAXRS resource when building the response of the
+`retrieve-a-subscription-by-id` endpoint) and inspects `getSubscriptionEvents()`.
+
+Before the fix the `BCD_CHANGE` transition was dropped and the test would see
+only 3 events. After the fix the BCD update appears as a `CHANGE`-typed
+`SubscriptionEvent` with the same id and effective date as the underlying
+`BCD_UPDATE` transition, mirroring how the field is rendered in the REST
+response by `SubscriptionJson.EventSubscriptionJson`.
+
+## Build status
+
+`mvn -pl entitlement -am -DskipTests compile`:
+
+```
+[INFO] killbill ........................................... SUCCESS [  0.204 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.734 s]
+[INFO] killbill-util ...................................... SUCCESS [  1.531 s]
+[INFO] killbill-tenant .................................... SUCCESS [  0.676 s]
+[INFO] killbill-account ................................... SUCCESS [  0.691 s]
+[INFO] killbill-catalog ................................... SUCCESS [  0.920 s]
+[INFO] killbill-subscription .............................. SUCCESS [  0.930 s]
+[INFO] killbill-entitlement ............................... SUCCESS [  0.903 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+Test classes also compile cleanly (`mvn -pl entitlement -am -DskipTests test-compile`
+→ BUILD SUCCESS). The test itself cannot be executed in this environment because
+Mockito's inline mock maker is incompatible with the JDK 25 runtime present on
+the machine ("Mockito cannot mock this class: class org.killbill.clock.ClockMock"),
+which is an environment limitation analogous to the embedded-MySQL ARM issue
+noted in the task description. The compile-clean bar required by the task is
+met.
+
+## Confidence level
+
+**Medium-high.**
+
+- The root cause is mechanically obvious: a missing `case` in a `switch`
+  whose other arms exhibit exactly the same shape; the BCD transition itself
+  is already constructed and surfaced by the subscription module, only the
+  entitlement-level translation drops it.
+- The mapping target (`SubscriptionEventType.CHANGE`) is the only option that
+  keeps the change limited to this repo without modifying the external
+  `killbill-api` enum. There is one residual semantic ambiguity: consumers
+  cannot now distinguish a plan-CHANGE event from a BCD-CHANGE event purely
+  from the `eventType` field. Most callers can still disambiguate by
+  observing that for a BCD update `prevPlan == nextPlan` (and likewise for
+  phase/priceList), since `DefaultSubscriptionBase.rebuildTransitionsInternal`
+  carries the existing plan/phase through unchanged.
+- The `DefaultSubscriptionEvent.overlaps`-based deduplication in
+  `SubscriptionEventOrdering.removeOverlappingSubscriptionEvents` was
+  inspected: a BCD event mapped to `CHANGE` will not overlap a preceding
+  plan-`CHANGE` event because their `prevPlan` values differ, and it will
+  not overlap a preceding `PHASE` event because the `eventType` field
+  differs. No regression in deduplication is expected.
+- Confidence is not "high" only because the test cannot be executed in this
+  environment (JDK 25 / Mockito incompatibility) and because a full
+  integration run against the JAXRS layer would be the strongest validation.

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java
@@ -89,6 +89,12 @@ public class SubscriptionEventOrdering extends EntitlementOrderingBase {
             case TRANSFER:
                 return List.of(SubscriptionEventType.START_BILLING);
             case CHANGE:
+            // BCD_CHANGE events represent an update of the billCycleDay on the subscription. The
+            // public SubscriptionEventType enum (in killbill-api) does not expose a dedicated
+            // value for BCD updates, so we surface them as CHANGE events here. Without this
+            // mapping the BCD_CHANGE transition is silently dropped and never appears in the
+            // events list returned by the subscription API (see issue #2224).
+            case BCD_CHANGE:
                 return List.of(SubscriptionEventType.CHANGE);
             case CANCEL:
             case EXPIRED:

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultSubscriptionBundleTimeline.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultSubscriptionBundleTimeline.java
@@ -146,6 +146,65 @@ public class TestDefaultSubscriptionBundleTimeline extends EntitlementTestSuiteN
         assertNull(events.get(3).getNextPhase());
     }
 
+    // Regression test for https://github.com/killbill/killbill/issues/2224 - BCD_UPDATE events
+    // were silently dropped by SubscriptionEventOrdering and never appeared in the events list
+    // returned from the subscription API. They must now surface as CHANGE events.
+    @Test(groups = "fast")
+    public void testBCDUpdateEventIsIncludedInTimeline() throws CatalogApiException {
+        clock.setDay(new LocalDate(2013, 1, 1));
+
+        final DateTimeZone accountTimeZone = DateTimeZone.UTC;
+        final UUID accountId = UUID.randomUUID();
+        final String externalKey = "foo";
+
+        final List<BlockingState> blockingStates = new ArrayList<BlockingState>();
+
+        final UUID entitlementId = UUID.randomUUID();
+
+        final List<SubscriptionBaseTransition> allTransitions = new ArrayList<SubscriptionBaseTransition>();
+
+        DateTime effectiveDate = new DateTime(2013, 1, 1, 15, 43, 25, 0, DateTimeZone.UTC);
+        final SubscriptionBaseTransition tr1 = createTransition(entitlementId, EventType.API_USER, ApiEventType.CREATE, effectiveDate, clock.getUTCNow(), null, "trial");
+        allTransitions.add(tr1);
+
+        final BlockingState bsCreate = new DefaultBlockingState(UUID.randomUUID(), entitlementId, BlockingStateType.SUBSCRIPTION,
+                                                                DefaultEntitlementApi.ENT_STATE_START, KILLBILL_SERVICES.ENTITLEMENT_SERVICE.getServiceName(),
+                                                                false, false, false, effectiveDate, clock.getUTCNow(), clock.getUTCNow(), 0L);
+        blockingStates.add(bsCreate);
+
+        // PHASE transition
+        effectiveDate = effectiveDate.plusDays(30);
+        clock.addDays(30);
+        final SubscriptionBaseTransition tr2 = createTransition(entitlementId, EventType.PHASE, null, effectiveDate, clock.getUTCNow(), "trial", "phase");
+        allTransitions.add(tr2);
+
+        // BCD_UPDATE transition - no plan/phase change, just a BCD update
+        effectiveDate = effectiveDate.plusDays(10);
+        clock.addDays(10);
+        final SubscriptionBaseTransition tr3 = createTransition(entitlementId, EventType.BCD_UPDATE, null, effectiveDate, clock.getUTCNow(), "phase", "phase");
+        allTransitions.add(tr3);
+
+        final List<Entitlement> entitlements = new ArrayList<Entitlement>();
+        final Entitlement entitlement = createEntitlement(entitlementId, allTransitions, blockingStates);
+        entitlements.add(entitlement);
+
+        final SubscriptionBundleTimeline timeline = new DefaultSubscriptionBundleTimeline(accountId, bundleId, externalKey, entitlements, internalCallContext);
+
+        final List<SubscriptionEvent> events = timeline.getSubscriptionEvents();
+        // Expect: START_ENTITLEMENT, START_BILLING, PHASE, CHANGE (the BCD update)
+        assertEquals(events.size(), 4);
+
+        assertEquals(events.get(0).getSubscriptionEventType(), SubscriptionEventType.START_ENTITLEMENT);
+        assertEquals(events.get(1).getSubscriptionEventType(), SubscriptionEventType.START_BILLING);
+        assertEquals(events.get(2).getSubscriptionEventType(), SubscriptionEventType.PHASE);
+        assertEquals(events.get(3).getSubscriptionEventType(), SubscriptionEventType.CHANGE);
+
+        // The BCD_UPDATE event should carry the id of the BCD transition
+        assertEquals(events.get(3).getId(), tr3.getId());
+        assertEquals(internalCallContext.toLocalDate(events.get(3).getEffectiveDate())
+                                        .compareTo(new LocalDate(tr3.getEffectiveTransitionTime(), accountTimeZone)), 0);
+    }
+
     @Test(groups="fast")
     public void testOneSimpleEntitlementCancelImmediately() throws CatalogApiException {
         testOneSimpleEntitlementCancelImmediatelyImpl(false);


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2224, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

Closes #2224 (proposes a fix; needs maintainer review)

## Arm a (no graph)

SubscriptionEventOrdering.toEventTypes did not handle BCD_CHANGE
(produced from SubscriptionBase EventType.BCD_UPDATE); the case fell
through to the default branch and returned an empty list, so the
transition was silently dropped before reaching the timeline used by
the JAXRS subscription endpoint. The BCD update therefore never
appeared in the events field of /1.0/kb/subscriptions/{id}.

This change maps BCD_CHANGE to the closest available value of the
public SubscriptionEventType enum, CHANGE, so the BCD event surfaces
in the subscription timeline. A regression test in the entitlement
module mocks an entitlement with a BCD_UPDATE transition and asserts
the resulting SubscriptionEvent list contains a CHANGE event with
the BCD transition's id and effective date.

## Diff stat

```
 FIX_REPORT.md                                      | 104 +++++++++++++++++++++
 .../entitlement/api/SubscriptionEventOrdering.java |   6 ++
 .../api/TestDefaultSubscriptionBundleTimeline.java |  59 ++++++++++++
 3 files changed, 169 insertions(+)
```

## Compile status

[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
--
