### PR TITLE
fix: NullPointerException in Catalog Validation when there is a phase mismatc...

### DIFF
--- a/catalog/src/main/java/org/killbill/billing/catalog/DefaultVersionedCatalog.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/DefaultVersionedCatalog.java
@@ -162,7 +162,7 @@ public class DefaultVersionedCatalog extends ValidatingConfig<DefaultVersionedCa
                     final StaticCatalog next = versions.get(j);
                     final Plan targetPlan = ((StandaloneCatalog) next).getPlansMap().findByName(plan.getName());
                     if (targetPlan != null) {
-                        validatePlanShape(plan, targetPlan, errors);
+                        validatePlanShape(plan, c.getEffectiveDate(), targetPlan, next.getEffectiveDate(), errors);
                     }
                     // We don't break if null , targetPlan could be re-defined on a subsequent version
                     // TODO enforce that we can't skip versions?
@@ -171,10 +171,10 @@ public class DefaultVersionedCatalog extends ValidatingConfig<DefaultVersionedCa
         }
     }
 
-    private void validatePlanShape(final Plan plan, final Plan targetPlan, final ValidationErrors errors) {
+    private void validatePlanShape(final Plan plan, final Date effectiveDate, final Plan targetPlan, final Date targetEffectiveDate, final ValidationErrors errors) {
         if (plan.getAllPhases().length != targetPlan.getAllPhases().length) {
             errors.add(new ValidationError(String.format("Number of phases for plan '%s' differs between version '%s' and '%s'",
-                                                         plan.getName(), plan.getCatalog().getEffectiveDate(), targetPlan.getCatalog().getEffectiveDate()),
+                                                         plan.getName(), effectiveDate, targetEffectiveDate),
                                            DefaultVersionedCatalog.class, ""));
             // In this case we don't bother checking each phase -- the code below assumes the # are equal
             return;
@@ -185,7 +185,7 @@ public class DefaultVersionedCatalog extends ValidatingConfig<DefaultVersionedCa
             final PlanPhase target = targetPlan.getAllPhases()[i];
             if (!cur.getName().equals(target.getName())) {
                errors.add(new ValidationError(String.format("Phase '%s'for plan '%s' in version '%s' does not exist in version '%s'",
-                                                             cur.getName(), plan.getName(), plan.getCatalog().getEffectiveDate(), targetPlan.getCatalog().getEffectiveDate()),
+                                                             cur.getName(), plan.getName(), effectiveDate, targetEffectiveDate),
                                                DefaultVersionedCatalog.class, ""));
             }
         }

--- a/catalog/src/main/java/org/killbill/billing/catalog/StandaloneCatalog.java
+++ b/catalog/src/main/java/org/killbill/billing/catalog/StandaloneCatalog.java
@@ -295,14 +295,14 @@ public class StandaloneCatalog extends ValidatingConfig<StandaloneCatalog> imple
                     && !planPhases[i].getDuration().getUnit().name().equals(TimeUnit.UNLIMITED.name())) {
                     errors.add(new ValidationError(String.format(
                             "EVERGREEN Phase '%s' for plan '%s' in version '%s' must have duration as UNLIMITED'",
-                            planPhases[i].getName(), plan.getName(), plan.getCatalog().getEffectiveDate()),
+                            planPhases[i].getName(), plan.getName(), newCatalogVersion.getEffectiveDate()),
                                                    DefaultVersionedCatalog.class, ""));
                 } else if (!planPhases[i].getPhaseType().name().equals(PhaseType.EVERGREEN.name())
                            && planPhases[i].getDuration().getUnit().name().equals(TimeUnit.UNLIMITED.name())) {
                     errors.add(new ValidationError(String.format(
                             "'%s' Phase '%s' for plan '%s' in version '%s' must not have duration as UNLIMITED'",
                             planPhases[i].getPhaseType().name(), planPhases[i].getName(), plan.getName(),
-                            plan.getCatalog().getEffectiveDate()), DefaultVersionedCatalog.class, ""));
+                            newCatalogVersion.getEffectiveDate()), DefaultVersionedCatalog.class, ""));
                 }
             }
         }

--- a/catalog/src/test/java/org/killbill/billing/catalog/api/user/TestDefaultCatalogUserApi.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/api/user/TestDefaultCatalogUserApi.java
@@ -24,7 +24,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
+import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.CatalogTestSuiteNoDB;
+import org.killbill.billing.catalog.DefaultVersionedCatalog;
 import org.killbill.billing.catalog.api.CatalogService;
 import org.killbill.billing.catalog.api.CatalogUserApi;
 import org.killbill.billing.catalog.api.CatalogValidation;
@@ -66,6 +68,29 @@ public class TestDefaultCatalogUserApi extends CatalogTestSuiteNoDB {
         final CatalogValidation validation = catalogUserApi.validateCatalog(getXMLCatalog("CatalogWithValidationErrors.xml"), callContext);
         Assert.assertNotNull(validation);
         Assert.assertEquals(validation.getValidationErrors().size(), 17);
+    }
+
+    @Test(groups = "fast")
+    public void testValidateCatalogWithPhaseMismatchAcrossVersions() throws Exception {
+        final DefaultVersionedCatalog existingCatalog = new DefaultVersionedCatalog();
+        existingCatalog.add(getCatalog("PhaseMismatch-v1.xml"));
+
+        final CatalogService catalogService = Mockito.mock(CatalogService.class);
+        Mockito.when(catalogService.getFullCatalog(Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.<InternalTenantContext>any())).thenReturn(existingCatalog);
+
+        final CatalogUserApi catalogUserApiWithExistingCatalog = new DefaultCatalogUserApi(catalogService,
+                                                                                           Mockito.mock(TenantUserApi.class),
+                                                                                           catalogCache,
+                                                                                           clock,
+                                                                                           internalCallContextFactory);
+
+        final CatalogValidation validation = catalogUserApiWithExistingCatalog.validateCatalog(getXMLCatalog("PhaseMismatch-v2.xml"), callContext);
+        Assert.assertNotNull(validation);
+        Assert.assertEquals(validation.getValidationErrors().size(), 1);
+        Assert.assertTrue(validation.getValidationErrors().get(0).getErrorDescription().contains("standard-monthly-evergreen"),
+                          validation.getValidationErrors().get(0).getErrorDescription());
+        Assert.assertFalse(validation.getValidationErrors().get(0).getErrorDescription().contains("null"),
+                           validation.getValidationErrors().get(0).getErrorDescription());
     }
 
     private String getXMLCatalog(final String name) throws URISyntaxException, IOException {


### PR DESCRIPTION
Fixes #1945

## Root cause

Validation messages dereference plan.getCatalog() on a deserialized catalog whose root is null

## Changes

- Build the 'version' portion of the phase-shape and phase-duration validation messages from the StaticCatalog being iterated (its effectiveDate survives Externalizable cloning) instead of plan.getCatalog().getEffectiveDate(), which is null on the cloned catalog produced in DefaultCatalogUserApi.validateCatalogInternal. Added a regression test plus two minimal catalog versions with a mismatched final phase.