### PR TITLE
Complete empty-catalog handling in StandaloneCatalogMapper (#2124)

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/plugin/StandaloneCatalogMapper.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/plugin/StandaloneCatalogMapper.java
@@ -115,19 +115,25 @@ public class StandaloneCatalogMapper {
         result.setSupportedCurrencies(toArray(pluginCatalog.getCurrencies()));
         result.setUnits(toDefaultUnits(pluginCatalog.getUnits()));
         result.setPlanRules(toDefaultPlanRules(pluginCatalog.getPlanRules()));
-        for (final Product cur : pluginCatalog.getProducts()) {
-            final Product target = result.getCatalogEntityCollectionProduct().findByName(cur.getName());
-            if (target != null) {
-                ((DefaultProduct) target).setAvailable(toFilteredDefaultProduct(cur.getAvailable()));
-                ((DefaultProduct) target).setIncluded(toFilteredDefaultProduct(cur.getIncluded()));
+        if (pluginCatalog.getProducts() != null) {
+            for (final Product cur : pluginCatalog.getProducts()) {
+                final Product target = result.getCatalogEntityCollectionProduct().findByName(cur.getName());
+                if (target != null) {
+                    ((DefaultProduct) target).setAvailable(toFilteredDefaultProduct(cur.getAvailable()));
+                    ((DefaultProduct) target).setIncluded(toFilteredDefaultProduct(cur.getIncluded()));
+                }
             }
         }
         result.initialize(result);
         return result;
     }
 
-    private DefaultPlanRules toDefaultPlanRules(final PlanRules input) {
+    private DefaultPlanRules toDefaultPlanRules(@Nullable final PlanRules input) {
         final DefaultPlanRules result = new DefaultPlanRules();
+        if (input == null) {
+            // An empty catalog version may come without any rules - see #2124
+            return result;
+        }
         result.setBillingAlignmentCase(toDefaultCaseBillingAlignments(input.getCaseBillingAlignment()));
         result.setCancelCase(toDefaultCaseCancelPolicys(input.getCaseCancelPolicy()));
         result.setChangeAlignmentCase(toDefaultCaseChangePlanAlignments(input.getCaseChangePlanAlignment()));
@@ -227,11 +233,13 @@ public class StandaloneCatalogMapper {
         result.setToProductCategory(input.getToProductCategory());
     }
 
-    private Iterable<Product> toDefaultProducts(final Iterable<Product> input) {
+    private Iterable<Product> toDefaultProducts(@Nullable final Iterable<Product> input) {
         if (tmpDefaultProducts == null) {
             final Map<String, Product> map = new HashMap<>();
-            for (final Product product : input) {
-                map.put(product.getName(), toDefaultProduct(product));
+            if (input != null) {
+                for (final Product product : input) {
+                    map.put(product.getName(), toDefaultProduct(product));
+                }
             }
             tmpDefaultProducts = map;
         }
@@ -256,11 +264,13 @@ public class StandaloneCatalogMapper {
         return filteredAndOrdered;
     }
 
-    private Iterable<Plan> toDefaultPlans(final StaticCatalog staticCatalog, final Iterable<Plan> input) {
+    private Iterable<Plan> toDefaultPlans(final StaticCatalog staticCatalog, @Nullable final Iterable<Plan> input) {
         if (tmpDefaultPlans == null) {
             final Map<String, Plan> map = new HashMap<>();
-            for (final Plan plan : input) {
-                map.put(plan.getName(), toDefaultPlan(staticCatalog, plan));
+            if (input != null) {
+                for (final Plan plan : input) {
+                    map.put(plan.getName(), toDefaultPlan(staticCatalog, plan));
+                }
             }
             tmpDefaultPlans = map;
         }
@@ -531,9 +541,11 @@ public class StandaloneCatalogMapper {
         return toArray(tmp);
     }
 
-    private <C> C[] toArray(final Iterable<C> input) {
-        if (!input.iterator().hasNext()) {
-            throw new IllegalStateException("Nothing to convert into array");
+    private <C> C[] toArray(@Nullable final Iterable<C> input) {
+        if (input == null || !input.iterator().hasNext()) {
+            // Null (rather than empty) arrays are filled in with defaults by
+            // CatalogSafetyInitializer when the resulting catalog is initialized - see #2124
+            return null;
         }
         final C[] foo = (C[]) java.lang.reflect.Array
                 .newInstance(input.iterator().next().getClass(), 1);

--- a/catalog/src/test/java/org/killbill/billing/catalog/plugin/TestCatalogPluginMapping.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/plugin/TestCatalogPluginMapping.java
@@ -57,6 +57,21 @@ public class TestCatalogPluginMapping extends CatalogTestSuiteNoDB {
         Assert.assertEquals(output.getPriceLists().getDefaultPricelist().getName(), new PriceListDefault().getName());
     }
 
+    @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/2124")
+    public void testMappingWithEmptyPluginCatalog() {
+        // A catalog plugin may return a version with no entries at all (e.g. all plans retired):
+        // mapping it should not throw
+        final StandalonePluginCatalog pluginCatalog = Mockito.mock(StandalonePluginCatalog.class);
+        Mockito.when(pluginCatalog.getEffectiveDate()).thenReturn(DateTime.now());
+
+        final StandaloneCatalogMapper mapper = new StandaloneCatalogMapper("test-catalog");
+        final StandaloneCatalog output = mapper.toStandaloneCatalog(pluginCatalog);
+
+        Assert.assertEquals(output.getPriceLists().getDefaultPricelist().getName(), new PriceListDefault().getName());
+        Assert.assertFalse(output.getProducts().iterator().hasNext());
+        Assert.assertFalse(output.getPlans().iterator().hasNext());
+    }
+
     @Test(groups = "fast")
     public void testMappingFromExistingCatalog() throws Exception {
         final StandaloneCatalog inputCatalog = getCatalog("SpyCarAdvanced.xml");


### PR DESCRIPTION
Addresses the remaining cases of #2124.

77fdd493 (#2125) fixed the null default pricelist, but mapping a genuinely empty catalog version from a plugin (e.g. one where all plans were retired) can still fail on other paths in `StandaloneCatalogMapper`:

- empty/null `currencies` → `IllegalStateException("Nothing to convert into array")` / NPE in `toArray`
- null `products` or `plans` → NPE in the mapper loops
- null `planRules` → NPE in `toDefaultPlanRules`

## Change

All of these are now treated as empty:

- `toArray` returns `null` for null/empty input instead of throwing — consistent with `toArrayWithTransform`, and `CatalogSafetyInitializer.initializeNonRequiredNullFieldsWithDefaultValue` already fills null array fields with zero-length defaults when the resulting catalog is initialized (the other `toArray` caller only ever passes non-empty input).
- `toDefaultProducts` / `toDefaultPlans` / the product-availability loop tolerate null input.
- `toDefaultPlanRules(null)` returns an empty `DefaultPlanRules`.

## Test

Added `testMappingWithEmptyPluginCatalog`: a `StandalonePluginCatalog` mock that stubs only `getEffectiveDate()` (everything else empty/null, the same pattern as the #1944 test). It fails on current master with the `IllegalStateException` above and passes with this change. The existing mapping tests (`testEmptyCatalog`, `testMappingFromExistingCatalog` round-trip) are unchanged and still pass — behaviour for populated catalogs is untouched.

`mvn -pl catalog test -Dgroups=fast`: 87/87 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)