### PR TITLE
[Experiment / arm a (no graph)] Fix #1922: do not merge child amounts into a stale parent DRAFT invoice (issue #1922)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,99 @@
+# Fix Report — Kill Bill issue #1922
+
+Parent summary invoices missing or merged across billing cycles.
+
+## Root cause
+
+`InvoiceDispatcher.processParentInvoiceForInvoiceGenerationWithLock(...)`
+([`invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java:1351`](invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java)) reuses
+*any* existing parent DRAFT invoice returned by `InvoiceDao.getParentDraftInvoice(...)` and folds the
+new child invoice's amount into the prior cycle's `PARENT_SUMMARY` item via `updateInvoiceItemAmount`.
+The lookup query
+([`invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceSqlDao.sql.stg:73`](invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceSqlDao.sql.stg))
+ignored the billing date entirely and ordered by `record_id ASC`, returning the oldest DRAFT first.
+
+In the steady state, the per-day parent auto-commit notification scheduled in
+`DefaultInvoiceDao.notifyOfParentInvoiceCreation` ensures the prior DRAFT is committed before the
+next cycle starts, so this code path is never exercised cross-cycle. But when that auto-commit is
+delayed, retried unsuccessfully, or disabled (as in #1922's reporter, who drove invoicing through
+the public `POST /invoices` API for many children), the August DRAFT is still around when the
+September child invoices land. Each September child invoice then sees the August DRAFT, finds an
+existing `PARENT_SUMMARY` for itself, and `updateInvoiceItemAmount` collapses both periods'
+amounts onto the same item. The early `return` after the merge means no new DRAFT is ever opened
+for September — matching the reporter's "parent invoices are not generated **or miss children
+entries in the summary**".
+
+## Fix summary
+
+- **`invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java`** — In
+  `processParentInvoiceForInvoiceGenerationWithLock`, compute the child invoice's local
+  date (`invoiceDate`) up-front. If the existing parent DRAFT's `invoiceDate` differs from
+  the current `invoiceDate`, treat it as stale (`draftParentInvoice = null`) so the
+  cross-cycle merge path is never taken and a fresh DRAFT is opened for the new cycle. The
+  same-day multi-action path (e.g. plan change + recurring on the same day) is preserved
+  because the dates match.
+- **`invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceSqlDao.sql.stg`** —
+  `getParentDraftInvoice` now orders by `invoice_date DESC, record_id DESC`. With the
+  staleness check above, once a new DRAFT is opened for the current cycle, subsequent
+  child invoices in that cycle will reliably pick up the *current* DRAFT (rather than the
+  older stale one) and append their items. The only caller besides the dispatcher is
+  `TestInvoiceDao#testCreateParentInvoice`, which exercises a single DRAFT and is
+  insensitive to ordering.
+
+## How the regression test reproduces the bug
+
+`invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcher.java::testParentInvoiceNotMergedAcrossBillingCycles`
+sets the test clock to 2025-08-01, creates one parent and three child accounts
+(`isPaymentDelegatedToParent = true`), persists one `COMMITTED` child invoice per child for
+August totaling $60, and runs `dispatcher.processParentInvoiceForInvoiceGeneration` on each.
+It then advances the clock to 2025-09-01 **without committing the August parent DRAFT**
+(simulating the delayed/disabled auto-commit) and repeats the process with three September
+child invoices totaling $66.
+
+Expected: two parent DRAFT invoices, one per cycle, each with three `PARENT_SUMMARY`
+items and the correct per-cycle totals. The August DRAFT must still hold $60 unchanged.
+
+Before the fix, the September dispatch finds the August DRAFT, hits the merge branch for
+every child, and never opens a September DRAFT — so `getInvoicesByAccount(parent)` returns
+one invoice (not two) with $126 collapsed onto the August items. The first
+`assertEquals(parentInvoices.size(), 2, ...)` fires the assertion.
+
+## Build / test status
+
+```
+$ mvn -pl invoice -am -DskipTests compile
+...
+[INFO] killbill-invoice ................................... SUCCESS [  1.250 s]
+[INFO] BUILD SUCCESS
+```
+
+Both `compile` and `test-compile` pass cleanly for the invoice module after the changes.
+
+The slow test could **not** be exercised in this sandbox: the embedded-DB Killbill test
+harness fails to bootstrap on this machine because (a) Mockito's inline mock maker cannot
+instrument the test-only `ClockMock` class on Java 25 (`Java 25 (69) is not supported by the
+current version of Byte Buddy`) and (b) no MariaDB binary is published for `aarch64`
+(`archive not found: /mysql-Mac_OS_X-aarch64.tar.gz`). Every other `@Test(groups = "slow")`
+in `TestInvoiceDispatcher` fails the same way, so this is an environment issue rather than a
+regression introduced here. The new test follows the same construction pattern as
+`TestInvoiceDao#testCreateParentInvoice` and the `slow` tests already in
+`TestInvoiceDispatcher`, and only uses APIs that work in the standard CI configuration
+(Java 11 + an x86_64 MariaDB).
+
+## Confidence: medium
+
+High confidence on the root cause and the direction of the fix:
+
+- The merge-vs-create logic in the dispatcher is the only code path that ever attaches a
+  child amount to an *existing* parent invoice — the bug description (no new parent invoice,
+  or missing per-child entries on the summary) maps to exactly the two ways this can go
+  wrong when a stale DRAFT is reused across periods.
+- The same-day multi-action case covered by
+  `TestIntegrationParentInvoice#testParentInvoiceGenerationMultipleActionsSameDay` still
+  satisfies `parentDraft.invoiceDate == today`, so the existing assertion of "one merged
+  `PARENT_SUMMARY` per child" is preserved.
+
+Medium (not high) because I could not run the full `slow` invoice suite in this sandbox to
+verify there are no second-order assertion failures elsewhere (e.g. tests that incidentally
+relied on `record_id ASC` ordering through `getParentDraftInvoice`). A normal CI run on
+Java 11 + the standard MariaDB image should be a green or red signal.

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -1357,7 +1357,18 @@ public class InvoiceDispatcher {
         final InternalCallContext parentContext = internalCallContextFactory.createInternalCallContext(parentAccountRecordId, context);
 
         final BigDecimal childInvoiceAmount = InvoiceCalculatorUtils.computeChildInvoiceAmount(childInvoice.getCurrency(), childInvoice.getInvoiceItems());
+        final LocalDate invoiceDate = context.toLocalDate(context.getCreatedDate());
         InvoiceModelDao draftParentInvoice = invoiceDao.getParentDraftInvoice(childAccount.getParentAccountId(), parentContext);
+
+        // If the existing parent DRAFT belongs to a prior billing cycle (different invoice date), do not merge new
+        // child amounts into it — that silently combines amounts from different periods on the same PARENT_SUMMARY
+        // item, and prevents a new parent DRAFT from being created for the current cycle (see #1922). This happens
+        // when the parent DRAFT auto-commit was delayed or disabled before the next cycle's child invoices arrived.
+        if (draftParentInvoice != null && !invoiceDate.equals(draftParentInvoice.getInvoiceDate())) {
+            log.info("Existing parent DRAFT invoiceId='{}' has invoiceDate='{}' which differs from current invoiceDate='{}'; a new parent DRAFT will be created for the current cycle",
+                     draftParentInvoice.getId(), draftParentInvoice.getInvoiceDate(), invoiceDate);
+            draftParentInvoice = null;
+        }
 
         final String description = childAccount.getExternalKey().concat(" summary");
         if (draftParentInvoice != null) {
@@ -1385,7 +1396,6 @@ public class InvoiceDispatcher {
                 return;
             }
 
-            final LocalDate invoiceDate = context.toLocalDate(context.getCreatedDate());
             draftParentInvoice = new InvoiceModelDao(childAccount.getParentAccountId(), invoiceDate, childAccount.getCurrency(), InvoiceStatus.DRAFT, true);
             final InvoiceItem parentInvoiceItem = new ParentInvoiceItem(UUID.randomUUID(), context.getCreatedDate(), draftParentInvoice.getId(), childAccount.getParentAccountId(), childAccount.getId(), childInvoiceAmount, childAccount.getCurrency(), description);
             draftParentInvoice.addInvoiceItem(new InvoiceItemModelDao(parentInvoiceItem));

--- a/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceSqlDao.sql.stg
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/dao/InvoiceSqlDao.sql.stg
@@ -76,7 +76,7 @@ getParentDraftInvoice() ::= <<
    WHERE account_id = :accountId
      AND status = 'DRAFT'
    <AND_CHECK_TENANT("")>
-   <defaultOrderBy("")>
+   order by invoice_date desc, <recordIdField("")> desc
 >>
 
 getInvoiceByAccountRecordIdAfter() ::= <<

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcher.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcher.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.account.api.Account;
@@ -47,9 +48,13 @@ import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.invoice.api.InvoiceStatus;
 import org.killbill.billing.invoice.dao.InvoiceItemModelDao;
 import org.killbill.billing.invoice.dao.InvoiceModelDao;
+import org.killbill.billing.invoice.model.DefaultInvoice;
+import org.killbill.billing.invoice.model.RecurringInvoiceItem;
 import org.killbill.billing.junction.BillingEventSet;
+import org.killbill.billing.mock.MockAccountBuilder;
 import org.killbill.billing.subscription.api.SubscriptionBase;
 import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
@@ -349,5 +354,125 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
         Assert.assertEquals(invoices.size(), 1);
         return invoices.get(0);
     }
-    
+
+    // Regression test for https://github.com/killbill/killbill/issues/1922
+    //
+    // When the parent DRAFT invoice generated for a prior billing cycle has not yet been committed (e.g. the
+    // auto-commit notification was delayed or disabled) and a new cycle's child invoices arrive, the previous
+    // behaviour blindly merged the new amounts into the prior cycle's PARENT_SUMMARY items. The result was that
+    // no parent invoice was generated for the new cycle and amounts from different periods collapsed onto the
+    // same items. After the fix, a stale parent DRAFT is left alone and a new parent DRAFT is created for the
+    // current cycle.
+    @Test(groups = "slow")
+    public void testParentInvoiceNotMergedAcrossBillingCycles() throws Exception {
+        final DateTime cycle1Clock = new DateTime(2025, 8, 1, 10, 0, 0, 0, DateTimeZone.UTC);
+        clock.setTime(cycle1Clock);
+
+        final Account parentAccount = createParentOrChildAccount(null, false);
+        final Account child1 = createParentOrChildAccount(parentAccount.getId(), true);
+        final Account child2 = createParentOrChildAccount(parentAccount.getId(), true);
+        final Account child3 = createParentOrChildAccount(parentAccount.getId(), true);
+
+        // Cycle 1 (August): each child commits an invoice and we run the parent-summary dispatch on it.
+        final UUID child1Inv1 = persistCommittedChildInvoice(child1, new BigDecimal("10.00"), new LocalDate(2025, 8, 1));
+        final UUID child2Inv1 = persistCommittedChildInvoice(child2, new BigDecimal("20.00"), new LocalDate(2025, 8, 1));
+        final UUID child3Inv1 = persistCommittedChildInvoice(child3, new BigDecimal("30.00"), new LocalDate(2025, 8, 1));
+
+        dispatcher.processParentInvoiceForInvoiceGeneration(child1, child1Inv1, contextFor(child1));
+        dispatcher.processParentInvoiceForInvoiceGeneration(child2, child2Inv1, contextFor(child2));
+        dispatcher.processParentInvoiceForInvoiceGeneration(child3, child3Inv1, contextFor(child3));
+
+        final InternalCallContext parentContext = contextFor(parentAccount);
+        List<InvoiceModelDao> parentInvoices = invoiceDao.getInvoicesByAccount(false, true, parentContext);
+        Assert.assertEquals(parentInvoices.size(), 1, "Cycle 1 should produce exactly one parent DRAFT invoice");
+        Assert.assertEquals(parentInvoices.get(0).getStatus(), InvoiceStatus.DRAFT);
+        Assert.assertEquals(parentInvoices.get(0).getInvoiceItems().size(), 3, "Cycle 1 parent DRAFT should hold one PARENT_SUMMARY per child");
+        Assert.assertEquals(totalAmount(parentInvoices.get(0)).compareTo(new BigDecimal("60.00")), 0);
+
+        // Simulate the August parent DRAFT auto-commit being delayed/disabled (no commit happens) before September.
+        final DateTime cycle2Clock = new DateTime(2025, 9, 1, 10, 0, 0, 0, DateTimeZone.UTC);
+        clock.setTime(cycle2Clock);
+
+        // Cycle 2 (September): same children commit a new invoice each.
+        final UUID child1Inv2 = persistCommittedChildInvoice(child1, new BigDecimal("11.00"), new LocalDate(2025, 9, 1));
+        final UUID child2Inv2 = persistCommittedChildInvoice(child2, new BigDecimal("22.00"), new LocalDate(2025, 9, 1));
+        final UUID child3Inv2 = persistCommittedChildInvoice(child3, new BigDecimal("33.00"), new LocalDate(2025, 9, 1));
+
+        dispatcher.processParentInvoiceForInvoiceGeneration(child1, child1Inv2, contextFor(child1));
+        dispatcher.processParentInvoiceForInvoiceGeneration(child2, child2Inv2, contextFor(child2));
+        dispatcher.processParentInvoiceForInvoiceGeneration(child3, child3Inv2, contextFor(child3));
+
+        parentInvoices = invoiceDao.getInvoicesByAccount(false, true, contextFor(parentAccount));
+        Assert.assertEquals(parentInvoices.size(), 2,
+                            "Cycle 2 must produce a separate parent DRAFT for the new billing period (not merge into the prior cycle's DRAFT)");
+
+        final InvoiceModelDao augustParent = parentInvoices.stream()
+                                                           .filter(i -> new LocalDate(2025, 8, 1).equals(i.getInvoiceDate()))
+                                                           .findFirst()
+                                                           .orElseThrow(() -> new AssertionError("Cycle 1 parent DRAFT missing"));
+        Assert.assertEquals(augustParent.getInvoiceItems().size(), 3, "Cycle 1 parent items must not have been removed or duplicated");
+        Assert.assertEquals(totalAmount(augustParent).compareTo(new BigDecimal("60.00")), 0,
+                            "Cycle 1 amounts must not be polluted by Cycle 2");
+
+        final InvoiceModelDao septemberParent = parentInvoices.stream()
+                                                              .filter(i -> new LocalDate(2025, 9, 1).equals(i.getInvoiceDate()))
+                                                              .findFirst()
+                                                              .orElseThrow(() -> new AssertionError("Cycle 2 parent DRAFT was not generated"));
+        Assert.assertEquals(septemberParent.getStatus(), InvoiceStatus.DRAFT);
+        Assert.assertEquals(septemberParent.getInvoiceItems().size(), 3,
+                            "Cycle 2 parent DRAFT must contain one PARENT_SUMMARY per child");
+        Assert.assertEquals(totalAmount(septemberParent).compareTo(new BigDecimal("66.00")), 0);
+
+        for (final InvoiceItemModelDao item : septemberParent.getInvoiceItems()) {
+            Assert.assertEquals(item.getType(), InvoiceItemType.PARENT_SUMMARY);
+            Assert.assertNotNull(item.getChildAccountId());
+        }
+    }
+
+    private Account createParentOrChildAccount(@Nullable final UUID parentAccountId, final boolean isPaymentDelegatedToParent) throws AccountApiException {
+        final MockAccountBuilder builder = new MockAccountBuilder()
+                .name(UUID.randomUUID().toString().substring(0, 8))
+                .firstNameLength(6)
+                .email(UUID.randomUUID().toString().substring(0, 8))
+                .phone(UUID.randomUUID().toString().substring(0, 8))
+                .migrated(false)
+                .externalKey(UUID.randomUUID().toString().substring(0, 8))
+                .billingCycleDayLocal(1)
+                .currency(Currency.USD)
+                .paymentMethodId(UUID.randomUUID())
+                .timeZone(DateTimeZone.UTC)
+                .createdDate(clock.getUTCNow());
+        if (parentAccountId != null) {
+            builder.parentAccountId(parentAccountId);
+            builder.isPaymentDelegatedToParent(isPaymentDelegatedToParent);
+        }
+        return accountUserApi.createAccount(builder.build(), callContext);
+    }
+
+    private InternalCallContext contextFor(final Account account) {
+        return internalCallContextFactory.createInternalCallContext(account.getId(), callContext);
+    }
+
+    private UUID persistCommittedChildInvoice(final Account childAccount, final BigDecimal amount, final LocalDate targetDate) throws Exception {
+        final InternalCallContext childContext = contextFor(childAccount);
+        final DefaultInvoice childInvoice = new DefaultInvoice(UUID.randomUUID(), childAccount.getId(), null,
+                                                               targetDate, targetDate, Currency.USD, false, InvoiceStatus.COMMITTED);
+        final RecurringInvoiceItem item = new RecurringInvoiceItem(childInvoice.getId(), childAccount.getId(),
+                                                                   UUID.randomUUID(), UUID.randomUUID(),
+                                                                   "test product", "test plan", "test phase", null,
+                                                                   targetDate, targetDate.plusMonths(1),
+                                                                   amount, amount, Currency.USD);
+        childInvoice.addInvoiceItem(item);
+        invoiceUtil.createInvoice(childInvoice, childContext);
+        return childInvoice.getId();
+    }
+
+    private static BigDecimal totalAmount(final InvoiceModelDao invoice) {
+        BigDecimal total = BigDecimal.ZERO;
+        for (final InvoiceItemModelDao item : invoice.getInvoiceItems()) {
+            total = total.add(item.getAmount());
+        }
+        return total;
+    }
+
 }


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #1922, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

