### PR TITLE
[Experiment / arm b-cloud (ARK cloud MCP)] Fix #2156: Emit RFC 9562 UUIDv7 identifiers from UUIDs.randomUUID() (issue #2156)

### DIFF
--- a/FIX_REPORT.md
+++ b/FIX_REPORT.md
@@ -1,0 +1,120 @@
+# Fix Report — issue #2156: Adopt UUIDv7 for system identifiers
+
+## Root cause / design summary
+
+Issue #2156 asks Kill Bill to start emitting **RFC 9562 UUIDv7** identifiers
+instead of the random RFC 4122 v4 values produced today, so that primary keys
+become time-ordered (better B-tree locality / write performance) without
+breaking the existing `BINARY(16)` / `CHAR(36)` storage shape. Pierre's comment
+on the issue makes clear that *replacing* `record_id` with `id` as the actual
+primary key column is a 6+ month effort, so the in-scope change is the
+generator itself: every Kill Bill subsystem already routes through the
+centralised utility `org.killbill.billing.util.UUIDs` (`api/src/main/java/org/killbill/billing/util/UUIDs.java`),
+whose static method `UUIDs.randomUUID()` was hard-coded to call a private
+`rndUUIDv4()` helper. Switching that single entry point to generate v7 IDs
+flows through the rest of the codebase automatically.
+
+## Change summary
+
+### `api/src/main/java/org/killbill/billing/util/UUIDs.java`
+- `randomUUID()` now delegates to the new `rndUUIDv7()` generator (was `rndUUIDv4()`).
+- Added `randomUUIDv7()` as a self-documenting alias and `randomUUIDv4()` for the
+  small set of call sites that may explicitly need a non-time-ordered identifier.
+- Added `unixTimestampMillis(UUID)` helper that extracts the embedded 48-bit
+  Unix-epoch-ms field from a v7 UUID, throwing `IllegalArgumentException` if the
+  supplied UUID is not v7.
+- Implemented `rndUUIDv7()` per RFC 9562 §5.7:
+  - bits  0–47 (top of MSB): `unix_ts_ms`
+  - bits 48–51:               version `0b0111`
+  - bits 52–63:               `rand_a`
+  - bits 64–65 (top of LSB): variant `0b10`
+  - bits 66–127:              `rand_b`
+- Uses a per-thread `long[3]` state holding the last emitted `(ts, msb, lsb)`.
+  On a same-millisecond call we apply the "monotonic random" method (RFC 9562
+  §6.2 method 1): increment the 74-bit random payload by one (with carry from
+  `rand_b` into `rand_a` and, on the astronomically unlikely full wrap, a +1ms
+  bump of the timestamp). This guarantees that successive UUIDs emitted by the
+  same thread are *strictly* increasing under the natural unsigned 128-bit
+  byte ordering — the exact property a database B-tree sees.
+- Reuses the existing `threadRandom` `ThreadLocal<Random>` (so the existing
+  `UUIDs.setRandom(...)` test hook still works) and the bundled
+  `LightSecureRandom` PRNG — no new entropy source, no new dependency.
+
+### `util/src/test/java/org/killbill/billing/util/TestUUIDs.java` (new)
+A plain-TestNG (`fast` group) regression test, deliberately *not* extending
+`UtilTestSuiteNoDB` so it requires no Guice / no embedded bus. Seven test cases:
+
+| Test | What it asserts |
+| --- | --- |
+| `testRandomUUIDIsVersion7` | `UUIDs.randomUUID().version() == 7` and variant is IETF (the central behavioural switch) |
+| `testRandomUUIDv7Explicit` | Same, via the explicit `randomUUIDv7()` alias |
+| `testRandomUUIDv4StillAvailable` | `randomUUIDv4()` still yields a true v4 UUID for callers that opt out |
+| `testV7TimestampEncodesCurrentMillis` | `unixTimestampMillis(id)` falls between `System.currentTimeMillis()` samples taken just before and after generation — i.e. the timestamp prefix is real wall-clock |
+| `testUnixTimestampRejectsNonV7` | The extractor throws `IllegalArgumentException` on a v4 input |
+| `testV7MonotonicallyOrderedWithinSameThread` | 10 000 sequential UUIDs are strictly increasing under unsigned 128-bit comparison — proves the B-tree-locality property the issue is asking for |
+| `testV7Uniqueness` | 50 000 sequential UUIDs are all distinct |
+
+## How the test exercises the fix / new behaviour
+
+`testRandomUUIDIsVersion7` is the direct regression check: prior to this commit
+it would fail with `expected [7] but found [4]`, exactly as it does when run
+against the unmodified `UUIDs.java`. `testV7MonotonicallyOrderedWithinSameThread`
+is the substantive behavioural guarantee the issue is asking for — random
+UUIDv4s would fail this test essentially every run, whereas the new monotonic
+v7 implementation must pass it deterministically. `testV7TimestampEncodesCurrentMillis`
+proves the timestamp is real (not just any 48-bit prefix), and the v4 escape
+hatch test (`testRandomUUIDv4StillAvailable`) protects the small surface area
+where a non-time-ordered ID may still be desirable.
+
+## Build status
+
+`mvn -pl util -am -DskipTests compile` (the required verification command):
+
+```
+[INFO] Reactor Summary for killbill 0.24.17-SNAPSHOT:
+[INFO]
+[INFO] killbill ........................................... SUCCESS [  0.154 s]
+[INFO] killbill-api ....................................... SUCCESS [  0.168 s]
+[INFO] killbill-util ...................................... SUCCESS [  0.344 s]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+```
+
+For additional confidence I also ran the new test directly:
+
+```
+mvn -pl util -Dtest=TestUUIDs -DfailIfNoTests=false -Dcheck.skip-spotbugs=true test
+…
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.122 s -- in org.killbill.billing.util.TestUUIDs
+…
+[INFO] BUILD SUCCESS
+```
+
+(`-Dcheck.skip-spotbugs=true` is purely an environment workaround — the
+SpotBugs version pinned by the project bundles an ASM that can't parse the
+Java 25 class files in this sandbox's JDK. It is **not** required for the
+compile step the task asks for.)
+
+## Confidence level
+
+**High.**
+
+- Behavioural change is confined to a single method body in a single class that
+  is already the codebase's *only* UUID factory; ripple effects are by
+  construction — every existing call site keeps the same `UUID` return type and
+  the same 128-bit shape that flows into the schema.
+- The bit layout matches RFC 9562 §5.7 verbatim and is asserted both
+  structurally (`version() == 7`, `variant() == 2`) and semantically
+  (timestamp prefix matches wall-clock).
+- Monotonicity is proven by a 10 000-iteration loop in the test, not just
+  argued; uniqueness over 50 000 iterations rules out trivial off-by-one bugs
+  in the same-ms carry logic.
+- No build files were touched; no new dependencies; the legacy v4 helper is
+  preserved verbatim for any caller that specifically needs random IDs.
+- The existing `UUIDs.setRandom(...)` test injection point is untouched and
+  flows through the new v7 generator, so downstream tests that seed
+  determinism keep working.
+
+The one thing this PR explicitly does *not* do is the larger schema change
+Pierre flagged (dropping `record_id` and using `id` as the actual DB primary
+key). That remains tracked under #2156 as a follow-up.

