### PR TITLE
[Entitlement] Expose BCD_UPDATE and QUANTITY_UPDATE events in subscription event stream

### DIFF
--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/EntitlementOrderingBase.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/EntitlementOrderingBase.java
@@ -45,6 +45,8 @@ public abstract class EntitlementOrderingBase {
 
             case PHASE:
             case CHANGE:
+            case BCD_UPDATE:
+            case QUANTITY_UPDATE:
                 return ENT_BILLING_SERVICE_NAME;
 
             default:

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/SubscriptionEventOrdering.java
@@ -95,11 +95,16 @@ public class SubscriptionEventOrdering extends EntitlementOrderingBase {
                 return List.of(SubscriptionEventType.STOP_BILLING);
             case PHASE:
                 return List.of(SubscriptionEventType.PHASE);
+            case BCD_CHANGE:
+                return List.of(SubscriptionEventType.BCD_UPDATE);
+            case QUANTITY_CHANGE:
+                return List.of(SubscriptionEventType.QUANTITY_UPDATE);
             /*
              * Those can be ignored:
              */
             // Marker event
             case UNCANCEL:
+            case UNDO_CHANGE:
                 // Junction billing events-- that info is part of blocking states, we will get outside of subscription base
             case START_BILLING_DISABLED:
             case END_BILLING_DISABLED:

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultSubscriptionApi.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/api/TestDefaultSubscriptionApi.java
@@ -814,6 +814,48 @@ public class TestDefaultSubscriptionApi extends EntitlementTestSuiteWithEmbedded
         assertEquals(i, expected.size());
     }
 
+    @Test(groups = "slow", description = "Verify BCD_UPDATE events are exposed via Subscription.getSubscriptionEvents()")
+    public void testBCDUpdateAppearsInSubscriptionEvents() throws AccountApiException, EntitlementApiException, SubscriptionApiException {
+        final LocalDate initialDate = new LocalDate(2013, 8, 7);
+        clock.setDay(initialDate);
+
+        final Account account = createAccount(getAccountData(7));
+
+        final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("Shotgun", BillingPeriod.ANNUAL, PriceListSet.DEFAULT_PRICELIST_NAME, null);
+
+        testListener.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK);
+        final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec), account.getExternalKey(), initialDate, initialDate, false, true, Collections.emptyList(), callContext);
+        assertListenerStatus();
+
+        final Entitlement entitlement = entitlementApi.getEntitlementForId(entitlementId, false, callContext);
+        assertEquals(entitlement.getBillCycleDayLocal(), (Integer) 7);
+
+        // Update BCD to 15, effective immediately
+        testListener.pushExpectedEvents(NextEvent.BCD_CHANGE);
+        entitlement.updateBCD(15, initialDate, callContext);
+        assertListenerStatus();
+
+        assertEquals(entitlementApi.getEntitlementForId(entitlementId, false, callContext).getBillCycleDayLocal(), (Integer) 15);
+
+        final Subscription subscription = subscriptionApi.getSubscriptionForEntitlementId(entitlementId, false, callContext);
+        final List<SubscriptionEvent> events = subscription.getSubscriptionEvents();
+
+        // Expected: START_ENTITLEMENT, START_BILLING, BCD_UPDATE, PHASE
+        final List<SubscriptionEventType> eventTypes = events.stream()
+                                                             .map(SubscriptionEvent::getSubscriptionEventType)
+                                                             .collect(java.util.stream.Collectors.toList());
+        assertTrue(eventTypes.contains(SubscriptionEventType.BCD_UPDATE),
+                   "Expected BCD_UPDATE in subscription events but got: " + eventTypes);
+
+        final SubscriptionEvent bcdEvent = events.stream()
+                                                 .filter(e -> e.getSubscriptionEventType() == SubscriptionEventType.BCD_UPDATE)
+                                                 .findFirst()
+                                                 .orElseThrow();
+        assertEquals(internalCallContext.toLocalDate(bcdEvent.getEffectiveDate()), initialDate);
+
+        assertListenerStatus();
+    }
+
     private void checkSubscriptionEventAuditLog(final List<SubscriptionEvent> transitions, final int idx, final SubscriptionEventType expectedType) {
         assertEquals(transitions.get(idx).getSubscriptionEventType(), expectedType);
         final List<AuditLog> auditLogs = auditUserApi.getAuditLogs(transitions.get(idx).getId(), transitions.get(idx).getSubscriptionEventType().getObjectType(), AuditLevel.FULL, callContext);

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <check.skip-dependency-versions>true</check.skip-dependency-versions>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <killbill.version>${project.version}</killbill.version>
-        <killbill-api.version>0.54.1-SNAPSHOT</killbill-api.version>
+        <killbill-api.version>0.55.1-76b0c1b-SNAPSHOT</killbill-api.version>
         <main.basedir>${project.basedir}</main.basedir>
         <!-- Temporary until upgrade to 2.x -->
         <swagger.version>1.6.2</swagger.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <check.skip-dependency-versions>true</check.skip-dependency-versions>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <killbill.version>${project.version}</killbill.version>
+        <killbill-api.version>0.54.1-SNAPSHOT</killbill-api.version>
         <main.basedir>${project.basedir}</main.basedir>
         <!-- Temporary until upgrade to 2.x -->
         <swagger.version>1.6.2</swagger.version>


### PR DESCRIPTION
Fixes #2224.

`SubscriptionEventOrdering.toEventTypes()` fell through to the default (empty list) branch for `BCD_CHANGE` and `QUANTITY_CHANGE` transitions, so callers of `Subscription.getSubscriptionEvents()` never saw these events in the returned list — only `PHASE`, `CHANGE`, `START_BILLING`, and `STOP_BILLING` were mapped.

Add explicit case branches for `BCD_CHANGE → BCD_UPDATE` and `QUANTITY_CHANGE → QUANTITY_UPDATE`, and register both new types under `ENT_BILLING_SERVICE_NAME` in `EntitlementOrderingBase.getServiceName()`, consistent with `PHASE` and `CHANGE`.

Also explicitly lists `UNDO_CHANGE` in the ignored-event cases for clarity.

**Depends on:** killbill/killbill-api#<number> (adds `BCD_UPDATE` and `QUANTITY_UPDATE` to `SubscriptionEventType`)

A test in `TestDefaultSubscriptionApi` verifies that a `BCD_UPDATE` event appears in the subscription event stream after calling `updateBCD()`.