### PR TITLE
[Experiment / arm a (no graph)] Fix #2176: log JVM container tuning diagnostics at node boot (issue #2176)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,102 @@
+# Issue #2176 — Upgrade to Java 17: container-aware JVM diagnostics
+
+## Root cause / design summary
+
+Issue #2176 asks Kill Bill to be ready for JDK 17+ in container deployments.
+The referenced article emphasises that the practical risks of the JDK 8 → 17
+move are runtime / native-memory behaviours rather than source-level changes:
+container CPU detection bugs, glibc malloc arena explosion, G1 native-memory
+overhead, and the loss of JDK 8 monitoring heuristics. Kill Bill had no boot
+output describing the JVM it was running on, so operators had no easy way to
+verify that critical container-tuning flags (`-XX:ActiveProcessorCount`,
+`MALLOC_ARENA_MAX`, `-XX:NativeMemoryTracking`, `-XX:+UseContainerSupport`,
+matched `-Xms`/`-Xmx`) were actually in effect. The boot path that already
+records node identity — `org.killbill.billing.util.nodes.DefaultKillbillNodesService#init` —
+is the natural place to surface this diagnostic.
+
+## Change summary
+
+- **`util/src/main/java/org/killbill/billing/util/nodes/JvmInfo.java`** (new) —
+  pure utility that captures a JVM snapshot via `RuntimeMXBean`,
+  `MemoryMXBean`, `GarbageCollectorMXBean`, system properties and the
+  environment. Exposes Java version/vendor/VM, `availableProcessors()`,
+  heap init/max, GC names, `-XX:ActiveProcessorCount`, `MALLOC_ARENA_MAX`,
+  whether NMT is enabled and whether `UseContainerSupport` is on. Computes
+  a list of WARN-level recommendations based on the article's checklist
+  (active processor count, malloc arenas, native memory tracking,
+  container support, `-Xms`/`-Xmx` equality). `captureAndLog(Logger)`
+  emits one INFO summary line followed by one WARN per missing
+  recommendation. A package-private `build(...)` overload accepts injected
+  inputs so the warning logic is unit-testable without manipulating real
+  JVM args or env vars.
+- **`util/src/main/java/org/killbill/billing/util/nodes/DefaultKillbillNodesService.java`** —
+  call `JvmInfo.captureAndLog(logger)` at the top of the
+  `@LifecycleHandlerType(BOOT) init()` method so diagnostics appear once
+  per node start, alongside the existing node-info bootstrap.
+- **`util/src/test/java/org/killbill/billing/util/nodes/TestJvmInfo.java`** (new) —
+  TestNG `fast` group; covers `capture()` against the real JVM and the
+  warning logic against synthetic inputs.
+
+No build files or other modules were touched.
+
+## How the test exercises the new behaviour
+
+`TestJvmInfo` has five `fast`-group tests:
+
+1. `testCaptureReturnsRuntimeFacts` — calls the production `capture()` and
+   asserts non-empty `javaVersion`/`javaVmName`, `availableProcessors >= 1`,
+   and at least one GC MXBean. This guards the wiring between `JvmInfo`
+   and the JDK management APIs.
+2. `testWarningsWhenContainerTuningIsMissing` — builds a snapshot with no
+   `-XX:ActiveProcessorCount`, no `MALLOC_ARENA_MAX`, no NMT and mismatched
+   `-Xms`/`-Xmx`, then asserts the four corresponding warnings are present.
+3. `testNoWarningsWhenAllRecommendationsSatisfied` — feeds in the full
+   set of recommended flags and asserts the warning list is empty.
+4. `testContainerSupportDisabledIsFlagged` — passes
+   `-XX:-UseContainerSupport` and asserts both `isUseContainerSupport()`
+   becomes `false` and the matching warning fires.
+5. `testNativeMemoryTrackingOffIsTreatedAsDisabled` — `-XX:NativeMemoryTracking=off`
+   is not counted as enabled, mirroring how the JVM itself treats the value.
+
+All five passed locally:
+
+```
+[INFO] Running org.killbill.billing.util.nodes.TestJvmInfo
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.114 s
+```
+
+## Build status
+
+```
+$ mvn -pl util -am -DskipTests compile
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.215 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.757 s]
+[INFO] killbill-util ...................................... SUCCESS [  1.560 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  2.687 s
+```
+
+Test compile + run:
+
+```
+$ mvn -pl util -am test -Dtest=TestJvmInfo -Dsurefire.failIfNoSpecifiedTests=false
+[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
+[INFO] BUILD SUCCESS
+```
+
+## Confidence level
+
+**Medium-high.** The change is additive, has no external dependencies
+beyond `java.lang.management` (present in JDK 11 and 17), is exercised
+directly by unit tests, and lives behind the existing
+`DefaultKillbillNodesService` boot hook so the integration cost is one
+INFO line plus zero-or-more WARN lines per node start. The remaining
+uncertainty is policy-shaped, not technical: a different reviewer might
+want these diagnostics exposed via the JMX/metrics surface or via the
+`NodeInfo` payload rather than only the log, but those would be
+follow-on enhancements layered on top of `JvmInfo` rather than
+replacements for it.