Closes #1922 (proposes a fix; needs maintainer review)

## Arm a (no graph)

When a child account commits an invoice, InvoiceDispatcher looks up the
parent's existing DRAFT and either bumps the matching PARENT_SUMMARY's
amount or appends a new item. The lookup ignored the billing date and
returned the oldest DRAFT (record_id ASC), so if the prior cycle's
parent DRAFT had not yet been auto-committed (delayed, retrying, or
disabled), the next cycle's child invoices would silently collapse onto
the prior cycle's PARENT_SUMMARY items and no new parent invoice would
be opened — matching #1922's "parent invoices are not generated or miss
children entries in the summary".

Treat a parent DRAFT whose invoice_date differs from the current child
invoice's date as stale and open a new DRAFT for the new cycle. Same-day
multi-action behaviour (e.g. plan change + recurring on the same day) is
preserved because the dates match. getParentDraftInvoice now orders by
invoice_date DESC, record_id DESC so subsequent children in the new
cycle reliably pick up the freshly opened DRAFT.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Diff stat

```
 FIX_REPORT.md                                      |  99 ++++++++++++++++
 .../billing/invoice/InvoiceDispatcher.java         |  12 +-
 .../billing/invoice/dao/InvoiceSqlDao.sql.stg      |   2 +-
 .../billing/invoice/TestInvoiceDispatcher.java     | 127 ++++++++++++++++++++-
 4 files changed, 237 insertions(+), 3 deletions(-)
```

## Compile status

[INFO] BUILD SUCCESS
```
