### PR TITLE
jaxrs: clarify billingStartDate is read-only in the subscription JSON

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionJson.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/json/SubscriptionJson.java
@@ -74,6 +74,8 @@ public class SubscriptionJson extends JsonBase {
     private final EntitlementSourceType sourceType;
     private final DateTime cancelledDate;
     private final LocalDate chargedThroughDate;
+    @Schema(description = "Effective start of billing for this subscription, populated by the server. To request a specific billing start date " +
+                          "when creating a subscription, use the 'billingDate' query parameter instead of setting this field in the request body.")
     private final DateTime billingStartDate;
     private final DateTime billingEndDate;
     private final Integer billCycleDayLocal;


### PR DESCRIPTION
Fixes #2189 
The confusion here isn't actually a query-param inconsistency —
createSubscription, createSubscriptionWithAddOns, and
createSubscriptionsWithAddOns all already accept the same `billingDate`
query parameter. The mixup is with the `billingStartDate` field in the
request/response JSON body, which only reflects the server's computed
value on output and does nothing if set on input.

Added a schema description on that field spelling this out, so it's
clear in the generated docs that billing start is controlled via the
`billingDate` query parameter, not the JSON body.