### PR TITLE
nit: change jsr305 scope from compile to provided

### DIFF
--- a/beatrix/pom.xml
+++ b/beatrix/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/profiles/killbill/pom.xml
+++ b/profiles/killbill/pom.xml
@@ -60,19 +60,10 @@
             <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         </dependency>
-        <!--
-        adding jsr305 to 'compile' help weird various guice errors at runtime
-        (at least in embedded mode when mvn jetty:run invoked). In fact, 'provided' scope to jsr305 make guice "think"
-        that we're not add @Nullable to various dependency, eg:
-
-        [Guice/NullInjectedIntoNonNullable]: null returned by binding at KillbillServerModule.configure(KillbillServerModule.java:125)
-          but the 1st parameter sqlLog of DBIProvider.setSqlLog(DBIProvider.java:97) is not @Nullable
-
-        in this example, DBIProvider.setSqlLog() is already annotated by @Nullable, but reported as "not @Nullable".
-        -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/usage/pom.xml
+++ b/usage/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -67,6 +67,7 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>


### PR DESCRIPTION
As described. Past problem like [this one](https://github.com/killbill/killbill/compare/change-jsr305-scope?expand=1#diff-030ec92e9612718b2d2bc8aa5b7a65ebd296c063e121df61c273b3b00530b926L63) now gone. Tested manually using both embedded Jetty and Tomcat 10.1.56.