--- a/util/src/main/java/org/killbill/billing/util/nodes/DefaultKillbillNodesService.java
+++ b/util/src/main/java/org/killbill/billing/util/nodes/DefaultKillbillNodesService.java
@@ -81,6 +81,8 @@ public class DefaultKillbillNodesService implements KillbillNodesService {
 
     @LifecycleHandlerType(LifecycleLevel.BOOT)
     public void init() {
+        // Surface JVM/container tuning info at boot so operators can validate JDK 17+ deployments (issue #2176).
+        JvmInfo.captureAndLog(logger);
         try {
             final Optional<NodeInfoModelDao> nodeWithSameName =
                     nodeInfoDao.getAll()

--- a/util/src/main/java/org/killbill/billing/util/nodes/JvmInfo.java
+++ b/util/src/main/java/org/killbill/billing/util/nodes/JvmInfo.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.nodes;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.management.RuntimeMXBean;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+
+/**
+ * Captures JVM runtime diagnostics that are useful when running Kill Bill in
+ * containerized deployments, especially after upgrading to JDK 17+.
+ *
+ * <p>The fields surfaced here mirror the tuning checklist from the
+ * "JDK Memory Bloat in Containers" guidance referenced by issue #2176:
+ * cgroup-aware CPU count, heap sizing, active garbage collector, native
+ * memory tracking, and glibc malloc arenas. The class is deliberately
+ * dependency-free so it can be invoked from any boot path without pulling
+ * in Guice.</p>
+ */
+public final class JvmInfo {
+
+    private static final long BYTES_PER_MB = 1024L * 1024L;
+
+    private final String javaVersion;
+    private final String javaVendor;
+    private final String javaVmName;
+    private final int availableProcessors;
+    private final long maxHeapBytes;
+    private final long initialHeapBytes;
+    private final List<String> garbageCollectors;
+    private final List<String> inputArguments;
+    private final Optional<String> activeProcessorCount;
+    private final Optional<String> mallocArenaMax;
+    private final boolean nativeMemoryTrackingEnabled;
+    private final boolean useContainerSupport;
+    private final List<String> warnings;
+
+    JvmInfo(final String javaVersion,
+            final String javaVendor,
+            final String javaVmName,
+            final int availableProcessors,
+            final long maxHeapBytes,
+            final long initialHeapBytes,
+            final List<String> garbageCollectors,
+            final List<String> inputArguments,
+            final Optional<String> activeProcessorCount,
+            final Optional<String> mallocArenaMax,
+            final boolean nativeMemoryTrackingEnabled,
+            final boolean useContainerSupport,
+            final List<String> warnings) {
+        this.javaVersion = javaVersion;
+        this.javaVendor = javaVendor;
+        this.javaVmName = javaVmName;
+        this.availableProcessors = availableProcessors;
+        this.maxHeapBytes = maxHeapBytes;
+        this.initialHeapBytes = initialHeapBytes;
+        this.garbageCollectors = Collections.unmodifiableList(new ArrayList<>(garbageCollectors));
+        this.inputArguments = Collections.unmodifiableList(new ArrayList<>(inputArguments));
+        this.activeProcessorCount = activeProcessorCount;
+        this.mallocArenaMax = mallocArenaMax;
+        this.nativeMemoryTrackingEnabled = nativeMemoryTrackingEnabled;
+        this.useContainerSupport = useContainerSupport;
+        this.warnings = Collections.unmodifiableList(new ArrayList<>(warnings));
+    }
+
+    /**
+     * Captures a snapshot from the running JVM and environment.
+     */
+    public static JvmInfo capture() {
+        final RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+        final MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
+        final MemoryUsage heap = memory.getHeapMemoryUsage();
+        final List<String> gcs = ManagementFactory.getGarbageCollectorMXBeans().stream()
+                                                  .map(GarbageCollectorMXBean::getName)
+                                                  .collect(Collectors.toList());
+        final List<String> args = runtime.getInputArguments();
+        return build(
+                System.getProperty("java.version", "unknown"),
+                System.getProperty("java.vendor", "unknown"),
+                System.getProperty("java.vm.name", "unknown"),
+                Runtime.getRuntime().availableProcessors(),
+                heap.getMax(),
+                heap.getInit(),
+                gcs,
+                args,
+                System::getenv);
+    }
+
+    /**
+     * Visible for testing: build a JvmInfo from explicit inputs.
+     */
+    static JvmInfo build(final String javaVersion,
+                         final String javaVendor,
+                         final String javaVmName,
+                         final int availableProcessors,
+                         final long maxHeapBytes,
+                         final long initialHeapBytes,
+                         final List<String> garbageCollectors,
+                         final List<String> inputArguments,
+                         final Function<String, String> env) {
+        final Optional<String> activeProcessorCount = findValuedArg(inputArguments, "-XX:ActiveProcessorCount=");
+        final Optional<String> mallocArena = Optional.ofNullable(env.apply("MALLOC_ARENA_MAX"));
+        final boolean nmt = findValuedArg(inputArguments, "-XX:NativeMemoryTracking=")
+                .filter(v -> !"off".equalsIgnoreCase(v))
+                .isPresent();
+        final boolean containerSupportDisabled = inputArguments.contains("-XX:-UseContainerSupport");
+        final boolean useContainerSupport = !containerSupportDisabled;
+
+        final List<String> warnings = new ArrayList<>();
+        if (containerSupportDisabled) {
+            warnings.add("UseContainerSupport is disabled; the JVM may read host CPU/memory instead of cgroup limits.");
+        }
+        if (activeProcessorCount.isEmpty()) {
+            warnings.add("-XX:ActiveProcessorCount is not set; the JVM will infer CPU count from cgroups, which has known detection bugs in some kernels.");
+        }
+        if (mallocArena.isEmpty()) {
+            warnings.add("MALLOC_ARENA_MAX is not set; glibc may allocate one malloc arena per thread, inflating native RSS in containers. Consider exporting MALLOC_ARENA_MAX=2.");
+        }
+        if (!nmt) {
+            warnings.add("-XX:NativeMemoryTracking is off; native memory regressions cannot be diagnosed without it. Consider -XX:NativeMemoryTracking=summary.");
+        }
+        if (maxHeapBytes > 0 && initialHeapBytes > 0 && initialHeapBytes != maxHeapBytes) {
+            warnings.add("-Xms differs from -Xmx; pinning both to the same value avoids heap resize pauses in containers.");
+        }
+
+        return new JvmInfo(javaVersion, javaVendor, javaVmName, availableProcessors,
+                           maxHeapBytes, initialHeapBytes, garbageCollectors, inputArguments,
+                           activeProcessorCount, mallocArena, nmt, useContainerSupport, warnings);
+    }
+
+    private static Optional<String> findValuedArg(final List<String> args, final String prefix) {
+        for (final String a : args) {
+            if (a.startsWith(prefix)) {
+                return Optional.of(a.substring(prefix.length()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    public String getJavaVersion() {
+        return javaVersion;
+    }
+
+    public String getJavaVendor() {
+        return javaVendor;
+    }
+
+    public String getJavaVmName() {
+        return javaVmName;
+    }
+
+    public int getAvailableProcessors() {
+        return availableProcessors;
+    }
+
+    public long getMaxHeapBytes() {
+        return maxHeapBytes;
+    }
+
+    public long getInitialHeapBytes() {
+        return initialHeapBytes;
+    }
+
+    public List<String> getGarbageCollectors() {
+        return garbageCollectors;
+    }
+
+    public List<String> getInputArguments() {
+        return inputArguments;
+    }
+
+    public Optional<String> getActiveProcessorCount() {
+        return activeProcessorCount;
+    }
+
+    public Optional<String> getMallocArenaMax() {
+        return mallocArenaMax;
+    }
+
+    public boolean isNativeMemoryTrackingEnabled() {
+        return nativeMemoryTrackingEnabled;
+    }
+
+    public boolean isUseContainerSupport() {
+        return useContainerSupport;
+    }
+
+    public List<String> getWarnings() {
+        return warnings;
+    }
+
+    /**
+     * Emits an INFO line summarising the JVM and a WARN line for each tuning
+     * recommendation that the current process does not satisfy.
+     */
+    public void logTo(final Logger logger) {
+        if (logger == null) {
+            return;
+        }
+        logger.info(String.format(Locale.ROOT,
+                                  "JVM diagnostics: java=%s vendor=%s vm=%s processors=%d heapMax=%dMB heapInit=%dMB gc=%s containerSupport=%s nmt=%s activeProcessorCount=%s MALLOC_ARENA_MAX=%s",
+                                  javaVersion,
+                                  javaVendor,
+                                  javaVmName,
+                                  availableProcessors,
+                                  maxHeapBytes < 0 ? -1 : maxHeapBytes / BYTES_PER_MB,
+                                  initialHeapBytes < 0 ? -1 : initialHeapBytes / BYTES_PER_MB,
+                                  garbageCollectors,
+                                  useContainerSupport,
+                                  nativeMemoryTrackingEnabled,
+                                  activeProcessorCount.orElse("<unset>"),
+                                  mallocArenaMax.orElse("<unset>")));
+        for (final String w : warnings) {
+            logger.warn("JVM tuning: {}", w);
+        }
+    }
+
+    /**
+     * Convenience wrapper to capture and log in one call from boot code.
+     */
+    public static JvmInfo captureAndLog(final Logger logger) {
+        final JvmInfo info = capture();
+        info.logTo(logger);
+        return info;
+    }
+
+    // For tests that want to ignore real environment variables.
+    static Function<String, String> emptyEnv() {
+        return new EmptyEnv();
+    }
+
+    private static final class EmptyEnv implements Function<String, String> {
+        private final Map<String, String> backing = Collections.emptyMap();
+
+        @Override
+        public String apply(final String name) {
+            return backing.get(name);
+        }
+    }
+}

--- a/util/src/test/java/org/killbill/billing/util/nodes/TestJvmInfo.java
+++ b/util/src/test/java/org/killbill/billing/util/nodes/TestJvmInfo.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.nodes;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestJvmInfo {
+
+    private static Function<String, String> envOf(final Map<String, String> values) {
+        return name -> values.get(name);
+    }
+
+    @Test(groups = "fast")
+    public void testCaptureReturnsRuntimeFacts() {
+        final JvmInfo info = JvmInfo.capture();
+
+        Assert.assertNotNull(info.getJavaVersion());
+        Assert.assertFalse(info.getJavaVersion().isEmpty());
+        Assert.assertNotNull(info.getJavaVmName());
+        Assert.assertTrue(info.getAvailableProcessors() >= 1,
+                          "availableProcessors should be at least 1, got " + info.getAvailableProcessors());
+        Assert.assertNotNull(info.getGarbageCollectors());
+        Assert.assertFalse(info.getGarbageCollectors().isEmpty(), "expected at least one GC MXBean");
+        Assert.assertNotNull(info.getWarnings());
+    }
+
+    @Test(groups = "fast")
+    public void testWarningsWhenContainerTuningIsMissing() {
+        final JvmInfo info = JvmInfo.build(
+                "17.0.10",
+                "Eclipse Adoptium",
+                "OpenJDK 64-Bit Server VM",
+                8,
+                512L * 1024L * 1024L,
+                256L * 1024L * 1024L,
+                List.of("G1 Young Generation", "G1 Old Generation"),
+                Collections.emptyList(),
+                envOf(new HashMap<>()));
+
+        final List<String> warnings = info.getWarnings();
+        Assert.assertTrue(warnings.stream().anyMatch(w -> w.contains("ActiveProcessorCount")),
+                          "expected ActiveProcessorCount warning, got " + warnings);
+        Assert.assertTrue(warnings.stream().anyMatch(w -> w.contains("MALLOC_ARENA_MAX")),
+                          "expected MALLOC_ARENA_MAX warning, got " + warnings);
+        Assert.assertTrue(warnings.stream().anyMatch(w -> w.contains("NativeMemoryTracking")),
+                          "expected NativeMemoryTracking warning, got " + warnings);
+        Assert.assertTrue(warnings.stream().anyMatch(w -> w.contains("-Xms")),
+                          "expected -Xms/-Xmx warning, got " + warnings);
+
+        Assert.assertTrue(info.getActiveProcessorCount().isEmpty());
+        Assert.assertTrue(info.getMallocArenaMax().isEmpty());
+        Assert.assertFalse(info.isNativeMemoryTrackingEnabled());
+        Assert.assertTrue(info.isUseContainerSupport());
+    }
+
+    @Test(groups = "fast")
+    public void testNoWarningsWhenAllRecommendationsSatisfied() {
+        final Map<String, String> env = new HashMap<>();
+        env.put("MALLOC_ARENA_MAX", "2");
+
+        final long heap = 512L * 1024L * 1024L;
+        final JvmInfo info = JvmInfo.build(
+                "17.0.10",
+                "Eclipse Adoptium",
+                "OpenJDK 64-Bit Server VM",
+                4,
+                heap,
+                heap,
+                List.of("G1 Young Generation", "G1 Old Generation"),
+                Arrays.asList("-XX:ActiveProcessorCount=4",
+                              "-XX:NativeMemoryTracking=summary",
+                              "-Xms512m",
+                              "-Xmx512m"),
+                envOf(env));
+
+        Assert.assertEquals(info.getActiveProcessorCount().orElse(null), "4");
+        Assert.assertEquals(info.getMallocArenaMax().orElse(null), "2");
+        Assert.assertTrue(info.isNativeMemoryTrackingEnabled());
+        Assert.assertTrue(info.isUseContainerSupport());
+        Assert.assertEquals(info.getWarnings(), Collections.emptyList(),
+                            "expected no warnings, got " + info.getWarnings());
+    }
+
+    @Test(groups = "fast")
+    public void testContainerSupportDisabledIsFlagged() {
+        final JvmInfo info = JvmInfo.build(
+                "17.0.10",
+                "Eclipse Adoptium",
+                "OpenJDK 64-Bit Server VM",
+                8,
+                512L * 1024L * 1024L,
+                512L * 1024L * 1024L,
+                List.of("G1 Young Generation"),
+                List.of("-XX:-UseContainerSupport",
+                        "-XX:ActiveProcessorCount=2",
+                        "-XX:NativeMemoryTracking=summary"),
+                envOf(Map.of("MALLOC_ARENA_MAX", "2")));
+
+        Assert.assertFalse(info.isUseContainerSupport());
+        Assert.assertTrue(info.getWarnings().stream().anyMatch(w -> w.contains("UseContainerSupport")),
+                          "expected UseContainerSupport warning, got " + info.getWarnings());
+    }
+
+    @Test(groups = "fast")
+    public void testNativeMemoryTrackingOffIsTreatedAsDisabled() {
+        final JvmInfo info = JvmInfo.build(
+                "17.0.10",
+                "Eclipse Adoptium",
+                "OpenJDK 64-Bit Server VM",
+                2,
+                256L * 1024L * 1024L,
+                256L * 1024L * 1024L,
+                List.of("G1 Young Generation"),
+                List.of("-XX:NativeMemoryTracking=off",
+                        "-XX:ActiveProcessorCount=2"),
+                envOf(Map.of("MALLOC_ARENA_MAX", "2")));
+
+        Assert.assertFalse(info.isNativeMemoryTrackingEnabled());
+        Assert.assertTrue(info.getWarnings().stream().anyMatch(w -> w.contains("NativeMemoryTracking")));
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2176, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

This is part of an extended Tier-2 run with three broad-scope issues (#2156 UUIDv7, #2157 PostgreSQL default, #2176 Java 17 tuning).

Closes #2176 (proposes a fix; needs maintainer review)

## Arm a (no graph)

The Java 17 upgrade guidance referenced in #2176 emphasises runtime
behaviours -- container CPU detection, glibc malloc arenas, NMT,
G1 native memory, -Xms/-Xmx pinning -- rather than source-level
changes. Operators had no way to confirm those flags were actually
applied because Kill Bill did not surface any JVM information at
startup.

Add a dependency-free JvmInfo utility under
util/src/main/java/org/killbill/billing/util/nodes that snapshots
java.version/vendor/VM, Runtime.availableProcessors(), heap init/max,
GC names, -XX:ActiveProcessorCount, MALLOC_ARENA_MAX,
NativeMemoryTracking and UseContainerSupport. captureAndLog(Logger)
emits one INFO summary plus one WARN per missing recommendation, and
is invoked from DefaultKillbillNodesService.init() so it runs once per
node start. The warning logic is exercised via a synthetic-input
build() overload from TestJvmInfo (5 fast-group tests).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Diff stat

```
 FIX_REPORT.md                                      | 102 ++++++++
 .../util/nodes/DefaultKillbillNodesService.java    |   2 +
 .../org/killbill/billing/util/nodes/JvmInfo.java   | 266 +++++++++++++++++++++
 .../killbill/billing/util/nodes/TestJvmInfo.java   | 143 +++++++++++
 4 files changed, 513 insertions(+)
```

