### PR TITLE
implements killbill/killbill#2250

### DIFF
--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SecurityResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/SecurityResource.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.jaxrs.resources;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import jakarta.inject.Inject;
@@ -47,7 +48,6 @@ import org.killbill.billing.jaxrs.util.Context;
 import org.killbill.billing.jaxrs.util.JaxrsUriBuilder;
 import org.killbill.billing.payment.api.InvoicePaymentApi;
 import org.killbill.billing.payment.api.PaymentApi;
-import org.killbill.billing.security.Permission;
 import org.killbill.billing.security.SecurityApiException;
 import org.killbill.billing.security.api.SecurityApi;
 import org.killbill.billing.util.api.AuditUserApi;
@@ -250,4 +250,19 @@ public class SecurityResource extends JaxRsResourceBase {
         return Response.status(Status.NO_CONTENT).build();
     }
 
+    @TimedResource
+    @GET
+    @Produces(APPLICATION_JSON)
+    @Path("/roles")
+    @Operation(summary = "List all active role definitions")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "successful operation", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = RoleDefinitionJson.class))))})
+    public Response getAvailableRoles(@jakarta.ws.rs.core.Context final HttpServletRequest request) {
+        final Map<String, List<String>> roles = securityApi.getAvailableRoles(context.createTenantContextNoAccountId(request));
+        final List<RoleDefinitionJson> json = roles
+                .entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> new RoleDefinitionJson(e.getKey(), e.getValue()))
+                .toList();
+        return Response.status(Status.OK).entity(json).build();
+    }
 }

