### PR TITLE
[Experiment / arm b-cloud (ARK cloud MCP)] Fix #2176: Log JVM/container diagnostics at boot for JDK 17 readiness (issue #2176)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,111 @@
+# Fix Report — Issue #2176 (Upgrade to Java 17 / JVM-in-container best practices)
+
+## Root cause / design summary
+
+Issue #2176 is an enhancement, not a bug: it tracks the move to JDK 17 and
+flags a set of container-related JVM footguns (cgroup-blind CPU detection,
+glibc malloc-arena bloat, GC overhead, observability of off-heap growth). Most
+of those items are deployment-time JVM flags rather than code, but the one
+piece that genuinely belongs in the application is a startup self-check that
+makes the situation visible. Today the server boots without ever logging which
+JVM, GC, heap, or cgroup view it is running under — when a container is
+OOM-killed by the kernel there is nothing in the application logs to point at
+`-XX:ActiveProcessorCount`, `MALLOC_ARENA_MAX`, or `NativeMemoryTracking`.
+
+The fix adds a small `JvmRuntimeDiagnostics` helper in the `profiles/killbill`
+boot module and wires a single call into
+`KillbillGuiceListener.startLifecycleStage2()` so the server logs its
+container/JVM state exactly once at boot, with targeted hints when it detects
+a containerized JDK 11+ environment that is missing the recommended knobs from
+the issue.
+
+## Change summary
+
+- **`profiles/killbill/src/main/java/org/killbill/billing/server/diagnostics/JvmRuntimeDiagnostics.java`** (new) —
+  Pure helper that collects a list of `Diagnostic{level, message}` records.
+  - Always logs: VM name/version/vendor, spec version, JVM-visible CPUs, max
+    heap, every active garbage collector, and whether `/proc/1/cgroup`
+    indicates a container (`docker` / `kubepods` / `containerd` / `lxc`).
+  - In a container, additionally emits:
+    - a **WARN** when `availableProcessors() >
+      CONTAINER_HIGH_CPU_WARN_THRESHOLD` (=16) **and** the process was started
+      without `-XX:ActiveProcessorCount`, since that is the classic cgroup-blind
+      thread-pool sizing failure mode called out in the issue;
+    - an **INFO** hint to set `MALLOC_ARENA_MAX` when the env var is unset
+      (glibc malloc arena bloat);
+    - an **INFO** hint to set `-XX:NativeMemoryTracking=summary` when the flag
+      is unset (so off-heap growth is observable in production).
+  - All inputs (CPU count, container detection, JVM args, env lookup) flow
+    through a package-private `Environment` interface so the helper has a clean
+    test seam and can never throw at boot.
+
+- **`profiles/killbill/src/main/java/org/killbill/billing/server/listeners/KillbillGuiceListener.java`** —
+  One added import and one `JvmRuntimeDiagnostics.log()` call at the top of
+  `startLifecycleStage2()`. No other behavior changed.
+
+- **`profiles/killbill/src/test/java/org/killbill/billing/server/diagnostics/TestJvmRuntimeDiagnostics.java`** (new) —
+  TestNG fast-group tests that exercise the helper through its `Environment`
+  test seam.
+
+No build files were touched and no other modules were modified.
+
+## How the test exercises the new behavior
+
+`TestJvmRuntimeDiagnostics` covers the four meaningful paths through the new
+helper plus a boundary case:
+
+| Test | Scenario | Assertion |
+| --- | --- | --- |
+| `testLogAndCollectAreSafeOnAnyHost` | Real host (default `Environment`) | `log()` and `collect()` never throw and always include the CPU line — the contract that lets `KillbillGuiceListener` call `log()` unconditionally at boot. |
+| `testNonContainerizedEmitsNoContainerHints` | 64 CPUs, **not** containerized | No CPU warning, no `MALLOC_ARENA_MAX` hint, no NMT hint — bare-metal users do not get noise. |
+| `testContainerizedWithUnpinnedCpuTriggersWarning` | Containerized with `17` JVM-visible CPUs and no `-XX:ActiveProcessorCount` | Emits a WARN containing both `ActiveProcessorCount` and the CPU count `17`. |
+| `testContainerizedWithPinnedCpuSuppressesWarning` | Containerized with 48 CPUs but `-XX:ActiveProcessorCount` + `-XX:NativeMemoryTracking` set | No CPU warning, no NMT hint. |
+| `testContainerizedWithoutMallocArenaMaxEmitsHint` | Containerized, `MALLOC_ARENA_MAX` unset | Emits the glibc malloc arena hint. |
+| `testContainerizedWithMallocArenaMaxSuppressesHint` | Containerized, `MALLOC_ARENA_MAX=2` | Glibc malloc arena hint is suppressed. |
+| `testCpuCountAtOrBelowThresholdDoesNotWarn` | Containerized, exactly `CONTAINER_HIGH_CPU_WARN_THRESHOLD` CPUs | No CPU warning (boundary — must be strictly above). |
+
+Because the helper is fed via the `Environment` seam, the tests run identically
+on macOS, Linux, ARM, or x86 — no embedded MySQL, no `/proc` access, no JVM
+restart with flags.
+
+## Build status
+
+`mvn -pl profiles/killbill -am -DskipTests=true clean compile` and
+`mvn -pl profiles/killbill -am -DskipTests=true test-compile` both produce:
+
+```
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  12.808 s
+[INFO] Finished at: 2026-05-27T10:33:23-06:00
+[INFO] ------------------------------------------------------------------------
+```
+
+(`-Dcheck.skip-*=true` was used to skip the non-compilation enforcer / scope /
+spotbugs / duplicate-finder plugins — these require `mvn install` of the
+test-jars to be available locally and are unrelated to the compilation gate.
+The same flags are used by the project's own `bin/start-server` script.)
+
+The TestNG tests themselves were not executed because the surefire phase
+transitively pulls in the embedded MySQL ARM artifact, which is not published
+for this host (`mysql-Mac_OS_X-aarch64.tar.gz` — explicitly called out in the
+task constraints as a known environment issue). The new test class compiles
+clean as part of `test-compile`.
+
+## Confidence
+
+**Medium-high.**
+
+- The change is small, localized to a single boot module, and adds no
+  dependencies.
+- The helper is deliberately defensive (best-effort container detection,
+  unconditional fallback to "not containerized" on non-Linux hosts, no
+  exceptions on the boot path) and is exercised by tests that do not depend
+  on host OS or container runtime.
+- The interpretation of issue #2176 as "log container/JVM diagnostics at boot
+  + emit hints for the specific footguns the issue lists" is a judgment call —
+  the issue itself is open-ended ("Upgrade to java 17") and most of its
+  bullet points are JVM flags rather than code. A reviewer may prefer the
+  hints in a different place (e.g. in `start-server` shell scripts) or with
+  different thresholds; both are easy follow-ups.

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/diagnostics/JvmRuntimeDiagnostics.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/diagnostics/JvmRuntimeDiagnostics.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2020-2026 Equinix, Inc
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.server.diagnostics;
+
+import java.io.IOException;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.management.RuntimeMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Emits JVM and container-awareness information at server boot so operators
+ * can quickly spot misconfigurations that lead to native-memory bloat or
+ * runaway thread pools when running on modern JDKs (JDK 11+ in containers).
+ *
+ * <p>See Kill Bill issue #2176 for the motivating discussion.</p>
+ */
+public final class JvmRuntimeDiagnostics {
+
+    private static final Logger logger = LoggerFactory.getLogger(JvmRuntimeDiagnostics.class);
+
+    // Most container-cgroup CPU quotas land well below this. When the JVM
+    // reports many more visible CPUs than that from inside a container, it is
+    // usually a sign that -XX:ActiveProcessorCount was not pinned and the JVM
+    // sized its ForkJoinPool/G1 worker threads against the host instead of the
+    // cgroup quota.
+    static final int CONTAINER_HIGH_CPU_WARN_THRESHOLD = 16;
+
+    enum Level { INFO, WARN }
+
+    public static final class Diagnostic {
+        public final Level level;
+        public final String message;
+
+        Diagnostic(final Level level, final String message) {
+            this.level = level;
+            this.message = message;
+        }
+
+        @Override
+        public String toString() {
+            return level + " " + message;
+        }
+    }
+
+    private JvmRuntimeDiagnostics() {}
+
+    /**
+     * Emit diagnostics to the static SLF4J logger. Safe to call at boot from
+     * any environment — never throws.
+     */
+    public static void log() {
+        for (final Diagnostic d : collect()) {
+            if (d.level == Level.WARN) {
+                logger.warn(d.message);
+            } else {
+                logger.info(d.message);
+            }
+        }
+    }
+
+    /**
+     * Collect diagnostics against the live JVM.
+     */
+    public static List<Diagnostic> collect() {
+        return collect(defaultEnvironment());
+    }
+
+    static List<Diagnostic> collect(final Environment env) {
+        final List<Diagnostic> out = new ArrayList<>();
+
+        final RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+        final MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
+        final List<GarbageCollectorMXBean> gcs = ManagementFactory.getGarbageCollectorMXBeans();
+
+        final int availableProcessors = env.availableProcessors();
+        final MemoryUsage heap = memory.getHeapMemoryUsage();
+        final long maxHeapMb = heap.getMax() <= 0 ? -1 : heap.getMax() / (1024L * 1024L);
+
+        out.add(info("Kill Bill JVM diagnostics (issue #2176):"));
+        out.add(info("  Java VM         : " + runtime.getVmName() + " " + runtime.getVmVersion() + " (" + runtime.getVmVendor() + ")"));
+        out.add(info("  Spec version    : " + runtime.getSpecVersion()));
+        out.add(info("  Available CPUs  : " + availableProcessors + " (JVM-visible — should respect cgroup quota on JDK 11+)"));
+        out.add(info("  Max heap        : " + (maxHeapMb < 0 ? "unbounded" : (maxHeapMb + " MB"))));
+        for (final GarbageCollectorMXBean gc : gcs) {
+            out.add(info("  GC              : " + gc.getName()));
+        }
+
+        final boolean inContainer = env.isContainerized();
+        out.add(info("  Containerized   : " + inContainer));
+
+        if (inContainer) {
+            // Container-specific hints. These mirror the best-practices from
+            // https://dzone.com/articles/jdk-memory-bloat-containers referenced
+            // in the upstream issue.
+            if (availableProcessors > CONTAINER_HIGH_CPU_WARN_THRESHOLD
+                && !env.hasActiveProcessorCountFlag()) {
+                out.add(new Diagnostic(Level.WARN,
+                                       "Detected container with " + availableProcessors
+                                       + " JVM-visible CPUs but -XX:ActiveProcessorCount is unset; "
+                                       + "pin ActiveProcessorCount to your cgroup CPU quota to avoid oversized "
+                                       + "ForkJoinPool/GC worker pools and the resulting native-memory bloat."));
+            }
+            if (env.getEnv("MALLOC_ARENA_MAX") == null) {
+                out.add(info("Hint: set MALLOC_ARENA_MAX (e.g. 2) in containerized deployments to limit glibc "
+                             + "malloc arena native-memory growth caused by thread proliferation."));
+            }
+            if (!env.hasNativeMemoryTrackingFlag()) {
+                out.add(info("Hint: enable -XX:NativeMemoryTracking=summary to make off-heap growth observable when "
+                             + "diagnosing container OOM-kills."));
+            }
+        }
+        return out;
+    }
+
+    private static Diagnostic info(final String message) {
+        return new Diagnostic(Level.INFO, message);
+    }
+
+    static boolean detectContainerized() {
+        // Best-effort: only Linux containers have /proc/1/cgroup. Returns
+        // false on macOS, Windows and bare-metal Linux without the file.
+        final Path cgroup = Paths.get("/proc/1/cgroup");
+        if (!Files.isReadable(cgroup)) {
+            return false;
+        }
+        try {
+            final String contents = Files.readString(cgroup);
+            return contents.contains("docker")
+                   || contents.contains("kubepods")
+                   || contents.contains("containerd")
+                   || contents.contains("/lxc/");
+        } catch (final IOException e) {
+            return false;
+        }
+    }
+
+    private static Environment defaultEnvironment() {
+        final List<String> jvmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
+        return new Environment() {
+            @Override
+            public int availableProcessors() {
+                return Runtime.getRuntime().availableProcessors();
+            }
+
+            @Override
+            public boolean isContainerized() {
+                return detectContainerized();
+            }
+
+            @Override
+            public boolean hasActiveProcessorCountFlag() {
+                return jvmArgs.stream().anyMatch(a -> a.startsWith("-XX:ActiveProcessorCount"));
+            }
+
+            @Override
+            public boolean hasNativeMemoryTrackingFlag() {
+                return jvmArgs.stream().anyMatch(a -> a.startsWith("-XX:NativeMemoryTracking"));
+            }
+
+            @Override
+            public String getEnv(final String name) {
+                return System.getenv(name);
+            }
+        };
+    }
+
+    /**
+     * Test seam — allows the diagnostics to be exercised without spinning up a
+     * real container or restarting the JVM with different flags.
+     */
+    interface Environment {
+        int availableProcessors();
+
+        boolean isContainerized();
+
+        boolean hasActiveProcessorCountFlag();
+
+        boolean hasNativeMemoryTrackingFlag();
+
+        String getEnv(String name);
+
+        static Environment from(final int cpus,
+                                final boolean container,
+                                final boolean activeProcessorCount,
+                                final boolean nativeMemoryTracking,
+                                final Function<String, String> envLookup) {
+            return new Environment() {
+                @Override
+                public int availableProcessors() {
+                    return cpus;
+                }
+
+                @Override
+                public boolean isContainerized() {
+                    return container;
+                }
+
+                @Override
+                public boolean hasActiveProcessorCountFlag() {
+                    return activeProcessorCount;
+                }
+
+                @Override
+                public boolean hasNativeMemoryTrackingFlag() {
+                    return nativeMemoryTracking;
+                }
+
+                @Override
+                public String getEnv(final String name) {
+                    return envLookup.apply(name);
+                }
+            };
+        }
+    }
+}

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/listeners/KillbillGuiceListener.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/listeners/KillbillGuiceListener.java
@@ -35,6 +35,7 @@ import org.killbill.billing.server.filters.Jersey1BackwardCompatibleFilter;
 import org.killbill.billing.server.filters.KillbillMDCInsertingServletFilter;
 import org.killbill.billing.server.filters.ProfilingContainerResponseFilter;
 import org.killbill.billing.server.filters.RequestDataFilter;
+import org.killbill.billing.server.diagnostics.JvmRuntimeDiagnostics;
 import org.killbill.billing.server.filters.ResponseCorsFilter;
 import org.killbill.billing.server.modules.KillbillServerModule;
 import org.killbill.billing.server.notifications.PushNotificationListener;
@@ -128,6 +129,9 @@ public class KillbillGuiceListener extends KillbillPlatformGuiceListener {
 
     @Override
     protected void startLifecycleStage2() {
+        // Log JVM + container-awareness state once at boot (see issue #2176).
+        JvmRuntimeDiagnostics.log();
+
         killbilleventHandler = injector.getInstance(KillbillEventHandler.class);
 
         // Perform Bus registration

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/diagnostics/TestJvmRuntimeDiagnostics.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/diagnostics/TestJvmRuntimeDiagnostics.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020-2026 Equinix, Inc
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.server.diagnostics;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.killbill.billing.server.diagnostics.JvmRuntimeDiagnostics.Diagnostic;
+import org.killbill.billing.server.diagnostics.JvmRuntimeDiagnostics.Environment;
+import org.killbill.billing.server.diagnostics.JvmRuntimeDiagnostics.Level;
+
+public class TestJvmRuntimeDiagnostics {
+
+    @Test(groups = "fast")
+    public void testLogAndCollectAreSafeOnAnyHost() {
+        // The static entry points must never throw at boot regardless of the
+        // host OS / JVM flags / env vars — this is the contract that lets
+        // KillbillGuiceListener call log() unconditionally.
+        JvmRuntimeDiagnostics.log();
+        final List<Diagnostic> diagnostics = JvmRuntimeDiagnostics.collect();
+        Assert.assertFalse(diagnostics.isEmpty(), "Diagnostics must always include the basic JVM lines");
+        Assert.assertTrue(containsInfo(diagnostics, "Available CPUs"),
+                          "CPU count must always be reported");
+    }
+
+    @Test(groups = "fast")
+    public void testNonContainerizedEmitsNoContainerHints() {
+        final List<Diagnostic> diagnostics = JvmRuntimeDiagnostics.collect(
+                Environment.from(64, false, false, false, noEnv()));
+
+        Assert.assertFalse(containsWarn(diagnostics, "ActiveProcessorCount"),
+                           "Non-containerized hosts must not get the CPU warning");
+        Assert.assertFalse(containsInfo(diagnostics, "MALLOC_ARENA_MAX"),
+                           "Non-containerized hosts must not get the glibc malloc arena hint");
+        Assert.assertFalse(containsInfo(diagnostics, "NativeMemoryTracking"),
+                           "Non-containerized hosts must not get the NMT hint");
+    }
+
+    @Test(groups = "fast")
+    public void testContainerizedWithUnpinnedCpuTriggersWarning() {
+        final int cpus = JvmRuntimeDiagnostics.CONTAINER_HIGH_CPU_WARN_THRESHOLD + 1;
+        final List<Diagnostic> diagnostics = JvmRuntimeDiagnostics.collect(
+                Environment.from(cpus, true, false, false, noEnv()));
+
+        Assert.assertTrue(containsWarn(diagnostics, "ActiveProcessorCount"),
+                          "Containerized hosts with many JVM-visible CPUs must be warned to pin ActiveProcessorCount");
+        Assert.assertTrue(containsWarn(diagnostics, String.valueOf(cpus)),
+                          "Warning must include the actual JVM-visible CPU count");
+    }
+
+    @Test(groups = "fast")
+    public void testContainerizedWithPinnedCpuSuppressesWarning() {
+        final List<Diagnostic> diagnostics = JvmRuntimeDiagnostics.collect(
+                Environment.from(JvmRuntimeDiagnostics.CONTAINER_HIGH_CPU_WARN_THRESHOLD + 32,
+                                 true, true, true, noEnv()));
+
+        Assert.assertFalse(containsWarn(diagnostics, "ActiveProcessorCount"),
+                           "Pinning -XX:ActiveProcessorCount must suppress the CPU warning");
+        Assert.assertFalse(containsInfo(diagnostics, "NativeMemoryTracking"),
+                           "Setting -XX:NativeMemoryTracking must suppress the NMT hint");
+    }
+
+    @Test(groups = "fast")
+    public void testContainerizedWithoutMallocArenaMaxEmitsHint() {
+        final List<Diagnostic> diagnostics = JvmRuntimeDiagnostics.collect(
+                Environment.from(4, true, true, true, noEnv()));
+
+        Assert.assertTrue(containsInfo(diagnostics, "MALLOC_ARENA_MAX"),
+                          "Containerized hosts without MALLOC_ARENA_MAX must receive the glibc malloc hint");
+    }
+
+    @Test(groups = "fast")
+    public void testContainerizedWithMallocArenaMaxSuppressesHint() {
+        final Function<String, String> envLookup = Map.of("MALLOC_ARENA_MAX", "2")::get;
+        final List<Diagnostic> diagnostics = JvmRuntimeDiagnostics.collect(
+                Environment.from(4, true, true, true, envLookup));
+
+        Assert.assertFalse(containsInfo(diagnostics, "MALLOC_ARENA_MAX"),
+                           "Setting MALLOC_ARENA_MAX must suppress the glibc malloc hint");
+    }
+
+    @Test(groups = "fast")
+    public void testCpuCountAtOrBelowThresholdDoesNotWarn() {
+        // Boundary: exactly at threshold should not warn, only strictly above.
+        final List<Diagnostic> diagnostics = JvmRuntimeDiagnostics.collect(
+                Environment.from(JvmRuntimeDiagnostics.CONTAINER_HIGH_CPU_WARN_THRESHOLD,
+                                 true, false, true, noEnv()));
+
+        Assert.assertFalse(containsWarn(diagnostics, "ActiveProcessorCount"),
+                           "CPU count at or below threshold must not warn");
+    }
+
+    private static boolean containsInfo(final List<Diagnostic> diagnostics, final String needle) {
+        return diagnostics.stream()
+                          .anyMatch(d -> d.level == Level.INFO && d.message.contains(needle));
+    }
+
+    private static boolean containsWarn(final List<Diagnostic> diagnostics, final String needle) {
+        return diagnostics.stream()
+                          .anyMatch(d -> d.level == Level.WARN && d.message.contains(needle));
+    }
+
+    private static Function<String, String> noEnv() {
+        return name -> null;
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment.** It is the **arm B (cloud-MCP)** variant — Claude Opus 4.7 driven by a graph-grounded MCP hosted on Cloud Run instead of a local Neo4j instance. Both the local-arm-b PR and this cloud-arm-b PR are filed for issue #2176. Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md`.

Closes #2176 (proposes a fix; needs maintainer review)

## Cloud-MCP arm

Add a small JvmRuntimeDiagnostics helper in profiles/killbill that runs
once at server boot (from KillbillGuiceListener.startLifecycleStage2)
and logs the JVM, GC, heap, and cgroup view of the host. When the
process is detected to be inside a container, the helper additionally
emits targeted hints for the specific footguns called out in the
issue:

  - WARN when -XX:ActiveProcessorCount is unset and the JVM-visible
    CPU count is suspiciously large (cgroup-blind sizing of ForkJoin
    / GC worker pools — the classic JDK-in-container failure mode).
  - INFO hint to set MALLOC_ARENA_MAX in containerized deployments
    (limits glibc malloc-arena native-memory growth).
  - INFO hint to enable -XX:NativeMemoryTracking=summary so off-heap
    growth is observable when diagnosing container OOM-kills.

All inputs flow through a package-private Environment seam so the
helper is fully unit-testable without spinning up containers or
restarting the JVM with different flags; TestJvmRuntimeDiagnostics
covers the bare-metal, containerized-unpinned, containerized-pinned,
malloc-arena, and threshold-boundary paths.

The behavior is deliberately additive — no build files were modified,
no module other than profiles/killbill is touched, and the helper is
defensive enough (best-effort container detection, no exceptions on
the boot path) that it is safe to call unconditionally on any host.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Diff stat

```
 FIX_REPORT.md                                      | 111 ++++++++++
 .../server/diagnostics/JvmRuntimeDiagnostics.java  | 241 +++++++++++++++++++++
 .../server/listeners/KillbillGuiceListener.java    |   4 +
 .../diagnostics/TestJvmRuntimeDiagnostics.java     | 125 +++++++++++
 4 files changed, 481 insertions(+)
```

