### PR TITLE
invoice: widen billing_events column from BLOB to MEDIUMBLOB

### DIFF
--- a/invoice/src/main/resources/org/killbill/billing/invoice/ddl.sql
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/ddl.sql
@@ -248,7 +248,7 @@ CREATE TABLE invoice_billing_events (
     record_id serial unique,
     id varchar(36) NOT NULL,
     invoice_id varchar(36) NOT NULL,
-	billing_events blob NOT NULL,
+	billing_events mediumblob NOT NULL,
     created_by varchar(50) NOT NULL,
     created_date datetime NOT NULL,
     account_record_id bigint /*! unsigned */ not null,

--- a/invoice/src/main/resources/org/killbill/billing/invoice/migration/V20260728140000__invoice_billing_events_mediumblob.sql
+++ b/invoice/src/main/resources/org/killbill/billing/invoice/migration/V20260728140000__invoice_billing_events_mediumblob.sql
@@ -1,0 +1,1 @@
+ALTER TABLE invoice_billing_events MODIFY COLUMN billing_events MEDIUMBLOB NOT NULL;


### PR DESCRIPTION
MySQL's BLOB type caps out at 65,535 bytes. The compressed account-wide billing-event history stored in
invoice_billing_events.billing_events exceeds this for accounts with enough invoice items, causing invoice creation to fail with "Data too long for column 'billing_events'" and roll back the invoice (while the auto-increment invoice number is not rolled back, leaving a numbering gap).

Widen the column to MEDIUMBLOB (16MB), matching the same type already used for plugin_properties in payment/ddl.sql. No PostgreSQL migration is needed: ddl-postgresql.sql maps both blob and mediumblob to bytea, which has no equivalent size cap.

Fixes #2278