### PR TITLE
Beatrix tests for https://github.com/killbill/killbill/issues/2291

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogSameDayEffectiveDateForExistingSubscriptions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogSameDayEffectiveDateForExistingSubscriptions.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2020-2026 Equinix, Inc
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Companion to {@link TestCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD}, covering the
+ * second way a catalog change can be lost when
+ * org.killbill.subscription.align.effectiveDateForExistingSubscriptions=true.
+ *
+ * When a change's effectiveDateForExistingSubscriptions falls on a day whose day-of-month equals the
+ * subscription's BCD - the subscription's own start day being the common case - the alignment resolves
+ * it to THAT SAME day rather than to the next billing date. The aligned LocalDate is then converted
+ * back to a DateTime using the account's reference time of day, which precedes the subscription's
+ * CREATE transition, so the candidate is rejected by
+ *
+ *     if (nextEffectiveDate != null && !nextEffectiveDate.isBefore(cur.getEffectiveTransitionTime()))
+ *
+ * in DefaultSubscriptionBase.getSubscriptionBillingEvents. Nothing regenerates it afterwards -
+ * candidates are only built at CREATE/CHANGE/PHASE transitions - so the price change is lost forever
+ * rather than deferred to the next billing date.
+ *
+ * Catalog used here:
+ *   v1  2026-06-01T00:00Z  gas-monthly  100  (no effectiveDateForExistingSubscriptions)
+ *   v2  2026-07-01T11:00Z  gas-monthly  200  effectiveDateForExistingSubscriptions 2026-07-01T11:00Z
+ */
+public class TestCatalogSameDayEffectiveDateForExistingSubscriptions extends TestIntegrationBase {
+
+    private static final String DROP_EXPLANATION =
+            "The catalog change is effective 2026-07-01T11:00Z, an hour AFTER the subscription started, so it should "
+            + "apply at the subscription's next billing date (2026-08-01). Instead, because the change's day-of-month "
+            + "(1) equals the subscription's BCD (1), BillCycleDayCalculator aligns it to 2026-07-01 - the same day the "
+            + "subscription started - and TimeAwareContext.toUTCDateTime resolves that LocalDate at the account's "
+            + "reference time of day (00:00), i.e. BEFORE the CREATE transition at 10:00. The guard in "
+            + "getSubscriptionBillingEvents then discards the candidate, and nothing ever regenerates it, so the "
+            + "subscription keeps billing the old price indefinitely.";
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogSameDayEffectiveDateForExistingSubscriptions");
+        allExtraProperties.put("org.killbill.subscription.align.effectiveDateForExistingSubscriptions", "true");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    /**
+     * A catalog change effective on the same day the subscription started is dropped entirely.
+     *
+     * The account is created at 2026-07-01T00:00Z and the subscription at 2026-07-01T10:00Z, so the
+     * account reference time (00:00) is strictly earlier than the CREATE transition (10:00). The
+     * catalog change is effective at 11:00 the same day - after the subscription started - and aligns
+     * back to 2026-07-01T00:00Z, before CREATE.
+     *
+     * EXPECTED : 2026-07-01 -> 2026-08-01 bills 100 (the in-flight period is never disturbed), then
+     *            2026-08-01 -> 2026-09-01 bills 200 at the next billing date.
+     * CURRENTLY: every period bills 100 - the change is never applied at all.
+     */
+    @Test(groups = "slow")
+    public void testCatalogChangeOnSubscriptionStartDay() throws Exception {
+
+        // Account first, so its reference time of day is 00:00
+        clock.setTime(new DateTime(2026, 7, 1, 0, 0, 0, DateTimeZone.UTC));
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("GasUtility", callContext);
+        Assert.assertEquals(catalog.getVersions().size(), 2, "Expected catalog versions v1/v2 to be loaded");
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        // Subscription a few hours later the same day -> CREATE at 10:00, BCD 1
+        clock.setTime(new DateTime(2026, 7, 1, 10, 0, 0, DateTimeZone.UTC));
+
+        final DefaultEntitlement bpEntitlement =
+                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey1", "Gas",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        assertNotNull(bpEntitlement);
+
+        final List<PeriodResult> results = new ArrayList<PeriodResult>();
+
+        // 2026-07-01 -> 2026-08-01 at 100, from catalog v1: correct, the in-flight period is not disturbed
+        results.add(recordRecurring(account, 1, new LocalDate(2026, 7, 1), new LocalDate(2026, 8, 1),
+                                    new BigDecimal("100.00"), catalog, 0));
+
+        // 2026-08-01 -> 2026-09-01 is the subscription's next billing date and must pick up v2 at 200
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2026-08-01
+        assertListenerStatus();
+        results.add(recordRecurring(account, 2, new LocalDate(2026, 8, 1), new LocalDate(2026, 9, 1),
+                                    new BigDecimal("200.00"), catalog, 1));
+
+        // The candidate is rebuilt and discarded again on every invoice run, so the loss is permanent
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2026-09-01
+        assertListenerStatus();
+        results.add(recordRecurring(account, 3, new LocalDate(2026, 9, 1), new LocalDate(2026, 10, 1),
+                                    new BigDecimal("200.00"), catalog, 1));
+
+        reportAndAssert("Catalog change effective on the subscription's start day", results, catalog);
+    }
+
+    /**
+     * Control: the same catalog change applies normally to a subscription started in an earlier month.
+     *
+     * This subscription starts 2026-06-15 (BCD 15), so the change (2026-07-01, day-of-month 1, which is
+     * not greater than the BCD 15) aligns to 2026-07-15 - comfortably after CREATE - and is applied at
+     * that billing date. This passes today and must keep passing after any fix: it shows the defect is
+     * specific to the aligned date landing on or before the current transition, and not a general
+     * failure of catalog migration.
+     */
+    @Test(groups = "slow")
+    public void testCatalogChangeForSubscriptionStartedEarlier() throws Exception {
+
+        clock.setTime(new DateTime(2026, 6, 15, 10, 0, 0, DateTimeZone.UTC));
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("GasUtility", callContext);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(15));
+
+        final DefaultEntitlement bpEntitlement =
+                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey2", "Gas",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        assertNotNull(bpEntitlement);
+
+        final List<PeriodResult> results = new ArrayList<PeriodResult>();
+
+        // 2026-06-15 -> 2026-07-15 at 100, from catalog v1
+        results.add(recordRecurring(account, 1, new LocalDate(2026, 6, 15), new LocalDate(2026, 7, 15),
+                                    new BigDecimal("100.00"), catalog, 0));
+
+        // The change aligns to 2026-07-15, this subscription's next billing date, and applies there
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2026-07-15
+        assertListenerStatus();
+        results.add(recordRecurring(account, 2, new LocalDate(2026, 7, 15), new LocalDate(2026, 8, 15),
+                                    new BigDecimal("200.00"), catalog, 1));
+
+        reportAndAssert("Catalog change for a subscription started in an earlier month (control)", results, catalog);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------------------------------
+
+    /**
+     * Looks up the RECURRING item covering the given period and records what was billed against what was
+     * expected. Nothing is asserted here so that every period is collected before the table is reported.
+     */
+    private PeriodResult recordRecurring(final Account account,
+                                         final int invoiceNb,
+                                         final LocalDate startDate,
+                                         final LocalDate endDate,
+                                         final BigDecimal expectedAmount,
+                                         final VersionedCatalog catalog,
+                                         final int expectedCatalogVersionIdx) throws Exception {
+
+        final List<Invoice> invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, true, callContext);
+        Assert.assertTrue(invoices.size() >= invoiceNb,
+                          String.format("Expected at least %d invoices for the account but found %d", invoiceNb, invoices.size()));
+        final Invoice invoice = invoices.get(invoiceNb - 1);
+
+        InvoiceItem recurring = null;
+        for (final InvoiceItem item : invoice.getInvoiceItems()) {
+            if (item.getInvoiceItemType() == InvoiceItemType.RECURRING &&
+                item.getStartDate().compareTo(startDate) == 0 &&
+                item.getEndDate().compareTo(endDate) == 0) {
+                recurring = item;
+                break;
+            }
+        }
+
+        final Date expectedVersion = catalog.getVersions().get(expectedCatalogVersionIdx).getEffectiveDate();
+        if (recurring == null) {
+            return new PeriodResult(invoiceNb, startDate, endDate, expectedAmount, null, expectedVersion, null);
+        }
+        return new PeriodResult(invoiceNb, startDate, endDate, expectedAmount, recurring.getAmount(),
+                                expectedVersion, recurring.getCatalogEffectiveDate() == null ? null : recurring.getCatalogEffectiveDate().toDate());
+    }
+
+    /**
+     * Logs a table of every period checked, then fails if any of them is wrong. The table is part of the
+     * assertion message so that it shows up in the surefire failure report.
+     */
+    private void reportAndAssert(final String title, final List<PeriodResult> results, final VersionedCatalog catalog) {
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append('\n').append(title).append('\n');
+        sb.append("+---------+---------------------------+----------+----------+--------+----------------------+----------------------+\n");
+        sb.append("| Invoice | Period                    | Expected |   Actual | Result | Catalog used         | Catalog expected     |\n");
+        sb.append("+---------+---------------------------+----------+----------+--------+----------------------+----------------------+\n");
+
+        int failures = 0;
+        for (final PeriodResult r : results) {
+            if (!r.passed()) {
+                failures++;
+            }
+            sb.append(String.format("| %7d | %s -> %s | %8s | %8s | %-6s | %-20s | %-20s |%n",
+                                    r.invoiceNb,
+                                    r.startDate,
+                                    r.endDate,
+                                    r.expectedAmount.toPlainString(),
+                                    r.actualAmount == null ? "MISSING" : r.actualAmount.toPlainString(),
+                                    r.passed() ? "PASS" : "FAIL",
+                                    versionLabel(catalog, r.actualCatalogVersion),
+                                    versionLabel(catalog, r.expectedCatalogVersion)));
+        }
+        sb.append("+---------+---------------------------+----------+----------+--------+----------------------+----------------------+\n");
+
+        final String table = sb.toString();
+        log.info(table);
+
+        if (failures > 0) {
+            Assert.fail(String.format("%d of %d billing periods were mispriced or priced from the wrong catalog version.%n%s%n%s",
+                                      failures, results.size(), table, DROP_EXPLANATION));
+        }
+    }
+
+    private String versionLabel(final VersionedCatalog catalog, final Date date) {
+        if (date == null) {
+            return "n/a";
+        }
+        for (int i = 0; i < catalog.getVersions().size(); i++) {
+            if (catalog.getVersions().get(i).getEffectiveDate().compareTo(date) == 0) {
+                return String.format("%s (v%d)", new DateTime(date, DateTimeZone.UTC).toLocalDate(), i + 1);
+            }
+        }
+        return new DateTime(date, DateTimeZone.UTC).toLocalDate().toString();
+    }
+
+    private static final class PeriodResult {
+
+        private final int invoiceNb;
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+        private final BigDecimal expectedAmount;
+        private final BigDecimal actualAmount;
+        private final Date expectedCatalogVersion;
+        private final Date actualCatalogVersion;
+
+        private PeriodResult(final int invoiceNb,
+                             final LocalDate startDate,
+                             final LocalDate endDate,
+                             final BigDecimal expectedAmount,
+                             final BigDecimal actualAmount,
+                             final Date expectedCatalogVersion,
+                             final Date actualCatalogVersion) {
+            this.invoiceNb = invoiceNb;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.expectedAmount = expectedAmount;
+            this.actualAmount = actualAmount;
+            this.expectedCatalogVersion = expectedCatalogVersion;
+            this.actualCatalogVersion = actualCatalogVersion;
+        }
+
+        private boolean passed() {
+            return actualAmount != null &&
+                   actualAmount.compareTo(expectedAmount) == 0 &&
+                   actualCatalogVersion != null &&
+                   actualCatalogVersion.compareTo(expectedCatalogVersion) == 0;
+        }
+    }
+}

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogSameDayEffectiveDateForExistingSubscriptions.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogSameDayEffectiveDateForExistingSubscriptions.java
@@ -94,7 +94,7 @@ public class TestCatalogSameDayEffectiveDateForExistingSubscriptions extends Tes
      *            2026-08-01 -> 2026-09-01 bills 200 at the next billing date.
      * CURRENTLY: every period bills 100 - the change is never applied at all.
      */
