### PR TITLE
catalog: wire planNames hint through CatalogCache to catalog plugin API

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/caching/CatalogCache.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/caching/CatalogCache.java
@@ -17,6 +17,9 @@
 
 package org.killbill.billing.catalog.caching;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.catalog.api.VersionedCatalog;
@@ -26,6 +29,22 @@ public interface CatalogCache {
     public void loadDefaultCatalog(final String url) throws CatalogApiException;
 
     public VersionedCatalog getCatalog(final boolean useDefaultCatalog, final boolean filterTemplateCatalog, final boolean internalUse, InternalTenantContext tenantContext) throws CatalogApiException;
+
+    /**
+     * Returns the tenant catalog, optionally restricted to the specified plan names.
+     * <p>
+     * When {@code planNames} is non-empty, catalog plugins that implement the
+     * {@code getVersionedPluginCatalog(Set<String>, ...)} overload may return a shallow
+     * catalog containing only the requested plans, reducing serialization overhead for
+     * tenants with large catalogs.
+     *
+     * @param planNames set of plan names the caller requires; empty means "all plans"
+     */
+    default VersionedCatalog getCatalog(final boolean useDefaultCatalog, final boolean filterTemplateCatalog,
+                                        final boolean internalUse, final Set<String> planNames,
+                                        final InternalTenantContext tenantContext) throws CatalogApiException {
+        return getCatalog(useDefaultCatalog, filterTemplateCatalog, internalUse, tenantContext);
+    }
 
     public void clearCatalog(InternalTenantContext tenantContext);
 }

--- a/catalog/src/main/java/org/killbill/billing/catalog/caching/DefaultCatalogCache.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/caching/DefaultCatalogCache.java
@@ -20,6 +20,7 @@ package org.killbill.billing.catalog.caching;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -142,7 +143,27 @@ public class DefaultCatalogCache implements CatalogCache {
         }
     }
 
