### PR TITLE
[Experiment / arm b-cloud (ARK cloud MCP)] Fix #2157: Adopt PostgreSQL as the default database (issue #2157)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,84 @@
+# Fix Report — Issue #2157: Adopt PostgreSQL as the default database
+
+## Root cause / design summary
+
+This is an enhancement request rather than a bug. The bundled Kill Bill reference-implementation
+configuration `profiles/killbill/src/main/resources/killbill-server.properties` previously defaulted
+both the main DAO (`org.killbill.dao.url`) and the OSGi plugin DAO (`org.killbill.billing.osgi.dao.url`)
+to MySQL (`jdbc:mysql://127.0.0.1:3306/killbill`). Because that file is loaded as `killbill-server.properties`
+on the classpath at startup and supplies the property values consumed by `org.killbill.commons.jdbi.guice.DaoConfig#getJdbcUrl()`
+(which is then routed through `org.killbill.billing.server.dao.EmbeddedDBFactory#get(DaoConfig)` inside
+`org.killbill.billing.server.modules.KillBillEmbeddedDBProvider`), the reference profile shipped MySQL as
+its de-facto default DB engine. Per the issue, PostgreSQL is the preferred default; this change updates the
+reference configuration so that — without any user override — the server profile resolves a PostgreSQL
+`EmbeddedDB` instance.
+
+## Change summary
+
+- `profiles/killbill/src/main/resources/killbill-server.properties` — switched the two `*.dao.url` entries
+  (main DAO and OSGi DAO) from `jdbc:mysql://127.0.0.1:3306/killbill` to
+  `jdbc:postgresql://127.0.0.1:5432/killbill`, and updated the matching `user`/`password` defaults to
+  `postgres`/`postgres`. Added a short comment explaining that PostgreSQL is now the default and how to
+  override it back to MySQL.
+- `profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestEmbeddedDBFactory.java` — added
+  `testDefaultReferenceImplementationIsPostgres()`. The new test loads the bundled
+  `killbill-server.properties` from the classpath, asserts that both `org.killbill.dao.url` and
+  `org.killbill.billing.osgi.dao.url` point at PostgreSQL, then feeds that resource through
+  `AugmentedConfigurationObjectFactory` and `EmbeddedDBFactory.get(...)` to assert the resulting
+  `EmbeddedDB.getDBEngine()` is `DBEngine.POSTGRESQL`.
+
+## How the test exercises the new behaviour
+
+`testDefaultReferenceImplementationIsPostgres` reads the *real* `killbill-server.properties` file shipped
+inside the `profiles/killbill` jar (the same file the reference implementation uses at startup), then
+runs the same code path the server uses to derive its `EmbeddedDB` — `DaoConfig` built via
+`AugmentedConfigurationObjectFactory` and routed through `EmbeddedDBFactory.get(DaoConfig)`. The test
+fails if either of the two URLs regresses to a non-PostgreSQL URL or if the factory no longer recognizes
+the URL as PostgreSQL, pinning the new default.
+
+## Build status
+
+```
+mvn -pl profiles/killbill -am -DskipTests -Dcheck.skip-spotbugs=true -Dcheck.skip-dependency-scope=true compile
+...
+[INFO] killbill-profiles-killbill ......................... SUCCESS [  0.849 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  12.541 s
+```
+
+Test-compile was also verified separately:
+
+```
+mvn -pl profiles/killbill -am -DskipTests -Dcheck.skip-spotbugs=true -Dcheck.skip-dependency-scope=true test-compile
+...
+[INFO] killbill-profiles-killbill ......................... SUCCESS [  1.411 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  13.792 s
+```
+
+Note: `-Dcheck.skip-spotbugs=true -Dcheck.skip-dependency-scope=true` were needed because the build
+environment runs JDK 25, and the SpotBugs version pinned by `killbill-oss-parent:0.146.67` (4.7.2.1)
+ships an ASM that does not understand class-file major version 69. The skip flags only disable the
+SpotBugs/dependency-scope checks; the actual `javac` compilation of main and test sources still
+targets Java 11 and succeeds.
+
+## Confidence level
+
+**Medium.**
+
+- The change correctly redirects the reference-implementation defaults to PostgreSQL, and the new
+  regression test asserts that property values and resolved `EmbeddedDB.DBEngine` are both PostgreSQL.
+- Both `mvn ... compile` and `mvn ... test-compile` pass for `profiles/killbill` and all its dependent
+  modules.
+- The wider Kill Bill test suite (`*TestSuiteWithEmbeddedDB`) provisions its own embedded DB via
+  `org.killbill.billing.GuicyKillbillTestSuiteWithEmbeddedDB` / `KillbillTestSuiteWithEmbeddedDB`,
+  independently of `killbill-server.properties`, so this property change should not destabilize
+  existing tests. The environment's known embedded-MySQL-on-ARM failure (`mysql-Mac_OS_X-aarch64.tar.gz`)
+  is unrelated and explicitly out of scope per the task.
+- I cannot independently verify the integration-test profile in the larger Kill Bill ecosystem (docker-compose
+  recipes, kpm seeding, etc.) since those live outside this repo; the change here is the minimal, focused
+  edit inside the killbill repo to make PostgreSQL the configured default.

--- a/profiles/killbill/src/main/resources/killbill-server.properties
+++ b/profiles/killbill/src/main/resources/killbill-server.properties
@@ -23,9 +23,11 @@
 # KILLBILL GENERIC PROPERTIES
 #
 # Database config
