### PR TITLE
[Experiment / arm b (ARK graph)] Fix #2224: surface BCD_UPDATE events in subscription timeline (issue #2224)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,127 @@
+# Fix Report — Issue #2224
+
+**BCD_UPDATE event does not seem to be returned from subscription events**
+
+## Root cause / design summary
+
+When the timeline of a subscription is built for the API response, every
+`SubscriptionBaseTransition` is converted into a user-facing `SubscriptionEvent`
+by `SubscriptionEventOrdering.computeSubscriptionBaseEvents()`
+(`entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java`).
+The mapping happens in the private switch
+`SubscriptionEventOrdering.toEventTypes(SubscriptionBaseTransitionType)`.
+That switch never handled `SubscriptionBaseTransitionType.BCD_CHANGE`
+(the internal type written to `subscription_events` as `BCD_UPDATE` rows),
+so BCD updates fell through to `default → Collections.emptyList()` and were
+silently dropped from `Subscription.getSubscriptionEvents()` — and therefore
+from the JSON returned by `GET /subscriptions/{id}`. BCD updates were already
+emitted on the external bus (`ExtBusEventType.SUBSCRIPTION_BCD_CHANGE`) but
+never reached the REST events array. This is a bug, not an intentional
+omission: there is no business reason to hide BCD changes from clients that
+read the subscription timeline.
+
+The public `SubscriptionEventType` enum in `killbill-api` 0.54.0 (locked by
+`killbill-oss-parent`) does not have a dedicated BCD value, so the fix maps
+`BCD_CHANGE` to `SERVICE_STATE_CHANGE` — the closest existing value — and
+tags the produced event with `serviceStateName = "BCD_CHANGE"` and
+`serviceName = "billing-service"` so consumers can identify it unambiguously.
+
+## Change summary
+
+| File | Change |
+| ---- | ------ |
+| `entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java` | Added `case BCD_CHANGE → SERVICE_STATE_CHANGE` to `toEventTypes`. Extended `toSubscriptionEvent` to set `serviceName = BILLING_SERVICE_NAME` and `serviceStateName = "BCD_CHANGE"` when the transition originates from a `BCD_CHANGE`, so the event is distinguishable from other `SERVICE_STATE_CHANGE` events. |
+| `jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionJson.java` | Patched `EventSubscriptionJson.getAuditLogsForSubscriptionEvent` to route audit-log lookups for `serviceStateName = "BCD_CHANGE"` events to `getAuditLogsForSubscriptionEvent` (rows live in `subscription_events`) instead of the default `BLOCKING_STATES` path that the enum's `objectType` would otherwise dictate. Added the corresponding import of `SubscriptionBaseTransitionType`. |
+| `entitlement/src/test/java/org/killbill/billing/entitlement/api/TestSubscriptionEventOrderingBCD.java` | New regression test class with two tests (see below). |
+
+No build files, schema, migrations, or unrelated code were touched.
+
+## How the test exercises the fix / new behaviour
+
+`TestSubscriptionEventOrderingBCD` (entitlement module, `fast` group, no DB):
+
+1. **`testBcdChangeTransitionSurfacedAsSubscriptionEvent`** — mocks a
+   `SubscriptionBaseTransition` whose `getTransitionType()` returns
+   `BCD_CHANGE`, invokes the package-visible
+   `SubscriptionEventOrdering.toSubscriptionEvent(...)`, and asserts that the
+   produced `SubscriptionEvent`:
+   - has `SubscriptionEventType == SERVICE_STATE_CHANGE`,
+   - has `serviceStateName == "BCD_CHANGE"`,
+   - has `serviceName == EntitlementOrderingBase.BILLING_SERVICE_NAME`,
+   - preserves the original `id`, `entitlementId`, and `effectiveDate`.
+
+   Before the fix `toEventTypes(BCD_CHANGE)` returned an empty list, so the
+   transition never reached `toSubscriptionEvent` at all and the event was
+   missing from the timeline.
+
+2. **`testNonBcdTransitionUsesDefaultServiceStateName`** — pins the existing
+   behaviour for non-BCD transitions (here `CHANGE`): `serviceStateName`
+   must remain `eventType.toString()` so the BCD special-case does not leak
+   into other event types.
+
+Both tests pass:
+
+```
+[INFO] Running org.killbill.billing.entitlement.api.TestSubscriptionEventOrderingBCD
+[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.428 s
+[INFO] BUILD SUCCESS
+```
+
+## Build status
+
+`mvn -pl entitlement,jaxrs -am -DskipTests compile` (clean build):
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.153 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.631 s]
+[INFO] killbill-util ...................................... SUCCESS [  1.377 s]
+[INFO] killbill-tenant .................................... SUCCESS [  0.657 s]
+[INFO] killbill-account ................................... SUCCESS [  0.721 s]
+[INFO] killbill-catalog ................................... SUCCESS [  0.940 s]
+[INFO] killbill-subscription .............................. SUCCESS [  0.926 s]
+[INFO] killbill-entitlement ............................... SUCCESS [  0.879 s]
+[INFO] killbill-overdue ................................... SUCCESS [  0.673 s]
+[INFO] killbill-jaxrs ..................................... SUCCESS [  1.354 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  8.458 s
+```
+
+`mvn -pl entitlement -am test-compile` (verifies the regression test
+compiles):
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+...
+[INFO] killbill-entitlement ............................... SUCCESS [  1.006 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  6.103 s
+```
+
+## Confidence level
+
+**Medium–high.**
+
+- The root cause is mechanical and pinpoint: a missing `case` in a small
+  `switch`. The fix is symmetrical with the surrounding cases and behind
+  no feature flag.
+- The chosen `SubscriptionEventType.SERVICE_STATE_CHANGE` mapping is the
+  only API-compatible choice given the locked `killbill-api` 0.54.0 enum
+  (no `BCD_CHANGE` value). A future API bump should add a dedicated
+  `BCD_CHANGE` value and the mapping can move to that.
+- The audit-log routing patch in `EventSubscriptionJson` is required
+  because `SERVICE_STATE_CHANGE.getObjectType() == BLOCKING_STATES`, but
+  BCD rows live in `subscription_events`. Without the patch BCD events
+  would appear but their audit logs would silently be empty.
+- The new unit tests cover both the positive case (BCD surfaced and tagged
+  correctly) and a guardrail against accidentally regressing the existing
+  behaviour for non-BCD transitions.
+- Confidence is not "high" because I could not run the broader integration
+  suite (`TestWithBCDUpdate.java`) — those tests require an embedded MySQL
+  ARM64 binary that is unavailable in this environment, as noted in the
+  task constraints. The compilation and the targeted unit test are clean.

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java
@@ -95,6 +95,11 @@ public class SubscriptionEventOrdering extends EntitlementOrderingBase {
                 return List.of(SubscriptionEventType.STOP_BILLING);
             case PHASE:
                 return List.of(SubscriptionEventType.PHASE);
+            // BCD updates are stored as subscription events but no dedicated SubscriptionEventType
+            // exists in the public API enum; surface them as SERVICE_STATE_CHANGE so they appear in
+            // the timeline. They can be distinguished by their serviceStateName ("BCD_CHANGE").
+            case BCD_CHANGE:
+                return List.of(SubscriptionEventType.SERVICE_STATE_CHANGE);
             /*
              * Those can be ignored:
              */
@@ -143,14 +148,19 @@ public class SubscriptionEventOrdering extends EntitlementOrderingBase {
 
     @VisibleForTesting
     static SubscriptionEvent toSubscriptionEvent(final SubscriptionBaseTransition in, final SubscriptionEventType eventType, final InternalTenantContext internalTenantContext) {
+        final boolean isBcdChange = in.getTransitionType() == SubscriptionBaseTransitionType.BCD_CHANGE;
+        // For BCD updates we want consumers to see this is a billing-side change tagged "BCD_CHANGE",
+        // rather than the generic SERVICE_STATE_CHANGE that the public enum forces us to use.
+        final String serviceName = isBcdChange ? BILLING_SERVICE_NAME : getServiceName(eventType);
+        final String serviceStateName = isBcdChange ? SubscriptionBaseTransitionType.BCD_CHANGE.toString() : eventType.toString();
         return new DefaultSubscriptionEvent(in.getId(),
                                             in.getSubscriptionId(),
                                             in.getEffectiveTransitionTime(),
                                             eventType,
                                             false,
                                             false,
-                                            getServiceName(eventType),
-                                            eventType.toString(),
+                                            serviceName,
+                                            serviceStateName,
                                             (in.getPreviousPlan() != null ? in.getPreviousPlan().getProduct() : null),
                                             in.getPreviousPlan(),
                                             in.getPreviousPhase(),

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestSubscriptionEventOrderingBCD.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestSubscriptionEventOrderingBCD.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api;
+
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
+import org.killbill.billing.subscription.api.user.SubscriptionBaseTransition;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Regression test for issue #2224: BCD_UPDATE events were silently dropped by
+ * {@link SubscriptionEventOrdering} because the {@code BCD_CHANGE} branch was
+ * missing from the internal {@code toEventTypes} switch. As a result, BCD
+ * updates never appeared in the subscription events returned by the API.
+ *
+ * <p>The fix surfaces the event as
+ * {@link SubscriptionEventType#SERVICE_STATE_CHANGE} (the closest existing
+ * value in the public API enum) and tags it with a {@code serviceStateName}
+ * of {@code "BCD_CHANGE"} so consumers can distinguish it.
+ */
+public class TestSubscriptionEventOrderingBCD {
+
+    @Test(groups = "fast")
+    public void testBcdChangeTransitionSurfacedAsSubscriptionEvent() {
+        final UUID eventId = UUID.randomUUID();
+        final UUID subscriptionId = UUID.randomUUID();
+        final DateTime effective = new DateTime(2026, 5, 15, 0, 0, DateTimeZone.UTC);
+        final DateTime created = effective.minusDays(1);
+
+        final SubscriptionBaseTransition tr = Mockito.mock(SubscriptionBaseTransition.class);
+        Mockito.when(tr.getId()).thenReturn(eventId);
+        Mockito.when(tr.getSubscriptionId()).thenReturn(subscriptionId);
+        Mockito.when(tr.getEffectiveTransitionTime()).thenReturn(effective);
+        Mockito.when(tr.getCreatedDate()).thenReturn(created);
+        Mockito.when(tr.getTransitionType()).thenReturn(SubscriptionBaseTransitionType.BCD_CHANGE);
+        // BCD updates do not carry plan/phase/pricelist info — leave them null
+        Mockito.when(tr.getPreviousPlan()).thenReturn(null);
+        Mockito.when(tr.getPreviousPhase()).thenReturn(null);
+        Mockito.when(tr.getPreviousPriceList()).thenReturn(null);
+        Mockito.when(tr.getNextPlan()).thenReturn(null);
+        Mockito.when(tr.getNextPhase()).thenReturn(null);
+        Mockito.when(tr.getNextPriceList()).thenReturn(null);
+
+        final SubscriptionEvent event = SubscriptionEventOrdering.toSubscriptionEvent(
+                tr, SubscriptionEventType.SERVICE_STATE_CHANGE, (InternalTenantContext) null);
+
+        assertNotNull(event, "BCD_CHANGE transition must produce a non-null SubscriptionEvent");
+        assertEquals(event.getId(), eventId);
+        assertEquals(event.getEntitlementId(), subscriptionId);
+        assertEquals(event.getEffectiveDate(), effective);
+        assertEquals(event.getSubscriptionEventType(), SubscriptionEventType.SERVICE_STATE_CHANGE,
+                "BCD updates surface as SERVICE_STATE_CHANGE (closest existing API enum value)");
+        assertEquals(event.getServiceStateName(), SubscriptionBaseTransitionType.BCD_CHANGE.toString(),
+                "serviceStateName must be 'BCD_CHANGE' so consumers can distinguish BCD updates "
+                        + "from other SERVICE_STATE_CHANGE events");
+        assertEquals(event.getServiceName(), EntitlementOrderingBase.BILLING_SERVICE_NAME,
+                "BCD updates are a billing-side concept, so serviceName must reflect that");
+    }
+
+    @Test(groups = "fast")
+    public void testNonBcdTransitionUsesDefaultServiceStateName() {
+        // Sanity check: regular CHANGE events must not be affected by the BCD branch.
+        final UUID eventId = UUID.randomUUID();
+        final UUID subscriptionId = UUID.randomUUID();
+        final DateTime effective = new DateTime(2026, 5, 15, 0, 0, DateTimeZone.UTC);
+
+        final SubscriptionBaseTransition tr = Mockito.mock(SubscriptionBaseTransition.class);
+        Mockito.when(tr.getId()).thenReturn(eventId);
+        Mockito.when(tr.getSubscriptionId()).thenReturn(subscriptionId);
+        Mockito.when(tr.getEffectiveTransitionTime()).thenReturn(effective);
+        Mockito.when(tr.getCreatedDate()).thenReturn(effective);
+        Mockito.when(tr.getTransitionType()).thenReturn(SubscriptionBaseTransitionType.CHANGE);
+        Mockito.when(tr.getPreviousPlan()).thenReturn(null);
+        Mockito.when(tr.getPreviousPhase()).thenReturn(null);
+        Mockito.when(tr.getPreviousPriceList()).thenReturn(null);
+        Mockito.when(tr.getNextPlan()).thenReturn(null);
+        Mockito.when(tr.getNextPhase()).thenReturn(null);
+        Mockito.when(tr.getNextPriceList()).thenReturn(null);
+
+        final SubscriptionEvent event = SubscriptionEventOrdering.toSubscriptionEvent(
+                tr, SubscriptionEventType.CHANGE, (InternalTenantContext) null);
+
+        assertEquals(event.getSubscriptionEventType(), SubscriptionEventType.CHANGE);
+        assertEquals(event.getServiceStateName(), SubscriptionEventType.CHANGE.toString(),
+                "Non-BCD events keep the historical serviceStateName == eventType.toString() behavior");
+    }
+}

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionJson.java
@@ -43,6 +43,7 @@ import org.killbill.billing.entitlement.api.Entitlement.EntitlementState;
 import org.killbill.billing.entitlement.api.Subscription;
 import org.killbill.billing.entitlement.api.SubscriptionEvent;
 import org.killbill.billing.entitlement.api.SubscriptionEventType;
+import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.util.audit.AccountAuditLogs;
 import org.killbill.billing.util.audit.AuditLog;
 import org.killbill.billing.util.catalog.CatalogDateHelper;
@@ -158,6 +159,11 @@ public class SubscriptionJson extends JsonBase {
         private static List<AuditLog> getAuditLogsForSubscriptionEvent(final SubscriptionEvent subscriptionEvent, @Nullable final AccountAuditLogs accountAuditLogs) {
             if (accountAuditLogs == null) {
                 return null;
+            }
+            // BCD updates are surfaced as SERVICE_STATE_CHANGE for API compatibility, but the
+            // underlying record lives in subscription_events, so route the audit-log lookup there.
+            if (SubscriptionBaseTransitionType.BCD_CHANGE.toString().equals(subscriptionEvent.getServiceStateName())) {
+                return accountAuditLogs.getAuditLogsForSubscriptionEvent(subscriptionEvent.getId());
             }
             final ObjectType subscriptionEventObjectType = subscriptionEvent.getSubscriptionEventType().getObjectType();
             if (subscriptionEventObjectType == ObjectType.SUBSCRIPTION_EVENT) {


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2224, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

Closes #2224 (proposes a fix; needs maintainer review)

## Arm b (ARK graph)

SubscriptionEventOrdering.toEventTypes() had no case for
SubscriptionBaseTransitionType.BCD_CHANGE, so BCD updates fell through
to the default empty-list branch and were silently dropped from the
events returned by Subscription.getSubscriptionEvents() and the REST
GET /subscriptions/{id} response. They were already published on the
external bus as SUBSCRIPTION_BCD_CHANGE but never appeared in the
timeline that clients see.

The public SubscriptionEventType enum in killbill-api 0.54.0 has no
dedicated BCD value, so map BCD_CHANGE to SERVICE_STATE_CHANGE (the
closest existing value) and tag the produced event with
serviceStateName="BCD_CHANGE" plus serviceName=billing-service so
consumers can distinguish BCD updates from other service-state changes.

Also patch EventSubscriptionJson.getAuditLogsForSubscriptionEvent to
route audit-log lookups for these events through
getAuditLogsForSubscriptionEvent (the BCD row lives in
subscription_events) instead of the BLOCKING_STATES path implied by
SERVICE_STATE_CHANGE.getObjectType().

Adds TestSubscriptionEventOrderingBCD covering both the BCD case and
a regression guard for non-BCD transitions.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Diff stat

```
 FIX_REPORT.md                                      | 127 +++++++++++++++++++++
 .../entitlement/api/SubscriptionEventOrdering.java |  14 ++-
 .../api/TestSubscriptionEventOrderingBCD.java      | 109 ++++++++++++++++++
 .../billing/jaxrs/json/SubscriptionJson.java       |   6 +
 4 files changed, 254 insertions(+), 2 deletions(-)
```

## Compile status

[INFO] BUILD SUCCESS
```
--
