### PR TITLE
[Experiment / arm b (ARK graph)] Fix #2157: adopt PostgreSQL as the default database engine (issue #2157)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,112 @@
+# Fix Report — Issue #2157
+
+## Root cause / design summary
+
+Issue #2157 asks to adopt PostgreSQL as the default database engine of the Kill
+Bill reference implementation. Per Pierre's comment, no single class hard-codes
+a "default" engine at runtime — but the **operator-facing default** is the JDBC
+URL that ships in `profiles/killbill/src/main/resources/killbill-server.properties`
+(the file that `./bin/start-server` consumes by default via the
+`org.killbill.server.properties` system property). That file was set to
+`jdbc:mysql://127.0.0.1:3306/killbill` for both the core DAO
+(`org.killbill.dao.url`) and the OSGi plugin DAO
+(`org.killbill.billing.osgi.dao.url`). The companion helper script
+`bin/db-helper` also defaulted `DRIVER="mysql"`. Together, these are the
+user-visible "default" — anyone following the README path lands on MySQL.
+
+## Change summary
+
+- **`profiles/killbill/src/main/resources/killbill-server.properties`** — switched
+  `org.killbill.dao.url` and `org.killbill.billing.osgi.dao.url` from
+  `jdbc:mysql://127.0.0.1:3306/killbill` to
+  `jdbc:postgresql://127.0.0.1:5432/killbill`, and updated the default user /
+  password to `postgres` / `postgres` (the conventional defaults for a fresh
+  PostgreSQL install; the canonical `root` / `root` defaults are MySQL-specific).
+  Added a short comment documenting the new default and that operators can
+  override these properties to switch engines.
+
+- **`bin/db-helper`** — changed `DRIVER="mysql"` to `DRIVER="postgres"`,
+  switched the default `USER` / `PWD` to `postgres` / `postgres`, and updated
+  the `usage()` text accordingly. The script already supported both engines via
+  the `--driver` flag; only the default changed.
+
+- **`profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestDefaultDatabaseConfig.java`**
+  (new) — TestNG regression test in the `fast` group that loads the shipped
+  `killbill-server.properties` from the classpath and asserts (a) both DAO URLs
+  start with `jdbc:postgresql:` and (b) `EmbeddedDBFactory.get(daoConfig)`
+  resolves to `EmbeddedDB.DBEngine.POSTGRESQL`. The latter exercises the same
+  parsing path used at runtime by `KillBillEmbeddedDBProvider`.
+
+## How the test exercises the fix / new behaviour
+
+`TestDefaultDatabaseConfig#testDefaultDaoUrlIsPostgresql` loads the properties
+file straight from the classpath (the file under
+`profiles/killbill/src/main/resources/`) and asserts both `org.killbill.dao.url`
+and `org.killbill.billing.osgi.dao.url` start with `jdbc:postgresql:`. This
+guards against accidental regressions to MySQL/H2 in the default properties.
+
+`TestDefaultDatabaseConfig#testEmbeddedDBFactoryResolvesToPostgresql` builds a
+`DaoConfig` (using the same `AugmentedConfigurationObjectFactory` machinery as
+the existing `TestEmbeddedDBFactory`) from the shipped properties and runs the
+config through `EmbeddedDBFactory.get(...)`. It asserts the resolved
+`DBEngine` is `POSTGRESQL`. This mirrors the exact code path that
+`KillBillEmbeddedDBProvider` (and ultimately `GlobalLockerModule`,
+`DBTestingHelper`, etc.) take at runtime to decide engine-specific behaviour.
+
+## Build status
+
+`mvn -pl profiles/killbill -am -DskipTests ... compile`:
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO] killbill ........................................... SUCCESS
+[INFO] killbill-api ....................................... SUCCESS
+[INFO] killbill-util ...................................... SUCCESS
+[INFO] killbill-tenant .................................... SUCCESS
+[INFO] killbill-account ................................... SUCCESS
+[INFO] killbill-catalog ................................... SUCCESS
+[INFO] killbill-currency .................................. SUCCESS
+[INFO] killbill-subscription .............................. SUCCESS
+[INFO] killbill-entitlement ............................... SUCCESS
+[INFO] killbill-junction .................................. SUCCESS
+[INFO] killbill-usage ..................................... SUCCESS
+[INFO] killbill-invoice ................................... SUCCESS
+[INFO] killbill-overdue ................................... SUCCESS
+[INFO] killbill-payment ................................... SUCCESS
+[INFO] killbill-beatrix ................................... SUCCESS
+[INFO] killbill-jaxrs ..................................... SUCCESS
+[INFO] killbill-profiles .................................. SUCCESS
+[INFO] killbill-profiles-killbill ......................... SUCCESS
+[INFO] BUILD SUCCESS
+```
+
+`mvn -pl profiles/killbill -am -DskipTests ... test-compile` also reports
+`BUILD SUCCESS`, and the new test class lands at
+`profiles/killbill/target/test-classes/org/killbill/billing/server/dao/TestDefaultDatabaseConfig.class`.
+
+(Compile invocation passes the standard `-Dcheck.skip-*=true` flags used by the
+project's own CI workflow because the cached snapshot artifacts in the local
+Maven repository miss some test-classifier jars unrelated to this change.)
+
+## Confidence level
+
+**Medium-high.** The change is small, targeted, and limited to the operator-
+facing default configuration plus a regression test. The existing PostgreSQL
+support in Kill Bill is mature (see `GlobalLockerModule`, `ddl-postgresql.sql`,
+`bin/db-helper`'s existing `postgres` branch, `wipeoutTenant-postgresql.sql`,
+`trimTenant-postgresql.sql`, the CI workflow's PostgreSQL setup steps), so
+flipping the default does not break any code path — it just changes which
+engine an operator running `./bin/start-server` (with no overrides) connects
+to.
+
+Lower-confidence aspects:
+- The e2e GitHub Actions matrix in `.github/workflows/ci.yml` still pins
+  `database: 'mysql'`. That is a CI configuration choice (matrix-driven) and
+  intentionally left alone — the issue asks about the project default, not
+  about which engine CI exercises. Operators or maintainers can flip the
+  matrix entry separately if desired.
+- I could not run the new test end-to-end on this machine because the test
+  classpath cannot start an embedded PostgreSQL on Apple Silicon (same family
+  of issue as the MySQL ARM tar.gz failure noted in the task brief).
+  Compile-clean is the bar for build verification per the task constraints,
+  and the test reaches `BUILD SUCCESS` in `test-compile`.

--- a/bin/db-helper
+++ b/bin/db-helper
@@ -29,12 +29,13 @@ POM="$TOP/pom.xml"
 ACTION=
 HOST="localhost"
 DATABASE="killbill"
-USER="root"
-PWD="root"
+USER="postgres"
+PWD="postgres"
 PORT=
 PORT_MYSQL=3306
 PORT_POSTGRES=5432
-DRIVER="mysql"
+# PostgreSQL is the default database engine for Kill Bill (issue #2157).
+DRIVER="postgres"
 TEST_ALSO=
 OUTPUT_FILE=
 DDL_FILE=
@@ -61,12 +62,12 @@ eval set -- "${ARGS}"
 function usage() {
     echo -n "./db_helper"
     echo -n " -a|--action <create|clean|dump|migrate|dryRunMigrate|repair|info>"
-    echo -n " --driver <mysql|postgres> (default = mysql)"
+    echo -n " --driver <mysql|postgres> (default = postgres)"
     echo -n " -h|--host host (default = localhost)"
     echo -n " --port port"
     echo -n " -d|--database database_name (default = killbill)"
-    echo -n " -u|--user user_name (default = root)"
-    echo -n " -p|--password password (default = root)"
+    echo -n " -u|--user user_name (default = postgres)"
+    echo -n " -p|--password password (default = postgres)"
     echo -n " -t|--test (also include test ddl)"
     echo -n " -f|--file file (output file, for dump only)"
     echo -n " --help this message"

--- a/profiles/killbill/src/main/resources/killbill-server.properties
+++ b/profiles/killbill/src/main/resources/killbill-server.properties
@@ -23,9 +23,11 @@
 # KILLBILL GENERIC PROPERTIES
 #
 # Database config
-org.killbill.dao.url=jdbc:mysql://127.0.0.1:3306/killbill
-org.killbill.dao.user=root
-org.killbill.dao.password=root
+# PostgreSQL is the default database engine for Kill Bill (issue #2157).
+# Override these properties to switch to MySQL or another supported engine.
+org.killbill.dao.url=jdbc:postgresql://127.0.0.1:5432/killbill
+org.killbill.dao.user=postgres
+org.killbill.dao.password=postgres
 org.killbill.dao.logLevel=DEBUG
 
 # Use the SpyCarAdvanced.xml catalog
@@ -62,9 +64,9 @@ org.killbill.tenant.broadcast.rate=1s
 # PLUGIN SPECIFIC PROPERTIES
 #
 # Database config (OSGI plugins)
-org.killbill.billing.osgi.dao.url=jdbc:mysql://127.0.0.1:3306/killbill
-org.killbill.billing.osgi.dao.user=root
-org.killbill.billing.osgi.dao.password=root
+org.killbill.billing.osgi.dao.url=jdbc:postgresql://127.0.0.1:5432/killbill
+org.killbill.billing.osgi.dao.user=postgres
+org.killbill.billing.osgi.dao.password=postgres
 
 # Allow jruby concurrency
 org.killbill.jruby.context.scope=THREADSAFE

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestDefaultDatabaseConfig.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestDefaultDatabaseConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.server.dao;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.killbill.billing.KillbillTestSuite;
+import org.killbill.commons.embeddeddb.EmbeddedDB;
+import org.killbill.commons.embeddeddb.EmbeddedDB.DBEngine;
+import org.killbill.commons.jdbi.guice.DaoConfig;
+import org.skife.config.AugmentedConfigurationObjectFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+// Regression test for issue #2157: PostgreSQL is the default database engine
+// for the Kill Bill reference implementation. The shipped killbill-server.properties
+// must resolve to a PostgreSQL JDBC URL so that operators running ./bin/start-server
+// (and the OSGi plugin DAO) land on PostgreSQL out of the box.
+public class TestDefaultDatabaseConfig extends KillbillTestSuite {
+
+    private static final String SERVER_PROPERTIES = "killbill-server.properties";
+
+    private static final String CORE_DAO_URL = "org.killbill.dao.url";
+    private static final String CORE_DAO_USER = "org.killbill.dao.user";
+    private static final String CORE_DAO_PASSWORD = "org.killbill.dao.password";
+
+    private static final String OSGI_DAO_URL = "org.killbill.billing.osgi.dao.url";
+
+    @Test(groups = "fast")
+    public void testDefaultDaoUrlIsPostgresql() throws Exception {
+        final Properties properties = loadServerProperties();
+
+        final String coreUrl = properties.getProperty(CORE_DAO_URL);
+        Assert.assertNotNull(coreUrl, CORE_DAO_URL + " must be set in " + SERVER_PROPERTIES);
+        Assert.assertTrue(coreUrl.startsWith("jdbc:postgresql:"),
+                          "Default " + CORE_DAO_URL + " must be a PostgreSQL JDBC URL, got: " + coreUrl);
+
+        final String osgiUrl = properties.getProperty(OSGI_DAO_URL);
+        Assert.assertNotNull(osgiUrl, OSGI_DAO_URL + " must be set in " + SERVER_PROPERTIES);
+        Assert.assertTrue(osgiUrl.startsWith("jdbc:postgresql:"),
+                          "Default " + OSGI_DAO_URL + " must be a PostgreSQL JDBC URL, got: " + osgiUrl);
+    }
+
+    @Test(groups = "fast")
+    public void testEmbeddedDBFactoryResolvesToPostgresql() throws Exception {
+        final Properties properties = loadServerProperties();
+        final DaoConfig daoConfig = new AugmentedConfigurationObjectFactory(properties).build(DaoConfig.class);
+
+        final EmbeddedDB embeddedDB = EmbeddedDBFactory.get(daoConfig);
+        Assert.assertEquals(embeddedDB.getDBEngine(), DBEngine.POSTGRESQL,
+                            "EmbeddedDBFactory must resolve the default killbill-server.properties to PostgreSQL");
+        Assert.assertEquals(embeddedDB.getDatabaseName(), "killbill");
+    }
+
+    private Properties loadServerProperties() throws Exception {
+        final Properties properties = new Properties();
+        try (final InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(SERVER_PROPERTIES)) {
+            Assert.assertNotNull(stream, SERVER_PROPERTIES + " must be available on the classpath");
+            properties.load(stream);
+        }
+        return properties;
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2157, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

This is part of an extended Tier-2 run with three broad-scope issues (#2156 UUIDv7, #2157 PostgreSQL default, #2176 Java 17 tuning).

Closes #2157 (proposes a fix; needs maintainer review)

## Arm b (ARK graph)

Switch the operator-facing defaults from MySQL to PostgreSQL so that
following the README path (./bin/start-server, ./bin/db-helper) lands
on PostgreSQL out of the box. Both MySQL and PostgreSQL remain fully
supported; operators can opt back into MySQL by overriding the JDBC URL
properties or passing --driver mysql to db-helper.

Changes:
* profiles/killbill/src/main/resources/killbill-server.properties:
  flip org.killbill.dao.url and org.killbill.billing.osgi.dao.url to
  jdbc:postgresql://127.0.0.1:5432/killbill, with the conventional
  postgres/postgres credential defaults.
* bin/db-helper: default DRIVER to "postgres" (was "mysql") plus
  matching default USER/PWD and usage text.
* profiles/killbill/.../TestDefaultDatabaseConfig.java: new TestNG fast
  regression test that loads the shipped killbill-server.properties from
  the classpath and asserts (a) both DAO URLs start with jdbc:postgresql:
  and (b) EmbeddedDBFactory.get(daoConfig) resolves to DBEngine.POSTGRESQL,
  mirroring the runtime path used by KillBillEmbeddedDBProvider.

## Diff stat

```
 FIX_REPORT.md                                      | 112 +++++++++++++++++++++
 bin/db-helper                                      |  13 +--
 .../src/main/resources/killbill-server.properties  |  14 +--
 .../server/dao/TestDefaultDatabaseConfig.java      |  78 ++++++++++++++
 4 files changed, 205 insertions(+), 12 deletions(-)
```

