### PR TITLE
[Experiment / arm b (ARK graph)] Fix #2176: log JVM container/ergonomics advisories at startup for Java 17 (issue #2176)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,136 @@
+# Fix #2176 — Java 17 deployment readiness diagnostics
+
+## Root cause / design summary
+
+Issue #2176 is an enhancement asking Kill Bill to be a better citizen on Java 17+
+in containerized deployments. The dzone article and follow-up comment list four
+JVM-tuning best practices (explicit `-XX:ActiveProcessorCount`, `MALLOC_ARENA_MAX`,
+G1 tuning vs ParallelGC, Native Memory Tracking) that silently degrade behavior
+when omitted under JDK 17. There is no single faulty class — the gap is that
+nothing in the running server tells an operator whether those knobs are set.
+Fix: introduce a tiny, no-dependency diagnostics utility
+(`org.killbill.billing.util.jvm.JvmEnvironmentInfo`) that captures the JVM's
+container/ergonomics state and emits advisory warnings when the issue-#2176
+recommendations are not in effect, and invoke it once at startup from
+`KillbillGuiceListener.startLifecycleStage3()`.
+
+## Change summary
+
+- `util/src/main/java/org/killbill/billing/util/jvm/JvmEnvironmentInfo.java` (new)
+  - Captures: Java major version, JVM name/vendor, available processors, max
+    heap, GC bean names, container heuristic (`/.dockerenv`, `/proc/1/cgroup`),
+    `MALLOC_ARENA_MAX`, NMT setting, `ActiveProcessorCount`, `MaxGCPauseMillis`.
+  - Exposes a pure `static List<String> computeWarnings(JvmEnvironmentInfo)`
+    so the advisory logic is unit-testable independently of the JVM running
+    the tests.
+  - `logTo(Logger)` emits an INFO summary plus one WARN line per active advisory.
+    Wrapped in `try/catch` so startup diagnostics can never break startup.
+
+- `profiles/killbill/src/main/java/org/killbill/billing/server/listeners/KillbillGuiceListener.java`
+  - Two-line change: one import, one call to
+    `JvmEnvironmentInfo.capture().logTo(logger)` inside
+    `startLifecycleStage3()`, alongside the existing Swagger init.
+
+- `util/src/test/java/org/killbill/billing/util/jvm/TestJvmEnvironmentInfo.java` (new)
+  - Regression test (group `fast`, no DB, no Guice).
+
+## How the test exercises the new behaviour
+
+`TestJvmEnvironmentInfo` covers:
+
+1. `parseJavaMajorVersion` — JDK 17-style (`"17"`, `"17.0.9"`), legacy 1.x style
+   (`"1.8.0_392"` ⇒ `8`), and malformed inputs (returns `-1`).
+2. `capture()` on the real test JVM — sanity-checks `availableProcessors >= 1`,
+   `maxHeapBytes > 0`, that `summary()` is formatted, and that `logTo(logger)`
+   does not throw.
+3. `computeWarnings` driven by synthetic `JvmEnvironmentInfo` instances:
+   - Containerized + Java 17 + G1 + no tuning ⇒ exactly the four expected
+     advisories (`ActiveProcessorCount`, `MALLOC_ARENA_MAX`, `MaxGCPauseMillis`,
+     `NativeMemoryTracking`).
+   - Same shape with all four flags supplied ⇒ no warnings.
+   - Non-containerized Java 11 ⇒ no warnings.
+   - Java 17 + ParallelGC ⇒ no G1 advisory (proves the G1 branch is gated on
+     the actual GC, not the Java version).
+4. `summary()` formats `Long.MAX_VALUE` heap as `unbounded`.
+
+This locks in both the pure advisory logic and the real-JVM smoke path, so a
+future regression that e.g. drops the `MALLOC_ARENA_MAX` check or breaks the
+GC-name detection fails the test.
+
+## Build status
+
+`mvn -pl util -am -DskipTests compile`:
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.147 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.112 s]
+[INFO] killbill-util ...................................... SUCCESS [  0.192 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+`mvn -pl util test-compile` (verifies the new test compiles — 121 sources):
+
+```
+[INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ killbill-util ---
+[INFO] Changes detected - recompiling the module! :dependency
+[INFO] Compiling 121 source files with javac [forked debug deprecation release 11] to target/test-classes
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+`mvn -pl profiles/killbill -am -DskipTests compile` (covers the listener edit;
+`-Dcheck.skip-dependency-scope=true` used to bypass the hubspot dependency-scope
+plugin which insists on `*-tests.jar` artifacts that are not relevant to a
+source-compile check):
+
+```
+[INFO] killbill ........................................... SUCCESS [  0.129 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.096 s]
+[INFO] killbill-util ...................................... SUCCESS [  0.163 s]
+[INFO] killbill-tenant .................................... SUCCESS [  0.019 s]
+[INFO] killbill-account ................................... SUCCESS [  0.015 s]
+[INFO] killbill-catalog ................................... SUCCESS [  0.019 s]
+[INFO] killbill-currency .................................. SUCCESS [  0.014 s]
+[INFO] killbill-subscription .............................. SUCCESS [  0.802 s]
+[INFO] killbill-entitlement ............................... SUCCESS [  0.745 s]
+[INFO] killbill-junction .................................. SUCCESS [  0.767 s]
+[INFO] killbill-usage ..................................... SUCCESS [  0.429 s]
+[INFO] killbill-invoice ................................... SUCCESS [  1.113 s]
+[INFO] killbill-overdue ................................... SUCCESS [  0.539 s]
+[INFO] killbill-payment ................................... SUCCESS [  1.062 s]
+[INFO] killbill-beatrix ................................... SUCCESS [  0.509 s]
+[INFO] killbill-jaxrs ..................................... SUCCESS [  1.196 s]
+[INFO] killbill-profiles .................................. SUCCESS [  0.002 s]
+[INFO] killbill-profiles-killbill ......................... SUCCESS [  0.732 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+Test JVM used: `openjdk version "25.0.2"` (Homebrew). Project source target
+remains Java 11 — no `pom.xml` changes.
+
+## Confidence level
+
+**Medium-high.**
+
+Reasoning:
+- All edited modules compile clean (only pre-existing deprecation warnings).
+- The unit test exercises every branch of the advisory logic with synthetic
+  inputs, so the warning behavior is locked down regardless of which JVM CI
+  happens to use.
+- The runtime call site (`startLifecycleStage3()`) is wrapped so a buggy
+  diagnostic cannot crash the server.
+- The change is additive and surface-area-tiny: one new file, one import +
+  one call line in the listener, one test file. No build files, no behavior
+  changes to existing code paths.
+- Not "high" because: I could not execute the new test in this environment
+  (Maven `surefire` would require pulling in the broader test fixture); the
+  container-detection heuristic is intentionally best-effort and platform
+  specific; and the advisory list is opinionated and may need tightening
+  based on operator feedback.

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/listeners/KillbillGuiceListener.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/listeners/KillbillGuiceListener.java
@@ -40,6 +40,7 @@ import org.killbill.billing.server.modules.KillbillServerModule;
 import org.killbill.billing.server.notifications.PushNotificationListener;
 import org.killbill.billing.server.providers.KillbillExceptionListener;
 import org.killbill.billing.server.security.TenantFilter;
+import org.killbill.billing.util.jvm.JvmEnvironmentInfo;
 import org.killbill.billing.util.nodes.KillbillVersions;
 import org.killbill.bus.api.PersistentBus;
 import org.killbill.commons.skeleton.modules.BaseServerModuleBuilder;
@@ -153,6 +154,9 @@ public class KillbillGuiceListener extends KillbillPlatformGuiceListener {
     @Override
     protected void startLifecycleStage3() {
         super.startLifecycleStage3();
+
+        // Surface JVM ergonomics relevant to Java 17+ container deployments (see issue #2176).
+        JvmEnvironmentInfo.capture().logTo(logger);
 
         final BeanConfig beanConfig = new BeanConfig();
         beanConfig.setResourcePackage("org.killbill.billing.jaxrs.resources");

--- a/util/src/main/java/org/killbill/billing/util/jvm/JvmEnvironmentInfo.java
+++ b/util/src/main/java/org/killbill/billing/util/jvm/JvmEnvironmentInfo.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2020-2025 Equinix, Inc
+ * Copyright 2014-2025 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.jvm;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+
+/**
+ * Captures the running JVM's container/ergonomics-relevant settings and emits
+ * advisory warnings for the Java 17+ best practices documented in issue #2176
+ * (explicit processor count, glibc malloc arena cap, G1GC tuning, native memory
+ * tracking). The warning logic is pure ({@link #computeWarnings(JvmEnvironmentInfo)})
+ * so it can be exercised deterministically by tests independent of the JVM the
+ * test harness happens to run on.
+ */
+public final class JvmEnvironmentInfo {
+
+    private final int javaMajorVersion;
+    private final String javaVersion;
+    private final String vmName;
+    private final String vmVendor;
+    private final int availableProcessors;
+    private final long maxHeapBytes;
+    private final List<String> garbageCollectors;
+    private final boolean containerized;
+    private final String mallocArenaMax;
+    private final String nativeMemoryTracking;
+    private final String activeProcessorCount;
+    private final String maxGcPauseMillis;
+
+    public JvmEnvironmentInfo(final int javaMajorVersion,
+                              final String javaVersion,
+                              final String vmName,
+                              final String vmVendor,
+                              final int availableProcessors,
+                              final long maxHeapBytes,
+                              final List<String> garbageCollectors,
+                              final boolean containerized,
+                              final String mallocArenaMax,
+                              final String nativeMemoryTracking,
+                              final String activeProcessorCount,
+                              final String maxGcPauseMillis) {
+        this.javaMajorVersion = javaMajorVersion;
+        this.javaVersion = javaVersion;
+        this.vmName = vmName;
+        this.vmVendor = vmVendor;
+        this.availableProcessors = availableProcessors;
+        this.maxHeapBytes = maxHeapBytes;
+        this.garbageCollectors = garbageCollectors == null
+                                 ? Collections.emptyList()
+                                 : Collections.unmodifiableList(new ArrayList<>(garbageCollectors));
+        this.containerized = containerized;
+        this.mallocArenaMax = mallocArenaMax;
+        this.nativeMemoryTracking = nativeMemoryTracking;
+        this.activeProcessorCount = activeProcessorCount;
+        this.maxGcPauseMillis = maxGcPauseMillis;
+    }
+
+    /**
+     * Reads the running JVM's settings. Safe to call from any thread at any
+     * point in the lifecycle; never throws.
+     */
+    public static JvmEnvironmentInfo capture() {
+        return capture(System::getProperty, System::getenv);
+    }
+
+    static JvmEnvironmentInfo capture(final Function<String, String> properties,
+                                      final Function<String, String> env) {
+        final int major = parseJavaMajorVersion(properties.apply("java.specification.version"),
+                                                properties.apply("java.version"));
+        final List<String> gcs = ManagementFactory.getGarbageCollectorMXBeans().stream()
+                                                  .map(GarbageCollectorMXBean::getName)
+                                                  .collect(Collectors.toUnmodifiableList());
+        return new JvmEnvironmentInfo(
+                major,
+                nullToUnknown(properties.apply("java.version")),
+                nullToUnknown(properties.apply("java.vm.name")),
+                nullToUnknown(properties.apply("java.vm.vendor")),
+                Runtime.getRuntime().availableProcessors(),
+                Runtime.getRuntime().maxMemory(),
+                gcs,
+                detectContainer(),
+                env.apply("MALLOC_ARENA_MAX"),
+                properties.apply("java.nativeMemoryTracking"),
+                properties.apply("jdk.internal.vm.options.ActiveProcessorCount"),
+                properties.apply("jdk.internal.vm.options.MaxGCPauseMillis"));
+    }
+
+    static int parseJavaMajorVersion(final String specVersion, final String fallbackVersion) {
+        final String candidate = specVersion != null ? specVersion : fallbackVersion;
+        if (candidate == null) {
+            return -1;
+        }
+        // "17", "17.0.9", "1.8.0_392"
+        final String[] parts = candidate.split("\\.");
+        try {
+            final int first = Integer.parseInt(parts[0]);
+            if (first == 1 && parts.length > 1) {
+                return Integer.parseInt(parts[1]);
+            }
+            return first;
+        } catch (final NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private static boolean detectContainer() {
+        // Heuristic: presence of /.dockerenv, or cgroup v1/v2 markers under /proc.
+        try {
+            if (Files.exists(Path.of("/.dockerenv"))) {
+                return true;
+            }
+            final Path cgroup = Path.of("/proc/1/cgroup");
+            if (Files.exists(cgroup)) {
+                final String content = Files.readString(cgroup);
+                if (content.contains("docker") || content.contains("kubepods") || content.contains("containerd")) {
+                    return true;
+                }
+            }
+        } catch (final Exception ignored) {
+            // best-effort detection
+        }
+        return false;
+    }
+
+    private static String nullToUnknown(final String s) {
+        return s == null ? "unknown" : s;
+    }
+
+    public int getJavaMajorVersion() {
+        return javaMajorVersion;
+    }
+
+    public String getJavaVersion() {
+        return javaVersion;
+    }
+
+    public String getVmName() {
+        return vmName;
+    }
+
+    public String getVmVendor() {
+        return vmVendor;
+    }
+
+    public int getAvailableProcessors() {
+        return availableProcessors;
+    }
+
+    public long getMaxHeapBytes() {
+        return maxHeapBytes;
+    }
+
+    public List<String> getGarbageCollectors() {
+        return garbageCollectors;
+    }
+
+    public boolean isContainerized() {
+        return containerized;
+    }
+
+    public String getMallocArenaMax() {
+        return mallocArenaMax;
+    }
+
+    public String getNativeMemoryTracking() {
+        return nativeMemoryTracking;
+    }
+
+    public String getActiveProcessorCount() {
+        return activeProcessorCount;
+    }
+
+    public String getMaxGcPauseMillis() {
+        return maxGcPauseMillis;
+    }
+
+    /**
+     * Pure: given a captured environment, return the list of advisory warnings
+     * that apply. Tests pass synthetic inputs in to drive every branch.
+     */
+    public static List<String> computeWarnings(final JvmEnvironmentInfo info) {
+        final List<String> warnings = new ArrayList<>();
+
+        // Java 17+ on containers warrants extra scrutiny per issue #2176.
+        final boolean java17OrLater = info.javaMajorVersion >= 17;
+
+        if (info.containerized && isBlank(info.activeProcessorCount)) {
+            warnings.add(String.format(Locale.ROOT,
+                                       "Running in a container with Runtime.availableProcessors()=%d but "
+                                       + "-XX:ActiveProcessorCount is not set. Setting it explicitly avoids "
+                                       + "the JVM mis-reading the host CPU count when cgroup CPU shares are used.",
+                                       info.availableProcessors));
+        }
+
+        if (info.containerized && isBlank(info.mallocArenaMax)) {
+            warnings.add("Running in a container but MALLOC_ARENA_MAX is not set. glibc allocates one "
+                         + "arena per thread (default cap = 8 * CPUs), which can balloon native RSS on "
+                         + "thread-heavy services. Consider setting MALLOC_ARENA_MAX=2 or 4.");
+        }
+
+        if (java17OrLater && info.garbageCollectors.stream().anyMatch(JvmEnvironmentInfo::isG1)
+            && isBlank(info.maxGcPauseMillis)) {
+            warnings.add("Java 17+ defaulted to G1GC but -XX:MaxGCPauseMillis is not set. Either tune G1 "
+                         + "(e.g. -XX:MaxGCPauseMillis=200 -XX:G1HeapRegionSize=16m) or switch to ParallelGC "
+                         + "(-XX:+UseParallelGC) for the lowest native memory footprint.");
+        }
+
+        if (java17OrLater && isBlank(info.nativeMemoryTracking)) {
+            warnings.add("Java 17+ is running without Native Memory Tracking. Enable with "
+                         + "-XX:NativeMemoryTracking=summary to baseline heap, native, thread and GC overhead.");
+        }
+
+        return Collections.unmodifiableList(warnings);
+    }
+
+    private static boolean isG1(final String gc) {
+        return gc != null && gc.toLowerCase(Locale.ROOT).contains("g1");
+    }
+
+    private static boolean isBlank(final String s) {
+        return s == null || s.isBlank();
+    }
+
+    /** Single-line, human-readable summary suitable for an INFO log. */
+    public String summary() {
+        final Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put("java", javaVersion);
+        fields.put("major", javaMajorVersion);
+        fields.put("vm", vmName);
+        fields.put("vendor", vmVendor);
+        fields.put("processors", availableProcessors);
+        fields.put("maxHeapMB", maxHeapBytes == Long.MAX_VALUE ? "unbounded" : (maxHeapBytes / (1024L * 1024L)));
+        fields.put("gc", garbageCollectors);
+        fields.put("containerized", containerized);
+        fields.put("MALLOC_ARENA_MAX", mallocArenaMax == null ? "unset" : mallocArenaMax);
+        fields.put("nativeMemoryTracking", nativeMemoryTracking == null ? "off" : nativeMemoryTracking);
+        return fields.entrySet().stream()
+                     .map(e -> e.getKey() + "=" + e.getValue())
+                     .collect(Collectors.joining(", ", "JVM environment: ", ""));
+    }
+
+    /**
+     * Logs the captured environment at INFO and each advisory warning at WARN.
+     * Never throws; intended to be called once at startup.
+     */
+    public void logTo(final Logger logger) {
+        if (logger == null) {
+            return;
+        }
+        try {
+            logger.info(summary());
+            for (final String w : computeWarnings(this)) {
+                logger.warn("[JVM tuning, issue #2176] {}", w);
+            }
+        } catch (final RuntimeException ignored) {
+            // Diagnostics must never break startup.
+        }
+    }
+}

--- a/util/src/test/java/org/killbill/billing/util/jvm/TestJvmEnvironmentInfo.java
+++ b/util/src/test/java/org/killbill/billing/util/jvm/TestJvmEnvironmentInfo.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020-2025 Equinix, Inc
+ * Copyright 2014-2025 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.jvm;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestJvmEnvironmentInfo {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestJvmEnvironmentInfo.class);
+
+    @Test(groups = "fast")
+    public void testParseJavaMajorVersionForJdk17Style() {
+        assertEquals(JvmEnvironmentInfo.parseJavaMajorVersion("17", "17.0.9"), 17);
+        assertEquals(JvmEnvironmentInfo.parseJavaMajorVersion(null, "17.0.9"), 17);
+        assertEquals(JvmEnvironmentInfo.parseJavaMajorVersion("21", null), 21);
+    }
+
+    @Test(groups = "fast")
+    public void testParseJavaMajorVersionForLegacy1xStyle() {
+        assertEquals(JvmEnvironmentInfo.parseJavaMajorVersion(null, "1.8.0_392"), 8);
+        assertEquals(JvmEnvironmentInfo.parseJavaMajorVersion("1.8", "1.8.0_392"), 8);
+    }
+
+    @Test(groups = "fast")
+    public void testParseJavaMajorVersionForGarbageInput() {
+        assertEquals(JvmEnvironmentInfo.parseJavaMajorVersion(null, null), -1);
+        assertEquals(JvmEnvironmentInfo.parseJavaMajorVersion("not-a-number", null), -1);
+    }
+
+    @Test(groups = "fast")
+    public void testCaptureOnRunningJvmReturnsRealValues() {
+        final JvmEnvironmentInfo info = JvmEnvironmentInfo.capture();
+        assertNotNull(info);
+        // Project source target is Java 11, so the test JVM must be >= 11.
+        assertTrue(info.getJavaMajorVersion() >= 11,
+                   "Expected Java 11+, was " + info.getJavaMajorVersion());
+        assertTrue(info.getAvailableProcessors() >= 1);
+        assertTrue(info.getMaxHeapBytes() > 0L);
+        assertNotNull(info.getGarbageCollectors());
+        assertNotNull(info.summary());
+        assertTrue(info.summary().startsWith("JVM environment: "));
+        // logTo must never throw on a real JVM.
+        info.logTo(logger);
+    }
+
+    @Test(groups = "fast")
+    public void testWarningsTriggerForContainerizedJava17WithG1AndDefaults() {
+        // Containerized Java 17 with G1 and no tuning flags should trigger all four advisories.
+        final JvmEnvironmentInfo info = new JvmEnvironmentInfo(
+                17,
+                "17.0.9",
+                "OpenJDK 64-Bit Server VM",
+                "Eclipse Adoptium",
+                4,
+                512L * 1024 * 1024,
+                List.of("G1 Young Generation", "G1 Old Generation"),
+                true,                       // containerized
+                null,                       // MALLOC_ARENA_MAX unset
+                null,                       // NMT off
+                null,                       // ActiveProcessorCount unset
+                null);                      // MaxGCPauseMillis unset
+
+        final List<String> warnings = JvmEnvironmentInfo.computeWarnings(info);
+        assertEquals(warnings.size(), 4, "warnings: " + warnings);
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("ActiveProcessorCount")));
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("MALLOC_ARENA_MAX")));
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("MaxGCPauseMillis")));
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("NativeMemoryTracking")));
+    }
+
+    @Test(groups = "fast")
+    public void testWarningsSuppressedWhenAllRecommendationsApplied() {
+        // Containerized Java 17 with all flags set => no advisories.
+        final JvmEnvironmentInfo info = new JvmEnvironmentInfo(
+                17,
+                "17.0.9",
+                "OpenJDK 64-Bit Server VM",
+                "Eclipse Adoptium",
+                4,
+                512L * 1024 * 1024,
+                List.of("G1 Young Generation", "G1 Old Generation"),
+                true,
+                "2",          // MALLOC_ARENA_MAX
+                "summary",    // NMT
+                "4",          // ActiveProcessorCount
+                "200");       // MaxGCPauseMillis
+
+        assertTrue(JvmEnvironmentInfo.computeWarnings(info).isEmpty());
+    }
+
+    @Test(groups = "fast")
+    public void testNonContainerJava11SkipsContainerAndJava17Warnings() {
+        // Non-containerized Java 11 should not trip container or Java-17 specific warnings.
+        final JvmEnvironmentInfo info = new JvmEnvironmentInfo(
+                11,
+                "11.0.20",
+                "OpenJDK 64-Bit Server VM",
+                "Eclipse Adoptium",
+                8,
+                1024L * 1024 * 1024,
+                List.of("G1 Young Generation", "G1 Old Generation"),
+                false,
+                null,
+                null,
+                null,
+                null);
+
+        final List<String> warnings = JvmEnvironmentInfo.computeWarnings(info);
+        assertTrue(warnings.isEmpty(), "unexpected warnings: " + warnings);
+    }
+
+    @Test(groups = "fast")
+    public void testParallelGcOnJava17DoesNotTriggerG1Warning() {
+        final JvmEnvironmentInfo info = new JvmEnvironmentInfo(
+                17,
+                "17.0.9",
+                "OpenJDK 64-Bit Server VM",
+                "Eclipse Adoptium",
+                4,
+                512L * 1024 * 1024,
+                List.of("PS Scavenge", "PS MarkSweep"),
+                false,
+                null,
+                "summary",
+                null,
+                null);
+
+        final List<String> warnings = JvmEnvironmentInfo.computeWarnings(info);
+        assertFalse(warnings.stream().anyMatch(w -> w.contains("MaxGCPauseMillis")),
+                    "ParallelGC should not trigger G1 advisory: " + warnings);
+    }
+
+    @Test(groups = "fast")
+    public void testSummaryFormatsUnboundedHeap() {
+        final JvmEnvironmentInfo info = new JvmEnvironmentInfo(
+                17, "17", "vm", "vendor", 2,
+                Long.MAX_VALUE, List.of("G1 Young Generation"),
+                false, null, null, null, null);
+        assertTrue(info.summary().contains("maxHeapMB=unbounded"));
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2176, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

This is part of an extended Tier-2 run with three broad-scope issues (#2156 UUIDv7, #2157 PostgreSQL default, #2176 Java 17 tuning).

Closes #2176 (proposes a fix; needs maintainer review)

## Arm b (ARK graph)

Issue #2176 (Upgrade to Java 17) lists four JVM-tuning best practices that
silently degrade behavior on Java 17+ in containers when omitted:
-XX:ActiveProcessorCount, MALLOC_ARENA_MAX, G1 tuning vs ParallelGC, and
NativeMemoryTracking. The server currently gives operators no signal about
whether any of these are in effect.

Adds util/jvm/JvmEnvironmentInfo, a no-dependency utility that captures the
running JVM's container/ergonomics state (major version, processors, max heap,
GC bean names, container heuristic via /.dockerenv and /proc/1/cgroup, plus
MALLOC_ARENA_MAX, NMT, ActiveProcessorCount, MaxGCPauseMillis) and computes a
pure list of advisory warnings keyed off Java 17+ and the container heuristic.
KillbillGuiceListener.startLifecycleStage3() now logs an INFO summary and one
WARN per advisory; the call is wrapped so diagnostics can never break startup.

The pure computeWarnings() function is exercised by TestJvmEnvironmentInfo with
synthetic inputs covering every branch (containerized Java 17 + G1 + no flags
triggers exactly four advisories, all flags set triggers none, non-containerized
Java 11 triggers none, ParallelGC on Java 17 skips the G1 advisory) plus a
smoke test of capture() on the actual test JVM and parseJavaMajorVersion()
across legacy 1.x and modern major-version strings.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Diff stat

```
 FIX_REPORT.md                                      | 136 ++++++++++
 .../server/listeners/KillbillGuiceListener.java    |   4 +
 .../billing/util/jvm/JvmEnvironmentInfo.java       | 287 +++++++++++++++++++++
 .../billing/util/jvm/TestJvmEnvironmentInfo.java   | 165 ++++++++++++
 4 files changed, 592 insertions(+)
```

