### PR TITLE
WIP: remove netty completely from project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.147.11</version>
+        <version>0.147.12-68c0cb3-SNAPSHOT</version>
     </parent>
     <artifactId>killbill</artifactId>
     <version>0.25.1-SNAPSHOT</version>
@@ -66,11 +66,6 @@
     </properties>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>

--- a/tenant/pom.xml
+++ b/tenant/pom.xml
@@ -45,10 +45,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.zonky.test</groupId>
             <artifactId>embedded-postgres</artifactId>
             <!-- Technically, test-runtime -->

--- a/tenant/src/test/java/org/killbill/billing/tenant/api/TestDefaultTenant.java
+++ b/tenant/src/test/java/org/killbill/billing/tenant/api/TestDefaultTenant.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.tenant.api;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.UUID;
 
 import org.killbill.billing.tenant.TenantTestSuiteNoDB;
@@ -26,16 +27,42 @@ import org.redisson.codec.SerializationCodec;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import io.netty.buffer.ByteBuf;
-
 public class TestDefaultTenant extends TenantTestSuiteNoDB {
 
     @Test(groups = "fast")
-    public void testExternalizable() throws IOException {
-        final DefaultTenant tenantdata = new DefaultTenant(UUID.randomUUID(), clock.getUTCNow(), clock.getUTCNow(), "er44TT-yy4r", "TTR445ee2", null);
-        final Codec code = new SerializationCodec();
-        final ByteBuf byteBuf = code.getValueEncoder().encode(tenantdata);
-        final DefaultTenant tenantData2 = (DefaultTenant) code.getValueDecoder().decode(byteBuf, null);
-        Assert.assertEquals(tenantData2, tenantdata);
+    public void testExternalizable() throws Throwable {
+        final Codec codec = new SerializationCodec();
+
+        final DefaultTenant tenantData = new DefaultTenant(UUID.randomUUID(), clock.getUTCNow(), clock.getUTCNow(), "er44TT-yy4r", "TTR445ee2", null);
+        final DefaultTenant tenantData2 = externalize(codec, tenantData);
+        Assert.assertEquals(tenantData2, tenantData);
+
+        final DefaultTenant withSecret = new DefaultTenant(UUID.randomUUID(), clock.getUTCNow(), clock.getUTCNow(), "external", "apiKey", "apiSecret");
+        final DefaultTenant withSecret2 = externalize(codec, withSecret);
+        Assert.assertNotEquals(withSecret2, withSecret);
+        Assert.assertNotNull(withSecret.getApiSecret());
+        Assert.assertNull(withSecret2.getApiSecret());
+    }
+
+    private DefaultTenant externalize(final Codec codec, final DefaultTenant tenant) throws Throwable {
+        // Keep the Redisson codec path, but avoid a direct test dependency on Netty's ByteBuf.
+        final Object encoded = invokeRedissonCodecMethod(codec.getValueEncoder(), "encode", tenant);
+        return (DefaultTenant) invokeRedissonCodecMethod(codec.getValueDecoder(), "decode", encoded, null);
+    }
+
+    private Object invokeRedissonCodecMethod(final Object target, final String methodName, final Object... args) throws Throwable {
+        final Method method = findMethod(target.getClass(), methodName, args.length);
+
+        method.setAccessible(true);
+        return method.invoke(target, args);
+    }
+
+    private Method findMethod(final Class<?> clazz, final String methodName, final int argumentCount) throws IOException {
+        for (final Method method : clazz.getDeclaredMethods()) {
+            if (methodName.equals(method.getName()) && method.getParameterCount() == argumentCount) {
+                return method;
+            }
+        }
+        throw new IOException("Unable to find Redisson codec method " + methodName + " on " + clazz.getName());
     }
 }


### PR DESCRIPTION
This is works that will be happened in killbill.

On the other hand, we need to wipe out netty from killbill-oss-parent, and publish.

killbill-commons will complains (clock, jooby) about this, so we might need to adjust things there. 