+    @Override
+    public VersionedCatalog getCatalog(final boolean useDefaultCatalog, final boolean filterTemplateCatalog,
+                                       final boolean internalUse, final Set<String> planNames,
+                                       final InternalTenantContext tenantContext) throws CatalogApiException {
+        if (internalUse) {
+            Preconditions.checkState(tenantContext.getAccountRecordId() != null, "Unexpected null accountRecordId in context issued from internal Kill Bill service");
+        }
+
+        final VersionedCatalog pluginVersionedCatalog = getCatalogFromPlugins(tenantContext, planNames);
+        if (pluginVersionedCatalog != null) {
+            return pluginVersionedCatalog;
+        }
+
+        return getCatalog(useDefaultCatalog, filterTemplateCatalog, internalUse, tenantContext);
+    }
+
     private VersionedCatalog getCatalogFromPlugins(final InternalTenantContext internalTenantContext) throws CatalogApiException {
+        return getCatalogFromPlugins(internalTenantContext, Collections.emptySet());
+    }
+
+    private VersionedCatalog getCatalogFromPlugins(final InternalTenantContext internalTenantContext, final Set<String> planNames) throws CatalogApiException {
         final TenantContext tenantContext = internalCallContextFactory.createTenantContext(internalTenantContext);
         final Set<String> allServices = pluginRegistry.getAllServices();
         for (final String service : allServices) {
@@ -168,7 +189,7 @@ public class DefaultCatalogCache implements CatalogCache {
                 }
             }
 
-            final VersionedPluginCatalog pluginCatalog = plugin.getVersionedPluginCatalog(Collections.emptyList(), tenantContext);
+            final VersionedPluginCatalog pluginCatalog = plugin.getVersionedPluginCatalog(planNames, Collections.emptyList(), tenantContext);
             // First plugin that gets something (for that tenant) returns it
             if (pluginCatalog != null) {
                 // The log entry is only interesting if there are multiple plugins

--- a/catalog/src/main/java/org/killbill/billing/catalog/caching/DefaultCatalogCache.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/caching/DefaultCatalogCache.java
@@ -20,7 +20,6 @@ package org.killbill.billing.catalog.caching;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 

--- a/catalog/src/test/java/org/killbill/billing/catalog/caching/TestDefaultCatalogCachePlanNames.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/caching/TestDefaultCatalogCachePlanNames.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.caching;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.catalog.DefaultVersionedCatalog;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.catalog.io.VersionedCatalogLoader;
+import org.killbill.billing.catalog.override.PriceOverrideSvc;
+import org.killbill.billing.catalog.plugin.VersionedCatalogMapper;
+import org.killbill.billing.catalog.plugin.api.CatalogPluginApi;
+import org.killbill.billing.catalog.plugin.api.VersionedPluginCatalog;
+import org.killbill.billing.osgi.api.OSGIServiceRegistration;
+import org.killbill.billing.util.cache.CacheController;
+import org.killbill.billing.util.cache.CacheControllerDispatcher;
+import org.killbill.billing.util.cache.Cachable.CacheType;
+import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestDefaultCatalogCachePlanNames {
+
+    private CatalogPluginApi mockPlugin;
+    private DefaultCatalogCache catalogCache;
+    private InternalTenantContext mockContext;
+    private VersionedPluginCatalog mockPluginCatalog;
+
+    @SuppressWarnings("unchecked")
+    @BeforeMethod(groups = "fast")
+    public void setup() throws CatalogApiException {
+        mockPlugin = Mockito.mock(CatalogPluginApi.class);
+        mockPluginCatalog = Mockito.mock(VersionedPluginCatalog.class);
+
+        final OSGIServiceRegistration<CatalogPluginApi> pluginRegistry = Mockito.mock(OSGIServiceRegistration.class);
+        Mockito.when(pluginRegistry.getAllServices()).thenReturn(Collections.singleton("test-plugin"));
+        Mockito.when(pluginRegistry.getServiceForName("test-plugin")).thenReturn(mockPlugin);
+
+        // Plugin has no latest version (bypasses tenant catalog cache)
+        Mockito.when(mockPlugin.getLatestCatalogVersion(Mockito.any(), Mockito.any())).thenReturn(null);
+
+        final VersionedCatalogMapper mapper = Mockito.mock(VersionedCatalogMapper.class);
+        Mockito.when(mapper.toVersionedCatalog(Mockito.any())).thenReturn(new DefaultVersionedCatalog());
+
+        @SuppressWarnings("rawtypes")
+        final CacheController rawCacheController = Mockito.mock(CacheController.class);
+        final CacheControllerDispatcher dispatcher = Mockito.mock(CacheControllerDispatcher.class);
+        Mockito.when(dispatcher.getCacheController(CacheType.TENANT_CATALOG)).thenReturn(rawCacheController);
+
+        final VersionedCatalogLoader loader = Mockito.mock(VersionedCatalogLoader.class);
+        // Return an empty catalog so defaultCatalog is not null if the non-plugin path is reached
+        Mockito.when(loader.loadDefaultCatalog(Mockito.anyString())).thenReturn(new DefaultVersionedCatalog());
+
+        final PriceOverrideSvc priceOverride = Mockito.mock(PriceOverrideSvc.class);
+        final InternalCallContextFactory contextFactory = Mockito.mock(InternalCallContextFactory.class);
+        Mockito.when(contextFactory.createTenantContext(Mockito.any())).thenReturn(Mockito.mock(org.killbill.billing.util.callcontext.TenantContext.class));
+
+        catalogCache = new DefaultCatalogCache(pluginRegistry, mapper, dispatcher, loader, priceOverride, contextFactory);
+
+        mockContext = Mockito.mock(InternalTenantContext.class);
+        Mockito.when(mockContext.getAccountRecordId()).thenReturn(1L);
+        Mockito.when(mockContext.getTenantRecordId()).thenReturn(99L);
+    }
+
+    @Test(groups = "fast")
+    public void testPlanNamesForwardedToPlugin() throws CatalogApiException {
+        final Set<String> planNames = Set.of("shotgun-monthly", "assault-monthly");
+
+        // Mock the 3-arg overload explicitly (Mockito does not auto-execute default interface methods)
+        Mockito.when(mockPlugin.getVersionedPluginCatalog(Mockito.eq(planNames), Mockito.any(), Mockito.any()))
+               .thenReturn(mockPluginCatalog);
+
+        final VersionedCatalog result = catalogCache.getCatalog(true, false, true, planNames, mockContext);
+        Assert.assertNotNull(result);
+
+        // Verify the plugin was called with exactly the planNames we passed
+        @SuppressWarnings("unchecked")
+        final ArgumentCaptor<Set<String>> planNamesCaptor = ArgumentCaptor.forClass(Set.class);
+        Mockito.verify(mockPlugin).getVersionedPluginCatalog(planNamesCaptor.capture(), Mockito.any(), Mockito.any());
+        Assert.assertEquals(planNamesCaptor.getValue(), planNames,
+                            "Plugin must receive the planNames set passed to getCatalog()");
+    }
+
+    @Test(groups = "fast")
+    public void testEmptyPlanNamesCallsPluginWith3ArgOverload() throws CatalogApiException {
+        // Mock the 3-arg overload for empty set — this is what getCatalog(emptySet) will call
+        Mockito.when(mockPlugin.getVersionedPluginCatalog(Mockito.eq(Collections.emptySet()), Mockito.any(), Mockito.any()))
+               .thenReturn(mockPluginCatalog);
+
+        final VersionedCatalog result = catalogCache.getCatalog(true, false, true, Collections.emptySet(), mockContext);
+        Assert.assertNotNull(result);
+
+        Mockito.verify(mockPlugin).getVersionedPluginCatalog(
+                Mockito.eq(Collections.emptySet()), Mockito.any(), Mockito.any());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <check.skip-dependency-versions>true</check.skip-dependency-versions>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <killbill.version>${project.version}</killbill.version>
+        <killbill-plugin-api.version>0.27.4-SNAPSHOT</killbill-plugin-api.version>
         <main.basedir>${project.basedir}</main.basedir>
         <!-- Temporary until upgrade to 2.x -->
         <swagger.version>1.6.2</swagger.version>


### PR DESCRIPTION
Adds a getCatalog overload on CatalogCache that accepts a Set<String> planNames and threads it through to the catalog plugin via the new CatalogPluginApi.getVersionedPluginCatalog(planNames, properties, context) overload introduced in killbill-plugin-api.

Plugins managing large catalogs can now return a shallow catalog containing only the requested plans when Kill Bill passes a non-empty plan set, reducing serialization overhead. The default implementation on CatalogPluginApi falls back to the full-catalog method, so existing plugins remain unaffected.

DefaultCatalogCache.getCatalog(planNames) delegates to the existing getCatalog() for all non-plugin paths (file-based, cached tenant catalog) since the optimization only applies to plugin-supplied catalogs.

Depends on killbill-plugin-api#<PR> which adds the planNames overload to CatalogPluginApi.

Fixes #2258