### PR TITLE
invoice: date CBA_ADJ items consistently with the invoice, not call time

### DIFF
--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/CBADao.java
@@ -24,9 +24,12 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import org.joda.time.LocalDate;
 
 import javax.annotation.Nullable;
 import jakarta.inject.Inject;
@@ -245,8 +248,23 @@ public class CBADao {
                                              final InternalCallContext context) {
         return new InvoiceItemModelDao(new CreditBalanceAdjInvoiceItem(invoice.getId(),
                                                                        invoice.getAccountId(),
-                                                                       context.getCreatedDate().toLocalDate(),
+                                                                       getCBAItemDate(invoice, context),
                                                                        amount.negate(),
                                                                        invoice.getCurrency()));
+    }
+
+    // The credit balance adjustment should be dated consistently with the invoice's own items
+    // (e.g. the requestedDate of a credit that was just inserted on this invoice), not the time
+    // this transaction happens to run at -- otherwise a credit created with a past or future
+    // effectiveDate ends up with its CREDIT_ADJ item correctly dated but its CBA_ADJ side effect
+    // dated "today". Falls back to the call time only for the degenerate case of an invoice with
+    // no items yet.
+    private LocalDate getCBAItemDate(final InvoiceModelDao invoice, final InternalCallContext context) {
+        return invoice.getInvoiceItems()
+                      .stream()
+                      .map(InvoiceItemModelDao::getStartDate)
+                      .filter(Objects::nonNull)
+                      .max(Comparator.naturalOrder())
+                      .orElseGet(() -> context.getCreatedDate().toLocalDate());
     }
 }

--- a/invoice/src/test/java/org/killbill/billing/invoice/api/user/TestDefaultInvoiceUserApi.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/api/user/TestDefaultInvoiceUserApi.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.Account;
@@ -552,6 +553,38 @@ public class TestDefaultInvoiceUserApi extends InvoiceTestSuiteWithEmbeddedDB {
         final BigDecimal accountCBA2 = invoiceUserApi.getAccountCBA(accountId, callContext);
         Assert.assertEquals(accountBalance2.compareTo(new BigDecimal("-150")), 0);
         Assert.assertEquals(accountCBA2.compareTo(new BigDecimal("150")), 0);
+    }
+
+    @Test(groups = "slow", description = "https://github.com/killbill/killbill/issues/2202")
+    public void testGeneratedCBAItemUsesCreditEffectiveDateNotCallTime() throws Exception {
+
+        final Account account = invoiceUtil.createAccount(callContext);
+        final UUID accountId = account.getId();
+
+        // Invoice created in DRAFT state so we can add a credit item on top of it
+        final InvoiceItem externalCharge = new ExternalChargeInvoiceItem(null, accountId, null, "description", clock.getUTCToday(), clock.getUTCToday(), new BigDecimal("100.00"), accountCurrency, null);
+        final List<InvoiceItem> items = invoiceUserApi.insertExternalCharges(accountId, clock.getUTCToday(), List.of(externalCharge), false, null, callContext);
+        assertEquals(items.size(), 1);
+        final Invoice invoice = invoiceUserApi.getInvoice(items.get(0).getInvoiceId(), callContext);
+
+        // Credit dated well in the past, distinct from "today" (when this transaction actually runs)
+        final LocalDate creditEffectiveDate = clock.getUTCToday().minusDays(10);
+        final InvoiceItem creditItemInput = new CreditAdjInvoiceItem(invoice.getId(), accountId, creditEffectiveDate, "something", new BigDecimal("200.00"), accountCurrency, null);
+        invoiceUserApi.insertCredits(accountId, creditEffectiveDate, List.of(creditItemInput), true, null, callContext);
+
+        // Committing the invoice triggers CBA generation: balance goes negative (100 charge - 200 credit),
+        // so a positive CBA_ADJ item is auto-generated to track the resulting credit balance
+        invoiceUserApi.commitInvoice(invoice.getId(), callContext);
+
+        final Invoice committedInvoice = invoiceUserApi.getInvoice(items.get(0).getInvoiceId(), callContext);
+        final InvoiceItem cbaItem = committedInvoice.getInvoiceItems().stream()
+                .filter(invoiceItem -> InvoiceItemType.CBA_ADJ == invoiceItem.getInvoiceItemType() &&
+                                       invoiceItem.getAmount().compareTo(BigDecimal.ZERO) > 0)
+                .findFirst()
+                .orElse(null);
+        Assert.assertNotNull(cbaItem);
+        Assert.assertEquals(cbaItem.getStartDate(), creditEffectiveDate,
+                            "CBA_ADJ item should be dated consistently with the credit's effective date, not the current call time");
     }
 
     @Test(groups = "slow")


### PR DESCRIPTION
buildCBAItem dated the auto-generated CBA_ADJ item using context.getCreatedDate() (the time this transaction happens to run), rather than any date tied to the invoice or the credit that triggered it. This meant a credit created via the API with an explicit past or future requestedDate produced a CREDIT_ADJ item correctly dated, but its CBA_ADJ side effect dated "today" instead.

Date the CBA_ADJ item using the latest start date among the invoice's own items instead, which naturally reflects the requestedDate of a credit that was just inserted on it. Falls back to the previous call-time behavior only when the invoice has no items yet (shouldn't happen in practice, but keeps the method total).

Added a regression test that creates a credit ten days in the past, commits the invoice to trigger CBA generation, and asserts the resulting CBA_ADJ item is dated to match.

Fixes #2202