--- a/jaxrs/src/test/java/org/killbill/billing/jaxrs/resources/TestSecurityResource.java
+++ b/jaxrs/src/test/java/org/killbill/billing/jaxrs/resources/TestSecurityResource.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.jaxrs.resources;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+
+import org.killbill.billing.jaxrs.JaxrsTestSuiteNoDB;
+import org.killbill.billing.jaxrs.json.RoleDefinitionJson;
+import org.killbill.billing.jaxrs.util.Context;
+import org.killbill.billing.security.api.SecurityApi;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestSecurityResource extends JaxrsTestSuiteNoDB {
+
+    private HttpServletRequest servletRequest;
+    private SecurityApi securityApi;
+    private Context context;
+
+    @BeforeMethod(groups = "fast")
+    public void beforeMethod() {
+        if (hasFailed()) {
+            return;
+        }
+        servletRequest = mock(HttpServletRequest.class);
+        securityApi = mock(SecurityApi.class);
+        context = mock(Context.class);
+    }
+
+    private SecurityResource createSecurityResource() {
+        return new SecurityResource(
+                securityApi,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                context
+        );
+    }
+
+    @Test(groups = "fast")
+    public void testGetAvailableRolesReturnsSortedByRoleName() {
+        // Use a LinkedHashMap with intentionally unsorted insertion order
+        final Map<String, List<String>> unsortedRoles = new LinkedHashMap<>();
+        unsortedRoles.put("supervisor_role", List.of("permission:read"));
+        unsortedRoles.put("admin_role", List.of("permission:all"));
+        unsortedRoles.put("manager_role", List.of("permission:write", "permission:read"));
+
+        when(securityApi.getAvailableRoles(any())).thenReturn(unsortedRoles);
+
+        final SecurityResource resource = createSecurityResource();
+        final Response response = resource.getAvailableRoles(servletRequest);
+
+        Assert.assertEquals(response.getStatus(), 200);
+
+        @SuppressWarnings("unchecked")
+        final List<RoleDefinitionJson> result = (List<RoleDefinitionJson>) response.getEntity();
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.get(0).getRole(), "admin_role");
+        Assert.assertEquals(result.get(1).getRole(), "manager_role");
+        Assert.assertEquals(result.get(2).getRole(), "supervisor_role");
+    }
+
+    @Test(groups = "fast")
+    public void testGetAvailableRolesReturnsSortedRegardlessOfMapType() {
+        // Use a HashMap which has no guaranteed iteration order
+        final Map<String, List<String>> roles = new HashMap<>();
+        roles.put("delta", List.of("perm:d"));
+        roles.put("alpha", List.of("perm:a"));
+        roles.put("charlie", List.of("perm:c"));
+        roles.put("bravo", List.of("perm:b"));
+
+        when(securityApi.getAvailableRoles(any())).thenReturn(roles);
+
+        final SecurityResource resource = createSecurityResource();
+        final Response response = resource.getAvailableRoles(servletRequest);
+
+        @SuppressWarnings("unchecked")
+        final List<RoleDefinitionJson> result = (List<RoleDefinitionJson>) response.getEntity();
+        Assert.assertEquals(result.size(), 4);
+        Assert.assertEquals(result.get(0).getRole(), "alpha");
+        Assert.assertEquals(result.get(1).getRole(), "bravo");
+        Assert.assertEquals(result.get(2).getRole(), "charlie");
+        Assert.assertEquals(result.get(3).getRole(), "delta");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.147.6</version>
+        <version>0.147.11</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.25.1-SNAPSHOT</version>

--- a/util/src/main/java/org/killbill/billing/util/security/api/DefaultSecurityApi.java
+++ b/util/src/main/java/org/killbill/billing/util/security/api/DefaultSecurityApi.java
@@ -49,6 +49,7 @@ import org.killbill.billing.security.Logical;
 import org.killbill.billing.security.Permission;
 import org.killbill.billing.security.SecurityApiException;
 import org.killbill.billing.security.api.SecurityApi;
+import org.killbill.billing.util.security.shiro.dao.RolesPermissionsModelDao;
 import org.killbill.commons.utils.Strings;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
@@ -249,6 +250,16 @@ public class DefaultSecurityApi implements SecurityApi {
         return userDao.getRoleDefinition(role).stream()
                 .map(input -> input == null ? null : input.getPermission())
                 .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public Map<String, List<String>> getAvailableRoles(final TenantContext tenantContext) {
+        final Map<String, List<String>> result = new HashMap<>();
+        for (final RolesPermissionsModelDao rolePermission : userDao.getAllPermissions()) {
+            result.computeIfAbsent(rolePermission.getRoleName(), ignored -> new ArrayList<>())
+                              .add(rolePermission.getPermission());
+        }
+        return result;
     }
 
     private List<String> sanitizePermissions(final List<String> permissionsRaw) throws SecurityApiException {

--- a/util/src/main/java/org/killbill/billing/util/security/shiro/dao/DefaultUserDao.java
+++ b/util/src/main/java/org/killbill/billing/util/security/shiro/dao/DefaultUserDao.java
@@ -154,7 +154,7 @@ public class DefaultUserDao implements UserDao {
     }
 
     @Override
-    public Set<String> getAllPermissions() {
+    public List<RolesPermissionsModelDao> getAllPermissions() {
         return dbi.inTransaction((handle, status) -> {
             final RolesPermissionsSqlDao rolesPermissionsSqlDao = handle.attach(RolesPermissionsSqlDao.class);
             return rolesPermissionsSqlDao.getAllPermissions();

--- a/util/src/main/java/org/killbill/billing/util/security/shiro/dao/RolesPermissionsSqlDao.java
+++ b/util/src/main/java/org/killbill/billing/util/security/shiro/dao/RolesPermissionsSqlDao.java
@@ -40,7 +40,7 @@ public interface RolesPermissionsSqlDao extends Transactional<RolesPermissionsSq
     public List<RolesPermissionsModelDao> getByRoleName(@Bind("roleName") final String roleName);
 
     @SqlQuery
-    public Set<String> getAllPermissions();
+    List<RolesPermissionsModelDao> getAllPermissions();
 
     @SqlUpdate
     public void create(@SmartBindBean final RolesPermissionsModelDao rolesPermissions);

--- a/util/src/main/java/org/killbill/billing/util/security/shiro/dao/UserDao.java
+++ b/util/src/main/java/org/killbill/billing/util/security/shiro/dao/UserDao.java
@@ -34,7 +34,7 @@ public interface UserDao {
 
     public List<RolesPermissionsModelDao> getRoleDefinition(String role);
 
-    public Set<String> getAllPermissions();
+    public List<RolesPermissionsModelDao> getAllPermissions();
 
     public void updateUserPassword(String username, String password, String createdBy) throws SecurityApiException;
 

--- a/util/src/main/resources/org/killbill/billing/util/security/shiro/dao/RolesPermissionsSqlDao.sql.stg
+++ b/util/src/main/resources/org/killbill/billing/util/security/shiro/dao/RolesPermissionsSqlDao.sql.stg
@@ -59,7 +59,7 @@ and is_active = TRUE
 >>
 
 getAllPermissions() ::= <<
-select distinct permission
+select <allTableFields("")>
 from <tableName()>
 where is_active = TRUE
 ;

--- a/util/src/test/java/org/killbill/billing/util/security/shiro/realm/TestKillBillJdbcRealm.java
+++ b/util/src/test/java/org/killbill/billing/util/security/shiro/realm/TestKillBillJdbcRealm.java
@@ -20,6 +20,7 @@ package org.killbill.billing.util.security.shiro.realm;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.shiro.SecurityUtils;
@@ -340,6 +341,25 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
 
         securityApi.updateRoleDefinition("original", List.of(), callContext);
         Assert.assertEquals(securityApi.getRoleDefinition("original", callContext).size(), 0);
+    }
+
+    @Test(groups = "slow")
+    public void testGetAvailableRoles() throws SecurityApiException {
+        securityApi.addRoleDefinition("admin", List.of("tenant:add", "tenant:update"), callContext);
+        securityApi.addRoleDefinition("finance", List.of("invoice:credit"), callContext);
+
+        Map<String, List<String>> result = securityApi.getAvailableRoles(callContext);
+        Assert.assertTrue(result.keySet().containsAll(List.of("admin", "finance")));
+        Assert.assertTrue(result.values().stream()
+                                .flatMap(List::stream)
+                                .toList().containsAll(List.of("tenant:add", "tenant:update", "invoice:credit")));
+
+        securityApi.updateRoleDefinition("admin", List.of("tenant:add", "tenant:update", "tenant:delete"), callContext);
+        result = securityApi.getAvailableRoles(callContext);
+        Assert.assertTrue(result.values().stream()
+                                .flatMap(List::stream)
+                                .toList().containsAll(List.of("tenant:add", "tenant:update", "tenant:delete", "invoice:credit")));
+
     }
 
     private void testInvalidPermissionScenario(final List<String> permissions) {


### PR DESCRIPTION
Original ticket #2250 . Commits are self explanatory. Why this PR while we already [have another contribution here](https://github.com/killbill/killbill/pull/2267) ? In fact, this PR heavily inspired by the contributor PR, except that:

During review, I wondering why we can't reuse `RolesPermissionsSqlDao#getAllPermissions()` ? It turns out that:
- The `RolesPermissionsSqlDao#getAllPermissions()` just return the permission (string). So I just refactor the [sql.stg file](https://github.com/killbill/killbill/pull/2271/changes#diff-64429f1b57f780ce210000f9573e74ee801bbc870ead03a80fac5198b89b1352R62) and the method return value.
- The `RolesPermissionsSqlDao#getAllPermissions()` safe to refactor because it is actually not used anywhere (see commit message and description in 82ab05ff098730b0e2262f1be229ed6410f3d62c). 

Nevertheless, we have no other options but to execute this ticket #2250 , since other PRs are broken.

So:
1. If original `RolesPermissionsSqlDao#getAllPermissions()` is just leftover (unused), it is cleaner to use this one.
2. Otherwise, lets use the another contribution and close this one.