### PR TITLE
Configure global lock settings and OSGi plugin resource limits

### DIFF
--- a/profiles/killbill/src/main/resources/killbill-server.properties
+++ b/profiles/killbill/src/main/resources/killbill-server.properties
@@ -66,6 +66,26 @@ org.killbill.billing.osgi.dao.url=jdbc:mysql://127.0.0.1:3306/killbill
 org.killbill.billing.osgi.dao.user=root
 org.killbill.billing.osgi.dao.password=root
 
+# Limit database connections and resources for OSGi plugins to prevent connection exhaustion
+org.killbill.billing.osgi.dao.connectionTimeout=10s
+org.killbill.billing.osgi.dao.idleTimeout=10m
+org.killbill.billing.osgi.dao.maxLifetime=30m
+org.killbill.billing.osgi.dao.maximumPoolSize=10
+org.killbill.billing.osgi.dao.minimumIdle=2
+
+# Enforce authentication for plugins calling internal APIs (prevent authentication bypass)
+org.killbill.security.skipAuthForPlugins=false
+
+#
+# GLOBAL DISTRIBUTED LOCK CONFIGURATION (Double-Invoicing & Concurrency Protection)
+#
+# The lock retry backoff schedule for retry queues when a lock cannot be acquired
+org.killbill.rescheduleIntervalOnLock=10s,30s,1m,2m,5m,10m
+
+# Maximum number of retry attempts to grab the global lock (100ms wait per attempt)
+org.killbill.invoice.globalLock.retries=100
+org.killbill.payment.globalLock.retries=100
+
 # Allow jruby concurrency
 org.killbill.jruby.context.scope=THREADSAFE
 


### PR DESCRIPTION
# Overview

This PR introduces explicit configurations for global distributed locking and OSGi database connection pooling. These changes improve concurrency handling under heavy billing workloads, protect the core application from database connection exhaustion, and strengthen plugin security.

**Fixes/Refers to:** #2280

---

# Changes

## Global Distributed Locking

* Configured `org.killbill.rescheduleIntervalOnLock` to:

  ```
  10s,30s,1m,2m,5m,10m
  ```

  to reduce the initial retry intervals for tasks blocked on distributed locks.

* Increased the maximum lock retry attempts by setting:

  * `org.killbill.invoice.globalLock.retries=100`
  * `org.killbill.payment.globalLock.retries=100`

  This helps prevent premature failures during concurrent operations on the same account.

## OSGi Plugin Database Resource Isolation

Configured dedicated connection pool settings for OSGi plugin data sources to isolate plugin database usage from the core application:

* Connection timeout: **10 seconds**
* Maximum pool size: **10**

These limits help prevent slow or leaking plugins from exhausting the main database connection pool.

## Security

Explicitly disabled authentication bypass for plugins invoking core APIs by setting:

```properties
org.killbill.security.skipAuthForPlugins=false
```

This ensures that all plugin requests to core APIs are authenticated according to the configured security policies.

---

# Benefits

* Improved resilience under high-concurrency billing workloads.
* Reduced risk of failures caused by distributed lock contention.
* Better isolation of plugin database resources from the core application.
* Protection against database connection pool exhaustion.
* Stronger security by enforcing authentication for plugin-to-core API communication.
