### PR TITLE
security: add endpoint to list all available role definitions

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SecurityResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SecurityResource.java
@@ -18,7 +18,9 @@
 
 package org.killbill.billing.jaxrs.resources;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import jakarta.inject.Inject;
@@ -199,6 +201,22 @@ public class SecurityResource extends JaxRsResourceBase {
         return Response.status(Status.NO_CONTENT).build();
     }
 
+
+    @TimedResource
+    @GET
+    @Produces(APPLICATION_JSON)
+    @Path("/roles")
+    @Operation(summary = "List all available role definitions")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RoleDefinitionJson.class))))})
+    public Response getAvailableRoles(@jakarta.ws.rs.core.Context final HttpServletRequest request,
+                                      @jakarta.ws.rs.core.Context final UriInfo uriInfo) {
+        final Map<String, List<String>> availableRoles = securityApi.getAvailableRoles(context.createTenantContextNoAccountId(request));
+        final List<RoleDefinitionJson> result = new ArrayList<>(availableRoles.size());
+        for (final Map.Entry<String, List<String>> entry : availableRoles.entrySet()) {
+            result.add(new RoleDefinitionJson(entry.getKey(), entry.getValue()));
+        }
+        return Response.status(Status.OK).entity(result).build();
+    }
 
     @TimedResource
     @GET

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <properties>
         <check.skip-dependency-versions>true</check.skip-dependency-versions>
         <check.spotbugs-exclude-filter-file>${main.basedir}/spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
+        <killbill-api.version>0.55.1-9088692-SNAPSHOT</killbill-api.version>
         <killbill.version>${project.version}</killbill.version>
         <main.basedir>${project.basedir}</main.basedir>
     </properties>

--- a/util/src/main/java/org/killbill/billing/util/security/api/DefaultSecurityApi.java
+++ b/util/src/main/java/org/killbill/billing/util/security/api/DefaultSecurityApi.java
@@ -52,6 +52,7 @@ import org.killbill.billing.security.api.SecurityApi;
 import org.killbill.commons.utils.Strings;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.security.shiro.dao.RolesPermissionsModelDao;
 import org.killbill.billing.util.security.shiro.dao.UserDao;
 import org.killbill.billing.util.security.shiro.realm.KillBillJdbcRealm;
 import org.slf4j.Logger;