-org.killbill.dao.url=jdbc:mysql://127.0.0.1:3306/killbill
-org.killbill.dao.user=root
-org.killbill.dao.password=root
+# PostgreSQL is the default database for the Kill Bill reference implementation (see issue #2157).
+# To use MySQL instead, override these properties (e.g. -Dorg.killbill.dao.url=jdbc:mysql://127.0.0.1:3306/killbill).
+org.killbill.dao.url=jdbc:postgresql://127.0.0.1:5432/killbill
+org.killbill.dao.user=postgres
+org.killbill.dao.password=postgres
 org.killbill.dao.logLevel=DEBUG
 
 # Use the SpyCarAdvanced.xml catalog
@@ -62,9 +64,10 @@ org.killbill.tenant.broadcast.rate=1s
 # PLUGIN SPECIFIC PROPERTIES
 #
 # Database config (OSGI plugins)
-org.killbill.billing.osgi.dao.url=jdbc:mysql://127.0.0.1:3306/killbill
-org.killbill.billing.osgi.dao.user=root
-org.killbill.billing.osgi.dao.password=root
+# PostgreSQL is the default database for the Kill Bill reference implementation (see issue #2157).
+org.killbill.billing.osgi.dao.url=jdbc:postgresql://127.0.0.1:5432/killbill
+org.killbill.billing.osgi.dao.user=postgres
+org.killbill.billing.osgi.dao.password=postgres
 
 # Allow jruby concurrency
 org.killbill.jruby.context.scope=THREADSAFE

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestEmbeddedDBFactory.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/dao/TestEmbeddedDBFactory.java
@@ -18,6 +18,7 @@
 
 package org.killbill.billing.server.dao;
 
+import java.io.InputStream;
 import java.util.Properties;
 
 import org.killbill.billing.KillbillTestSuite;
@@ -47,6 +48,26 @@ public class TestEmbeddedDBFactory extends KillbillTestSuite {
         final EmbeddedDB genericEmbeddedDb = EmbeddedDBFactory.get(createDaoConfig("jdbc:derby://localhost:1527/killbill;collation=TERRITORY_BASED:PRIMARY", "root", "root"));
         Assert.assertEquals(genericEmbeddedDb.getDBEngine(), DBEngine.GENERIC);
         checkEmbeddedDb(genericEmbeddedDb);
+    }
+
+    // Regression test for issue #2157: the bundled killbill-server.properties reference
+    // implementation must default to PostgreSQL for both the main DAO and the OSGI DAO.
+    @Test(groups = "fast")
+    public void testDefaultReferenceImplementationIsPostgres() throws Exception {
+        final Properties properties = new Properties();
+        try (final InputStream in = getClass().getResourceAsStream("/killbill-server.properties")) {
+            Assert.assertNotNull(in, "killbill-server.properties resource not found on the classpath");
+            properties.load(in);
+        }
+
+        Assert.assertEquals(properties.getProperty("org.killbill.dao.url"),
+                            "jdbc:postgresql://127.0.0.1:5432/killbill");
+        Assert.assertEquals(properties.getProperty("org.killbill.billing.osgi.dao.url"),
+                            "jdbc:postgresql://127.0.0.1:5432/killbill");
+
+        final DaoConfig daoConfig = new AugmentedConfigurationObjectFactory(properties).build(DaoConfig.class);
+        final EmbeddedDB embeddedDb = EmbeddedDBFactory.get(daoConfig);
+        Assert.assertEquals(embeddedDb.getDBEngine(), DBEngine.POSTGRESQL);
     }
 
     private void checkEmbeddedDb(final EmbeddedDB embeddedDb) {


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment.** It is the **arm B (cloud-MCP)** variant — Claude Opus 4.7 driven by a graph-grounded MCP hosted on Cloud Run instead of a local Neo4j instance. Both the local-arm-b PR and this cloud-arm-b PR are filed for issue #2157. Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md`.

Closes #2157 (proposes a fix; needs maintainer review)

## Cloud-MCP arm

Change the bundled Kill Bill reference-implementation configuration in
profiles/killbill/src/main/resources/killbill-server.properties so that
the main DAO URL (org.killbill.dao.url) and the OSGi plugin DAO URL
(org.killbill.billing.osgi.dao.url) default to PostgreSQL
(jdbc:postgresql://127.0.0.1:5432/killbill) instead of MySQL. The
matching default user/password are updated to postgres/postgres, and a
short comment explains how to override back to MySQL.

These property values feed DaoConfig#getJdbcUrl(), which is routed
through EmbeddedDBFactory.get(DaoConfig) inside
KillBillEmbeddedDBProvider, so flipping the URL flips the engine the
reference server resolves at startup.

Add a regression test in TestEmbeddedDBFactory
(testDefaultReferenceImplementationIsPostgres) that loads the bundled
killbill-server.properties from the classpath, asserts both DAO URLs
target PostgreSQL, then runs the property set through
EmbeddedDBFactory.get(...) and asserts the resolved
EmbeddedDB.DBEngine is POSTGRESQL.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Diff stat

```
 FIX_REPORT.md                                      | 84 ++++++++++++++++++++++
 .../src/main/resources/killbill-server.properties  | 15 ++--
 .../billing/server/dao/TestEmbeddedDBFactory.java  | 21 ++++++
 3 files changed, 114 insertions(+), 6 deletions(-)
```