--- a/api/src/main/java/org/killbill/billing/util/UUIDs.java
+++ b/api/src/main/java/org/killbill/billing/util/UUIDs.java
@@ -29,7 +29,49 @@ import java.util.UUID;
  */
 public abstract class UUIDs {
 
-    public static UUID randomUUID() { return rndUUIDv4(); }
+    /**
+     * Generate a random Kill Bill identifier.
+     *
+     * <p>Since issue #2156 this returns an RFC 9562 (formerly draft-ietf-uuidrev-rfc4122bis)
+     * <strong>version 7</strong> UUID — a 128-bit value whose top 48 bits encode the
+     * Unix epoch in milliseconds, followed by a 4-bit version field, 74 bits of
+     * randomness, and a 2-bit variant field. The result is still a {@link UUID}
+     * and is wire-/storage-compatible with the previously generated v4 values, but
+     * is time-ordered, which yields significantly better B-tree locality when used
+     * as a database key (see https://www.rfc-editor.org/rfc/rfc9562 §5.7).</p>
+     *
+     * <p>Within a single thread, two successive calls are guaranteed to produce
+     * lexicographically increasing UUIDs (when compared as unsigned 128-bit byte
+     * strings), even if invoked within the same millisecond.</p>
+     */
+    public static UUID randomUUID() { return rndUUIDv7(); }
+
+    /**
+     * Generate a legacy RFC 4122 version 4 (purely random) UUID. Retained for
+     * call sites that explicitly require a non-time-ordered identifier, e.g.
+     * security tokens or test fixtures whose ordering must not leak the wall
+     * clock. New code should prefer {@link #randomUUID()}.
+     */
+    public static UUID randomUUIDv4() { return rndUUIDv4(); }
+
+    /**
+     * Explicit accessor for the new RFC 9562 version 7 generator. Equivalent
+     * to {@link #randomUUID()} but self-documenting at the call site.
+     */
+    public static UUID randomUUIDv7() { return rndUUIDv7(); }
+
+    /**
+     * Extract the embedded Unix timestamp (in milliseconds since the epoch) from
+     * a v7 UUID. Throws {@link IllegalArgumentException} if the supplied UUID is
+     * not version 7.
+     */
+    public static long unixTimestampMillis(final UUID uuid) {
+        if (uuid.version() != 7) {
+            throw new IllegalArgumentException("Not a UUIDv7: " + uuid);
+        }
+        // Top 48 bits of the most-significant long.
+        return uuid.getMostSignificantBits() >>> 16;
+    }
 
     public static void setRandom(final Random random) {
         threadRandom.set(random);
@@ -38,6 +80,77 @@ public abstract class UUIDs {
     public static Random getRandom() {
         return threadRandom.get();
     }
+
+    // RFC 9562 UUIDv7 layout (bit indexes within the 128-bit value, MSB first):
+    //   [ 0..47]  unix_ts_ms  (48 bits)
+    //   [48..51]  version     (4 bits) = 0b0111
+    //   [52..63]  rand_a      (12 bits)
+    //   [64..65]  variant     (2 bits) = 0b10
+    //   [66..127] rand_b      (62 bits)
+    //
+    // Monotonicity within a single thread is preserved using the "monotonic
+    // random" method (RFC 9562 §6.2 method 1): on a same-ms call we increment
+    // the previously-emitted random payload by one, carrying through rand_a
+    // and finally bumping the timestamp if the entire 74-bit random space
+    // wraps (in practice unreachable).
+    private static UUID rndUUIDv7() {
+        final long now = System.currentTimeMillis();
+        final long[] state = threadV7State.get();
+
+        long ts;
+        long msb;
+        long lsb;
+
+        if (now > state[0]) {
+            ts = now;
+            final Random random = threadRandom.get();
+            final byte[] bytes = new byte[10]; // 80 random bits, we keep 74
+            random.nextBytes(bytes);
+            final long randA = (((bytes[0] & 0xffL) << 8) | (bytes[1] & 0xffL)) & 0x0FFFL;
+            long randB = 0L;
+            for (int i = 2; i < 10; i++) {
+                randB = (randB << 8) | (bytes[i] & 0xffL);
+            }
+            randB &= 0x3FFFFFFFFFFFFFFFL;
+            msb = (ts << 16) | (0x7L << 12) | randA;
+            lsb = (0x2L << 62) | randB;
+        } else {
+            // Clock did not advance (same ms, or it ran backwards). Reuse the
+            // last timestamp and increment the 74-bit random payload so the
+            // emitted UUID remains strictly greater than the previous one.
+            ts = state[0];
+            msb = state[1];
+            lsb = state[2];
+
+            long randB = (lsb & 0x3FFFFFFFFFFFFFFFL) + 1L;
+            if ((randB & ~0x3FFFFFFFFFFFFFFFL) != 0L) {
+                randB = 0L;
+                long randA = (msb & 0x0FFFL) + 1L;
+                if ((randA & ~0x0FFFL) != 0L) {
+                    // Entire 74-bit random space exhausted within one ms. Roll
+                    // the timestamp forward; with current clocks this is unreachable.
+                    randA = 0L;
+                    ts++;
+                }
+                msb = (ts << 16) | (0x7L << 12) | randA;
+            }
+            lsb = (0x2L << 62) | randB;
+        }
+
+        state[0] = ts;
+        state[1] = msb;
+        state[2] = lsb;
+
+        return new UUID(msb, lsb);
+    }
+
+    private static final ThreadLocal<long[]> threadV7State =
+        new ThreadLocal<long[]>() {
+            @Override
+            protected long[] initialValue() {
+                return new long[]{ -1L, 0L, 0L };
+            }
+    };
 
     private static UUID rndUUIDv4() {
         // ~ return UUID.randomUUID() :

--- a/util/src/test/java/org/killbill/billing/util/TestUUIDs.java
+++ b/util/src/test/java/org/killbill/billing/util/TestUUIDs.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Regression tests for issue #2156 — adopt RFC 9562 UUIDv7 for system identifiers.
+ */
+public class TestUUIDs {
+
+    @Test(groups = "fast")
+    public void testRandomUUIDIsVersion7() {
+        final UUID id = UUIDs.randomUUID();
+        Assert.assertEquals(id.version(), 7, "UUIDs.randomUUID() must yield a UUIDv7");
+        Assert.assertEquals(id.variant(), 2, "UUID variant must be IETF (RFC 4122/9562)");
+    }
+
+    @Test(groups = "fast")
+    public void testRandomUUIDv7Explicit() {
+        final UUID id = UUIDs.randomUUIDv7();
+        Assert.assertEquals(id.version(), 7);
+        Assert.assertEquals(id.variant(), 2);
+    }
+
+    @Test(groups = "fast")
+    public void testRandomUUIDv4StillAvailable() {
+        final UUID id = UUIDs.randomUUIDv4();
+        Assert.assertEquals(id.version(), 4, "randomUUIDv4() must remain a UUIDv4");
+        Assert.assertEquals(id.variant(), 2);
+    }
+
+    @Test(groups = "fast")
+    public void testV7TimestampEncodesCurrentMillis() {
+        final long before = System.currentTimeMillis();
+        final UUID id = UUIDs.randomUUIDv7();
+        final long after = System.currentTimeMillis();
+
+        final long ts = UUIDs.unixTimestampMillis(id);
+        Assert.assertTrue(ts >= before && ts <= after,
+                          "Encoded ts " + ts + " was not in [" + before + ", " + after + "]");
+    }
+
+    @Test(groups = "fast", expectedExceptions = IllegalArgumentException.class)
+    public void testUnixTimestampRejectsNonV7() {
+        UUIDs.unixTimestampMillis(UUIDs.randomUUIDv4());
+    }
+
+    /**
+     * The core property we care about for B-tree locality: successive UUIDs
+     * emitted by the same thread must be strictly increasing under the natural
+     * (unsigned 128-bit, big-endian) byte ordering — i.e. the order a database
+     * would see when treating the UUID as a binary primary key.
+     */
+    @Test(groups = "fast")
+    public void testV7MonotonicallyOrderedWithinSameThread() {
+        final int n = 10_000;
+        final UUID[] ids = new UUID[n];
+        for (int i = 0; i < n; i++) {
+            ids[i] = UUIDs.randomUUIDv7();
+        }
+
+        for (int i = 1; i < n; i++) {
+            final UUID a = ids[i - 1];
+            final UUID b = ids[i];
+            final int cmp = compareUnsigned128(a, b);
+            Assert.assertTrue(cmp < 0,
+                              "UUIDv7s not monotonic at i=" + i + ": " + a + " >= " + b);
+        }
+    }
+
+    @Test(groups = "fast")
+    public void testV7Uniqueness() {
+        final int n = 50_000;
+        final Set<UUID> seen = new HashSet<>(n);
+        for (int i = 0; i < n; i++) {
+            Assert.assertTrue(seen.add(UUIDs.randomUUIDv7()),
+                              "Duplicate UUIDv7 generated within a single thread");
+        }
+    }
+
+    private static int compareUnsigned128(final UUID a, final UUID b) {
+        final int msbCmp = Long.compareUnsigned(a.getMostSignificantBits(),
+                                                b.getMostSignificantBits());
+        if (msbCmp != 0) {
+            return msbCmp;
+        }
+        return Long.compareUnsigned(a.getLeastSignificantBits(),
+                                    b.getLeastSignificantBits());
+    }
+}


### PR DESCRIPTION
> **Note: This PR is an artefact of an automated A/B experiment.** It is the **arm B (cloud-MCP)** variant — Claude Opus 4.7 driven by a graph-grounded MCP hosted on Cloud Run instead of a local Neo4j instance. Both the local-arm-b PR and this cloud-arm-b PR are filed for issue #2156. Full writeup at `ARKEval/killbill-eval/multi-issue/CONSOLIDATED_RESULTS.md`.

Closes #2156 (proposes a fix; needs maintainer review)

## Cloud-MCP arm

Switches the central org.killbill.billing.util.UUIDs.randomUUID() factory
from RFC 4122 v4 (random) to RFC 9562 v7 (time-ordered) UUIDs. Every
Kill Bill subsystem already routes through this single utility, so the
change flows through the rest of the codebase without further edits.

Why: per #2156, time-ordered UUIDs give substantially better B-tree
locality and write-heavy index performance when used as primary keys,
without altering the on-disk shape (still 128-bit / BINARY(16)).

How: rndUUIDv7() lays out 48 bits of unix_ts_ms, 4 bits version, 12 bits
rand_a, 2 bits variant and 62 bits rand_b per RFC 9562 Section 5.7. A
per-thread (ts, msb, lsb) state plus the "monotonic random" method
(RFC 9562 Section 6.2 method 1) guarantees that two successive UUIDs
emitted by the same thread are strictly increasing under unsigned
128-bit byte ordering, even within a single millisecond.

A non-time-ordered escape hatch is preserved as UUIDs.randomUUIDv4()
for the small set of call sites that may need it. A v7 timestamp
extractor (UUIDs.unixTimestampMillis(UUID)) is also added.

Regression test in util/src/test/java/.../TestUUIDs.java covers version
+ variant bits, timestamp-prefix correctness, 10k-iteration monotonicity
and 50k-iteration uniqueness, plus the preserved v4 alias.

## Diff stat

```
 FIX_REPORT.md                                      | 120 +++++++++++++++++++++
 .../main/java/org/killbill/billing/util/UUIDs.java | 115 +++++++++++++++++++-
 .../java/org/killbill/billing/util/TestUUIDs.java  | 110 +++++++++++++++++++
 3 files changed, 344 insertions(+), 1 deletion(-)
```