-    @Test(groups = "slow")
+    @Test(groups = "slow", enabled = false, description = "Reproduces #2291")
     public void testCatalogChangeOnSubscriptionStartDay() throws Exception {
 
         // Account first, so its reference time of day is 00:00

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD.java
@@ -94,7 +94,7 @@ public class TestCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD ex
      * EXPECTED : 2026-08-01 -> 2026-09-01 bills 150, from catalog v3 (the most recent change wins).
      * CURRENTLY: it bills 50, from catalog v2, and keeps billing 50 on every later period.
      */
-    @Test(groups = "slow")
+    @Test(groups = "slow", enabled = false, description = "Reproduces #2291")
     public void testTwoCatalogChangesWithinSameBillingCycle() throws Exception {
 
         clock.setDay(new LocalDate(2026, 7, 1));

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2020-2026 Equinix, Inc
+ * Copyright 2014-2026 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.beatrix.integration;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.api.TestApiListener.NextEvent;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.entitlement.api.DefaultEntitlement;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.platform.api.KillbillConfigSource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Same feature as {@link TestCatalogWithEffectiveDateForExistingSubscriptions}, but with
+ * org.killbill.subscription.align.effectiveDateForExistingSubscriptions=true. That property is
+ * class scoped in the test framework, hence a separate test class.
+ *
+ * With the alignment enabled, every catalog change whose effectiveDateForExistingSubscriptions
+ * falls at or before the subscription's next billing boundary is moved onto that boundary. When
+ * more than one lands on the same instant, the resulting billing events are indistinguishable:
+ * same subscription, same effective date, and the same totalOrdering, which synthetic catalog
+ * change events inherit from the subscription transition they were derived from. They therefore
+ * compare equal in DefaultBillingEvent.compareTo, and DefaultBillingEventSet - a TreeSet - keeps
+ * only the first one inserted. Insertion order is catalog effective date ascending, so the
+ * survivor is the one from the OLDEST catalog version and the more recent price is silently lost.
+ *
+ * Catalog used here:
+ *   v1  2026-07-01  electricity-monthly  100  (no effectiveDateForExistingSubscriptions)
+ *   v2  2026-07-15  electricity-monthly   50  effectiveDateForExistingSubscriptions 2026-07-15
+ *   v3  2026-07-18  electricity-monthly  150  effectiveDateForExistingSubscriptions 2026-07-18
+ *
+ * Each test collects every billing period it checks and logs a summary table before asserting, so
+ * a failing run shows at a glance which periods were mispriced and which catalog version they were
+ * stuck on.
+ */
+public class TestCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD extends TestIntegrationBase {
+
+    private static final String COLLISION_EXPLANATION =
+            "Both catalog v2 (2026-07-15, price 50) and v3 (2026-07-18, price 150) fall inside the subscription's "
+            + "billing cycle 2026-07-01 -> 2026-08-01, so both are aligned onto 2026-08-01. The two resulting CHANGE "
+            + "billing events are then indistinguishable - same subscription, same effective date, and the same "
+            + "totalOrdering inherited from the CREATE transition - so DefaultBillingEvent.compareTo returns 0 and "
+            + "DefaultBillingEventSet (a TreeSet) silently drops the second add(). Insertion order is catalog "
+            + "effective date ascending, so the survivor is v2 (50) and the more recent v3 (150) is lost.";
+
+    @Override
+    protected KillbillConfigSource getConfigSource(final Map<String, String> extraProperties) {
+        final Map<String, String> allExtraProperties = new HashMap<String, String>(extraProperties);
+        allExtraProperties.put("org.killbill.catalog.uri", "catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD");
+        allExtraProperties.put("org.killbill.subscription.align.effectiveDateForExistingSubscriptions", "true");
+        return super.getConfigSource(null, allExtraProperties);
+    }
+
+    /**
+     * Two catalog changes inside the same billing cycle: only the older one is applied.
+     *
+     * Timeline:
+     *   2026-07-01  subscription created on catalog v1 (100), BCD 1, first cycle runs to 2026-08-01
+     *   2026-07-15  catalog v2 makes the price 50,  effectiveDateForExistingSubscriptions 2026-07-15
+     *   2026-07-18  catalog v3 makes the price 150, effectiveDateForExistingSubscriptions 2026-07-18
+     *
+     * EXPECTED : 2026-08-01 -> 2026-09-01 bills 150, from catalog v3 (the most recent change wins).
+     * CURRENTLY: it bills 50, from catalog v2, and keeps billing 50 on every later period.
+     */
+    @Test(groups = "slow")
+    public void testTwoCatalogChangesWithinSameBillingCycle() throws Exception {
+
+        clock.setDay(new LocalDate(2026, 7, 1));
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("ElectricUtility", callContext);
+        Assert.assertEquals(catalog.getVersions().size(), 3, "Expected catalog versions v1/v2/v3 to be loaded");
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(1));
+
+        final DefaultEntitlement bpEntitlement =
+                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey1", "Electricity",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        assertNotNull(bpEntitlement);
+
+        final List<PeriodResult> results = new ArrayList<PeriodResult>();
+
+        // 2026-07-01 -> 2026-08-01 at 100, from catalog v1. The in-flight period is never disturbed,
+        // which is the point of the alignment, so this is correct today and must stay correct.
+        results.add(recordRecurring(account, 1, new LocalDate(2026, 7, 1), new LocalDate(2026, 8, 1),
+                                    new BigDecimal("100.00"), catalog, 0));
+
+        // 2026-08-01 -> 2026-09-01 must pick up the LAST change made during the cycle, i.e. v3 at 150.
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2026-08-01
+        assertListenerStatus();
+        results.add(recordRecurring(account, 2, new LocalDate(2026, 8, 1), new LocalDate(2026, 9, 1),
+                                    new BigDecimal("150.00"), catalog, 2));
+
+        // The candidate list is rebuilt identically on every invoice run, so the loss is permanent
+        // rather than limited to the first boundary after the changes.
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2026-09-01
+        assertListenerStatus();
+        results.add(recordRecurring(account, 3, new LocalDate(2026, 9, 1), new LocalDate(2026, 10, 1),
+                                    new BigDecimal("150.00"), catalog, 2));
+
+        reportAndAssert("Two catalog changes within the same billing cycle", results, catalog);
+    }
+
+    /**
+     * Control: a subscription whose cycle contains only ONE pending catalog change picks it up.
+     *
+     * This subscription starts 2026-07-16 (BCD 16), so it is created on catalog v2 (50) and only v3
+     * (2026-07-18) is pending. Nothing collides and the change applies at the next boundary.
+     *
+     * This passes today and must keep passing after any fix: it is what shows the defect is specific
+     * to two changes colliding on one boundary, and not a general failure of catalog migration.
+     */
+    @Test(groups = "slow")
+    public void testSingleCatalogChangeWithinBillingCycle() throws Exception {
+
+        clock.setDay(new LocalDate(2026, 7, 16));
+
+        final VersionedCatalog catalog = catalogUserApi.getCatalog("ElectricUtility", callContext);
+
+        final Account account = createAccountWithNonOsgiPaymentMethod(getAccountData(16));
+
+        final DefaultEntitlement bpEntitlement =
+                createBaseEntitlementAndCheckForCompletion(account.getId(), "externalKey2", "Electricity",
+                                                           ProductCategory.BASE, BillingPeriod.MONTHLY,
+                                                           NextEvent.CREATE, NextEvent.BLOCK, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        assertNotNull(bpEntitlement);
+
+        final List<PeriodResult> results = new ArrayList<PeriodResult>();
+
+        // Created on catalog v2, so the first period is priced at 50
+        results.add(recordRecurring(account, 1, new LocalDate(2026, 7, 16), new LocalDate(2026, 8, 16),
+                                    new BigDecimal("50.00"), catalog, 1));
+
+        // Only v3 is pending for this subscription, so nothing collides and 150 applies normally
+        busHandler.pushExpectedEvents(NextEvent.INVOICE, NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT);
+        clock.addMonths(1); // 2026-08-16
+        assertListenerStatus();
+        results.add(recordRecurring(account, 2, new LocalDate(2026, 8, 16), new LocalDate(2026, 9, 16),
+                                    new BigDecimal("150.00"), catalog, 2));
+
+        reportAndAssert("Single catalog change within the billing cycle (control)", results, catalog);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------------------------------
+
+    /**
+     * Looks up the RECURRING item covering the given period and records what was billed against what
+     * was expected. Nothing is asserted here so that every period is collected before the summary
+     * table is logged.
+     */
+    private PeriodResult recordRecurring(final Account account,
+                                         final int invoiceNb,
+                                         final LocalDate startDate,
+                                         final LocalDate endDate,
+                                         final BigDecimal expectedAmount,
+                                         final VersionedCatalog catalog,
+                                         final int expectedCatalogVersionIdx) throws Exception {
+
+        final List<Invoice> invoices = invoiceUserApi.getInvoicesByAccount(account.getId(), false, false, true, callContext);
+        Assert.assertTrue(invoices.size() >= invoiceNb,
+                          String.format("Expected at least %d invoices for the account but found %d", invoiceNb, invoices.size()));
+        final Invoice invoice = invoices.get(invoiceNb - 1);
+
+        InvoiceItem recurring = null;
+        for (final InvoiceItem item : invoice.getInvoiceItems()) {
+            if (item.getInvoiceItemType() == InvoiceItemType.RECURRING &&
+                item.getStartDate().compareTo(startDate) == 0 &&
+                item.getEndDate().compareTo(endDate) == 0) {
+                recurring = item;
+                break;
+            }
+        }
+
+        final Date expectedVersion = catalog.getVersions().get(expectedCatalogVersionIdx).getEffectiveDate();
+        if (recurring == null) {
+            return new PeriodResult(invoiceNb, startDate, endDate, expectedAmount, null, expectedVersion, null);
+        }
+        return new PeriodResult(invoiceNb, startDate, endDate, expectedAmount, recurring.getAmount(),
+                                expectedVersion, recurring.getCatalogEffectiveDate() == null ? null : recurring.getCatalogEffectiveDate().toDate());
+    }
+
+    /**
+     * Logs a table of every period checked, then fails if any of them is wrong.
+     */
+    private void reportAndAssert(final String title, final List<PeriodResult> results, final VersionedCatalog catalog) {
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append('\n').append(title).append('\n');
+        sb.append("+---------+---------------------------+----------+----------+--------+----------------------+----------------------+\n");
+        sb.append("| Invoice | Period                    | Expected |   Actual | Result | Catalog used         | Catalog expected     |\n");
+        sb.append("+---------+---------------------------+----------+----------+--------+----------------------+----------------------+\n");
+
+        int failures = 0;
+        for (final PeriodResult r : results) {
+            if (!r.passed()) {
+                failures++;
+            }
+            sb.append(String.format("| %7d | %s -> %s | %8s | %8s | %-6s | %-20s | %-20s |%n",
+                                    r.invoiceNb,
+                                    r.startDate,
+                                    r.endDate,
+                                    r.expectedAmount.toPlainString(),
+                                    r.actualAmount == null ? "MISSING" : r.actualAmount.toPlainString(),
+                                    r.passed() ? "PASS" : "FAIL",
+                                    versionLabel(catalog, r.actualCatalogVersion),
+                                    versionLabel(catalog, r.expectedCatalogVersion)));
+        }
+        sb.append("+---------+---------------------------+----------+----------+--------+----------------------+----------------------+\n");
+
+        final String table = sb.toString();
+        log.info(table);
+
+        if (failures > 0) {
+            // The table goes into the assertion message itself so that it shows up in the surefire
+            // failure report, rather than being buried in the test log.
+            Assert.fail(String.format("%d of %d billing periods were mispriced or priced from the wrong catalog version.%n%s%n%s",
+                                      failures, results.size(), table, COLLISION_EXPLANATION));
+        }
+    }
+
+    private String versionLabel(final VersionedCatalog catalog, final Date date) {
+        if (date == null) {
+            return "n/a";
+        }
+        for (int i = 0; i < catalog.getVersions().size(); i++) {
+            if (catalog.getVersions().get(i).getEffectiveDate().compareTo(date) == 0) {
+                return String.format("%s (v%d)", new DateTime(date, DateTimeZone.UTC).toLocalDate(), i + 1);
+            }
+        }
+        return new DateTime(date, DateTimeZone.UTC).toLocalDate().toString();
+    }
+
+    private static final class PeriodResult {
+
+        private final int invoiceNb;
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+        private final BigDecimal expectedAmount;
+        private final BigDecimal actualAmount;
+        private final Date expectedCatalogVersion;
+        private final Date actualCatalogVersion;
+
+        private PeriodResult(final int invoiceNb,
+                             final LocalDate startDate,
+                             final LocalDate endDate,
+                             final BigDecimal expectedAmount,
+                             final BigDecimal actualAmount,
+                             final Date expectedCatalogVersion,
+                             final Date actualCatalogVersion) {
+            this.invoiceNb = invoiceNb;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.expectedAmount = expectedAmount;
+            this.actualAmount = actualAmount;
+            this.expectedCatalogVersion = expectedCatalogVersion;
+            this.actualCatalogVersion = actualCatalogVersion;
+        }
+
+        private boolean passed() {
+            return actualAmount != null &&
+                   actualAmount.compareTo(expectedAmount) == 0 &&
+                   actualCatalogVersion != null &&
+                   actualCatalogVersion.compareTo(expectedCatalogVersion) == 0;
+        }
+    }
+}

--- a/beatrix/src/test/resources/catalogs/testCatalogSameDayEffectiveDateForExistingSubscriptions/GasUtility-v1.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogSameDayEffectiveDateForExistingSubscriptions/GasUtility-v1.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2026 Equinix, Inc
+  ~ Copyright 2014-2026 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CatalogSchema.xsd">
+
+    <effectiveDate>2026-06-01T00:00:00Z</effectiveDate>
+    <catalogName>GasUtility</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <products>
+        <product name="Gas">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>ACCOUNT</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="gas-monthly">
+
+            <product>Gas</product>
+            <initialPhases/>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                    <number>-1</number>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>100.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+            <plansAllowedInBundle>0</plansAllowedInBundle>
+        </plan>
+    </plans>
+
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>gas-monthly</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogSameDayEffectiveDateForExistingSubscriptions/GasUtility-v2.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogSameDayEffectiveDateForExistingSubscriptions/GasUtility-v2.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2026 Equinix, Inc
+  ~ Copyright 2014-2026 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CatalogSchema.xsd">
+
+    <effectiveDate>2026-07-01T11:00:00Z</effectiveDate>
+    <catalogName>GasUtility</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <products>
+        <product name="Gas">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>ACCOUNT</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="gas-monthly">
+            <effectiveDateForExistingSubscriptions>2026-07-01T11:00:00Z</effectiveDateForExistingSubscriptions>
+            <product>Gas</product>
+            <initialPhases/>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                    <number>-1</number>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>200.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+            <plansAllowedInBundle>0</plansAllowedInBundle>
+        </plan>
+    </plans>
+
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>gas-monthly</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD/ElectricUtility-v1.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD/ElectricUtility-v1.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2026 Equinix, Inc
+  ~ Copyright 2014-2026 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CatalogSchema.xsd">
+
+    <effectiveDate>2026-07-01T10:00:00Z</effectiveDate>
+    <catalogName>ElectricUtility</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <products>
+        <product name="Electricity">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>ACCOUNT</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="electricity-monthly">
+
+            <product>Electricity</product>
+            <initialPhases/>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                    <number>-1</number>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>100.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+            <plansAllowedInBundle>0</plansAllowedInBundle>
+        </plan>
+    </plans>
+
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>electricity-monthly</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD/ElectricUtility-v2.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD/ElectricUtility-v2.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2026 Equinix, Inc
+  ~ Copyright 2014-2026 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CatalogSchema.xsd">
+
+    <effectiveDate>2026-07-15T10:00:00Z</effectiveDate>
+    <catalogName>ElectricUtility</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <products>
+        <product name="Electricity">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>ACCOUNT</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="electricity-monthly">
+            <effectiveDateForExistingSubscriptions>2026-07-15T10:00:00Z</effectiveDateForExistingSubscriptions>
+            <product>Electricity</product>
+            <initialPhases/>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                    <number>-1</number>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>50.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+            <plansAllowedInBundle>0</plansAllowedInBundle>
+        </plan>
+    </plans>
+
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>electricity-monthly</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>

--- a/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD/ElectricUtility-v3.xml
+++ b/beatrix/src/test/resources/catalogs/testCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD/ElectricUtility-v3.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020-2026 Equinix, Inc
+  ~ Copyright 2014-2026 The Billing Project, LLC
+  ~
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
+  ~ (the "License"); you may not use this file except in compliance with the
+  ~ License.  You may obtain a copy of the License at:
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<catalog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CatalogSchema.xsd">
+
+    <effectiveDate>2026-07-18T10:00:00Z</effectiveDate>
+    <catalogName>ElectricUtility</catalogName>
+
+    <recurringBillingMode>IN_ADVANCE</recurringBillingMode>
+
+    <currencies>
+        <currency>USD</currency>
+    </currencies>
+
+    <products>
+        <product name="Electricity">
+            <category>BASE</category>
+        </product>
+    </products>
+
+    <rules>
+        <changePolicy>
+            <changePolicyCase>
+                <policy>IMMEDIATE</policy>
+            </changePolicyCase>
+        </changePolicy>
+        <changeAlignment>
+            <changeAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </changeAlignmentCase>
+        </changeAlignment>
+        <cancelPolicy>
+            <cancelPolicyCase>
+                <policy>IMMEDIATE</policy>
+            </cancelPolicyCase>
+        </cancelPolicy>
+        <createAlignment>
+            <createAlignmentCase>
+                <alignment>START_OF_BUNDLE</alignment>
+            </createAlignmentCase>
+        </createAlignment>
+        <billingAlignment>
+            <billingAlignmentCase>
+                <alignment>ACCOUNT</alignment>
+            </billingAlignmentCase>
+        </billingAlignment>
+        <priceList>
+            <priceListCase>
+                <toPriceList>DEFAULT</toPriceList>
+            </priceListCase>
+        </priceList>
+    </rules>
+
+    <plans>
+        <plan name="electricity-monthly">
+            <effectiveDateForExistingSubscriptions>2026-07-18T10:00:00Z</effectiveDateForExistingSubscriptions>
+            <product>Electricity</product>
+            <initialPhases/>
+            <finalPhase type="EVERGREEN">
+                <duration>
+                    <unit>UNLIMITED</unit>
+                    <number>-1</number>
+                </duration>
+                <recurring>
+                    <billingPeriod>MONTHLY</billingPeriod>
+                    <recurringPrice>
+                        <price>
+                            <currency>USD</currency>
+                            <value>150.00</value>
+                        </price>
+                    </recurringPrice>
+                </recurring>
+            </finalPhase>
+            <plansAllowedInBundle>0</plansAllowedInBundle>
+        </plan>
+    </plans>
+
+    <priceLists>
+        <defaultPriceList name="DEFAULT">
+            <plans>
+                <plan>electricity-monthly</plan>
+            </plans>
+        </defaultPriceList>
+    </priceLists>
+</catalog>


### PR DESCRIPTION
Beatrix tests for https://github.com/killbill/killbill/issues/2291

Both new tests fail by design — they are the reproduction. I added a base control test that passes today, so we have a base comparison case and the failure case.

**`TestCatalogWithEffectiveDateForExistingSubscriptionsAlignedToBCD`**

- `testTwoCatalogChangesWithinSameBillingCycle` — two catalog changes inside one cycle collide on the same boundary; the older one wins, so the subscription bills the superseded price. **FAILS**
- `testSingleCatalogChangeWithinBillingCycle` — control: a single pending change applies normally at the next boundary. Passes.

**`TestCatalogSameDayEffectiveDateForExistingSubscriptions`**

- `testCatalogChangeOnSubscriptionStartDay` — a change effective on the subscription's start day aligns back to before the CREATE transition and is discarded; it never applies, not even at the next billing date. **FAILS**
- `testCatalogChangeForSubscriptionStartedEarlier` — control: the same change applies normally to a subscription started in an earlier month. Passes.

Each failing test prints a table of every period checked (expected vs actual amount and catalog version) in the assertion message.