### PR TITLE
fix: Issue with Fixed Term subscriptions created with 0.22.x

### DIFF
--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultSubscriptionBase.java
@@ -634,10 +634,10 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
 
             boolean canceledOrExpired = false;
             SubscriptionBaseTransitionData lastPlanTransition = null;
+            SubscriptionBaseTransitionData lastPhaseTransition = null;
             while (it.hasNext()) {
                 // Do not insert any transitions that happen after a CANCEL or EXPIRED event
-                if (canceledOrExpired) {
-                    break;
+                if (canceledOrExpired) {                    break;
                 }
 
                 final SubscriptionBaseTransitionData cur = (SubscriptionBaseTransitionData) it.next();
@@ -662,10 +662,13 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
                         lastPlanTransition = cur;
                     }
 
+                    if (isCreateOrTransfer || isChangeEvent || isPhaseEvent) {
+                        lastPhaseTransition = cur;
+                    }
+
                     // Look for any catalog change transition whose date is less the cur event
                     SubscriptionBillingEvent prevCandidateForCatalogChangeEvents = candidatesCatalogChangeEvents.poll();
-                    while (prevCandidateForCatalogChangeEvents != null &&
-                           prevCandidateForCatalogChangeEvents.getEffectiveDate().compareTo(cur.getEffectiveTransitionTime()) < 0) {
+                    while (prevCandidateForCatalogChangeEvents != null &&                           prevCandidateForCatalogChangeEvents.getEffectiveDate().compareTo(cur.getEffectiveTransitionTime()) < 0) {
                         result.add(prevCandidateForCatalogChangeEvents);
                         prevCandidateForCatalogChangeEvents = candidatesCatalogChangeEvents.poll();
                     }
@@ -725,10 +728,20 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
                     }
                 }
             }
+
+            final SubscriptionBillingEvent missingFixedTermExpiredEvent = canceledOrExpired ? null : buildMissingFixedTermExpiredEvent(lastPhaseTransition, lastActiveCatalog);
+            if (missingFixedTermExpiredEvent != null) {
+                candidatesCatalogChangeEvents.removeIf(candidate -> !candidate.getEffectiveDate().isBefore(missingFixedTermExpiredEvent.getEffectiveDate()));
+            }
+
             SubscriptionBillingEvent prevCandidateForCatalogChangeEvents = candidatesCatalogChangeEvents.poll();
             while (prevCandidateForCatalogChangeEvents != null) {
                 result.add(prevCandidateForCatalogChangeEvents);
                 prevCandidateForCatalogChangeEvents = candidatesCatalogChangeEvents.poll();
+            }
+
+            if (missingFixedTermExpiredEvent != null) {
+                result.add(missingFixedTermExpiredEvent);
             }
 
             return result;
@@ -737,9 +750,30 @@ public class DefaultSubscriptionBase extends EntityBase implements SubscriptionB
         }
     }
 
