### PR TITLE
invoice: improve logging consistency across invoice processing paths

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -683,7 +683,7 @@ public class InvoiceDispatcher {
         } catch (final AccountApiException e) {
             log.warn("Failed to generate invoice for accountId='{}', a future notification has NOT been recorded", accountId, e);
             long startNano = System.nanoTime();
-            invoicePluginDispatcher.onFailureCall(accountId, originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, inputProperties, internalCallContext);
+            invoicePluginDispatcher.onFailureCall(originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, inputProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
             return null;
         }
@@ -692,7 +692,7 @@ public class InvoiceDispatcher {
         Iterable<PluginProperty> pluginProperties = inputProperties;
 
         long startNano = System.nanoTime();
-        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(accountId, originalTargetDate, accountInvoices.getInvoices(), false, isRescheduled, callContext, pluginProperties, internalCallContext);
+        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(originalTargetDate, accountInvoices.getInvoices(), false, isRescheduled, callContext, pluginProperties, internalCallContext);
         pluginProperties = priorCallResult.getPluginProperties();
 
         invoiceTimings.put(InvoiceTiming.PLUGINS_PRIOR_CALL, System.nanoTime() - startNano);
@@ -716,7 +716,7 @@ public class InvoiceDispatcher {
         // If invoice comes back null, there is nothing new to generate, we can bail early
         if (invoice == null) {
             startNano = System.nanoTime();
-            invoicePluginDispatcher.onSuccessCall(accountId, originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, pluginProperties, internalCallContext);
+            invoicePluginDispatcher.onSuccessCall(originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, pluginProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
 
             log.info("Generated null invoice for accountId='{}', targetDate='{}'", accountId, originalTargetDate);
@@ -833,7 +833,7 @@ public class InvoiceDispatcher {
                                      final InvoiceModelDao refreshedInv = invoiceDao.getById(i.getId(), internalCallContext);
                                      final DefaultInvoice refreshedInvoice = new DefaultInvoice(refreshedInv);
                                      long startNano1 = System.nanoTime();
-                                     invoicePluginDispatcher.onSuccessCall(accountId, actualTargetDate, refreshedInvoice, accountInvoices.getInvoices(), false, isRescheduled, callContext, completionProperties, internalCallContext);
+                                     invoicePluginDispatcher.onSuccessCall(actualTargetDate, refreshedInvoice, accountInvoices.getInvoices(), false, isRescheduled, callContext, completionProperties, internalCallContext);
                                      invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano1);
                                      resultingInvoices.add(refreshedInvoice);
                                  } catch (final InvoiceApiException e) {
@@ -846,7 +846,7 @@ public class InvoiceDispatcher {
                 splitInvoices.stream()
                              .forEach(i -> {
                                  long startNano2 = System.nanoTime();
-                                 invoicePluginDispatcher.onFailureCall(accountId, actualTargetDate, invoice, accountInvoices.getInvoices(), false, isRescheduled, callContext, completionProperties, internalCallContext);
+                                 invoicePluginDispatcher.onFailureCall(actualTargetDate, invoice, accountInvoices.getInvoices(), false, isRescheduled, callContext, completionProperties, internalCallContext);
                                  invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano2);
                              });
 
@@ -872,7 +872,7 @@ public class InvoiceDispatcher {
         } catch (final AccountApiException e) {
             log.warn("Failed to generate invoice for accountId='{}', a future notification has NOT been recorded", accountId, e);
             long startNano = System.nanoTime();
-            invoicePluginDispatcher.onFailureCall(accountId, originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, inputProperties, internalCallContext);
+            invoicePluginDispatcher.onFailureCall(originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, inputProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
             return null;
         }
@@ -881,7 +881,7 @@ public class InvoiceDispatcher {
         Iterable<PluginProperty> pluginProperties = inputProperties;
 
         long startNano = System.nanoTime();
-        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(accountId, originalTargetDate, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
+        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(originalTargetDate, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
         invoiceTimings.put(InvoiceTiming.PLUGINS_PRIOR_CALL, System.nanoTime() - startNano);
         pluginProperties = priorCallResult.getPluginProperties();
 
@@ -903,7 +903,7 @@ public class InvoiceDispatcher {
         // If invoice comes back null, there is nothing new to generate, we can bail early
         if (invoice == null) {
             startNano = System.nanoTime();
-            invoicePluginDispatcher.onSuccessCall(accountId, originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
+            invoicePluginDispatcher.onSuccessCall(originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
 
             log.info("Generated null dryRun invoice for accountId='{}', targetDate='{}'", accountId, originalTargetDate);
@@ -941,7 +941,7 @@ public class InvoiceDispatcher {
 
         } finally {
             startNano = System.nanoTime();
-            invoicePluginDispatcher.onSuccessCall(accountId, actualTargetDate, invoice, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
+            invoicePluginDispatcher.onSuccessCall(actualTargetDate, invoice, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
         }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -208,8 +208,7 @@ public class InvoiceDispatcher {
         try {
             accountId = subscriptionApi.getAccountIdFromSubscriptionId(transition.getSubscriptionId(), context);
         } catch (final SubscriptionBaseApiException e) {
-            log.warn("Failed handling SubscriptionBase change.",
-                     new InvoiceApiException(ErrorCode.INVOICE_NO_ACCOUNT_ID_FOR_SUBSCRIPTION_ID, transition.getSubscriptionId().toString()));
+            log.warn("Failed to generate invoice, could not resolve accountId for subscriptionId='{}'", transition.getSubscriptionId(), e);
             return;
         }
 
@@ -244,8 +243,7 @@ public class InvoiceDispatcher {
 
             setFutureNotifications(account, notificationsBuilder.build(), context);
         } catch (final SubscriptionBaseApiException e) {
-            log.warn("Failed handling SubscriptionBase change.",
-                     new InvoiceApiException(ErrorCode.INVOICE_NO_ACCOUNT_ID_FOR_SUBSCRIPTION_ID, transition.getSubscriptionId().toString()));
+            log.warn("Failed to generate invoice, could not resolve accountId for subscriptionId='{}'", transition.getSubscriptionId(), e);
         } catch (final AccountApiException e) {
             log.warn("Failed to retrieve BillingEvents for accountId='{}'", accountId, e);
         } catch (final CatalogApiException e) {
@@ -443,19 +441,19 @@ public class InvoiceDispatcher {
             printInvoiceTiming(invoiceTimings);
             return result;
         } catch (final CatalogApiException e) {
-            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to generate invoice for accountId='{}'", accountId, e);
             if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
             return Collections.emptyList();
         } catch (final AccountApiException e) {
-            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to generate invoice for accountId='{}'", accountId, e);
             if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
             return Collections.emptyList();
         } catch (final SubscriptionBaseApiException e) {
-            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to generate invoice for accountId='{}'", accountId, e);
             if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
@@ -465,7 +463,7 @@ public class InvoiceDispatcher {
                 log.info("Invoice generation aborted by plugin for accountId='{}', targetDate='{}'", accountId, inputTargetDate);
                 return Collections.emptyList();
             }
-            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to generate invoice for accountId='{}'", accountId, e);
             // Only case where we park even if this is from an API call and isParkAccountsOnAllExceptions is not explicitly set.
             if (e.getCode() == ErrorCode.UNEXPECTED_ERROR.getCode() && !isDryRun) {
                 parkAccount(accountId, context);
@@ -479,7 +477,7 @@ public class InvoiceDispatcher {
             }
             throw e;
         } catch (RuntimeException e) { // The case of LockFailedException was handled prior we enter this method.
-            log.warn("Failed to generate invoice for accountId='{}', dryRunArguments='{}'", accountId, dryRunArguments, e);
+            log.warn("Failed to generate invoice for accountId='{}'", accountId, e);
             if (!isDryRun && !isApiCall && invoiceConfig.isParkAccountsOnAllExceptions(context)) {
                 parkAccount(accountId, context);
             }
@@ -685,7 +683,7 @@ public class InvoiceDispatcher {
         } catch (final AccountApiException e) {
             log.warn("Failed to generate invoice for accountId='{}', a future notification has NOT been recorded", accountId, e);
             long startNano = System.nanoTime();
-            invoicePluginDispatcher.onFailureCall(originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, inputProperties, internalCallContext);
+            invoicePluginDispatcher.onFailureCall(accountId, originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, inputProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
             return null;
         }
@@ -694,7 +692,7 @@ public class InvoiceDispatcher {
         Iterable<PluginProperty> pluginProperties = inputProperties;
 
         long startNano = System.nanoTime();
-        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(originalTargetDate, accountInvoices.getInvoices(), false, isRescheduled, callContext, pluginProperties, internalCallContext);
+        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(accountId, originalTargetDate, accountInvoices.getInvoices(), false, isRescheduled, callContext, pluginProperties, internalCallContext);
         pluginProperties = priorCallResult.getPluginProperties();
 
         invoiceTimings.put(InvoiceTiming.PLUGINS_PRIOR_CALL, System.nanoTime() - startNano);
@@ -718,7 +716,7 @@ public class InvoiceDispatcher {
         // If invoice comes back null, there is nothing new to generate, we can bail early
         if (invoice == null) {
             startNano = System.nanoTime();
-            invoicePluginDispatcher.onSuccessCall(originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, pluginProperties, internalCallContext);
+            invoicePluginDispatcher.onSuccessCall(accountId, originalTargetDate, null, accountInvoices.getInvoices(), false, isRescheduled, callContext, pluginProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
 
             log.info("Generated null invoice for accountId='{}', targetDate='{}'", accountId, originalTargetDate);
@@ -835,7 +833,7 @@ public class InvoiceDispatcher {
                                      final InvoiceModelDao refreshedInv = invoiceDao.getById(i.getId(), internalCallContext);
                                      final DefaultInvoice refreshedInvoice = new DefaultInvoice(refreshedInv);
                                      long startNano1 = System.nanoTime();
-                                     invoicePluginDispatcher.onSuccessCall(actualTargetDate, refreshedInvoice, accountInvoices.getInvoices(), false, isRescheduled, callContext, completionProperties, internalCallContext);
+                                     invoicePluginDispatcher.onSuccessCall(accountId, actualTargetDate, refreshedInvoice, accountInvoices.getInvoices(), false, isRescheduled, callContext, completionProperties, internalCallContext);
                                      invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano1);
                                      resultingInvoices.add(refreshedInvoice);
                                  } catch (final InvoiceApiException e) {
@@ -848,7 +846,7 @@ public class InvoiceDispatcher {
                 splitInvoices.stream()
                              .forEach(i -> {
                                  long startNano2 = System.nanoTime();
-                                 invoicePluginDispatcher.onFailureCall(actualTargetDate, invoice, accountInvoices.getInvoices(), false, isRescheduled, callContext, completionProperties, internalCallContext);
+                                 invoicePluginDispatcher.onFailureCall(accountId, actualTargetDate, invoice, accountInvoices.getInvoices(), false, isRescheduled, callContext, completionProperties, internalCallContext);
                                  invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano2);
                              });
 
@@ -874,7 +872,7 @@ public class InvoiceDispatcher {
         } catch (final AccountApiException e) {
             log.warn("Failed to generate invoice for accountId='{}', a future notification has NOT been recorded", accountId, e);
             long startNano = System.nanoTime();
-            invoicePluginDispatcher.onFailureCall(originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, inputProperties, internalCallContext);
+            invoicePluginDispatcher.onFailureCall(accountId, originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, inputProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
             return null;
         }
@@ -883,7 +881,7 @@ public class InvoiceDispatcher {
         Iterable<PluginProperty> pluginProperties = inputProperties;
 
         long startNano = System.nanoTime();
-        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(originalTargetDate, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
+        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(accountId, originalTargetDate, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
         invoiceTimings.put(InvoiceTiming.PLUGINS_PRIOR_CALL, System.nanoTime() - startNano);
         pluginProperties = priorCallResult.getPluginProperties();
 
@@ -905,7 +903,7 @@ public class InvoiceDispatcher {
         // If invoice comes back null, there is nothing new to generate, we can bail early
         if (invoice == null) {
             startNano = System.nanoTime();
-            invoicePluginDispatcher.onSuccessCall(originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
+            invoicePluginDispatcher.onSuccessCall(accountId, originalTargetDate, null, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
 
             log.info("Generated null dryRun invoice for accountId='{}', targetDate='{}'", accountId, originalTargetDate);
@@ -943,7 +941,7 @@ public class InvoiceDispatcher {
 
         } finally {
             startNano = System.nanoTime();
-            invoicePluginDispatcher.onSuccessCall(actualTargetDate, invoice, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
+            invoicePluginDispatcher.onSuccessCall(accountId, actualTargetDate, invoice, accountInvoices.getInvoices(), true, isRescheduled, callContext, pluginProperties, internalCallContext);
             invoiceTimings.put(InvoiceTiming.PLUGINS_COMPLETION_CALL, System.nanoTime() - startNano);
         }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -110,14 +110,15 @@ public class InvoicePluginDispatcher {
         }
     }
 
-    public PriorCallResult priorCall(final LocalDate targetDate,
+    public PriorCallResult priorCall(final UUID accountId,
+                              final LocalDate targetDate,
                               final List<Invoice> existingInvoices,
                               final boolean isDryRun,
                               final boolean isRescheduled,
                               final CallContext callContext,
                               final Iterable<PluginProperty> pluginProperties,
                               final InternalTenantContext internalTenantContext) throws InvoiceApiException {
-        log.debug("Invoking invoice plugins priorCall: targetDate='{}', isDryRun='{}', isRescheduled='{}'", targetDate, isDryRun, isRescheduled);
+        log.debug("Invoking invoice plugins priorCall: accountId='{}', targetDate='{}', isDryRun='{}', isRescheduled='{}'", accountId, targetDate, isDryRun, isRescheduled);
 
         Iterable<PluginProperty> inputPluginProperties = pluginProperties;
         final Map<String, InvoicePluginApi> invoicePlugins = getInvoicePlugins(internalTenantContext);
@@ -139,11 +140,11 @@ public class InvoicePluginDispatcher {
             if (priorInvoiceResult.getRescheduleDate() != null &&
                 (earliestRescheduleDate == null || earliestRescheduleDate.compareTo(priorInvoiceResult.getRescheduleDate()) > 0)) {
                 earliestRescheduleDate = priorInvoiceResult.getRescheduleDate();
-                log.info("Invoice plugin {} rescheduled invoice generation to {} for targetDate {}", invoicePluginName, earliestRescheduleDate, targetDate);
+                log.info("Invoice plugin {} rescheduled invoice generation for accountId='{}', targetDate='{}', rescheduled to '{}'", invoicePluginName, accountId, targetDate, earliestRescheduleDate);
             }
 
             if (priorInvoiceResult.isAborted()) {
-                log.info("Invoice plugin {} aborted invoice generation for targetDate {}", invoicePluginName, targetDate);
+                log.info("Invoice plugin {} aborted invoice generation for accountId='{}', targetDate='{}'", invoicePluginName, accountId, targetDate);
                 throw new InvoiceApiException(ErrorCode.INVOICE_PLUGIN_API_ABORTED, invoicePluginName);
             }
 
@@ -155,7 +156,8 @@ public class InvoicePluginDispatcher {
         return new PriorCallResult(earliestRescheduleDate, inputPluginProperties);
     }
 
-    public void onSuccessCall(final LocalDate targetDate,
+    public void onSuccessCall(final UUID accountId,
+                              final LocalDate targetDate,
                               @Nullable final DefaultInvoice invoice,
                               final List<Invoice> existingInvoices,
                               final boolean isDryRun,
@@ -163,11 +165,12 @@ public class InvoicePluginDispatcher {
                               final CallContext callContext,
                               final Iterable<PluginProperty> properties,
                               final InternalTenantContext internalTenantContext) {
-        log.debug("Invoking invoice plugins onSuccessCall: targetDate='{}', isDryRun='{}', isRescheduled='{}', invoice='{}'", targetDate, isDryRun, isRescheduled, invoice);
-        onCompletionCall(true, targetDate, invoice, existingInvoices, isDryRun, isRescheduled, callContext, properties, internalTenantContext);
+        log.debug("Invoking invoice plugins onSuccessCall: accountId='{}', targetDate='{}', isDryRun='{}', isRescheduled='{}', invoice='{}'", accountId, targetDate, isDryRun, isRescheduled, invoice);
+        onCompletionCall(true, accountId, targetDate, invoice, existingInvoices, isDryRun, isRescheduled, callContext, properties, internalTenantContext);
     }
 
-    public void onFailureCall(final LocalDate targetDate,
+    public void onFailureCall(final UUID accountId,
+                              final LocalDate targetDate,
                               @Nullable final DefaultInvoice invoice,
                               final List<Invoice> existingInvoices,
                               final boolean isDryRun,
@@ -175,11 +178,12 @@ public class InvoicePluginDispatcher {
                               final CallContext callContext,
                               final Iterable<PluginProperty> properties,
                               final InternalTenantContext internalTenantContext) {
-        log.debug("Invoking invoice plugins onFailureCall: targetDate='{}', isDryRun='{}', isRescheduled='{}', invoice='{}'", targetDate, isDryRun, isRescheduled, invoice);
-        onCompletionCall(false, targetDate, invoice, existingInvoices, isDryRun, isRescheduled, callContext, properties, internalTenantContext);
+        log.debug("Invoking invoice plugins onFailureCall: accountId='{}', targetDate='{}', isDryRun='{}', isRescheduled='{}', invoice='{}'", accountId, targetDate, isDryRun, isRescheduled, invoice);
+        onCompletionCall(false, accountId, targetDate, invoice, existingInvoices, isDryRun, isRescheduled, callContext, properties, internalTenantContext);
     }
 
     private void onCompletionCall(final boolean isSuccess,
+                                  final UUID accountId,
                                   final LocalDate targetDate,
                                   @Nullable final DefaultInvoice originalInvoice,
                                   final List<Invoice> existingInvoices,
@@ -214,8 +218,8 @@ public class InvoicePluginDispatcher {
                     }
                 }
             } catch (final RuntimeException e) {
-                log.warn("Invoice plugin {} threw an exception during {} call for targetDate='{}'",
-                         invoicePluginName, isSuccess ? "onSuccessCall" : "onFailureCall", targetDate, e);
+                log.warn("Invoice plugin {} threw an exception during {} call for accountId='{}', targetDate='{}'",
+                         invoicePluginName, isSuccess ? "onSuccessCall" : "onFailureCall", accountId, targetDate, e);
             }
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoicePluginDispatcher.java
@@ -110,14 +110,14 @@ public class InvoicePluginDispatcher {
         }
     }
 
-    public PriorCallResult priorCall(final UUID accountId,
-                              final LocalDate targetDate,
+    public PriorCallResult priorCall(final LocalDate targetDate,
                               final List<Invoice> existingInvoices,
                               final boolean isDryRun,
                               final boolean isRescheduled,
                               final CallContext callContext,
                               final Iterable<PluginProperty> pluginProperties,
                               final InternalTenantContext internalTenantContext) throws InvoiceApiException {
+        final UUID accountId = callContext.getAccountId();
         log.debug("Invoking invoice plugins priorCall: accountId='{}', targetDate='{}', isDryRun='{}', isRescheduled='{}'", accountId, targetDate, isDryRun, isRescheduled);
 
         Iterable<PluginProperty> inputPluginProperties = pluginProperties;
@@ -156,8 +156,7 @@ public class InvoicePluginDispatcher {
         return new PriorCallResult(earliestRescheduleDate, inputPluginProperties);
     }
 
-    public void onSuccessCall(final UUID accountId,
-                              final LocalDate targetDate,
+    public void onSuccessCall(final LocalDate targetDate,
                               @Nullable final DefaultInvoice invoice,
                               final List<Invoice> existingInvoices,
                               final boolean isDryRun,
@@ -165,12 +164,11 @@ public class InvoicePluginDispatcher {
                               final CallContext callContext,
                               final Iterable<PluginProperty> properties,
                               final InternalTenantContext internalTenantContext) {
-        log.debug("Invoking invoice plugins onSuccessCall: accountId='{}', targetDate='{}', isDryRun='{}', isRescheduled='{}', invoice='{}'", accountId, targetDate, isDryRun, isRescheduled, invoice);
-        onCompletionCall(true, accountId, targetDate, invoice, existingInvoices, isDryRun, isRescheduled, callContext, properties, internalTenantContext);
+        log.debug("Invoking invoice plugins onSuccessCall: accountId='{}', targetDate='{}', isDryRun='{}', isRescheduled='{}', invoice='{}'", callContext.getAccountId(), targetDate, isDryRun, isRescheduled, invoice);
+        onCompletionCall(true, targetDate, invoice, existingInvoices, isDryRun, isRescheduled, callContext, properties, internalTenantContext);
     }
 
-    public void onFailureCall(final UUID accountId,
-                              final LocalDate targetDate,
+    public void onFailureCall(final LocalDate targetDate,
                               @Nullable final DefaultInvoice invoice,
                               final List<Invoice> existingInvoices,
                               final boolean isDryRun,
@@ -178,12 +176,11 @@ public class InvoicePluginDispatcher {
                               final CallContext callContext,
                               final Iterable<PluginProperty> properties,
                               final InternalTenantContext internalTenantContext) {
-        log.debug("Invoking invoice plugins onFailureCall: accountId='{}', targetDate='{}', isDryRun='{}', isRescheduled='{}', invoice='{}'", accountId, targetDate, isDryRun, isRescheduled, invoice);
-        onCompletionCall(false, accountId, targetDate, invoice, existingInvoices, isDryRun, isRescheduled, callContext, properties, internalTenantContext);
+        log.debug("Invoking invoice plugins onFailureCall: accountId='{}', targetDate='{}', isDryRun='{}', isRescheduled='{}', invoice='{}'", callContext.getAccountId(), targetDate, isDryRun, isRescheduled, invoice);
+        onCompletionCall(false, targetDate, invoice, existingInvoices, isDryRun, isRescheduled, callContext, properties, internalTenantContext);
     }
 
     private void onCompletionCall(final boolean isSuccess,
-                                  final UUID accountId,
                                   final LocalDate targetDate,
                                   @Nullable final DefaultInvoice originalInvoice,
                                   final List<Invoice> existingInvoices,
@@ -219,7 +216,7 @@ public class InvoicePluginDispatcher {
                 }
             } catch (final RuntimeException e) {
                 log.warn("Invoice plugin {} threw an exception during {} call for accountId='{}', targetDate='{}'",
-                         invoicePluginName, isSuccess ? "onSuccessCall" : "onFailureCall", accountId, targetDate, e);
+                         invoicePluginName, isSuccess ? "onSuccessCall" : "onFailureCall", callContext.getAccountId(), targetDate, e);
             }
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java
@@ -93,7 +93,7 @@ public class InvoiceApiHelper {
         // Keep track of properties as they can be updated by plugins at each call
         Iterable<PluginProperty> pluginProperties = inputProperties;
 
-        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(accountId, targetDate, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
+        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(targetDate, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
         if (priorCallResult.getRescheduleDate() != null) {
             throw new InvoiceApiException(ErrorCode.INVOICE_PLUGIN_API_ABORTED, "delayed scheduling is unsupported for API calls");
         }
@@ -167,10 +167,10 @@ public class InvoiceApiHelper {
             if (success) {
                 for (final Invoice invoiceForPlugin : invoicesForPlugins) {
                     final DefaultInvoice refreshedInvoice = new DefaultInvoice(dao.getById(invoiceForPlugin.getId(), internalCallContext));
-                    invoicePluginDispatcher.onSuccessCall(accountId, targetDate, refreshedInvoice, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
+                    invoicePluginDispatcher.onSuccessCall(targetDate, refreshedInvoice, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
                 }
             } else {
-                invoicePluginDispatcher.onFailureCall(accountId, targetDate, null, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
+                invoicePluginDispatcher.onFailureCall(targetDate, null, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
             }
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/InvoiceApiHelper.java
@@ -93,7 +93,7 @@ public class InvoiceApiHelper {
         // Keep track of properties as they can be updated by plugins at each call
         Iterable<PluginProperty> pluginProperties = inputProperties;
 
-        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(targetDate, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
+        final PriorCallResult priorCallResult = invoicePluginDispatcher.priorCall(accountId, targetDate, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
         if (priorCallResult.getRescheduleDate() != null) {
             throw new InvoiceApiException(ErrorCode.INVOICE_PLUGIN_API_ABORTED, "delayed scheduling is unsupported for API calls");
         }
@@ -167,10 +167,10 @@ public class InvoiceApiHelper {
             if (success) {
                 for (final Invoice invoiceForPlugin : invoicesForPlugins) {
                     final DefaultInvoice refreshedInvoice = new DefaultInvoice(dao.getById(invoiceForPlugin.getId(), internalCallContext));
-                    invoicePluginDispatcher.onSuccessCall(targetDate, refreshedInvoice, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
+                    invoicePluginDispatcher.onSuccessCall(accountId, targetDate, refreshedInvoice, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
                 }
             } else {
-                invoicePluginDispatcher.onFailureCall(targetDate, null, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
+                invoicePluginDispatcher.onFailureCall(accountId, targetDate, null, existingInvoices, isDryRun, isRescheduled, context, pluginProperties, internalCallContext);
             }
         }
     }


### PR DESCRIPTION
Adds accountId context to InvoicePluginDispatcher method signatures (priorCall, onSuccessCall, onFailureCall, onCompletionCall) so that plugin-level log messages for reschedules, aborts, and completion call exceptions include the accountId alongside the targetDate.

Standardizes failure log messages in processAccountInternal to omit the dryRunArguments field, which is null on all async (bus/notification) paths and adds noise without value. The accountId and exception itself provide sufficient context for alerting.

Fixes non-standard log messages in processSubscriptionStartRequestedDate and processSubscriptionStartRequestedDateWithLock that were constructing a synthetic InvoiceApiException as the log cause instead of logging the actual caught SubscriptionBaseApiException, and that lacked subscriptionId context to identify the failing entity.

Fixes #2209 #2210