### PR TITLE
avoid passing null as subject during securityManager.login()

### DIFF
--- a/util/src/test/java/org/killbill/billing/util/security/shiro/realm/TestKillBillJdbcRealm.java
+++ b/util/src/test/java/org/killbill/billing/util/security/shiro/realm/TestKillBillJdbcRealm.java
@@ -45,6 +45,9 @@ import org.testng.annotations.Test;
 public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
 
     private SecurityManager securityManager;
+    // Needed to avoid NPE because of https://github.com/apache/shiro/issues/2804
+    // Also, related PR and discussion : https://github.com/apache/shiro/pull/2807#issuecomment-4779317586
+    private Subject emptySubject;
 
     @Override
     @BeforeMethod(groups = "slow")
@@ -57,6 +60,7 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
 
         securityManager = new DefaultSecurityManager(realms);
         SecurityUtils.setSecurityManager(securityManager);
+        emptySubject = new DelegatingSubject(securityManager);
     }
 
     @AfterMethod(groups = "slow")
@@ -163,7 +167,7 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
         securityApi.addUserRoles(username, password, List.of(role), callContext);
 
         final AuthenticationToken goodToken = new UsernamePasswordToken(username, password);
-        final Subject subject = securityManager.login(null, goodToken);
+        final Subject subject = securityManager.login(emptySubject, goodToken);
         try {
             ThreadContext.bind(subject);
 
@@ -200,7 +204,7 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
         securityApi.addUserRoles(username, password, List.of("restricted"), callContext);
 
         final AuthenticationToken goodToken = new UsernamePasswordToken(username, password);
-        final Subject subject = securityManager.login(null, goodToken);
+        final Subject subject = securityManager.login(emptySubject, goodToken);
 
         subject.checkPermission(Permission.ACCOUNT_CAN_CHARGE.toString());
         subject.checkPermission(Permission.INVOICE_CAN_CREDIT.toString());
@@ -216,7 +220,7 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
         securityApi.addRoleDefinition("newRestricted", List.of("account:*", "invoice", "tag:delete_tag_definition"), callContext);
         securityApi.updateUserRoles(username, List.of("newRestricted"), callContext);
 
-        final Subject newSubject = securityManager.login(null, goodToken);
+        final Subject newSubject = securityManager.login(emptySubject, goodToken);
         newSubject.checkPermission(Permission.ACCOUNT_CAN_CHARGE.toString());
         newSubject.checkPermission(Permission.INVOICE_CAN_CREDIT.toString());
         newSubject.checkPermission(Permission.TAG_CAN_DELETE_TAG_DEFINITION.toString());
@@ -240,7 +244,7 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
         securityApi.addUserRoles(username, password, List.of(role), callContext);
 
         final AuthenticationToken goodToken = new UsernamePasswordToken(username, password);
-        final Subject subject = securityManager.login(null, goodToken);
+        final Subject subject = securityManager.login(emptySubject, goodToken);
         try {
             ThreadContext.bind(subject);
             subject.checkPermission(Permission.ACCOUNT_CAN_CHARGE.toString());
@@ -282,7 +286,7 @@ public class TestKillBillJdbcRealm extends UtilTestSuiteWithEmbeddedDB {
         securityApi.addUserRoles(username, password, List.of(role), callContext);
 
         final AuthenticationToken goodToken = new UsernamePasswordToken(username, password);
-        final Subject subject = securityManager.login(null, goodToken);
+        final Subject subject = securityManager.login(emptySubject, goodToken);
         try {
             ThreadContext.bind(subject);
 


### PR DESCRIPTION
passing `null` as subject into `securityManager.login()` throw NPE in shiro:2.2.1: https://github.com/apache/shiro/issues/2804 . This is blocker for us when trying to [update parent pom](https://github.com/killbill/killbill-oss-parent/actions/runs/29334029051).

There's [fix for this](https://github.com/apache/shiro/pull/2807), but no new version released at this time. So, lets use this approach, since seems like this (not passing null) is preferred approach (see [comment](https://github.com/apache/shiro/pull/2807#issuecomment-4779317586), "_... Why would such a use-case be allowed at all?_")

Using this approach seems fixes the shiro-update PR:
1. Originally, I send this PR: https://github.com/killbill/killbill-oss-parent/pull/992
2. That PR error because (see original shiro issue in first paragraph) :
    ```
    2026-07-15T15:07:12.4439086Z [ERROR] org.killbill.billing.util.security.shiro.realm.TestKillBillJdbcRealm.testAuthorization:
    java.lang.NullPointerException: Cannot invoke "org.apache.shiro.subject.Subject.getSession(boolean)" because "subject" is null
    ```
3. I update the test (`TestKillBillJdbcRealm`) to use `emptySubject = new DelegatingSubject(securityManager);` instead of passing `null` for `login()` during test.
4. To test that this PR actually fix the shiro:2.2.1 problem, I send "DO NOT MERGE" PR and set CI to test [using this branch](https://github.com/killbill/killbill-oss-parent/pull/995/changes#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR40) instead of `master` branch. 
5. The PR [now green](https://github.com/killbill/killbill-oss-parent/pull/995).