@@ -249,6 +250,16 @@ public class DefaultSecurityApi implements SecurityApi {
         return userDao.getRoleDefinition(role).stream()
                 .map(input -> input == null ? null : input.getPermission())
                 .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public Map<String, List<String>> getAvailableRoles(final TenantContext tenantContext) {
+        final Map<String, List<String>> rolesToPermissions = new HashMap<>();
+        for (final RolesPermissionsModelDao rolePermission : userDao.getAllRoleDefinitions()) {
+            rolesToPermissions.computeIfAbsent(rolePermission.getRoleName(), ignored -> new ArrayList<>())
+                               .add(rolePermission.getPermission());
+        }
+        return rolesToPermissions;
     }
 
     private List<String> sanitizePermissions(final List<String> permissionsRaw) throws SecurityApiException {

--- a/util/src/main/java/org/killbill/billing/util/security/shiro/dao/DefaultUserDao.java
+++ b/util/src/main/java/org/killbill/billing/util/security/shiro/dao/DefaultUserDao.java
@@ -154,6 +154,14 @@ public class DefaultUserDao implements UserDao {
     }
 
     @Override
+    public List<RolesPermissionsModelDao> getAllRoleDefinitions() {
+        return dbi.inTransaction((handle, status) -> {
+            final RolesPermissionsSqlDao rolesPermissionsSqlDao = handle.attach(RolesPermissionsSqlDao.class);
+            return rolesPermissionsSqlDao.getAll();
+        });
+    }
+
+    @Override
     public Set<String> getAllPermissions() {
         return dbi.inTransaction((handle, status) -> {
             final RolesPermissionsSqlDao rolesPermissionsSqlDao = handle.attach(RolesPermissionsSqlDao.class);

--- a/util/src/main/java/org/killbill/billing/util/security/shiro/dao/RolesPermissionsSqlDao.java
+++ b/util/src/main/java/org/killbill/billing/util/security/shiro/dao/RolesPermissionsSqlDao.java
@@ -42,6 +42,9 @@ public interface RolesPermissionsSqlDao extends Transactional<RolesPermissionsSq
     @SqlQuery
     public Set<String> getAllPermissions();
 
+    @SqlQuery
+    public List<RolesPermissionsModelDao> getAll();
+
     @SqlUpdate
     public void create(@SmartBindBean final RolesPermissionsModelDao rolesPermissions);
 

--- a/util/src/main/java/org/killbill/billing/util/security/shiro/dao/UserDao.java
+++ b/util/src/main/java/org/killbill/billing/util/security/shiro/dao/UserDao.java
@@ -34,6 +34,8 @@ public interface UserDao {
 
     public List<RolesPermissionsModelDao> getRoleDefinition(String role);
 
+    public List<RolesPermissionsModelDao> getAllRoleDefinitions();
+
     public Set<String> getAllPermissions();
 
     public void updateUserPassword(String username, String password, String createdBy) throws SecurityApiException;

--- a/util/src/main/resources/org/killbill/billing/util/security/shiro/dao/RolesPermissionsSqlDao.sql.stg
+++ b/util/src/main/resources/org/killbill/billing/util/security/shiro/dao/RolesPermissionsSqlDao.sql.stg
@@ -65,6 +65,13 @@ where is_active = TRUE
 ;
 >>
 
+getAll() ::= <<
+select <allTableFields("")>
+from <tableName()>
+where is_active = TRUE
+;
+>>
+
 unactiveEvent() ::= <<
 update <tableName()>
 set

--- a/util/src/test/java/org/killbill/billing/util/security/shiro/realm/TestKillBillJdbcRealm.java
+++ b/util/src/test/java/org/killbill/billing/util/security/shiro/realm/TestKillBillJdbcRealm.java
@@ -20,6 +20,7 @@ package org.killbill.billing.util.security.shiro.realm;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.shiro.SecurityUtils;
@@ -340,6 +341,20 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
 
         securityApi.updateRoleDefinition("original", List.of(), callContext);
         Assert.assertEquals(securityApi.getRoleDefinition("original", callContext).size(), 0);
+    }
+
+    @Test(groups = "slow")
+    public void testGetAvailableRoles() throws SecurityApiException {
+        securityApi.addRoleDefinition("librarian", List.of("book:read", "book:lend"), callContext);
+        securityApi.addRoleDefinition("archivist", List.of("book:read"), callContext);
+
+        final Map<String, List<String>> availableRoles = securityApi.getAvailableRoles(callContext);
+
+        Assert.assertTrue(availableRoles.containsKey("librarian"));
+        Assert.assertEqualsNoOrder(availableRoles.get("librarian").toArray(), List.of("book:read", "book:lend").toArray());
+
+        Assert.assertTrue(availableRoles.containsKey("archivist"));
+        Assert.assertEqualsNoOrder(availableRoles.get("archivist").toArray(), List.of("book:read").toArray());
     }
 
     private void testInvalidPermissionScenario(final List<String> permissions) {


### PR DESCRIPTION
Fixes #2250 
Changes:
- `RolesPermissionsSqlDao#getAll()` + SQL template to fetch all active
  role/permission rows
- `UserDao#getAllRoleDefinitions()`
- `DefaultSecurityApi#getAvailableRoles()` groups the flat rows by role
  name into the `Map<String, List<String>>` the API expects
- `SecurityResource#getAvailableRoles()` wires it up as `GET /roles`
- test in `TestKillBillJdbcRealm`

Note: this needs a killbill-api dependency bump once #124/#127 make it
into a release (currently pinned to a commit snapshot in pom.xml so CI
can build against it — happy to switch to a released version once one's
out).