### PR TITLE
[Experiment / arm a (no graph)] Fix #2156: generate UUIDv7 identifiers from UUIDs.randomUUID() (issue #2156)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,123 @@
+# Fix Report — Issue #2156: Adopt UUIDv7 for all identifiers
+
+## Root cause / design summary
+
+The codebase already centralises identifier generation through
+`org.killbill.billing.util.UUIDs#randomUUID()`
+(`api/src/main/java/org/killbill/billing/util/UUIDs.java`), which is what
+~all entity-creation paths call (`DefaultAccount`, `DefaultSubscriptionBaseBundle`,
+`PaymentModelDao`, `PaymentTransactionModelDao`, `PaymentAttemptModelDao`,
+`InvoiceDispatcher`, `Context`, `EventBaseBuilder`, `TagModelDao`, etc. — 200+
+call sites). Previously that helper minted UUIDv4 values via its internal
+`rndUUIDv4()` method, so primary-key columns received random bytes that
+sit anywhere in a B-tree, defeating insertion-order locality.
+
+Per the issue and pierre's comment, fully replacing `record_id` with
+`id` as the storage primary key is a 6-month+ effort. The smallest change
+that actually advances the issue's goal — and the one with no migration
+risk — is to switch the canonical identifier source to UUIDv7
+(RFC 9562: 48-bit unix-ms timestamp || 4-bit version || 12-bit
+sub-ms sequence || 2-bit variant || 62 random bits). Every new `id`
+created from this point on is time-ordered; PostgreSQL 18+ (and any
+DB that accepts UUID(7) primary keys in the future) will benefit
+without further code changes. Existing rows are unaffected because
+`UUID` columns store the bytes opaquely.
+
+## Change summary by file
+
+- **`api/src/main/java/org/killbill/billing/util/UUIDs.java`**
+  - `randomUUID()` now delegates to a new `rndUUIDv7()` private method
+    instead of `rndUUIDv4()`.
+  - Added `randomUUIDv7()` (explicit) and `randomUUIDv4()` (legacy
+    escape hatch) public helpers so call sites can still request a
+    fully-random UUID if they have a reason to.
+  - `rndUUIDv7()` lays the bits out per RFC 9562 and, under a small
+    static monitor, keeps a `(lastMillis, sequence)` pair so that
+    successive calls within the same millisecond are still strictly
+    monotonically increasing (and never collide even at burst rates
+    exceeding the millisecond resolution). The 62 low bits come from
+    the existing `ThreadLocal<Random>` used by the v4 generator, so
+    entropy quality is unchanged.
+  - Class-level Javadoc explains the new default and the v4/v7 split.
+
+- **`util/src/test/java/org/killbill/billing/util/TestUUIDs.java`** (new)
+  - Six `@Test(groups = "fast")` cases that lock in the new contract.
+
+## How the test exercises the new behaviour
+
+`TestUUIDs` does not need DI, so it runs as a plain TestNG class:
+
+1. `testRandomUUIDReturnsVersion7` — generates 1 000 ids via
+   `UUIDs.randomUUID()` and asserts each carries `version() == 7` and
+   IETF variant. Would have failed before the change (v4).
+2. `testExplicitV7HelperReturnsVersion7` — covers the new explicit
+   `randomUUIDv7()` helper.
+3. `testLegacyV4HelperStillReturnsVersion4` — pins the v4 escape
+   hatch so future refactors don't quietly drop it.
+4. `testEmbeddedTimestampMatchesWallClock` — extracts the top 48
+   bits of the id and checks they fall inside `[before, after]`
+   wall-clock bounds, proving the timestamp prefix is real
+   (a pure-random v4 would fail this).
+5. `testMonotonicWithinSameMillisecond` — generates 5 000 ids in a
+   tight loop (many land in the same ms) and asserts each is
+   strictly `>` the previous one under unsigned 128-bit ordering.
+   This is the key property that makes UUIDv7 useful as a B-tree
+   primary key.
+6. `testUniquenessUnderConcurrency` — 8 threads × 2 000 ids each, all
+   added to a `HashSet`; asserts no collisions and all are v7. This
+   exercises the shared monotonic counter under contention.
+
+Helper `compareUnsigned()` is needed because `UUID#compareTo` treats
+the long halves as signed, which inverts ordering whenever the
+timestamp's high bit flips across an ordinary millisecond boundary.
+
+## Build status
+
+`mvn -pl api -am clean compile -DskipTests`:
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.212 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.905 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+`mvn -pl util -am test -Dtest=TestUUIDs`:
+
+```
+[INFO] Running org.killbill.billing.util.TestUUIDs
+[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.148 s
+[INFO]
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.356 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.415 s]
+[INFO] killbill-util ...................................... SUCCESS [  1.395 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+(A full-repo `mvn -DskipTests compile` halts on an unrelated, pre-existing
+missing-artifact error — `killbill-catalog:jar:tests:0.24.17-SNAPSHOT` —
+that is not produced by this change and is consistent with the
+environment caveat in the task brief.)
+
+## Confidence level
+
+**High** for the immediate scope (identifier generation now emits
+UUIDv7 with the correct bit layout, monotonic ordering, and no
+collisions under concurrency — all directly tested) and for backward
+compatibility (no existing code reads `UUID.version()` of stored ids;
+the `randomUUIDv4()` escape hatch is preserved).
+
+**Medium** as a complete answer to the broader issue: as pierre noted
+in the GitHub thread, harvesting the database benefit (using UUID as
+the literal primary key column instead of `record_id`) is a much
+larger schema migration that this change does not attempt. What this
+change does deliver is the prerequisite — every new `id` minted from
+now on is a v7 — so that the future schema migration becomes a pure
+DDL change rather than also requiring an id-rewrite.

--- a/api/src/main/java/org/killbill/billing/util/UUIDs.java
+++ b/api/src/main/java/org/killbill/billing/util/UUIDs.java
@@ -25,11 +25,32 @@ import java.util.UUID;
 /**
  * UUIDs helper.
  *
+ * Identifier generation defaults to UUIDv7 (RFC 9562): a 48-bit Unix
+ * millisecond timestamp followed by version/variant tag bits and random
+ * payload. Within a JVM, identifiers minted by {@link #randomUUID()} are
+ * strictly monotonically increasing — including across calls that fall in
+ * the same millisecond — which makes them friendly to B-tree primary keys
+ * in databases that recognise UUIDv7 (PostgreSQL 18+, etc.).
+ *
+ * The legacy UUIDv4 generator is retained as {@link #randomUUIDv4()} for
+ * callers that need a fully random identifier with no temporal correlation.
+ *
  * @author kares
  */
 public abstract class UUIDs {
 
-    public static UUID randomUUID() { return rndUUIDv4(); }
+    public static UUID randomUUID() { return rndUUIDv7(); }
+
+    /**
+     * @return a freshly generated UUIDv4 (fully random, no temporal ordering).
+     */
+    public static UUID randomUUIDv4() { return rndUUIDv4(); }
+
+    /**
+     * @return a freshly generated UUIDv7 (time-ordered, RFC 9562). Equivalent
+     *         to {@link #randomUUID()} but explicit about the version.
+     */
+    public static UUID randomUUIDv7() { return rndUUIDv7(); }
 
     public static void setRandom(final Random random) {
         threadRandom.set(random);
@@ -37,6 +58,58 @@ public abstract class UUIDs {
 
     public static Random getRandom() {
         return threadRandom.get();
+    }
+
+    // Guards the (lastMillis, sequence) pair used to keep UUIDv7 outputs
+    // monotonic when many identifiers are requested within the same ms.
+    private static final Object v7Lock = new Object();
+    private static long v7LastMillis = -1L;
+    private static int v7Sequence = 0;
+    // rand_a is 12 bits in the UUIDv7 layout; the counter occupies the same
+    // field, so it must never exceed 0xFFF.
+    private static final int V7_SEQUENCE_MAX = 0x0FFF;
+
+    private static UUID rndUUIDv7() {
+        final long timestamp;
+        final int sequence;
+        synchronized (v7Lock) {
+            long now = System.currentTimeMillis();
+            if (now > v7LastMillis) {
+                v7LastMillis = now;
+                v7Sequence = 0;
+            } else {
+                // Same millisecond (or, very rarely, a backwards clock step).
+                // Bump the sequence; if it overflows the 12-bit field, borrow
+                // a millisecond from the future so we never break ordering.
+                if (v7Sequence >= V7_SEQUENCE_MAX) {
+                    v7LastMillis += 1L;
+                    v7Sequence = 0;
+                } else {
+                    v7Sequence++;
+                }
+            }
+            timestamp = v7LastMillis;
+            sequence = v7Sequence;
+        }
+
+        final Random random = threadRandom.get();
+        final byte[] randB = new byte[8];
+        random.nextBytes(randB);
+
+        // High 64 bits: 48-bit ms timestamp | 4-bit version (0x7) | 12-bit sequence
+        long msb = (timestamp & 0x0000FFFFFFFFFFFFL) << 16;
+        msb |= 0x7000L;                       // version 7
+        msb |= (sequence & 0x0FFFL);          // rand_a (sub-ms counter)
+
+        // Low 64 bits: 2-bit variant (0b10) | 62 bits of randomness
+        long lsb = 0L;
+        for (int i = 0; i < 8; i++) {
+            lsb = (lsb << 8) | (randB[i] & 0xffL);
+        }
+        lsb &= 0x3FFFFFFFFFFFFFFFL;           // clear top two bits
+        lsb |= 0x8000000000000000L;           // set IETF variant (0b10xx...)
+
+        return new UUID(msb, lsb);
     }
 
     private static UUID rndUUIDv4() {

--- a/util/src/test/java/org/killbill/billing/util/TestUUIDs.java
+++ b/util/src/test/java/org/killbill/billing/util/TestUUIDs.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Regression coverage for the UUIDv7 adoption tracked by issue #2156.
+ *
+ * UUIDv7 (RFC 9562) carries a 48-bit Unix-ms timestamp in its leading bytes
+ * so that identifiers minted in chronological order sort lexicographically
+ * the same way — which is what makes them friendly to B-tree primary keys.
+ * The tests here lock in three properties that callers depend on:
+ *   1. {@link UUIDs#randomUUID()} now returns version-7 identifiers,
+ *   2. the leading timestamp matches wall-clock time,
+ *   3. successive calls (including within the same millisecond) are
+ *      strictly monotonically increasing.
+ */
+public class TestUUIDs {
+
+    @Test(groups = "fast")
+    public void testRandomUUIDReturnsVersion7() {
+        for (int i = 0; i < 1_000; i++) {
+            final UUID id = UUIDs.randomUUID();
+            Assert.assertEquals(id.version(), 7, "Expected UUIDv7, got: " + id);
+            Assert.assertEquals(id.variant(), 2, "Expected IETF variant, got: " + id);
+        }
+    }
+
+    @Test(groups = "fast")
+    public void testExplicitV7HelperReturnsVersion7() {
+        final UUID id = UUIDs.randomUUIDv7();
+        Assert.assertEquals(id.version(), 7);
+        Assert.assertEquals(id.variant(), 2);
+    }
+
+    @Test(groups = "fast")
+    public void testLegacyV4HelperStillReturnsVersion4() {
+        // The v4 generator is preserved for callers that explicitly want an
+        // identifier with no temporal correlation.
+        final UUID id = UUIDs.randomUUIDv4();
+        Assert.assertEquals(id.version(), 4);
+        Assert.assertEquals(id.variant(), 2);
+    }
+
+    @Test(groups = "fast")
+    public void testEmbeddedTimestampMatchesWallClock() {
+        final long before = System.currentTimeMillis();
+        final UUID id = UUIDs.randomUUID();
+        final long after = System.currentTimeMillis();
+
+        // For UUIDv7, the high 48 bits of the most-significant-long carry the
+        // Unix-ms timestamp.
+        final long embedded = id.getMostSignificantBits() >>> 16;
+
+        Assert.assertTrue(embedded >= before,
+                          "Embedded timestamp " + embedded + " precedes wall clock " + before);
+        Assert.assertTrue(embedded <= after + 1,
+                          "Embedded timestamp " + embedded + " is past wall clock " + after);
+    }
+
+    @Test(groups = "fast")
+    public void testMonotonicWithinSameMillisecond() {
+        // Generate a burst tight enough that many calls land in the same ms;
+        // each successive id must still compare strictly greater than the
+        // previous one. This is the property that makes UUIDv7 useful as a
+        // primary key — pure v4 would fail this test.
+        final int n = 5_000;
+        UUID previous = UUIDs.randomUUID();
+        for (int i = 1; i < n; i++) {
+            final UUID next = UUIDs.randomUUID();
+            Assert.assertTrue(compareUnsigned(next, previous) > 0,
+                              "UUIDv7 ordering violated at i=" + i +
+                              ": previous=" + previous + " next=" + next);
+            previous = next;
+        }
+    }
+
+    @Test(groups = "fast")
+    public void testUniquenessUnderConcurrency() throws Exception {
+        // Multi-threaded burst — exercises the shared monotonic counter and
+        // confirms no collisions slip through.
+        final int threads = 8;
+        final int perThread = 2_000;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            final List<Future<List<UUID>>> futures = new ArrayList<>(threads);
+            for (int t = 0; t < threads; t++) {
+                futures.add(pool.submit(new Callable<List<UUID>>() {
+                    @Override
+                    public List<UUID> call() {
+                        final List<UUID> local = new ArrayList<>(perThread);
+                        for (int i = 0; i < perThread; i++) {
+                            local.add(UUIDs.randomUUID());
+                        }
+                        return local;
+                    }
+                }));
+            }
+
+            final Set<UUID> all = new HashSet<>(threads * perThread);
+            for (final Future<List<UUID>> f : futures) {
+                for (final UUID id : f.get(30, TimeUnit.SECONDS)) {
+                    Assert.assertEquals(id.version(), 7);
+                    Assert.assertTrue(all.add(id), "Duplicate UUID generated: " + id);
+                }
+            }
+            Assert.assertEquals(all.size(), threads * perThread);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    // UUIDs are unsigned 128-bit values, but UUID#compareTo treats the longs
+    // as signed which inverts ordering around the sign bit. For UUIDv7 the
+    // timestamp lives in the top 48 bits, so the top bit can flip across an
+    // ordinary millisecond boundary — we need an unsigned comparison.
+    private static int compareUnsigned(final UUID a, final UUID b) {
+        final int hi = Long.compareUnsigned(a.getMostSignificantBits(), b.getMostSignificantBits());
+        if (hi != 0) {
+            return hi;
+        }
+        return Long.compareUnsigned(a.getLeastSignificantBits(), b.getLeastSignificantBits());
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2156, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

This is part of an extended Tier-2 run with three broad-scope issues (#2156 UUIDv7, #2157 PostgreSQL default, #2176 Java 17 tuning).

Closes #2156 (proposes a fix; needs maintainer review)

## Arm a (no graph)

The codebase funnels nearly all entity-id creation through
org.killbill.billing.util.UUIDs#randomUUID() — accounts, subscriptions,
invoices, payments, tags, custom fields, payment methods, audit
records, all go through this one entry point. Until now it minted
UUIDv4 values, so primary-key columns received random bytes that
scatter through B-tree indexes and defeat insertion-order locality.

Switch the default generator to UUIDv7 (RFC 9562): 48-bit Unix-ms
timestamp || 4-bit version || 12-bit sub-ms counter || 2-bit variant
|| 62 random bits. A small synchronized (lastMillis, sequence) pair
keeps consecutive ids strictly monotonically increasing within a JVM
even at burst rates that exceed millisecond resolution; entropy for
the random tail still comes from the existing ThreadLocal Random.

This is the prerequisite for the issue's database-side ambition (use
UUIDs as B-tree-friendly primary keys on PostgreSQL 18+ and similar):
every new id minted from now on is already time-ordered, so the
follow-up schema migration that pierre flagged as a 6-month effort
becomes a pure DDL change rather than also requiring an id-rewrite.

Keep randomUUIDv4() as an explicit escape hatch and add randomUUIDv7()
for callers that want to be unambiguous about what they're getting.
No existing code reads UUID#version() of stored ids, so existing data
is unaffected.

Add TestUUIDs (no-DI, fast group) covering: version-7 bit layout,
embedded-timestamp matches wall clock, strict monotonic ordering
across a 5k burst (using unsigned 128-bit comparison since the
timestamp's high bit flips across millisecond boundaries), and
uniqueness under 8-thread × 2k contention.

## Diff stat

```
 FIX_REPORT.md                                      | 123 +++++++++++++++++
 .../main/java/org/killbill/billing/util/UUIDs.java |  75 +++++++++-
 .../java/org/killbill/billing/util/TestUUIDs.java  | 151 +++++++++++++++++++++
 3 files changed, 348 insertions(+), 1 deletion(-)
```

