### PR TITLE
[Experiment / arm b (ARK graph)] Fix #2156: add opt-in UUIDv7 generation in UUIDs helper (issue #2156)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,144 @@
+# Fix for Kill Bill issue #2156 — Adopt UUIDv7 for all identifiers
+
+## Root cause / design summary
+
+Kill Bill mints every domain-object identifier through a single helper:
+`UUIDs.randomUUID()` at `api/src/main/java/org/killbill/billing/util/UUIDs.java`.
+That helper delegates to the private `rndUUIDv4()` implementation, which
+produces a purely random UUIDv4 — fine for uniqueness but poor for B-tree
+primary-key locality on a write-heavy workload, which is the concern raised
+in the issue. Pierre's comment notes that fully switching from `record_id`
+to `id` is a multi-quarter effort, so the change here is scoped to giving
+Kill Bill the ability to generate time-ordered UUIDv7 identifiers via the
+same `UUIDs.randomUUID()` entry point, gated by an opt-in system property
+so existing deployments keep their current v4 behavior.
+
+## Change summary
+
+### `api/src/main/java/org/killbill/billing/util/UUIDs.java`
+- Added `randomUUIDv7()` which builds a UUIDv7 per
+  [RFC 9562 §5.7](https://www.rfc-editor.org/rfc/rfc9562#name-uuid-version-7):
+  48 bits of Unix milliseconds, 4 bits version (`0x7`), 12 bits `rand_a`,
+  2 bits IETF variant, 62 bits `rand_b`. Entropy is sourced from the
+  existing `threadRandom` (the lightweight SHA1PRNG-backed
+  `LightSecureRandom`), so we reuse the same RNG path the existing v4
+  generator relies on.
+- Added `randomUUIDv4()` as the public name for the historical generator;
+  the existing private `rndUUIDv4()` is kept as-is and now serves both
+  entry points.
+- Made `randomUUID()` dispatch to v4 (default) or v7 (when the
+  `org.killbill.uuid.v7.enabled` system property is set to `true`).
+  Every existing call site (135 occurrences across 78 files) is unchanged
+  and automatically benefits when v7 is turned on — no source churn
+  required.
+- Added a process-wide monotonic millisecond counter
+  (`nextMonotonicMillis()`, backed by an `AtomicLong`) so concurrent
+  v7 generation in the same wall-clock millisecond — or small backwards
+  clock jumps from NTP — still yield strictly increasing identifiers.
+  Without this guard, UUIDv7 ids generated in the same ms could shuffle
+  randomly on the `rand_a`/`rand_b` bytes, defeating the whole point of a
+  sortable id.
+- Exposed two small helpers: `isUUIDv7Enabled()` (so other code can branch
+  on the toggle without reading the system property itself) and
+  `timestampMillisFromV7(UUID)` (useful for migration tooling, log
+  correlation, and the new tests). The latter validates the UUID version
+  and throws `IllegalArgumentException` for non-v7 input.
+
+### `util/src/test/java/org/killbill/billing/util/TestUUIDs.java` (new)
+A TestNG `fast`-group suite covering the new behavior. See below.
+
+## How the test exercises the fix / new behaviour
+
+`TestUUIDs` has 7 test methods, all in the `fast` group:
+
+1. `testRandomUUIDv4VersionAndVariant` — explicit v4 path still returns
+   `version()==4`, `variant()==2` (IETF). Guards against any regression to
+   the historical generator.
+2. `testRandomUUIDv7VersionAndVariant` — `randomUUIDv7()` returns
+   `version()==7`, `variant()==2`. Confirms the bit layout is right.
+3. `testRandomUUIDv7EncodesTimestampDeterministically` — calls the
+   package-private `rndUUIDv7(unixMillis)` with a fixed timestamp and
+   asserts `timestampMillisFromV7(id) == unixMillis`. This is independent
+   of the JVM-wide monotonic counter, so it stays deterministic regardless
+   of which other tests have run first.
+4. `testRandomUUIDv7IsMonotonic` — generates 10,000 v7 ids back-to-back
+   and asserts strict `compareTo > 0` ordering on every step. This is the
+   key property the issue is about: time-ordered ids that play well with
+   B-tree indexes. It only passes because of the monotonic-millis guard;
+   without it, the random `rand_a` bytes would reorder pairs of ids
+   generated within the same millisecond.
+5. `testRandomUUIDv7IsUnique` — 10,000 ids, all distinct.
+6. `testTimestampExtractionRejectsNonV7` — `timestampMillisFromV7()`
+   throws `IllegalArgumentException` when handed a non-v7 UUID.
+7. `testRandomUUIDDefaultsToV4` — confirms `isUUIDv7Enabled()` is `false`
+   in a JVM that has not set the property, and that `randomUUID()` still
+   returns v4 in that mode. This pins the backward-compatibility contract.
+
+Tests live in the `util` module because that's where the project already
+keeps `UUIDs`-adjacent unit coverage (`util/src/test/java/.../util/`); the
+`api` module has no test sources at all.
+
+## Build status
+
+`mvn -pl api -am -DskipTests compile` (the primary module — `UUIDs.java`
+lives in `api/`):
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.219 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.796 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+`mvn -pl util -am -Dtest=TestUUIDs -Dsurefire.failIfNoSpecifiedTests=false test`
+(executes the new test):
+
+```
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.147 s -- in org.killbill.billing.util.TestUUIDs
+[INFO] Results:
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.371 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.449 s]
+[INFO] killbill-util ...................................... SUCCESS [  2.503 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+Note: a full repo-root `mvn -DskipTests compile` fails further downstream
+in the `subscription` module because `killbill-catalog:jar:tests` is not
+present in the local Maven cache, and a separate `mvn install` against
+this checkout fails because SpotBugs 4.7.2.1 cannot parse class files
+emitted by the JDK 25 currently on this machine ("Unsupported class file
+major version 69"). Both are pre-existing environment issues unrelated to
+this change.
+
+## Confidence level
+
+**High.**
+
+- The change is additive and gated behind an opt-in system property; the
+  default behavior of `randomUUID()` is bit-for-bit unchanged, so the 78
+  call sites that depend on it cannot regress without flipping the flag.
+- The v7 layout is mechanically verified by an explicit-timestamp test
+  that round-trips an arbitrary 48-bit value through
+  `rndUUIDv7`/`timestampMillisFromV7`, plus version/variant assertions.
+- The monotonicity guard is exercised at 10k iterations — large enough to
+  reliably catch any same-millisecond reordering caused by the random
+  `rand_a`/`rand_b` bits.
+- Compile and the new test suite both pass cleanly on the targeted
+  modules. The pre-existing environment failures (catalog test-jar,
+  SpotBugs/JDK 25) do not touch `UUIDs` or any code path I modified.
+
+The one limitation worth flagging: as Pierre's comment notes, real
+adoption of UUIDv7 as a database primary key would also need Kill Bill to
+stop relying on `record_id` and use `id` directly — that is the
+multi-quarter effort described in the issue, and is explicitly out of
+scope here. This change unblocks that future work by making sure every
+new identifier generated by Kill Bill can already be v7 with a single
+JVM flag flip.

--- a/api/src/main/java/org/killbill/billing/util/UUIDs.java
+++ b/api/src/main/java/org/killbill/billing/util/UUIDs.java
@@ -21,6 +21,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * UUIDs helper.
@@ -29,7 +30,55 @@ import java.util.UUID;
  */
 public abstract class UUIDs {
 
-    public static UUID randomUUID() { return rndUUIDv4(); }
+    /**
+     * When this system property is set to {@code true} at JVM startup,
+     * {@link #randomUUID()} returns time-ordered UUIDv7 identifiers (see
+     * <a href="https://www.rfc-editor.org/rfc/rfc9562#name-uuid-version-7">RFC 9562</a>)
+     * instead of the historical UUIDv4. UUIDv7 ids carry a 48-bit Unix
+     * millisecond prefix that keeps inserts roughly monotonic for B-tree
+     * primary keys (issue #2156).
+     */
+    public static final String UUID_V7_PROPERTY = "org.killbill.uuid.v7.enabled";
+
+    private static final boolean USE_UUID_V7 = Boolean.getBoolean(UUID_V7_PROPERTY);
+
+    private static final long V7_MILLIS_MASK = 0xFFFFFFFFFFFFL;
+    private static final long V7_VERSION_BITS = 0x7000L;
+    private static final long V7_LSB_VARIANT_CLEAR_MASK = 0x3FFFFFFFFFFFFFFFL;
+    private static final long V7_LSB_VARIANT_SET_MASK = 0x8000000000000000L;
+
+    private static final AtomicLong lastV7Millis = new AtomicLong(0L);
+
+    public static UUID randomUUID() {
+        return USE_UUID_V7 ? randomUUIDv7() : randomUUIDv4();
+    }
+
+    /** Returns {@code true} when {@link #randomUUID()} dispatches to UUIDv7. */
+    public static boolean isUUIDv7Enabled() {
+        return USE_UUID_V7;
+    }
+
+    /** Always generates a UUIDv4 (purely random), regardless of {@link #UUID_V7_PROPERTY}. */
+    public static UUID randomUUIDv4() {
+        return rndUUIDv4();
+    }
+
+    /** Always generates a UUIDv7 (time-ordered), regardless of {@link #UUID_V7_PROPERTY}. */
+    public static UUID randomUUIDv7() {
+        return rndUUIDv7(nextMonotonicMillis());
+    }
+
+    /**
+     * Extracts the 48-bit Unix millisecond timestamp embedded in a UUIDv7.
+     *
+     * @throws IllegalArgumentException if {@code uuid} is not version 7
+     */
+    public static long timestampMillisFromV7(final UUID uuid) {
+        if (uuid.version() != 7) {
+            throw new IllegalArgumentException("Not a UUIDv7: " + uuid);
+        }
+        return uuid.getMostSignificantBits() >>> 16;
+    }
 
     public static void setRandom(final Random random) {
         threadRandom.set(random);
@@ -37,6 +86,42 @@ public abstract class UUIDs {
 
     public static Random getRandom() {
         return threadRandom.get();
+    }
+
+    // Ensures the millisecond counter handed to UUIDv7 is strictly monotonic
+    // within this JVM, so concurrent generations within the same wall-clock
+    // millisecond (and small backwards clock jumps) still yield sortable ids.
+    private static long nextMonotonicMillis() {
+        final long now = System.currentTimeMillis();
+        while (true) {
+            final long last = lastV7Millis.get();
+            final long next = (now > last) ? now : last + 1L;
+            if (lastV7Millis.compareAndSet(last, next)) {
+                return next;
+            }
+        }
+    }
+
+    // Visible for tests.
+    static UUID rndUUIDv7(final long unixMillis) {
+        final Random random = threadRandom.get();
+        final byte[] bytes = new byte[10];
+        random.nextBytes(bytes);
+
+        // msb: [48 bits unix_ts_ms][4 bits version=0x7][12 bits rand_a]
+        long msb = (unixMillis & V7_MILLIS_MASK) << 16;
+        msb |= V7_VERSION_BITS;
+        msb |= ((bytes[0] & 0x0fL) << 8) | (bytes[1] & 0xffL);
+
+        // lsb: [2 bits variant=10][62 bits rand_b]
+        long lsb = 0L;
+        for (int i = 2; i < 10; i++) {
+            lsb = (lsb << 8) | (bytes[i] & 0xffL);
+        }
+        lsb &= V7_LSB_VARIANT_CLEAR_MASK;
+        lsb |= V7_LSB_VARIANT_SET_MASK;
+
+        return new UUID(msb, lsb);
     }
 
     private static UUID rndUUIDv4() {

--- a/util/src/test/java/org/killbill/billing/util/TestUUIDs.java
+++ b/util/src/test/java/org/killbill/billing/util/TestUUIDs.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Regression coverage for {@link UUIDs}, in particular the UUIDv7 support
+ * introduced for issue #2156.
+ */
+public class TestUUIDs {
+
+    @Test(groups = "fast")
+    public void testRandomUUIDv4VersionAndVariant() {
+        final UUID id = UUIDs.randomUUIDv4();
+        Assert.assertEquals(id.version(), 4, "expected UUIDv4");
+        Assert.assertEquals(id.variant(), 2, "expected IETF variant");
+    }
+
+    @Test(groups = "fast")
+    public void testRandomUUIDv7VersionAndVariant() {
+        final UUID id = UUIDs.randomUUIDv7();
+        Assert.assertEquals(id.version(), 7, "expected UUIDv7");
+        Assert.assertEquals(id.variant(), 2, "expected IETF variant");
+    }
+
+    @Test(groups = "fast")
+    public void testRandomUUIDv7EncodesTimestampDeterministically() {
+        // Use the package-private overload so the assertion is independent
+        // of the JVM-wide monotonic counter (which other tests in this
+        // class may have advanced past wall-clock time).
+        final long millis = 0x0000018E_1B2C3D4EL; // arbitrary 48-bit value
+        final UUID id = UUIDs.rndUUIDv7(millis);
+
+        Assert.assertEquals(id.version(), 7);
+        Assert.assertEquals(id.variant(), 2);
+        Assert.assertEquals(UUIDs.timestampMillisFromV7(id), millis,
+                            "UUIDv7 must embed the supplied unix-ms timestamp in the high 48 bits");
+    }
+
+    /**
+     * UUIDv7 ids generated in sequence must be strictly increasing under
+     * Java's signed {@code UUID.compareTo} for the entire 48-bit timestamp
+     * range we care about. The monotonic millisecond counter in
+     * {@link UUIDs#randomUUIDv7()} is what makes this hold even when many
+     * ids are produced within the same wall-clock millisecond.
+     */
+    @Test(groups = "fast")
+    public void testRandomUUIDv7IsMonotonic() {
+        UUID prev = UUIDs.randomUUIDv7();
+        for (int i = 0; i < 10_000; i++) {
+            final UUID next = UUIDs.randomUUIDv7();
+            Assert.assertTrue(next.compareTo(prev) > 0,
+                              "v7 ids must be strictly increasing: " + prev + " -> " + next);
+            prev = next;
+        }
+    }
+
+    @Test(groups = "fast")
+    public void testRandomUUIDv7IsUnique() {
+        final int count = 10_000;
+        final Set<UUID> seen = new HashSet<>(count * 2);
+        for (int i = 0; i < count; i++) {
+            Assert.assertTrue(seen.add(UUIDs.randomUUIDv7()), "duplicate UUIDv7 generated");
+        }
+    }
+
+    @Test(groups = "fast", expectedExceptions = IllegalArgumentException.class)
+    public void testTimestampExtractionRejectsNonV7() {
+        UUIDs.timestampMillisFromV7(UUIDs.randomUUIDv4());
+    }
+
+    /**
+     * The default of {@link UUIDs#randomUUID()} must remain UUIDv4 to keep
+     * historical behavior; UUIDv7 is opt-in via the
+     * {@code org.killbill.uuid.v7.enabled} system property (which is not
+     * set in the test JVM).
+     */
+    @Test(groups = "fast")
+    public void testRandomUUIDDefaultsToV4() {
+        Assert.assertFalse(UUIDs.isUUIDv7Enabled(),
+                           "UUIDv7 should be opt-in; toggle should be off by default in tests");
+        Assert.assertEquals(UUIDs.randomUUID().version(), 4);
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment** comparing Claude Opus 4.7 fixing this issue **with** vs **without** access to the `killbill-ds4-hybrid` ARKGraph (a code+data+business knowledge graph of the killbill repo). It is **not** a hand-authored PR. Two PRs are filed for issue #2156, one per arm of the experiment; please pick the one whose approach you prefer (or reject both). Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md` in the experiment repo.

This is part of an extended Tier-2 run with three broad-scope issues (#2156 UUIDv7, #2157 PostgreSQL default, #2176 Java 17 tuning).

Closes #2156 (proposes a fix; needs maintainer review)

## Arm b (ARK graph)

Kill Bill mints every identifier through UUIDs.randomUUID(), which today
produces a UUIDv4. The issue asks for UUIDv7 support so that primary keys
carry a leading 48-bit Unix-ms prefix and stay roughly monotonic for
B-tree indexes under write-heavy workloads.

Make randomUUID() dispatch to either UUIDv4 (default, unchanged) or
UUIDv7 based on the org.killbill.uuid.v7.enabled system property, and
expose explicit randomUUIDv4() / randomUUIDv7() helpers plus a
timestampMillisFromV7() extractor. The v7 generator reuses the existing
threadRandom (SHA1PRNG-backed LightSecureRandom) for entropy and routes
the millisecond timestamp through a per-JVM AtomicLong monotonic counter
so concurrent generation in the same wall-clock millisecond, and small
NTP-style backwards clock jumps, still yield strictly increasing ids.

All 135 existing call sites across 78 files keep using
UUIDs.randomUUID() unchanged and automatically benefit when the flag is
flipped. The full record_id -> id switch called out in the issue's
discussion is a separate, much larger effort and is intentionally out of
scope.

Adds util/src/test/java/org/killbill/billing/util/TestUUIDs.java with
unit coverage for v4 and v7 version/variant bits, deterministic
timestamp encoding, 10k-iteration strict monotonicity, uniqueness, and
the version/variant guard on timestampMillisFromV7.

## Diff stat

```
 FIX_REPORT.md                                      | 144 +++++++++++++++++++++
 .../main/java/org/killbill/billing/util/UUIDs.java |  87 ++++++++++++-
 .../java/org/killbill/billing/util/TestUUIDs.java  | 104 +++++++++++++++
 3 files changed, 334 insertions(+), 1 deletion(-)
```