+    private SubscriptionBillingEvent buildMissingFixedTermExpiredEvent(@Nullable final SubscriptionBaseTransitionData lastPhaseTransition,
+                                                                      @Nullable final StaticCatalog lastActiveCatalog) throws CatalogApiException {
+        if (lastPhaseTransition == null || lastActiveCatalog == null) {
+            return null;
+        }
+
+        final Plan lastPlan = lastPhaseTransition.getNextPlan();
+        final PlanPhase lastPhase = lastPhaseTransition.getNextPhase();
+        if (lastPlan == null ||
+            lastPhase == null ||
+            lastPhase.getPhaseType() != PhaseType.FIXEDTERM ||
+            lastPlan.getFinalPhase() == null ||
+            !lastPhase.getName().equals(lastPlan.getFinalPhase().getName())) {
+            return null;
+        }
+
+        final DateTime expiryDate = lastPhase.getDuration().addToDateTime(lastPhaseTransition.getEffectiveTransitionTime());
+        return new DefaultSubscriptionBillingEvent(SubscriptionBaseTransitionType.EXPIRED, null, null, expiryDate,
+                                                   lastPhaseTransition.getTotalOrdering(), lastPhaseTransition.getNextBillingCycleDayLocal(),
+                                                   lastPhaseTransition.getNextQuantity(), CatalogDateHelper.toUTCDateTime(lastActiveCatalog.getEffectiveDate()));
+    }
+
     // Align to next BCD based on recurring section for the phase
     private DateTime alignToNextBCDIfRequired(final Plan curPlan, final PlanPhase curPlanPhase, final DateTime prevTransitionDate, final DateTime curTransitionDate, final SubscriptionCatalog catalog, final Integer bcdLocal, final InternalTenantContext context) throws SubscriptionBaseApiException, CatalogApiException {
-
         if (!apiService.isEffectiveDateForExistingSubscriptionsAlignedToBCD(context)) {
             return curTransitionDate;
         }

--- a/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestDefaultSubscriptionBase.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/api/user/TestDefaultSubscriptionBase.java
@@ -29,6 +29,7 @@ import org.killbill.billing.catalog.api.BillingAlignment;
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.entitlement.api.Entitlement.EntitlementState;
 import org.killbill.billing.subscription.SubscriptionTestSuiteNoDB;
+import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.subscription.api.user.DefaultSubscriptionBase.NextBillingCycleDayLocal;
 import org.killbill.billing.subscription.events.SubscriptionBaseEvent;
 import org.killbill.billing.subscription.events.bcd.BCDEventBuilder;
@@ -281,6 +282,140 @@ public class TestDefaultSubscriptionBase extends SubscriptionTestSuiteNoDB {
 
         DateTime result = subscriptionBase.getEffectiveDateForPolicy(billingPolicy, alignment, context);
         Assert.assertEquals(result, clock.getUTCNow());
+    }
+
+    @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/1909")
+    public void testFixedTermBillingEventsWithoutExpiredEventOnDisk() throws Exception {
+        final DateTime startDate = new DateTime(2023, 5, 1, 0, 0, DateTimeZone.UTC);
+        final DefaultSubscriptionBase subscriptionBase = new DefaultSubscriptionBase(new SubscriptionBuilder().setAlignStartDate(startDate), subscriptionBaseApiService, clock);
+
+        final UUID subscriptionId = UUID.randomUUID();
+        final List<SubscriptionBaseEvent> inputEvents = new LinkedList<SubscriptionBaseEvent>();
+        inputEvents.add(new ApiEventCreate(new ApiEventBuilder().setApiEventType(CREATE)
+                                                                .setEventPlan("pistol-monthly-fixedterm-no-trial")
+                                                                .setEventPlanPhase("pistol-monthly-fixedterm-no-trial-fixedterm")
+                                                                .setEventPriceList("fixedTerm")
+                                                                .setFromDisk(true)
+                                                                .setUuid(UUID.randomUUID())
+                                                                .setSubscriptionId(subscriptionId)
+                                                                .setCreatedDate(startDate)
+                                                                .setUpdatedDate(startDate)
+                                                                .setEffectiveDate(startDate)
+                                                                .setTotalOrdering(1)
+                                                                .setActive(true)));
+        subscriptionBase.rebuildTransitions(inputEvents, catalog);
+
+        final List<SubscriptionBillingEvent> result = subscriptionBase.getSubscriptionBillingEvents(catalog.getCatalog(), subscriptionCatalogApi.getPriceOverrideSvcStatus(), internalCallContext);
+
+        Assert.assertEquals(result.size(), 2);
+        Assert.assertEquals(result.get(0).getType(), SubscriptionBaseTransitionType.CREATE);
+        Assert.assertEquals(result.get(0).getEffectiveDate().compareTo(startDate), 0);
+        Assert.assertEquals(result.get(1).getType(), SubscriptionBaseTransitionType.EXPIRED);
+        Assert.assertEquals(result.get(1).getEffectiveDate().compareTo(startDate.plusMonths(12)), 0);
+    }
+
+    @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/1909")
+    public void testFixedTermBillingEventsAfterPhaseWithoutExpiredEventOnDisk() throws Exception {
+        final DateTime startDate = new DateTime(2023, 5, 1, 0, 0, DateTimeZone.UTC);
+        final DateTime fixedTermPhaseDate = startDate.plusDays(30);
+        final DefaultSubscriptionBase subscriptionBase = new DefaultSubscriptionBase(new SubscriptionBuilder().setAlignStartDate(startDate), subscriptionBaseApiService, clock);
+
+        final UUID subscriptionId = UUID.randomUUID();
+        final List<SubscriptionBaseEvent> inputEvents = new LinkedList<SubscriptionBaseEvent>();
+        inputEvents.add(new ApiEventCreate(new ApiEventBuilder().setApiEventType(CREATE)
+                                                                .setEventPlan("pistol-monthly-fixedterm")
+                                                                .setEventPlanPhase("pistol-monthly-fixedterm-trial")
+                                                                .setEventPriceList("fixedTerm")
+                                                                .setFromDisk(true)
+                                                                .setUuid(UUID.randomUUID())
+                                                                .setSubscriptionId(subscriptionId)
+                                                                .setCreatedDate(startDate)
+                                                                .setUpdatedDate(startDate)
+                                                                .setEffectiveDate(startDate)
+                                                                .setTotalOrdering(1)
+                                                                .setActive(true)));
+        inputEvents.add(new PhaseEventData(new PhaseEventBuilder().setPhaseName("pistol-monthly-fixedterm-fixedterm")
+                                                                  .setUuid(UUID.randomUUID())
+                                                                  .setSubscriptionId(subscriptionId)
+                                                                  .setCreatedDate(startDate)
+                                                                  .setUpdatedDate(startDate)
+                                                                  .setEffectiveDate(fixedTermPhaseDate)
+                                                                  .setTotalOrdering(2)
+                                                                  .setActive(true)));
+        subscriptionBase.rebuildTransitions(inputEvents, catalog);
+
+        final List<SubscriptionBillingEvent> result = subscriptionBase.getSubscriptionBillingEvents(catalog.getCatalog(), subscriptionCatalogApi.getPriceOverrideSvcStatus(), internalCallContext);
+
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.get(0).getType(), SubscriptionBaseTransitionType.CREATE);
+        Assert.assertEquals(result.get(1).getType(), SubscriptionBaseTransitionType.PHASE);
+        Assert.assertEquals(result.get(1).getEffectiveDate().compareTo(fixedTermPhaseDate), 0);
+        Assert.assertEquals(result.get(2).getType(), SubscriptionBaseTransitionType.EXPIRED);
+        Assert.assertEquals(result.get(2).getEffectiveDate().compareTo(fixedTermPhaseDate.plusMonths(12)), 0);
+    }
+
+    @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/1909")
+    public void testEvergreenBillingEventsHaveNoExpiredEvent() throws Exception {
+        final DateTime startDate = new DateTime(2023, 5, 1, 0, 0, DateTimeZone.UTC);
+        final DefaultSubscriptionBase subscriptionBase = new DefaultSubscriptionBase(new SubscriptionBuilder().setAlignStartDate(startDate), subscriptionBaseApiService, clock);
+
+        final UUID subscriptionId = UUID.randomUUID();
+        final List<SubscriptionBaseEvent> inputEvents = new LinkedList<SubscriptionBaseEvent>();
+        inputEvents.add(new ApiEventCreate(new ApiEventBuilder().setApiEventType(CREATE)
+                                                                .setEventPlan("shotgun-monthly")
+                                                                .setEventPlanPhase("shotgun-monthly-evergreen")
+                                                                .setEventPriceList("DEFAULT")
+                                                                .setFromDisk(true)
+                                                                .setUuid(UUID.randomUUID())
+                                                                .setSubscriptionId(subscriptionId)
+                                                                .setCreatedDate(startDate)
+                                                                .setUpdatedDate(startDate)
+                                                                .setEffectiveDate(startDate)
+                                                                .setTotalOrdering(1)
+                                                                .setActive(true)));
+        subscriptionBase.rebuildTransitions(inputEvents, catalog);
+
+        final List<SubscriptionBillingEvent> result = subscriptionBase.getSubscriptionBillingEvents(catalog.getCatalog(), subscriptionCatalogApi.getPriceOverrideSvcStatus(), internalCallContext);
+
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertEquals(result.get(0).getType(), SubscriptionBaseTransitionType.CREATE);
+    }
+
+    @Test(groups = "fast", description = "https://github.com/killbill/killbill/issues/1909")
+    public void testNonFinalFixedTermPhaseHasNoExpiredEvent() throws Exception {
+        final DateTime startDate = new DateTime(2023, 5, 1, 0, 0, DateTimeZone.UTC);
+        final DateTime fixedTermPhaseDate = startDate.plusDays(30);
+        final DefaultSubscriptionBase subscriptionBase = new DefaultSubscriptionBase(new SubscriptionBuilder().setAlignStartDate(startDate), subscriptionBaseApiService, clock);
+
+        final UUID subscriptionId = UUID.randomUUID();
+        final List<SubscriptionBaseEvent> inputEvents = new LinkedList<SubscriptionBaseEvent>();
+        inputEvents.add(new ApiEventCreate(new ApiEventBuilder().setApiEventType(CREATE)
+                                                                .setEventPlan("pistol-monthly-fixedterm-and-evergreen")
+                                                                .setEventPlanPhase("pistol-monthly-fixedterm-and-evergreen-trial")
+                                                                .setEventPriceList("fixedTerm")
+                                                                .setFromDisk(true)
+                                                                .setUuid(UUID.randomUUID())
+                                                                .setSubscriptionId(subscriptionId)
+                                                                .setCreatedDate(startDate)
+                                                                .setUpdatedDate(startDate)
+                                                                .setEffectiveDate(startDate)
+                                                                .setTotalOrdering(1)
+                                                                .setActive(true)));
+        inputEvents.add(new PhaseEventData(new PhaseEventBuilder().setPhaseName("pistol-monthly-fixedterm-and-evergreen-fixedterm")
+                                                                  .setUuid(UUID.randomUUID())
+                                                                  .setSubscriptionId(subscriptionId)
+                                                                  .setCreatedDate(startDate)
+                                                                  .setUpdatedDate(startDate)
+                                                                  .setEffectiveDate(fixedTermPhaseDate)
+                                                                  .setTotalOrdering(2)
+                                                                  .setActive(true)));
+        subscriptionBase.rebuildTransitions(inputEvents, catalog);
+
+        final List<SubscriptionBillingEvent> result = subscriptionBase.getSubscriptionBillingEvents(catalog.getCatalog(), subscriptionCatalogApi.getPriceOverrideSvcStatus(), internalCallContext);
+
+        Assert.assertEquals(result.size(), 2);
+        Assert.assertEquals(result.get(0).getType(), SubscriptionBaseTransitionType.CREATE);
+        Assert.assertEquals(result.get(1).getType(), SubscriptionBaseTransitionType.PHASE);
     }
 
 }


### PR DESCRIPTION
Fixes #1909

## Root cause

Legacy FIXEDTERM subscriptions have no EXPIRED event, so billing never stops

## Changes

- In DefaultSubscriptionBase.getSubscriptionBillingEvents, when no CANCEL/EXPIRED transition exists and the last Plan/PlanPhase transition lands on the plan's final FIXEDTERM phase, derive an EXPIRED billing event at phaseStart + phase duration (dropping catalog-version change candidates at/after that date), which stops billing exactly like the persisted EXPIRED event does for subscriptions created with 0.24.x. Added fast regression tests.