### PR TITLE
usage: expose billing transition times as a typed accessor on UsageCo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <check.skip-dependency-versions>true</check.skip-dependency-versions>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
         <killbill.version>${project.version}</killbill.version>
+        <killbill-plugin-api.version>0.27.4-SNAPSHOT</killbill-plugin-api.version>
         <main.basedir>${project.basedir}</main.basedir>
         <!-- Temporary until upgrade to 2.x -->
         <swagger.version>1.6.2</swagger.version>

--- a/usage/src/main/java/org/killbill/billing/usage/api/DefaultUsageContext.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/DefaultUsageContext.java
@@ -17,9 +17,14 @@
 
 package org.killbill.billing.usage.api;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+
+import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.invoice.api.DryRunType;
 import org.killbill.billing.usage.plugin.api.UsageContext;
@@ -30,11 +35,18 @@ public class DefaultUsageContext implements UsageContext {
     private final DryRunType dryRunType;
     private final LocalDate targetDate;
     private final TenantContext context;
+    private final Map<Map.Entry<UUID, String>, Set<DateTime>> usageTransitions;
 
     public DefaultUsageContext(final DryRunType dryRunType, final LocalDate targetDate, final TenantContext context) {
+        this(dryRunType, targetDate, context, null);
+    }
+
+    public DefaultUsageContext(final DryRunType dryRunType, final LocalDate targetDate, final TenantContext context,
+                               @Nullable final Map<Map.Entry<UUID, String>, Set<DateTime>> usageTransitions) {
         this.dryRunType = dryRunType;
         this.targetDate = targetDate;
         this.context = context;
+        this.usageTransitions = usageTransitions;
     }
 
     @Override
@@ -45,6 +57,11 @@ public class DefaultUsageContext implements UsageContext {
     @Override
     public LocalDate getInputTargetDate() {
         return targetDate;
+    }
+
+    @Override
+    public Map<Map.Entry<UUID, String>, Set<DateTime>> getUsageTransitions() {
+        return usageTransitions;
     }
 
     @Override

--- a/usage/src/main/java/org/killbill/billing/usage/api/svcs/DefaultInternalUserApi.java
+++ b/usage/src/main/java/org/killbill/billing/usage/api/svcs/DefaultInternalUserApi.java
@@ -19,7 +19,11 @@ package org.killbill.billing.usage.api.svcs;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -70,7 +74,14 @@ public class DefaultInternalUserApi extends BaseUserApi implements InternalUserA
         final DryRunType dryRunType = dryRunInfo != null ? dryRunInfo.getDryRunType() : null;
         final LocalDate inputTargetDate = dryRunInfo != null ? dryRunInfo.getInputTargetDate() : null;
 
-        final UsageContext usageContext = new DefaultUsageContext(dryRunType, inputTargetDate, tenantContext);
+        @SuppressWarnings("unchecked")
+        final Map<Map.Entry<UUID, String>, Set<DateTime>> usageTransitions = StreamSupport.stream(pluginProperties.spliterator(), false)
+                .filter(pp -> "USAGE_TRANSITIONS".equals(pp.getKey()) && pp.getValue() instanceof Map)
+                .findFirst()
+                .map(pp -> (Map<Map.Entry<UUID, String>, Set<DateTime>>) pp.getValue())
+                .orElse(null);
+
+        final UsageContext usageContext = new DefaultUsageContext(dryRunType, inputTargetDate, tenantContext, usageTransitions);
 
         final List<RawUsageRecord> resultFromPlugin = getAccountUsageFromPlugin(startDate, endDate, pluginProperties, usageContext);
         if (resultFromPlugin != null) {

--- a/usage/src/test/java/org/killbill/billing/usage/api/TestDefaultUsageContext.java
+++ b/usage/src/test/java/org/killbill/billing/usage/api/TestDefaultUsageContext.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.usage.api;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.invoice.api.DryRunType;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestDefaultUsageContext {
+
+    private final TenantContext mockContext = Mockito.mock(TenantContext.class);
+
+    @Test(groups = "fast")
+    public void testGetUsageTransitionsReturnsNullByDefault() {
+        final DefaultUsageContext ctx = new DefaultUsageContext(null, null, mockContext);
+        Assert.assertNull(ctx.getUsageTransitions(),
+                          "Single-argument constructor must expose null transitions for backwards compatibility");
+    }
+
+    @Test(groups = "fast")
+    public void testGetUsageTransitionsReturnsProvidedMap() {
+        final UUID subscriptionId = UUID.randomUUID();
+        final Map.Entry<UUID, String> key = new AbstractMap.SimpleEntry<>(subscriptionId, "UNIT_TYPE");
+        final Set<DateTime> times = Collections.singleton(new DateTime(2026, 1, 1, 0, 0));
+        final Map<Map.Entry<UUID, String>, Set<DateTime>> transitions = Collections.singletonMap(key, times);
+
+        final DefaultUsageContext ctx = new DefaultUsageContext(DryRunType.UPCOMING_INVOICE, new LocalDate(2026, 1, 31), mockContext, transitions);
+
+        Assert.assertEquals(ctx.getUsageTransitions(), transitions,
+                            "getUsageTransitions() must return the map passed to the constructor");
+    }
+
+    @Test(groups = "fast")
+    public void testGetUsageTransitionsNullExplicitlyPassed() {
+        final DefaultUsageContext ctx = new DefaultUsageContext(null, null, mockContext, null);
+        Assert.assertNull(ctx.getUsageTransitions(),
+                          "Explicitly passing null transitions must return null");
+    }
+
+    @Test(groups = "fast")
+    public void testOtherFieldsUnaffectedByTransitions() {
+        final LocalDate targetDate = new LocalDate(2026, 6, 15);
+        final UUID tenantId = UUID.randomUUID();
+        Mockito.when(mockContext.getTenantId()).thenReturn(tenantId);
+
+        final DefaultUsageContext ctx = new DefaultUsageContext(DryRunType.SUBSCRIPTION_ACTION, targetDate, mockContext, Collections.emptyMap());
+
+        Assert.assertEquals(ctx.getDryRunType(), DryRunType.SUBSCRIPTION_ACTION);
+        Assert.assertEquals(ctx.getInputTargetDate(), targetDate);
+        Assert.assertEquals(ctx.getTenantId(), tenantId);
+    }
+}

--- a/usage/src/test/java/org/killbill/billing/usage/api/svcs/TestDefaultInternalUserApiTransitions.java
+++ b/usage/src/test/java/org/killbill/billing/usage/api/svcs/TestDefaultInternalUserApiTransitions.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.usage.api.svcs;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.joda.time.DateTime;
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.osgi.api.OSGIServiceRegistration;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.usage.api.RawUsageRecord;
+import org.killbill.billing.usage.dao.RolledUpUsageDao;
+import org.killbill.billing.usage.plugin.api.UsageContext;
+import org.killbill.billing.usage.plugin.api.UsagePluginApi;
+import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestDefaultInternalUserApiTransitions {
+
+    private UsagePluginApi mockPlugin;
+    private DefaultInternalUserApi api;
+    private InternalTenantContext mockInternalContext;
+
+    @SuppressWarnings("unchecked")
+    @BeforeMethod(groups = "fast")
+    public void setup() {
+        mockPlugin = Mockito.mock(UsagePluginApi.class);
+
+        final OSGIServiceRegistration<UsagePluginApi> pluginRegistry = Mockito.mock(OSGIServiceRegistration.class);
+        Mockito.when(pluginRegistry.getAllServices()).thenReturn(Collections.singleton("test-plugin"));
+        Mockito.when(pluginRegistry.getServiceForName("test-plugin")).thenReturn(mockPlugin);
+
+        final TenantContext mockTenantContext = Mockito.mock(TenantContext.class);
+        Mockito.when(mockTenantContext.getAccountId()).thenReturn(UUID.randomUUID());
+
+        final InternalCallContextFactory contextFactory = Mockito.mock(InternalCallContextFactory.class);
+        Mockito.when(contextFactory.createTenantContext(Mockito.any())).thenReturn(mockTenantContext);
+
+        final RolledUpUsageDao dao = Mockito.mock(RolledUpUsageDao.class);
+
+        mockInternalContext = Mockito.mock(InternalTenantContext.class);
+
+        api = new DefaultInternalUserApi(dao, contextFactory, pluginRegistry);
+    }
+
+    @Test(groups = "fast")
+    public void testUsageTransitionsPassedToPlugin() {
+        final UUID subId = UUID.randomUUID();
+        final Map.Entry<UUID, String> key = Map.entry(subId, "UNIT_A");
+        final Set<DateTime> times = Set.of(new DateTime("2024-01-01T00:00:00Z"));
+        final Map<Map.Entry<UUID, String>, Set<DateTime>> transitions = Map.of(key, times);
+
+        final PluginProperty transitionsProp = new PluginProperty("USAGE_TRANSITIONS", transitions, false);
+        final List<PluginProperty> props = List.of(transitionsProp);
+
+        final DateTime start = new DateTime("2024-01-01T00:00:00Z");
+        final DateTime end = new DateTime("2024-02-01T00:00:00Z");
+
+        // Plugin returns an empty list so we don't need to stub the DAO
+        Mockito.when(mockPlugin.getUsageForAccount(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+               .thenReturn(Collections.emptyList());
+
+        api.getRawUsageForAccount(start, end, null, props, mockInternalContext);
+
+        final ArgumentCaptor<UsageContext> contextCaptor = ArgumentCaptor.forClass(UsageContext.class);
+        Mockito.verify(mockPlugin).getUsageForAccount(Mockito.eq(start), Mockito.eq(end), contextCaptor.capture(), Mockito.any());
+
+        Assert.assertEquals(contextCaptor.getValue().getUsageTransitions(), transitions,
+                            "Plugin must receive the USAGE_TRANSITIONS map via UsageContext");
+    }
+
+    @Test(groups = "fast")
+    public void testUsageTransitionsNullWhenPropertyAbsent() {
+        final List<PluginProperty> props = List.of(new PluginProperty("OTHER_KEY", "irrelevant", false));
+
+        final DateTime start = new DateTime("2024-01-01T00:00:00Z");
+        final DateTime end = new DateTime("2024-02-01T00:00:00Z");
+
+        Mockito.when(mockPlugin.getUsageForAccount(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+               .thenReturn(Collections.emptyList());
+
+        api.getRawUsageForAccount(start, end, null, props, mockInternalContext);
+
+        final ArgumentCaptor<UsageContext> contextCaptor = ArgumentCaptor.forClass(UsageContext.class);
+        Mockito.verify(mockPlugin).getUsageForAccount(Mockito.eq(start), Mockito.eq(end), contextCaptor.capture(), Mockito.any());
+
+        Assert.assertNull(contextCaptor.getValue().getUsageTransitions(),
+                          "getUsageTransitions() must be null when USAGE_TRANSITIONS is not in plugin properties");
+    }
+
+    @Test(groups = "fast")
+    public void testUsageTransitionsNullWhenPropertyValueIsNotAMap() {
+        // Malformed property: value is a String, not a Map — must be ignored
+        final PluginProperty badProp = new PluginProperty("USAGE_TRANSITIONS", "not-a-map", false);
+        final List<PluginProperty> props = List.of(badProp);
+
+        final DateTime start = new DateTime("2024-01-01T00:00:00Z");
+        final DateTime end = new DateTime("2024-02-01T00:00:00Z");
+
+        Mockito.when(mockPlugin.getUsageForAccount(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+               .thenReturn(Collections.emptyList());
+
+        api.getRawUsageForAccount(start, end, null, props, mockInternalContext);
+
+        final ArgumentCaptor<UsageContext> contextCaptor = ArgumentCaptor.forClass(UsageContext.class);
+        Mockito.verify(mockPlugin).getUsageForAccount(Mockito.eq(start), Mockito.eq(end), contextCaptor.capture(), Mockito.any());
+
+        Assert.assertNull(contextCaptor.getValue().getUsageTransitions(),
+                          "Non-Map USAGE_TRANSITIONS value must be treated as absent");
+    }
+}


### PR DESCRIPTION
- Adds a usageTransitions field to DefaultUsageContext and overrides getUsageTransitions() from the new UsageContext interface method
- DefaultInternalUserApi now extracts the transition map from the USAGE_TRANSITIONS plugin property and passes it to DefaultUsageContext, making it available to usage plugins via the typed accessor
- Existing plugins that read the USAGE_TRANSITIONS plugin property continue to work unchanged

Depends on killbill-plugin-api#<plugin-api-PR> which adds the default getUsageTransitions() method to UsageContext.

Fixes #2257