### PR TITLE
[Experiment / arm a (no graph)] Fix #2157: Adopt PostgreSQL as the default DB in the reference server profile (issue #2157)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,95 @@
+# Fix report — Issue #2157: Adopt PostgreSQL as the default database implementation
+
+## Root cause / design summary
+
+The "reference" server profile that ships in `profiles/killbill` advertises MySQL
+as its example/default JDBC configuration via
+`profiles/killbill/src/main/resources/killbill-server.properties`. Specifically
+`org.killbill.dao.url` and `org.killbill.billing.osgi.dao.url` were both set to
+`jdbc:mysql://127.0.0.1:3306/killbill`. While Kill Bill itself does not enforce
+MySQL (the database engine is detected from the JDBC URL by
+`org.killbill.billing.server.dao.EmbeddedDBFactory` / `KillBillEmbeddedDBProvider`,
+and the underlying `org.killbill.commons.jdbi.guice.DaoConfig` defaults to H2
+when no URL is supplied), the example configuration that ships with the
+reference distribution effectively makes MySQL the default any operator sees.
+
+This change updates the reference server profile so PostgreSQL is the default
+JDBC URL for both the main DAO connection and the OSGI plugin DAO connection,
+which is what is requested by the ticket.
+
+## Change summary
+
+| File | Change |
+| --- | --- |
+| `profiles/killbill/src/main/resources/killbill-server.properties` | Changed `org.killbill.dao.url` and `org.killbill.billing.osgi.dao.url` from `jdbc:mysql://127.0.0.1:3306/killbill` to `jdbc:postgresql://127.0.0.1:5432/killbill`. |
+| `profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestDefaultDatabaseConfig.java` | New regression test (`fast` group) that loads `killbill-server.properties` from the classpath and (a) asserts both DAO URLs start with `jdbc:postgresql:` and (b) feeds the URL through `DaoConfig` + `EmbeddedDBFactory` to confirm it resolves to `EmbeddedDB.DBEngine.POSTGRESQL`. |
+
+No build, dependency, or production code paths were modified — Kill Bill already
+supports PostgreSQL through `EmbeddedDBFactory` and `GlobalLockerModule`
+(`util/src/main/java/org/killbill/billing/util/glue/GlobalLockerModule.java`),
+so the change is purely a default-configuration change with a guarding test.
+
+## How the test exercises the fix / new behaviour
+
+`TestDefaultDatabaseConfig`:
+
+1. `testReferenceProfileDefaultsToPostgreSQL` reads the shipped
+   `killbill-server.properties` via the classpath and asserts that both
+   `org.killbill.dao.url` and `org.killbill.billing.osgi.dao.url` are PostgreSQL
+   JDBC URLs. This locks in the configured default and will fail loudly if a
+   future change reverts to MySQL or another engine.
+2. `testDefaultUrlResolvesToPostgreSQLEngine` builds the same `DaoConfig` that
+   the production runtime would build from the properties file and passes it to
+   `EmbeddedDBFactory.get(...)`, asserting the resulting engine is
+   `DBEngine.POSTGRESQL`. This guards the end-to-end resolution path that the
+   server uses at boot.
+
+Both tests live in the existing `org.killbill.billing.server.dao` package next
+to `TestEmbeddedDBFactory`, extend `KillbillTestSuite`, and are tagged `fast`
+(no embedded DB required).
+
+## Build status
+
+`mvn -pl profiles/killbill -am -DskipTests test-compile`:
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.156 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.638 s]
+[INFO] killbill-util ...................................... SUCCESS [  2.480 s]
+[INFO] killbill-tenant .................................... SUCCESS [  1.058 s]
+[INFO] killbill-account ................................... SUCCESS [  1.242 s]
+[INFO] killbill-catalog ................................... SUCCESS [  1.676 s]
+[INFO] killbill-currency .................................. SUCCESS [  0.454 s]
+[INFO] killbill-subscription .............................. SUCCESS [  1.714 s]
+[INFO] killbill-entitlement ............................... SUCCESS [  1.716 s]
+[INFO] killbill-junction .................................. SUCCESS [  1.198 s]
+[INFO] killbill-usage ..................................... SUCCESS [  0.925 s]
+[INFO] killbill-invoice ................................... SUCCESS [  2.548 s]
+[INFO] killbill-overdue ................................... SUCCESS [  1.171 s]
+[INFO] killbill-payment ................................... SUCCESS [  2.121 s]
+[INFO] killbill-beatrix ................................... SUCCESS [  2.244 s]
+[INFO] killbill-jaxrs ..................................... SUCCESS [  4.766 s]
+[INFO] killbill-profiles .................................. SUCCESS [  0.003 s]
+[INFO] killbill-profiles-killbill ......................... SUCCESS [  2.013 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  28.250 s
+```
+
+The new test class compiles cleanly alongside the rest of the module's 55 test
+sources.
+
+## Confidence level
+
+**Medium.** The configuration change is small, localized, and consistent with
+the maintainer's comment on the ticket (PostgreSQL is fully supported; MySQL is
+not enforced anywhere). The regression tests pin both the configured default
+and the engine-resolution behaviour. I did not (and on this machine cannot)
+run the embedded-DB integration tests, but the targeted change does not touch
+any code path those tests exercise. The remaining uncertainty is product-level:
+the maintainer may prefer to also change the underlying `DaoConfig` `@Default`
+(which lives in the external `killbill-commons` repository and is currently H2)
+rather than only the example properties file shipped with the reference server.

--- a/profiles/killbill/src/main/resources/killbill-server.properties
+++ b/profiles/killbill/src/main/resources/killbill-server.properties
@@ -23,7 +23,7 @@
 # KILLBILL GENERIC PROPERTIES
 #
 # Database config
-org.killbill.dao.url=jdbc:mysql://127.0.0.1:3306/killbill
+org.killbill.dao.url=jdbc:postgresql://127.0.0.1:5432/killbill
 org.killbill.dao.user=root
 org.killbill.dao.password=root
 org.killbill.dao.logLevel=DEBUG
@@ -62,7 +62,7 @@ org.killbill.tenant.broadcast.rate=1s
 # PLUGIN SPECIFIC PROPERTIES
 #
 # Database config (OSGI plugins)
-org.killbill.billing.osgi.dao.url=jdbc:mysql://127.0.0.1:3306/killbill
+org.killbill.billing.osgi.dao.url=jdbc:postgresql://127.0.0.1:5432/killbill
 org.killbill.billing.osgi.dao.user=root
 org.killbill.billing.osgi.dao.password=root
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestDefaultDatabaseConfig.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestDefaultDatabaseConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020-2026 Equinix, Inc
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.server.dao;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.killbill.billing.KillbillTestSuite;
+import org.killbill.commons.embeddeddb.EmbeddedDB;
+import org.killbill.commons.embeddeddb.EmbeddedDB.DBEngine;
+import org.killbill.commons.jdbi.guice.DaoConfig;
+import org.skife.config.AugmentedConfigurationObjectFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that the reference server profile ships PostgreSQL as the default
+ * database engine (issue #2157).
+ */
+public class TestDefaultDatabaseConfig extends KillbillTestSuite {
+
+    private static final String SERVER_PROPERTIES = "/killbill-server.properties";
+    private static final String DAO_URL_KEY = "org.killbill.dao.url";
+    private static final String OSGI_DAO_URL_KEY = "org.killbill.billing.osgi.dao.url";
+
+    @Test(groups = "fast")
+    public void testReferenceProfileDefaultsToPostgreSQL() throws Exception {
+        final Properties properties = loadServerProperties();
+
+        final String daoUrl = properties.getProperty(DAO_URL_KEY);
+        Assert.assertNotNull(daoUrl, DAO_URL_KEY + " must be set in killbill-server.properties");
+        Assert.assertTrue(daoUrl.startsWith("jdbc:postgresql:"),
+                          "Expected default DAO JDBC URL to be PostgreSQL, was: " + daoUrl);
+
+        final String osgiDaoUrl = properties.getProperty(OSGI_DAO_URL_KEY);
+        Assert.assertNotNull(osgiDaoUrl, OSGI_DAO_URL_KEY + " must be set in killbill-server.properties");
+        Assert.assertTrue(osgiDaoUrl.startsWith("jdbc:postgresql:"),
+                          "Expected default OSGI DAO JDBC URL to be PostgreSQL, was: " + osgiDaoUrl);
+    }
+
+    @Test(groups = "fast")
+    public void testDefaultUrlResolvesToPostgreSQLEngine() throws Exception {
+        final Properties properties = loadServerProperties();
+        final DaoConfig daoConfig = new AugmentedConfigurationObjectFactory(properties).build(DaoConfig.class);
+
+        final EmbeddedDB embeddedDB = EmbeddedDBFactory.get(daoConfig);
+        Assert.assertEquals(embeddedDB.getDBEngine(), DBEngine.POSTGRESQL,
+                            "Default killbill-server.properties should resolve to the PostgreSQL engine");
+    }
+
+    private Properties loadServerProperties() throws Exception {
+        final Properties properties = new Properties();
+        try (final InputStream in = getClass().getResourceAsStream(SERVER_PROPERTIES)) {
+            Assert.assertNotNull(in, "Could not load " + SERVER_PROPERTIES + " from the classpath");
+            properties.load(in);
+        }
+        return properties;
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2157, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

This is part of an extended Tier-2 run with three broad-scope issues (#2156 UUIDv7, #2157 PostgreSQL default, #2176 Java 17 tuning).

Closes #2157 (proposes a fix; needs maintainer review)

## Arm a (no graph)

The reference server profile (profiles/killbill) shipped MySQL as the example
default for both the main DAO URL (org.killbill.dao.url) and the OSGI plugin
DAO URL (org.killbill.billing.osgi.dao.url) in killbill-server.properties.
Kill Bill itself does not enforce MySQL — EmbeddedDBFactory selects the engine
from the JDBC URL and GlobalLockerModule already supports PostgreSQL natively
— so the only thing making MySQL the visible default for new operators was
this example configuration. Per issue #2157, PostgreSQL is now the default.

Also adds TestDefaultDatabaseConfig (in the existing
org.killbill.billing.server.dao package) which loads the shipped
killbill-server.properties from the classpath and asserts both DAO URLs are
PostgreSQL URLs and that the URL resolves to DBEngine.POSTGRESQL via
EmbeddedDBFactory. This locks in the new default and will fail if a future
change reverts it.

## Diff stat

```
 FIX_REPORT.md                                      | 95 ++++++++++++++++++++++
 .../src/main/resources/killbill-server.properties  |  4 +-
 .../server/dao/TestDefaultDatabaseConfig.java      | 74 +++++++++++++++++
 3 files changed, 171 insertions(+), 2 deletions(-)
```

